### PR TITLE
build imake at the top-level of the source tree and use it from there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,5 @@ src/utils/DARWIN/ivtmpnam
 src/IV/DARWIN/mkg3states
 src/GraphUnidraw/DARWIN/graphcmds.o-7f5490ff
 src/iclass/DARWIN/classinfo.o-9f882d1e
+
+imake

--- a/Makefile.orig
+++ b/Makefile.orig
@@ -598,7 +598,7 @@ cmcommit::
 	done
 
 imake::
-	-@if [ ! -f /usr/local/bin/imake ]; then  	echo building and installing /usr/local/bin/imake;  	gcc src/imake/imake.c;  	sudo install -c -m 0755 a.out /usr/local/bin/imake;  	rm a.out; fi
+	-@echo building imake; 	gcc -I ${XINCDIR} src/imake/imake.c -o imake
 
 clean::
 	@$(RM_CMD) make.makefile make.makefiles make.depend make.make make.imake

--- a/config/params.def
+++ b/config/params.def
@@ -171,7 +171,7 @@ config.guess config.sub configure configure.in MANIFEST.perceps MANIFEST.comterp
  * execute recursive make commands.
  */
 #ifndef ImakeCmd
-#define ImakeCmd imake
+#define ImakeCmd $(TOP)/imake
 #endif
 
 #ifndef ImakeFlags


### PR DESCRIPTION
This builds the imake binary at the top of the ivtools src tree, and uses it from there to do everything else.