### PR TITLE
avoid using fdstreams, also dump stack on crash

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -44,6 +44,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <cstdio>
+#include <iostream.h>
+#include <strstream>
 using namespace std;
 
 #ifdef LEAKCHECK
@@ -1051,6 +1053,15 @@ ostream& operator<< (ostream& out, const AttributeValue& sv) {
 	}
 #endif
     return out;
+}
+
+
+const char* AttributeValue::String() {
+    streambuf* strmbuf = nil;
+    strmbuf = new std::strstreambuf();
+    ostream out(strmbuf);
+    out << *this;
+    return ((std::strstreambuf*)strmbuf)->str();
 }
 
 void AttributeValue::negate() { 

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -384,6 +384,8 @@ public:
 
     friend ostream& operator << (ostream& s, const AttributeValue&);
     // output AttributeValue to ostream.
+    virtual const char* String();
+    // generate string using << operator
 
     void* value_ptr() { return &_v; }
     // returns void* pointer to value struct.

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -41,6 +41,9 @@
 #include <memory.h>
 
 #include <string.h>
+#include <iostream.h>
+#include <strstream>
+using namespace std;
 
 ComValue ComValue::_nullval;
 ComValue ComValue::_trueval(1, ComValue::BooleanType);
@@ -355,6 +358,16 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	}
     return out;
 }
+
+const char* ComValue::String() {
+    streambuf* strmbuf = nil;
+    strmbuf = new std::strstreambuf();
+    ostream out(strmbuf);
+    out << this;
+    return ((std::strstreambuf*)strmbuf)->str();
+}
+
+
 
 ComValue& ComValue::nullval() { 
   *&_nullval = ComValue();

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -136,6 +136,8 @@ public:
     friend ostream& operator << (ostream& s, const ComValue&);
     // print contents to ostream, brief or not depending on
     // associated ComTerp brief flag.
+    virtual const char* String();
+    // generate string using << operator
 
     static void comterp(const ComTerp* comterp) { _comterp = comterp; }
     // set static pointer to ComTerp used to provide brief flag.

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -162,14 +162,17 @@ void ForFunc::execute() {
   if (nargsfixed()>4) fprintf(stderr, "Unexpected for loop with more than one body\n");
   while (!SeqFunc::breakflag() && !comterp()->quitflag()) {
     SeqFunc::continueflag(0);
+    
     ComValue whileexpr(stack_arg_post_eval(1));
     if (whileexpr.is_false()) break;
     delete bodyexpr;
     ComValue keybody(stack_key_post_eval(body_symid, false, ComValue::unkval(), true));
-    if (keybody.is_unknown() && nargsfixed()>= 4)
+    if (keybody.is_unknown() && nargsfixed()>= 4) {
       bodyexpr = new ComValue(stack_arg_post_eval(3));
-    else
+    } 
+    else {
       bodyexpr = new ComValue(keybody);
+    }
     ComValue nextexpr(stack_arg_post_eval(2));
   }
   SeqFunc::breakflag(0);
@@ -179,6 +182,7 @@ void ForFunc::execute() {
     delete bodyexpr;
   } else 
     push_stack(ComValue::nullval());
+
 }
 
 /*****************************************************************************/

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -45,6 +45,7 @@ static const char *const SERVER_HOST = ACE_DEFAULT_SERVER_HOST;
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/comvalue.h>
 
+#include <execinfo.h>
 
 #if BUFSIZ>1024
 #undef BUFSIZ
@@ -66,8 +67,24 @@ static char newline;
 using std::cout;
 using std::cerr;
 
+void stack_trace_handler(int sig) {
+  void *array[10];
+  size_t size;
+
+  // get void*'s for all entries on the stack
+  size = backtrace(array, 10);
+
+  // print out all the frames to stderr
+  fprintf(stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
+}
+
+
 int main(int argc, char *argv[]) {
 
+    signal(SIGSEGV, stack_trace_handler);
+    
     boolean server_flag = argc>1 && strcmp(argv[1], "server") == 0;
     boolean logger_flag = argc>1 && strcmp(argv[1], "logger") == 0;
     boolean remote_flag = argc>1 && strcmp(argv[1], "remote") == 0;


### PR DESCRIPTION
This removes a reliance on iostreams that write to files or fd's, because these have historically been volatile, unreliable, and non-standard code.  But since the iostream I/O is so embedded into the ivtools package, it will still be used to write to a string, which then can be printed via fprintf, etc..

Also this adds a utility function to dump the stack upon a crash.