### PR TITLE
Improve DrawServ link/session logging and add UUID per graphic/session

### DIFF
--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -188,10 +188,25 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
 
     if (!ComterpHandler::logger_mode() && !log_only()) {
       comterp_->load_string(inbuf);
+
+      // this hides the logging of a ready command, interesting
+      #if 0
       if (fd>0 && !comterp_->muted() && strncmp(inbuf, "ready", 5)!=0)
 	cerr << "(" << fd << "):  " << inbuf << "\n";
+      #else
+      if (fd>0 && !comterp_->muted() ) { // && strncmp(inbuf, "ready", 5)!=0)
+	  struct timeval tv;
+	  ::gettimeofday(&tv, NULL);
+	  cerr << "[" << tv.tv_sec%100 << "." << tv.tv_usec << "] <" << fd << ":  " << inbuf << "\n";
+      }
+      #endif
+
+      
       comterp_->_fd = fd;
       comterp_->_outfunc = (outfuncptr)&ComTerpServ::fd_fputs;
+
+
+
 
       int  status = comterp_->ComTerp::run(false /* !once */, comterp_->force_nested() /* !nested */);
       if(comterp_->force_nested()) ComValue retval(comterp_->pop_stack(false));

--- a/src/DrawServ/ackback-handler.c
+++ b/src/DrawServ/ackback-handler.c
@@ -52,6 +52,7 @@ AckBackHandler::AckBackHandler ()
   _timer_started = false;
   _ackback_arrived = false;
   _eof_expected = false;
+  _period_count = 0;
 }
 
 AckBackHandler::~AckBackHandler() {
@@ -98,8 +99,17 @@ int AckBackHandler::handle_input (ACE_HANDLE fd)
 	  cerr << "unable to cancel timerid " << _timerid << "\n";
 	_timer_started = false;
       }
-      
-      cerr << "AckBack:  [" << (char*)&inv[0] << "]\n";
+
+      if (*(char*)&inv[0]!='\0') {
+	cerr << "AckBack:  [";
+	for(int i=0; i<_period_count; i++)  cerr << '.';
+	_period_count = 0;
+        cerr << (char*)&inv[0] << "]\n";
+      } else {
+	_period_count = 1;
+      }
+	
+	
       _ackback_arrived = true;
     }
     return 0;

--- a/src/DrawServ/ackback-handler.h
+++ b/src/DrawServ/ackback-handler.h
@@ -76,6 +76,7 @@ protected:
   long _timerid;
   ACE_HANDLE _handle;
   int _eof_expected;
+  int _period_count;
 
 };
 

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -162,10 +162,8 @@ void DrawLinkFunc::execute() {
     if (link && closev.is_true()) {
       ((DrawServ*)unidraw)->linkdown(link);
       link = nil;
-    }
-    
-    else if (link) {
-      link->dump(stderr);
+      push_stack(ComValue::nullval());
+      return;
     }
     
   }
@@ -174,7 +172,7 @@ void DrawLinkFunc::execute() {
   if (statev.int_val()==DrawLink::two_way) {
     DrawServHandler* handler = comterp() ? (DrawServHandler*)comterp()->handler() : nil;
     if (handler) {
-	DrawLink* link = (DrawLink*)handler->drawlink();
+	if (link==NULL) link  = (DrawLink*)handler->drawlink();
 	if (link != NULL) {
 	    link->state(DrawLink::two_way);
 	    

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -109,7 +109,12 @@ int DrawLink::open() {
     out << "drawlink(\"";
     char buffer[HOST_NAME_MAX];
     gethostname(buffer, HOST_NAME_MAX);
+    
     unsigned int sid = ((DrawServ*)unidraw)->sessionid();
+    uuid_t& suuid = ((DrawServ*)unidraw)->sessionuuid();
+    uuid_string_t suuid_str;
+    uuid_unparse(suuid, suuid_str);
+    
     void* ptr = nil;
     ((DrawServ*)unidraw)->sessionidtable()->find(ptr, sid);
     SessionId* sessionid = (SessionId*)ptr;
@@ -119,6 +124,7 @@ int DrawLink::open() {
     out << " :rid " << _local_linkid;
     out << " :lid " << _remote_linkid;
     out << " :sid 0x" << std::hex << sid << std::dec;
+    out << " :suuid \"" << suuid_str << "\"";
     if (sessionid) {
       out << " :pid " << sessionid->pid();
       out << " :user \"" << sessionid->username() << "\"";

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -70,6 +70,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <stdio.h>
+#include <uuid/uuid.h>
 
 using std::cout;
 using std::cerr;
@@ -107,6 +108,7 @@ void DrawServ::Init() {
   _compidtable = new CompIdTable(1024);
 
   _sessionid = unique_sessionid();
+  uuid_generate(_sessionuuid);
 #if 0
   _sessionid = 0xfff00000;  // for testing purposes
 #endif
@@ -138,8 +140,6 @@ DrawServ::~DrawServ ()
   delete _compidtable;
 #endif /* HAVE_ACE */
 }
-
-#ifdef HAVE_ACE
 
 DrawLink* DrawServ::linkup(const char* hostname, int portnum, 
 		     int state, int local_id, int remote_id,
@@ -375,27 +375,32 @@ void DrawServ::DistributeCmdString(const char* cmdstring, DrawLink* orglink) {
 	fputs(cmdstring, fp);
 	fputs("\n", fp);
 	fclose(fp);
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+        fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, tv.tv_usec, link->portnum(), cmdstring);
 	link->ackhandler()->start_timer();
       }
     }
     _linklist->Next(i);
   }
-
+  
 }
 
 void DrawServ::SendCmdString(DrawLink* link, const char* cmdstring) {
 
   if (cmdstring==NULL || *cmdstring=='\0') return;
-
+  
   if (link) {
     int fd = link->handle();
     if (fd>=0) {
-	FILE* fp=fdopen(dup(fd), "w");
+      FILE* fp=fdopen(dup(fd), "w");
       fputs(cmdstring, fp);
       fputs("\n", fp);
       fclose(fp);
       link->ackhandler()->start_timer();
-      fprintf(stdout, "<%d>: %s\n", link->portnum(), cmdstring);
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, tv.tv_usec, link->portnum(), cmdstring);
     }
   }
 }
@@ -636,26 +641,17 @@ void DrawServ::grid_message_callback(DrawLink* link, unsigned int id, unsigned i
 void DrawServ::print_gridtable() {
   GraphicIdTable* table = gridtable();
   GraphicIdTable_Iterator it(*table);
-  #if 0
-  printf("id          &grid       &grcomp     selector    selected\n");
-  printf("----------  ----------  ----------  ----------  --------\n");
-  #else
-  printf("id          comptype              selector    selected\n");
-  printf("----------  --------------------  ----------  --------\n");
-  #endif
+  printf("id          uuid8    comptype              selector    selected\n");
+  printf("----------  -------- --------------------  ----------  --------\n");
   while(it.more()) {
     GraphicId* grid = (GraphicId*)it.cur_value();
-    #if 0
-    printf("0x%08x  0x%08lx  0x%08lx  0x%08lx  %s\n", 
-	   (unsigned int)it.cur_key(), (unsigned long)grid, (unsigned long)grid->grcomp(),
-	   (unsigned long)grid->selector(), LinkSelection::selected_string(grid->selected()));
-    #else
     OverlayComp* comp = (OverlayComp*)grid->grcomp();
     const char* comptype = comp ? comp->GetClassName() : "nil";
-    printf("0x%08x  %-20s  0x%08x  %s\n",
- 	   (unsigned int)it.cur_key(), comptype,
+    uuid_string_t uuidstr;
+    uuid_unparse(grid->uuid(), uuidstr);
+    printf("0x%08x  %.8s %-20s  0x%08x  %s\n",
+ 	   (unsigned int)it.cur_key(), uuidstr, comptype,
  	   (unsigned int)grid->selector(), LinkSelection::selected_string(grid->selected()));
-    #endif
     it.next();
   }
 }
@@ -795,7 +791,7 @@ void DrawServ::SendAllToBackgroundEditor(DrawLink* link, DrawEditor* fged) {
 }
     
 void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
-
+  
     boolean original = false;
     int grid = 0;
     int sid = 0;
@@ -814,7 +810,7 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
 	    for (bgfcomp->Last(it); !bgfcomp->Done(it); bgfcomp->Prev(it)) {
 		OverlayComp* comp = (OverlayComp*)bgfcomp->GetComp(it);
 		original = add_grid(comp, grid, sid);
-
+		
 		if (comp && (original || linklist()->Number()>1)) {
 		    Creator* creator = unidraw->GetCatalog()->GetCreator();
 		    OverlayScript* scripter = (OverlayScript*)
@@ -822,7 +818,7 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
 		    if (scripter) {
 			scripter->SetSubject(comp);
 			if (comp->IsA(OVRASTER_COMP))
-			  ((RasterScript*)scripter)->SetCommandSerialize(true);
+			    ((RasterScript*)scripter)->SetCommandSerialize(true);
 			if (scripted) 
 			    sbuf << ';';
 			else 
@@ -836,7 +832,7 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
 	    }
 	}
     }
-
+    
     /* then send to new foreground connection pasted in front and moved to back */
     if (original || linklist()->Number()>1) {
 	sbuf << "\n";
@@ -844,21 +840,28 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
     }
     
 }
-    
+
 boolean DrawServ::add_grid(OverlayComp* comp, int& grid, int& sid) {
     boolean original = false;
     static int grid_sym = symbol_add("grid");
     static int sid_sym = symbol_add("sid");
-
+    static int uuid_sym = symbol_add("uuid");
+    uuid_t uuid;
+    
     AttributeList* al = comp->GetAttributeList();
     if (al!=NULL) {
-      
-      AttributeValue *gridv = al->find(grid_sym);
-      if (gridv!=NULL) grid = gridv->uint_val();
-      
-      AttributeValue *sidv = al->find(sid_sym);
-      if (sidv!=NULL) sid = sidv->uint_val();
-      
+	
+	AttributeValue *gridv = al->find(grid_sym);
+	if (gridv!=NULL) grid = gridv->uint_val();
+	
+	AttributeValue *sidv = al->find(sid_sym);
+	if (sidv!=NULL) sid = sidv->uint_val();
+	
+	AttributeValue *uuidv = al->find(uuid_sym);
+	if (uuidv!=NULL) {
+	  uuid_parse(uuidv->string_ptr(), uuid);
+	}
+	
     }
     
     /* unique id already assigned */
@@ -866,6 +869,7 @@ boolean DrawServ::add_grid(OverlayComp* comp, int& grid, int& sid) {
 	GraphicId* graphicid = new GraphicId();
 	graphicid->grcomp(comp);
 	graphicid->id(grid);
+	graphicid->uuid(uuid);
 	graphicid->selector(sid);
 	graphicid->selected(LinkSelection::NotSelected);
     } 
@@ -873,31 +877,37 @@ boolean DrawServ::add_grid(OverlayComp* comp, int& grid, int& sid) {
     /* generate unique id and add as attribute */
     /* also mark with selector id */
     else {
+	original = true;
 	GraphicId* graphicid = new GraphicId(sessionid());
 	graphicid->grcomp(comp);
 	graphicid->selector(((DrawServ*)unidraw)->sessionid());
+	
 	AttributeValue* gridv = new AttributeValue(grid=graphicid->id(), AttributeValue::UIntType);
 	gridv->state(AttributeValue::HexState);
 	al->add_attr(grid_sym, gridv);
+	
 	AttributeValue* sidv = new AttributeValue(sid=graphicid->selector(), AttributeValue::UIntType);
 	sidv->state(AttributeValue::HexState);
 	al->add_attr(sid_sym, sidv);
-	original = true;
+
+	uuid_string_t uuid_str;
+	uuid_unparse(graphicid->uuid(), uuid_str);
+	AttributeValue* uuidv = new AttributeValue((const char*)uuid_str);
+	al->add_attr(uuid_sym, uuidv);
 	
      	Editor* ed = DrawKit::Instance()->GetEditor();
 	OverlaySelection* sel = (OverlaySelection*)ed->GetViewer()->GetSelection();
 	Iterator it;
 	boolean is_selected = false;
 	for (sel->First(it); !sel->Done(it); sel->Next(it)) {
-	  OverlayView* view = (OverlayView*)sel->GetView(it);
-	  if (view && view->GetOverlayComp() == comp) {
-	    is_selected = true;
-	    break;
-	  }
+	    OverlayView* view = (OverlayView*)sel->GetView(it);
+	    if (view && view->GetOverlayComp() == comp) {
+		is_selected = true;
+		break;
+	    }
 	}
-	graphicid->selected(is_selected ? LinkSelection::LocallySelected : LinkSelection::NotSelected);
-    }
+	graphicid->selected(is_selected ? 
+			    (graphicid->selector() == sessionid() ? LinkSelection::LocallySelected : LinkSelection::WaitingToBeSelected) : 
+			    LinkSelection::NotSelected);    }
     return original;
 }
-
-#endif /* HAVE_ACE */

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -30,6 +30,7 @@
 #include <OverlayUnidraw/ovunidraw.h>
 #include <stdio.h>
 #include <strstream>
+#include <uuid/uuid.h>
 
 #include <OS/table.h>
 declareTable(GraphicIdTable,int,void*)
@@ -133,6 +134,9 @@ public:
   unsigned int sessionid() { return _sessionid; }
   // current unique session id.
 
+  uuid_t& sessionuuid() { return _sessionuuid; }
+  // current unique session id.
+
   void remove_sids(DrawLink*);
   // remove all SessionId's associated with this DrawLink
 
@@ -202,6 +206,8 @@ protected:
   
   int _sessionid;
   // unique session id.
+  uuid_t _sessionuuid;
+  // universally unique session id.
   
   int _comdraw_port;
   // port used for comdraw command interpreter

--- a/src/DrawServ/grid.c
+++ b/src/DrawServ/grid.c
@@ -38,15 +38,21 @@
 
 /*****************************************************************************/
 
-GraphicId::GraphicId (unsigned int sessionid) 
+GraphicId::GraphicId (unsigned int sessionid, uuid_t sessionuuid) 
 {
 #ifdef HAVE_ACE
   _comp = nil;
   if (sessionid != 0) {
+
     _id = DrawServ::unique_grid();
+    uuid_generate(_uuid);
+    
     _sid = sessionid&DrawServ::SessionIdMask;
+    if (sessionuuid!=NULL) uuid_copy(_suuid, sessionuuid);
+    
     GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
     table->insert(_id|_sid, this);
+    
   } else {
     _id = _sid = 0;
   }
@@ -69,6 +75,12 @@ void GraphicId::id(unsigned int id) {
   _id = id & DrawServ::GraphicIdMask;
   _sid = id & DrawServ::SessionIdMask;
   table->insert(id, this);
+#endif
+}
+
+void GraphicId::uuid(uuid_t uuid) {
+#ifdef HAVE_ACE
+  uuid_copy(_uuid, uuid);
 #endif
 }
 

--- a/src/DrawServ/grid.h
+++ b/src/DrawServ/grid.h
@@ -28,6 +28,7 @@
 #define grid_h
 
 #include <Unidraw/globals.h>
+#include <uuid/uuid.h>
 
 class DrawLink;
 class GraphicComp;
@@ -36,7 +37,7 @@ class GraphicIdList;
 //: object to encapsulate unique graphic id
 class GraphicId {
 public:
-  GraphicId(unsigned int sessionid=0);
+  GraphicId(unsigned int sessionid=0, uuid_t sessionuuid=nil);
   virtual ~GraphicId();
   
   unsigned int id() { return _id|_sid; }
@@ -45,12 +46,24 @@ public:
   void id(unsigned int id);
   // set associated unique composite integer id
 
+  const uuid_t& uuid() { return _uuid; }
+  // get associated universally unique composite integer id
+
+  void uuid(uuid_t uuid);
+  // set associated universally unique composite integer id
+
   unsigned int grid() { return _id; }
   // return graphic id portion of composite id
   // unique only to this process
 
   unsigned int sessionid() { return _sid; }
   // return session id portion of composite id
+
+  const uuid_t& sessionuuid() { return _suuid; }
+  // get associated universally unique session
+
+  void sessionuuid(uuid_t uuid) { uuid_copy(_suuid, uuid); }
+  // set associated universally unique session id
 
   virtual int is_list() { return 0; }
   // return true if can be cast to GraphicIds
@@ -79,8 +92,13 @@ public:
 protected:
   unsigned int _id;
   unsigned int _sid;
+  
+  uuid_t _uuid;
+  uuid_t  _suuid;
+  
   unsigned int _selector;
   int _selected;
+  
   GraphicComp* _comp;
 
 };


### PR DESCRIPTION
This change improves DrawServ debugging and link/session tracking across distributed editors.

Key updates:
Add timestamped inbound/outbound command logging for DrawServ and ComTerp handlers.
Propagate session UUIDs in drawlink() handshake messages.
Add graphic UUIDs and show abbreviated UUIDs in print_gridtable() output for easier correlation during debugging.
Fix drawlink(close) handling to return immediately after teardown.
reserve existing handler link when switching to two_way state.
Improve AckBack logging behavior by suppressing empty messages and compacting heartbeat-style output.
Minor formatting and cleanup adjustments in DrawServ send/foreground sync paths.