### PR TITLE
fix for macos 15 build

### DIFF
--- a/src/include/ivstd/fstream
+++ b/src/include/ivstd/fstream
@@ -214,16 +214,16 @@ public:
 
     // 27.9.1.3 Assign/swap:
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf& operator=(basic_filebuf&& __rhs);
+    basic_filebuf& operator=(basic_filebuf&& __rhs);
 #endif
     void swap(basic_filebuf& __rhs);
 
     // 27.9.1.4 Members:
-    inline _LIBCPP_INLINE_VISIBILITY bool is_open() const;
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf* open(const char* __s, ios_base::openmode __mode);
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf* open(const string& __s, ios_base::openmode __mode);
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf* open(FILE* fd, ios_base::openmode __mode);
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf* close();
+    bool is_open() const;
+    basic_filebuf* open(const char* __s, ios_base::openmode __mode);
+    basic_filebuf* open(const string& __s, ios_base::openmode __mode);
+    basic_filebuf* open(FILE* fd, ios_base::openmode __mode);
+    basic_filebuf* close();
 
 protected:
     // 27.9.1.5 Overridden virtual functions:
@@ -355,7 +355,6 @@ basic_filebuf<_CharT, _Traits>::basic_filebuf(basic_filebuf&& __rhs)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_filebuf<_CharT, _Traits>&
 basic_filebuf<_CharT, _Traits>::operator=(basic_filebuf&& __rhs)
 {
@@ -393,9 +392,9 @@ basic_filebuf<_CharT, _Traits>::swap(basic_filebuf& __rhs)
     basic_streambuf<char_type, traits_type>::swap(__rhs);
     if (__extbuf_ != __extbuf_min_ && __rhs.__extbuf_ != __rhs.__extbuf_min_)
     {
-        _VSTD::swap(__extbuf_, __rhs.__extbuf_);
-        _VSTD::swap(__extbufnext_, __rhs.__extbufnext_);
-        _VSTD::swap(__extbufend_, __rhs.__extbufend_);
+        std::swap(__extbuf_, __rhs.__extbuf_);
+        std::swap(__extbufnext_, __rhs.__extbufnext_);
+        std::swap(__extbufend_, __rhs.__extbufend_);
     }
     else
     {
@@ -418,18 +417,18 @@ basic_filebuf<_CharT, _Traits>::swap(basic_filebuf& __rhs)
         __rhs.__extbufnext_ = __rhs.__extbuf_ + __ln;
         __rhs.__extbufend_ = __rhs.__extbuf_ + __le;
     }
-    _VSTD::swap(__ebs_, __rhs.__ebs_);
-    _VSTD::swap(__intbuf_, __rhs.__intbuf_);
-    _VSTD::swap(__ibs_, __rhs.__ibs_);
-    _VSTD::swap(__file_, __rhs.__file_);
-    _VSTD::swap(__cv_, __rhs.__cv_);
-    _VSTD::swap(__st_, __rhs.__st_);
-    _VSTD::swap(__st_last_, __rhs.__st_last_);
-    _VSTD::swap(__om_, __rhs.__om_);
-    _VSTD::swap(__cm_, __rhs.__cm_);
-    _VSTD::swap(__owns_eb_, __rhs.__owns_eb_);
-    _VSTD::swap(__owns_ib_, __rhs.__owns_ib_);
-    _VSTD::swap(__always_noconv_, __rhs.__always_noconv_);
+    std::swap(__ebs_, __rhs.__ebs_);
+    std::swap(__intbuf_, __rhs.__intbuf_);
+    std::swap(__ibs_, __rhs.__ibs_);
+    std::swap(__file_, __rhs.__file_);
+    std::swap(__cv_, __rhs.__cv_);
+    std::swap(__st_, __rhs.__st_);
+    std::swap(__st_last_, __rhs.__st_last_);
+    std::swap(__om_, __rhs.__om_);
+    std::swap(__cm_, __rhs.__cm_);
+    std::swap(__owns_eb_, __rhs.__owns_eb_);
+    std::swap(__owns_ib_, __rhs.__owns_ib_);
+    std::swap(__always_noconv_, __rhs.__always_noconv_);
     if (this->eback() == (char_type*)__rhs.__extbuf_min_)
     {
         ptrdiff_t __n = this->gptr() - this->eback();
@@ -465,7 +464,6 @@ basic_filebuf<_CharT, _Traits>::swap(basic_filebuf& __rhs)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 swap(basic_filebuf<_CharT, _Traits>& __x, basic_filebuf<_CharT, _Traits>& __y)
 {
@@ -473,7 +471,6 @@ swap(basic_filebuf<_CharT, _Traits>& __x, basic_filebuf<_CharT, _Traits>& __y)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 bool
 basic_filebuf<_CharT, _Traits>::is_open() const
 {
@@ -561,7 +558,6 @@ basic_filebuf<_CharT, _Traits>::open(const char* __s, ios_base::openmode __mode)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_filebuf<_CharT, _Traits>*
 basic_filebuf<_CharT, _Traits>::open(const string& __s, ios_base::openmode __mode)
 {
@@ -704,7 +700,7 @@ basic_filebuf<_CharT, _Traits>::underflow()
             memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
             __extbufnext_ = __extbuf_ + (__extbufend_ - __extbufnext_);
             __extbufend_ = __extbuf_ + (__extbuf_ == __extbuf_min_ ? sizeof(__extbuf_min_) : __ebs_);
-            size_t __nmemb = _VSTD::min(static_cast<size_t>(__ibs_ - __unget_sz),
+            size_t __nmemb = std::min(static_cast<size_t>(__ibs_ - __unget_sz),
                                  static_cast<size_t>(__extbufend_ - __extbufnext_));
             codecvt_base::result __r;
             __st_last_ = __st_;
@@ -1106,38 +1102,36 @@ public:
     typedef typename traits_type::pos_type pos_type;
     typedef typename traits_type::off_type off_type;
 
-    inline _LIBCPP_INLINE_VISIBILITY basic_ifstream();
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in);
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_ifstream(const string& __s, ios_base::openmode __mode = ios_base::in);
+    basic_ifstream();
+    explicit basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in);
+    explicit basic_ifstream(const string& __s, ios_base::openmode __mode = ios_base::in);
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_ifstream(basic_ifstream&& __rhs);
+    basic_ifstream(basic_ifstream&& __rhs);
 #endif
 
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_ifstream& operator=(basic_ifstream&& __rhs);
+    basic_ifstream& operator=(basic_ifstream&& __rhs);
 #endif
-    inline _LIBCPP_INLINE_VISIBILITY void swap(basic_ifstream& __rhs);
+    void swap(basic_ifstream& __rhs);
 
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf<char_type, traits_type>* rdbuf() const;
-    inline _LIBCPP_INLINE_VISIBILITY bool is_open() const;
+    basic_filebuf<char_type, traits_type>* rdbuf() const;
+    bool is_open() const;
     void open(const char* __s, ios_base::openmode __mode = ios_base::in);
     void open(const string& __s, ios_base::openmode __mode = ios_base::in);
     void open(int fd, ios_base::openmode __mode = ios_base::in);
-    inline _LIBCPP_INLINE_VISIBILITY void close();
+    void close();
 
 private:
     basic_filebuf<char_type, traits_type> __sb_;
 };
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ifstream<_CharT, _Traits>::basic_ifstream()
     : basic_istream<char_type, traits_type>(&__sb_)
 {
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ifstream<_CharT, _Traits>::basic_ifstream(const char* __s, ios_base::openmode __mode)
     : basic_istream<char_type, traits_type>(&__sb_)
 {
@@ -1146,7 +1140,6 @@ basic_ifstream<_CharT, _Traits>::basic_ifstream(const char* __s, ios_base::openm
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ifstream<_CharT, _Traits>::basic_ifstream(const string& __s, ios_base::openmode __mode)
     : basic_istream<char_type, traits_type>(&__sb_)
 {
@@ -1157,28 +1150,25 @@ basic_ifstream<_CharT, _Traits>::basic_ifstream(const string& __s, ios_base::ope
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ifstream<_CharT, _Traits>::basic_ifstream(basic_ifstream&& __rhs)
-    : basic_istream<char_type, traits_type>(_VSTD::move(__rhs)),
-      __sb_(_VSTD::move(__rhs.__sb_))
+    : basic_istream<char_type, traits_type>(std::move(__rhs)),
+      __sb_(std::move(__rhs.__sb_))
 {
     this->set_rdbuf(&__sb_);
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ifstream<_CharT, _Traits>&
 basic_ifstream<_CharT, _Traits>::operator=(basic_ifstream&& __rhs)
 {
-    basic_istream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-    __sb_ = _VSTD::move(__rhs.__sb_);
+    basic_istream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
     return *this;
 }
 
 #endif  // _LIBCPP_HAS_NO_RVALUE_REFERENCES
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 basic_ifstream<_CharT, _Traits>::swap(basic_ifstream& __rhs)
 {
@@ -1187,7 +1177,6 @@ basic_ifstream<_CharT, _Traits>::swap(basic_ifstream& __rhs)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 swap(basic_ifstream<_CharT, _Traits>& __x, basic_ifstream<_CharT, _Traits>& __y)
 {
@@ -1195,7 +1184,6 @@ swap(basic_ifstream<_CharT, _Traits>& __x, basic_ifstream<_CharT, _Traits>& __y)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_filebuf<_CharT, _Traits>*
 basic_ifstream<_CharT, _Traits>::rdbuf() const
 {
@@ -1203,7 +1191,6 @@ basic_ifstream<_CharT, _Traits>::rdbuf() const
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 bool
 basic_ifstream<_CharT, _Traits>::is_open() const
 {
@@ -1241,7 +1228,6 @@ basic_ifstream<_CharT, _Traits>::open(int fd, ios_base::openmode __mode)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 basic_ifstream<_CharT, _Traits>::close()
 {
@@ -1262,38 +1248,36 @@ public:
     typedef typename traits_type::pos_type pos_type;
     typedef typename traits_type::off_type off_type;
 
-    inline _LIBCPP_INLINE_VISIBILITY basic_ofstream();
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_ofstream(const char* __s, ios_base::openmode __mode = ios_base::out);
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_ofstream(const string& __s, ios_base::openmode __mode = ios_base::out);
+    basic_ofstream();
+    explicit basic_ofstream(const char* __s, ios_base::openmode __mode = ios_base::out);
+    explicit basic_ofstream(const string& __s, ios_base::openmode __mode = ios_base::out);
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_ofstream(basic_ofstream&& __rhs);
+    basic_ofstream(basic_ofstream&& __rhs);
 #endif
 
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_ofstream& operator=(basic_ofstream&& __rhs);
+    basic_ofstream& operator=(basic_ofstream&& __rhs);
 #endif
-    inline _LIBCPP_INLINE_VISIBILITY void swap(basic_ofstream& __rhs);
+    void swap(basic_ofstream& __rhs);
 
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf<char_type, traits_type>* rdbuf() const;
-    inline _LIBCPP_INLINE_VISIBILITY bool is_open() const;
+    basic_filebuf<char_type, traits_type>* rdbuf() const;
+    bool is_open() const;
     void open(const char* __s, ios_base::openmode __mode = ios_base::out);
     void open(const string& __s, ios_base::openmode __mode = ios_base::out);
     void open(int fd, ios_base::openmode __mode = ios_base::out);
-    inline _LIBCPP_INLINE_VISIBILITY void close();
+    void close();
 
 private:
     basic_filebuf<char_type, traits_type> __sb_;
 };
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ofstream<_CharT, _Traits>::basic_ofstream()
     : basic_ostream<char_type, traits_type>(&__sb_)
 {
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ofstream<_CharT, _Traits>::basic_ofstream(const char* __s, ios_base::openmode __mode)
     : basic_ostream<char_type, traits_type>(&__sb_)
 {
@@ -1302,7 +1286,6 @@ basic_ofstream<_CharT, _Traits>::basic_ofstream(const char* __s, ios_base::openm
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ofstream<_CharT, _Traits>::basic_ofstream(const string& __s, ios_base::openmode __mode)
     : basic_ostream<char_type, traits_type>(&__sb_)
 {
@@ -1313,28 +1296,25 @@ basic_ofstream<_CharT, _Traits>::basic_ofstream(const string& __s, ios_base::ope
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ofstream<_CharT, _Traits>::basic_ofstream(basic_ofstream&& __rhs)
-    : basic_ostream<char_type, traits_type>(_VSTD::move(__rhs)),
-      __sb_(_VSTD::move(__rhs.__sb_))
+    : basic_ostream<char_type, traits_type>(std::move(__rhs)),
+      __sb_(std::move(__rhs.__sb_))
 {
     this->set_rdbuf(&__sb_);
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_ofstream<_CharT, _Traits>&
 basic_ofstream<_CharT, _Traits>::operator=(basic_ofstream&& __rhs)
 {
-    basic_ostream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-    __sb_ = _VSTD::move(__rhs.__sb_);
+    basic_ostream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
     return *this;
 }
 
 #endif  // _LIBCPP_HAS_NO_RVALUE_REFERENCES
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 basic_ofstream<_CharT, _Traits>::swap(basic_ofstream& __rhs)
 {
@@ -1343,7 +1323,6 @@ basic_ofstream<_CharT, _Traits>::swap(basic_ofstream& __rhs)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 swap(basic_ofstream<_CharT, _Traits>& __x, basic_ofstream<_CharT, _Traits>& __y)
 {
@@ -1351,7 +1330,6 @@ swap(basic_ofstream<_CharT, _Traits>& __x, basic_ofstream<_CharT, _Traits>& __y)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_filebuf<_CharT, _Traits>*
 basic_ofstream<_CharT, _Traits>::rdbuf() const
 {
@@ -1359,7 +1337,6 @@ basic_ofstream<_CharT, _Traits>::rdbuf() const
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 bool
 basic_ofstream<_CharT, _Traits>::is_open() const
 {
@@ -1397,7 +1374,6 @@ basic_ofstream<_CharT, _Traits>::open(int fd, ios_base::openmode __mode)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 basic_ofstream<_CharT, _Traits>::close()
 {
@@ -1418,39 +1394,37 @@ public:
     typedef typename traits_type::pos_type pos_type;
     typedef typename traits_type::off_type off_type;
 
-    inline _LIBCPP_INLINE_VISIBILITY basic_fstream();
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_fstream(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_fstream(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
-    inline _LIBCPP_INLINE_VISIBILITY explicit basic_fstream(int fd, ios_base::openmode __mode = ios_base::in | ios_base::out);
+    basic_fstream();
+    explicit basic_fstream(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+    explicit basic_fstream(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+    explicit basic_fstream(int fd, ios_base::openmode __mode = ios_base::in | ios_base::out);
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_fstream(basic_fstream&& __rhs);
+    basic_fstream(basic_fstream&& __rhs);
 #endif
 
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
-    inline _LIBCPP_INLINE_VISIBILITY basic_fstream& operator=(basic_fstream&& __rhs);
+    basic_fstream& operator=(basic_fstream&& __rhs);
 #endif
-    inline _LIBCPP_INLINE_VISIBILITY void swap(basic_fstream& __rhs);
+    void swap(basic_fstream& __rhs);
 
-    inline _LIBCPP_INLINE_VISIBILITY basic_filebuf<char_type, traits_type>* rdbuf() const;
-    inline _LIBCPP_INLINE_VISIBILITY bool is_open() const;
+    basic_filebuf<char_type, traits_type>* rdbuf() const;
+    bool is_open() const;
     void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
     void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
     void open(int fd, ios_base::openmode __mode = ios_base::in | ios_base::out);
-    inline _LIBCPP_INLINE_VISIBILITY void close();
+    void close();
 
 private:
     basic_filebuf<char_type, traits_type> __sb_;
 };
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_fstream<_CharT, _Traits>::basic_fstream()
     : basic_iostream<char_type, traits_type>(&__sb_)
 {
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_fstream<_CharT, _Traits>::basic_fstream(const char* __s, ios_base::openmode __mode)
     : basic_iostream<char_type, traits_type>(&__sb_)
 {
@@ -1459,7 +1433,6 @@ basic_fstream<_CharT, _Traits>::basic_fstream(const char* __s, ios_base::openmod
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_fstream<_CharT, _Traits>::basic_fstream(const string& __s, ios_base::openmode __mode)
     : basic_iostream<char_type, traits_type>(&__sb_)
 {
@@ -1468,7 +1441,6 @@ basic_fstream<_CharT, _Traits>::basic_fstream(const string& __s, ios_base::openm
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_fstream<_CharT, _Traits>::basic_fstream(int fd, ios_base::openmode __mode)
     : basic_iostream<char_type, traits_type>(&__sb_)
 {
@@ -1479,28 +1451,25 @@ basic_fstream<_CharT, _Traits>::basic_fstream(int fd, ios_base::openmode __mode)
 #ifndef _LIBCPP_HAS_NO_RVALUE_REFERENCES
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_fstream<_CharT, _Traits>::basic_fstream(basic_fstream&& __rhs)
-    : basic_iostream<char_type, traits_type>(_VSTD::move(__rhs)),
-      __sb_(_VSTD::move(__rhs.__sb_))
+    : basic_iostream<char_type, traits_type>(std::move(__rhs)),
+      __sb_(std::move(__rhs.__sb_))
 {
     this->set_rdbuf(&__sb_);
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_fstream<_CharT, _Traits>&
 basic_fstream<_CharT, _Traits>::operator=(basic_fstream&& __rhs)
 {
-    basic_iostream<char_type, traits_type>::operator=(_VSTD::move(__rhs));
-    __sb_ = _VSTD::move(__rhs.__sb_);
+    basic_iostream<char_type, traits_type>::operator=(std::move(__rhs));
+    __sb_ = std::move(__rhs.__sb_);
     return *this;
 }
 
 #endif  // _LIBCPP_HAS_NO_RVALUE_REFERENCES
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 basic_fstream<_CharT, _Traits>::swap(basic_fstream& __rhs)
 {
@@ -1509,7 +1478,6 @@ basic_fstream<_CharT, _Traits>::swap(basic_fstream& __rhs)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 swap(basic_fstream<_CharT, _Traits>& __x, basic_fstream<_CharT, _Traits>& __y)
 {
@@ -1517,7 +1485,6 @@ swap(basic_fstream<_CharT, _Traits>& __x, basic_fstream<_CharT, _Traits>& __y)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 basic_filebuf<_CharT, _Traits>*
 basic_fstream<_CharT, _Traits>::rdbuf() const
 {
@@ -1525,7 +1492,6 @@ basic_fstream<_CharT, _Traits>::rdbuf() const
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 bool
 basic_fstream<_CharT, _Traits>::is_open() const
 {
@@ -1563,7 +1529,6 @@ basic_fstream<_CharT, _Traits>::open(int fd, ios_base::openmode __mode)
 }
 
 template <class _CharT, class _Traits>
-inline _LIBCPP_INLINE_VISIBILITY
 void
 basic_fstream<_CharT, _Traits>::close()
 {


### PR DESCRIPTION
Build on macos 15 cannot understand `_LIBCPP_INLINE_VISIBILITY` and `_VSTD`, so remove or change it.