### PR TITLE
drawserv: change session/graphic ids to UUIDs, remove :remap collision mechanism

### DIFF
--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -58,6 +58,7 @@ ComterpHandler::ComterpHandler (ComTerpServ* serv)
     _timeoutscriptid = -1;
     _wrfptr = _rdfptr = nil;
     _log_only = 0;
+    _alt_fd = -1;
 }
 
 ComterpHandler::~ComterpHandler() {
@@ -197,7 +198,7 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
       if (fd>0 && !comterp_->muted() ) { // && strncmp(inbuf, "ready", 5)!=0)
 	  struct timeval tv;
 	  ::gettimeofday(&tv, NULL);
-	  cerr << "[" << tv.tv_sec%100 << "." << tv.tv_usec << "] <" << fd << ":  " << inbuf << "\n";
+	  cerr << "[" << tv.tv_sec%100 << "." << tv.tv_usec << "] <" << (_alt_fd>-1 ? _alt_fd : fd) << ":  " << inbuf << "\n";
       }
       #endif
 

--- a/src/ComTerp/comhandler.h
+++ b/src/ComTerp/comhandler.h
@@ -117,6 +117,12 @@ public:
   void log_only(int flag ) { _log_only = flag; }
   // set flag that indicates whether just this handler is in logging mode 
 
+  int alt_fd() { return _alt_fd; }
+  // return number used to log command lines sent or received
+
+  void alt_fd(int num ) { _alt_fd = num; }
+  // set number used to log command lines sent or received (default is fd)
+
 protected:
   // = Demultiplexing hooks.
   virtual int handle_input (ACE_HANDLE);
@@ -151,6 +157,9 @@ protected:
 
   int _log_only;
   // put just this handler into log mode
+
+  int _alt_fd;
+  // alternate fd (or portnum) to use when logging command lines
 };
 
 //: Specialize a ComterpAcceptor.

--- a/src/DrawServ/draweditor.c
+++ b/src/DrawServ/draweditor.c
@@ -89,7 +89,6 @@ void DrawEditor::AddCommands(ComTerp* comterp) {
   comterp->add_command("drawlink", new DrawLinkFunc(comterp, this));
   comterp->add_command("sid", new SessionIdFunc(comterp, this));
   comterp->add_command("grid", new GraphicIdFunc(comterp, this));
-  comterp->add_command("chgid", new ChangeIdFunc(comterp, this));
 #endif
 
   comterp->add_command("points", new DrawPointsFunc(comterp, this));

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -48,6 +48,7 @@
 
 #define TITLE "DrawLinkFunc"
 
+#if 1
 /*****************************************************************************/
 
 DrawLinkFunc::DrawLinkFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comterp, ed) {
@@ -71,10 +72,8 @@ void DrawLinkFunc::execute() {
   static int state_sym = symbol_add("state");
   ComValue default_state(0);
   ComValue statev(stack_key(state_sym, false, default_state, true));
-  static int lid_sym = symbol_add("lid");
-  ComValue lidv(stack_key(lid_sym));
-  static int rid_sym = symbol_add("rid");
-  ComValue ridv(stack_key(rid_sym));
+  static int linkid_sym = symbol_add("linkid");
+  ComValue linkidv(stack_key(linkid_sym));
   static int close_sym = symbol_add("close");
   ComValue closev(stack_key(close_sym));
   static int pid_sym = symbol_add("pid");
@@ -127,65 +126,50 @@ void DrawLinkFunc::execute() {
 
   /* creating a new link to remote drawserv */
   if (hostv.is_string() && portv.is_known() && statev.is_known()) {
-
-    /* cast of this link if it is a duplicate or cycle */
+    
+    /* cast off this link if it is a duplicate or cycle */
+    uuid_t sid;
+    uuid_parse(sidv.string_ptr(), sid);
     if (statev.int_val()==DrawLink::one_way && 
 	((DrawServ*)unidraw)->cycletest
-	(sidv.uint_val(), hostv.string_ptr(), userv.string_ptr(), pidv.int_val())) {
+	(sid, hostv.string_ptr(), userv.string_ptr(), pidv.int_val())) {
       fputs("ackback(cycle)\n", comterp()->handler()->wrfptr());
       fflush(comterp()->handler()->wrfptr());
       comterp()->quit();
       return;
     }
-
+    
     const char* hoststr = hostv.string_ptr();
     const char* portstr = portv.is_string() ? portv.string_ptr() : nil;
     u_short portnum = portstr ? atoi(portstr) : portv.ushort_val();
     u_short statenum = statev.ushort_val();
-    int lidnum = lidv.is_known() ? lidv.int_val() : -1;
-    int ridnum = ridv.is_known() ? ridv.int_val() : -1;
-
-    link = 
-      ((DrawServ*)unidraw)->linkup(hoststr, portnum, statenum, 
-				   lidnum, ridnum, this->comterp());
-  
-     
-  } 
-
-  /* return pointer to existing link */
-  else if (ridv.is_known() || lidv.is_known()) {
-    link = ((DrawServ*)unidraw)->linkget
-      (lidv.is_known() ? lidv.int_val() : -1, 
-       ridv.is_known() ? ridv.int_val() : -1);
     
-    /* close if that flag is set. */
-    if (link && closev.is_true()) {
-      ((DrawServ*)unidraw)->linkdown(link);
-      link = nil;
-      push_stack(ComValue::nullval());
-      return;
+    uuid_t linkid; uuid_clear(linkid);
+    if (linkidv.is_string()) {
+	uuid_parse(linkidv.string_ptr(),linkid);
     }
-    
-  }
-
- /* set state to complete linkup */
+	
+    link = ((DrawServ*)unidraw)->linkup(hoststr, portnum, statenum, linkid, this->comterp());
+  } 
+  
+  /* set state to complete linkup */
   if (statev.int_val()==DrawLink::two_way) {
     DrawServHandler* handler = comterp() ? (DrawServHandler*)comterp()->handler() : nil;
     if (handler) {
-	if (link==NULL) link  = (DrawLink*)handler->drawlink();
-	if (link != NULL) {
-	    link->state(DrawLink::two_way);
-	    
-	    // at this point paste all graphics to new connection
-	    DrawServ* drawserv = (DrawServ*)unidraw;
+      if (link==NULL) link  = (DrawLink*)handler->drawlink();
+      if (link != NULL) {
+	link->state(DrawLink::two_way);
+	
+	// at this point paste all graphics to new connection
+	DrawServ* drawserv = (DrawServ*)unidraw;
 	    if (hostv.is_string())
-		drawserv->SendAllToBackgroundEditor(link, (DrawEditor*)GetEditor());
+	      drawserv->SendAllToBackgroundEditor(link, (DrawEditor*)GetEditor());
 	    else 
-		drawserv->SendAllToForegroundEditor(link, (DrawEditor*)GetEditor());
-	}
+	      drawserv->SendAllToForegroundEditor(link, (DrawEditor*)GetEditor());
+      }
     }
   }
-
+  
   /* dump DrawLink table to stderr */
   else if(nargs()==0) 
     ((DrawServ*)unidraw)->linkdump(stderr);
@@ -197,14 +181,15 @@ void DrawLinkFunc::execute() {
   }
   else
     push_stack(ComValue::nullval());
-
+  
   return;
-
+  
 #endif
-
+  
 }
 
-
+#endif
+  
 /*****************************************************************************/
 
 SessionIdFunc::SessionIdFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comterp, ed) {
@@ -220,9 +205,6 @@ void SessionIdFunc::execute() {
 #else
   static int all_sym = symbol_add("all");
   ComValue allv(stack_key(all_sym));
-  static int remap_sym = symbol_add("remap");
-  ComValue remapv(stack_key(remap_sym));
-
   static int pid_sym = symbol_add("pid");
   ComValue pidv(stack_key(pid_sym));
   static int user_sym = symbol_add("user");
@@ -233,7 +215,6 @@ void SessionIdFunc::execute() {
   ComValue hostidv(stack_key(hostid_sym));
  
   ComValue sidv(stack_arg(0));
-  ComValue osidv(stack_arg(1));
 
   reset_stack();
 
@@ -245,14 +226,16 @@ void SessionIdFunc::execute() {
     return;
   }
 
-  if (sidv.is_known() && osidv.is_known()) {
-    if (remapv.is_false()) 
-      ((DrawServ*)unidraw)->sessionid_register_handle
-	(link, sidv.uint_val(), osidv.uint_val(), pidv.int_val(), 
-	 userv.string_ptr(), hostv.string_ptr(), 
-	 hostidv.int_val());
-    else
-      link->sid_insert(osidv.uint_val(), sidv.uint_val());
+  if (sidv.is_known()) {
+
+    uuid_t sid;
+    uuid_parse(sidv.string_ptr(), sid);
+    
+    ((DrawServ*)unidraw)->sessionid_register_handle
+      (link, sid, pidv.int_val(), 
+       userv.string_ptr(), hostv.string_ptr(), 
+       hostidv.int_val());
+    
   } else {
     ((DrawServ*)unidraw)->print_sidtable();
   }
@@ -283,59 +266,36 @@ void GraphicIdFunc::execute() {
   DrawLink* link = handler ? (DrawLink*)handler->drawlink() : nil;
 
   if (idv.is_known() && selectorv.is_known()) {
+    uuid_t id;
+    uuid_parse(idv.string_ptr(), id);
+    
+    uuid_t sid;
+    uuid_parse(selectorv.string_ptr(), sid);
+    
     if (grantv.is_unknown()) {
-      if (requestv.is_unknown()) 
+      
+      if (requestv.is_unknown())  {
 	((DrawServ*)unidraw)->grid_message_handle
-	  (link, idv.uint_val(), selectorv.uint_val(), statev.int_val());
-      else
+	  (link, id, sid, statev.int_val());
+      }
+      
+      else {
+	uuid_t rid;
+	uuid_parse(requestv.string_ptr(), rid);
 	((DrawServ*)unidraw)->grid_message_handle
-	  (link, idv.uint_val(), selectorv.uint_val(), statev.int_val(), 
-	   requestv.uint_val());
-    } else 
-    ((DrawServ*)unidraw)->grid_message_callback
-      (link, idv.uint_val(), selectorv.uint_val(), statev.int_val(), 
-       grantv.uint_val());
+	  (link, id, sid, statev.int_val(), rid);
+      }
+      
+    } else {
+      uuid_t gid;
+      uuid_parse(grantv.string_ptr(), gid);
+      
+      ((DrawServ*)unidraw)->grid_message_callback
+	(link, id, sid, statev.int_val(), gid);
+    }
+    
   } else if (idv.is_unknown()) {
     ((DrawServ*)unidraw)->print_gridtable();
-  }
-}
-
-/*****************************************************************************/
-
-ChangeIdFunc::ChangeIdFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comterp, ed) {
-}
-
-void ChangeIdFunc::execute() {
-
-  ComValue idv(stack_arg(0));
-  static int link_sym = symbol_add("link");
-  ComValue default_link(0);
-  ComValue linkv(stack_key(link_sym, false, default_link, true));
-  reset_stack();
-
-  DrawServHandler* handler = comterp() ? (DrawServHandler*)comterp()->handler() : nil;
-  DrawLink* link = handler ? (DrawLink*)handler->drawlink() : nil;
-  if (link == NULL) {
-    if (linkv.object_compview()) {
-      ComponentView* compview = (ComponentView*)linkv.obj_val();
-      if (compview && compview->GetSubject()) {
-	GraphicComp* comp = (GraphicComp*)compview->GetSubject();
-	Graphic* gr = comp ? comp->GetGraphic() : nil;
-	AttributeValueList* avl = new AttributeValueList();
-	if (comp && comp->IsA(DRAWLINK_COMP)) {
-	  DrawLinkComp* dlcomp = (DrawLinkComp*)comp;
-          if (dlcomp) link = dlcomp->drawlink();
-	}
-      }
-    }
-  }
-  
-  if (link != NULL && idv.is_known()) {
-    unsigned int id = idv.uint_val();
-    link->sid_change_inplace(id);
-    ComValue result(id, ComValue::UIntType);
-    result.state(AttributeValue::HexState);
-    push_stack(result);
   }
 }
 

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -34,7 +34,7 @@ public:
     DrawLinkFunc(ComTerp*,DrawEditor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s([hoststr [portnum]|link] :port [portnum] :state num :lid num :rid num :close :socket :timer [sec=5]) -- connect to remote drawserv"; }
+	return "%s([hoststr [portnum]|link] :port [portnum] :state num :linkid uuid :close :socket :timer [sec=5]) -- connect to remote drawserv"; }
 };
 
 //: command to reserve unique session id
@@ -56,16 +56,6 @@ public:
     virtual void execute();
     virtual const char* docstring() { 
 	return "%s(id selector :state selected :request newselector :grant oldselector) -- command to send message between remote selections"; }
-};
-
-//: command to change session (or graphic id) to use local session id
-// chgid(id :link drawlink) -- command to change session (or graphic id) to use local session id
-class ChangeIdFunc : public UnidrawFunc {
-public:
-    ChangeIdFunc(ComTerp*,DrawEditor*);
-    virtual void execute();
-    virtual const char* docstring() { 
-	return "%s(id :link drawlink) -- command to change session (or graphic id) to use local session id"; }
 };
 #endif /* defined(HAVE_ACE) */
 

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -43,8 +43,6 @@ using std::cerr;
 
 int DrawLink::_linkcnt = 0;
 
-implementTable(IncomingSidTable,unsigned int,unsigned int)
-
 const char* DrawLink::_state_strings[] =  { "new_link", "one_way", "two_way", "redundant" };
 
 /*****************************************************************************/
@@ -55,8 +53,7 @@ DrawLink::DrawLink (const char* hostname, int portnum, int state)
   _althost = nil;
   _port = portnum;
   _ok = false;
-  _local_linkid = _linkcnt++;
-  _remote_linkid = -1;
+  uuid_clear(_linkid);
   _state = state;
 
 #ifdef HAVE_ACE
@@ -67,8 +64,6 @@ DrawLink::DrawLink (const char* hostname, int portnum, int state)
 
   _comhandler = nil;
   _ackhandler = nil;
-  _incomingsidtable = new IncomingSidTable(32);
-  _incomingsidtable_size = 0;
 }
 
 DrawLink::~DrawLink () 
@@ -82,10 +77,9 @@ DrawLink::~DrawLink ()
     delete _host;
     delete _althost;
 #endif
-    delete _incomingsidtable;
 }
 
-int DrawLink::open() {
+int DrawLink::open(uuid_t linkid) {
 
 #if defined(HAVE_ACE) && (__GNUC__>3 || __GNUC__==3 && __GNUC_MINOR__>0)
   _addr = new ACE_INET_Addr(_port, _host);
@@ -110,21 +104,21 @@ int DrawLink::open() {
     char buffer[HOST_NAME_MAX];
     gethostname(buffer, HOST_NAME_MAX);
     
-    unsigned int sid = ((DrawServ*)unidraw)->sessionid();
-    uuid_t& suuid = ((DrawServ*)unidraw)->sessionuuid();
-    uuid_string_t suuid_str;
-    uuid_unparse(suuid, suuid_str);
+    uuid_t& sid = ((DrawServ*)unidraw)->sessionid();
+    uuid_string_t sid_str;
+    uuid_unparse(sid, sid_str);
+    
+    uuid_string_t linkid_str;
+    uuid_unparse(linkid, linkid_str);
     
     void* ptr = nil;
-    ((DrawServ*)unidraw)->sessionidtable()->find(ptr, sid);
+    ((DrawServ*)unidraw)->sessionidtable()->find(ptr, uuid_key(sid));
     SessionId* sessionid = (SessionId*)ptr;
     out << buffer << "\"";
     out << " :port " << ((DrawServ*)unidraw)->comdraw_port();
     out << " :state " << _state+1;
-    out << " :rid " << _local_linkid;
-    out << " :lid " << _remote_linkid;
-    out << " :sid 0x" << std::hex << sid << std::dec;
-    out << " :suuid \"" << suuid_str << "\"";
+    out << " :sid " << "\"" << sid_str << "\"";
+    out << " :linkid " << "\"" << linkid_str << "\"";
     if (sessionid) {
       out << " :pid " << sessionid->pid();
       out << " :user \"" << sessionid->username() << "\"";
@@ -146,8 +140,8 @@ int DrawLink::open() {
 
 int DrawLink::close() {
 #ifdef HAVE_ACE
-  fprintf(stderr, "Closing link to %s (%s) port # %d (lid=%d, rid=%d)\n", 
-	  hostname(), althostname(), portnum(), local_linkid(), remote_linkid());
+  fprintf(stderr, "Closing link to %s (%s) port # %d (lid=%.8s)\n", 
+	  hostname(), althostname(), portnum(), linkid_str());
   if (comhandler()) comhandler()->drawlink(nil);
   if (_socket) {
     if (ackhandler()) {
@@ -187,61 +181,24 @@ int DrawLink::handle() {
     return -1;
 }
 
-unsigned DrawLink::sid_lookup(unsigned int sid) {
-  unsigned int local_sid = 0;
-  if (_incomingsidtable_size==0) return sid;
-  incomingsidtable()->find(local_sid, sid);
-  return local_sid ? local_sid : sid;
-}
-
-void DrawLink::sid_change_inplace(unsigned int& id) {
-#ifdef HAVE_ACE
-  if (_incomingsidtable_size==0) return;
-  void* ptr = nil;
-
-  // check if graphic exists with remote session id (incoming, not yet translated)
-  ((DrawServ*)unidraw)->gridtable()->find(ptr, id);
-  if (ptr) return;  // found with remote sid, pass through unchanged
-
-  // check if graphic exists with local session id (already translated)
-  unsigned int lookup_id = sid_lookup(id & DrawServ::SessionIdMask) | (id & DrawServ::GraphicIdMask);
-  ((DrawServ*)unidraw)->gridtable()->find(ptr, lookup_id);
-  if (ptr) id = lookup_id;  // found with local sid, use translated value
-
-  // else not found at all, pass through unchanged (new graphic)
-#endif
-  return;
-}
-
-void DrawLink::sid_insert(unsigned int sid, unsigned int alt_sid) {
-  if (sid!=alt_sid) {
-    _incomingsidtable_size++;
-    _incomingsidtable->insert(sid, alt_sid);
-  }
-}
-
 void DrawLink::dump(FILE* fptr) {
-  fprintf(fptr, "Host                            Alt.                            Port    LID  RID  State\n");
-  fprintf(fptr, "------------------------------  ------------------------------  ------  ---  ---  -----\n");
-  fprintf(fptr, "%-30.30s  %-30.30s  %-6d  %-3d  %-3d  %-3d\n", 
+  fprintf(fptr, "Host                            Alt.                            Port    LID       State\n");
+  fprintf(fptr, "------------------------------  ------------------------------  ------  --------  -----\n");
+  fprintf(fptr, "%-30.30s  %-30.30s  %-6d  %.8s  %-3d\n", 
 	  hostname(), althostname(), portnum(),
-	  local_linkid(), remote_linkid(), state());
-  dump_incomingsidtable(fptr);
-}
-
-void DrawLink::dump_incomingsidtable(FILE* fptr) {
-  IncomingSidTable* table = incomingsidtable();
-  IncomingSidTable_Iterator it(*table);
-  printf("sid         osid\n");
-  printf("----------  ----------\n");
-  while(it.more()) {
-    unsigned int osid = (unsigned int)it.cur_value();
-    unsigned int sid = (unsigned int)it.cur_key();
-    fprintf(fptr, "0x%08x  0x%08x\n", sid, osid);
-    it.next();
-  }
+	  linkid_str(), state());
 }
 
 void DrawLink::start_timer(int seconds) {
   ackhandler()->start_timer(seconds);
+}
+
+const char* DrawLink::linkid_str() {
+  if (!uuid_is_null(_linkid)) {
+    if (_linkid_str[0] == '\0') {
+      uuid_unparse(_linkid, _linkid_str);
+    }
+    return _linkid_str;
+  } else
+    return "";
 }

--- a/src/DrawServ/drawlink.h
+++ b/src/DrawServ/drawlink.h
@@ -73,7 +73,7 @@ public:
     int portnum() { return _port; }
     // return port on remote host
 
-    int open();
+    int open(uuid_t linkid);
     // open link to remote DrawServ
 
     int close();
@@ -88,15 +88,13 @@ public:
     int handle();
     // return file descriptor associated with link
 
-    int local_linkid() { return _local_linkid; }
-    // get local DrawLink id
-    int remote_linkid() { return _remote_linkid; }
-    // get remote DrawLink id
-
-    void local_linkid(int id) { _local_linkid = id; }
+    void linkid(uuid_t id) { uuid_copy(_linkid, id); }
     // set local DrawLink id
-    void remote_linkid(int id) { _remote_linkid = id; }
-    // set remote DrawLink id
+    uuid_t& linkid() { return _linkid; }
+    // get DrawLink id
+     const char * linkid_str();
+    // get local DrawLink id string
+
 
     void comhandler(DrawServHandler* handler) { _comhandler = handler; }
     // set DrawServHandler associated with incoming connection
@@ -113,9 +111,6 @@ public:
     void start_timer(int seconds = 5);
     // Start timer waiting for ackback
 
-    IncomingSidTable* incomingsidtable() { return _incomingsidtable; }
-    // return pointer to table mapping incoming sessionid's to locally unique sessionid's
-
     void state(int val) { _state = val; notify(); }
     // set state of DrawLink
 
@@ -126,15 +121,6 @@ public:
     ACE_SOCK_Stream* socket() { return _socket; }
     // return pointer to connected socket.
 #endif
-
-    unsigned int sid_lookup(unsigned int sid);
-    // map incoming sid to local sid.
-
-    void sid_change_inplace(unsigned int& id);
-    // change sid portion of an id to use local sid.
-
-    void sid_insert(unsigned int sid, unsigned int alt_sid);
-    // insert new sid pair into table
 
     void dump(FILE*);
     // dump complete information on this DrawLink
@@ -148,11 +134,9 @@ protected:
     int _port;
     int _ok;
     static int _linkcnt;
-    int _local_linkid;
-    int _remote_linkid;
+    uuid_t _linkid;
+    uuid_string_t _linkid_str;
     int _state;
-    IncomingSidTable* _incomingsidtable;
-    int _incomingsidtable_size;
 
 #ifdef HAVE_ACE
     ACE_INET_Addr* _addr;

--- a/src/DrawServ/drawlinklist.c
+++ b/src/DrawServ/drawlinklist.c
@@ -62,7 +62,7 @@ void DrawLinkList::add_drawlink(DrawLink* new_link) {
 DrawLink* DrawLinkList::find_drawlink(GraphicId* grid) {
 #ifdef HAVE_ACE
   void* ptr = nil;
-  ((DrawServ*)unidraw)->sessionidtable()->find(ptr, grid->selector());
+  ((DrawServ*)unidraw)->sessionidtable()->find(ptr, grid->selectorkey());
   SessionId* sessionid = (SessionId*)ptr;
   return (DrawLink*) (sessionid ? sessionid->drawlink() : nil);
 #else

--- a/src/DrawServ/drawserv-handler.c
+++ b/src/DrawServ/drawserv-handler.c
@@ -23,6 +23,7 @@
 
 #ifdef HAVE_ACE
 
+#include <DrawServ/drawlink.h>
 #include <DrawServ/drawserv.h>
 #include <DrawServ/drawserv-handler.h>
 
@@ -50,6 +51,21 @@ int DrawServHandler::open (void * ptr)
 {
   ComterpHandler::open(ptr);
   return 0;
+}
+
+int
+DrawServHandler::handle_input (ACE_HANDLE fd) {
+  int save_alt_fd = _alt_fd;
+  if (_drawlink != NULL) {
+    _alt_fd = _drawlink->portnum();
+  } else {
+    _alt_fd = 99999;
+  }
+    
+  int status = UnidrawComterpHandler::handle_input(fd);
+  
+  _alt_fd = save_alt_fd;
+  return status;
 }
 
 void DrawServHandler::destroy (void) {

--- a/src/DrawServ/drawserv-handler.h
+++ b/src/DrawServ/drawserv-handler.h
@@ -50,6 +50,9 @@ public:
   virtual int open (void *);
   // open handler hook.
 
+  virtual int handle_input (ACE_HANDLE);
+  // called when input ready on ACE_HANDLE.
+
   virtual int handle_signal(int, siginfo_t*, ucontext_t*);
   // handle signals
 

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -76,15 +76,22 @@ using std::cout;
 using std::cerr;
 
 #ifdef HAVE_ACE
-implementTable(GraphicIdTable,int,void*)
-implementTable(SessionIdTable,int,void*)
+implementTable(GraphicIdTable,uint32_t,void*)
+implementTable(SessionIdTable,uint32_t,void*)
 implementTable(CompIdTable,void*,void*)
-
-unsigned int DrawServ::GraphicIdMask = 0x000fffff;
-unsigned int DrawServ::SessionIdMask = 0xfff00000;
 
 static int seed=0;
 #endif /* HAVE_ACE */
+
+// utility function for grabbing key from uuid_t.
+// Only needed until tables can be keyed on all 64 bits of the UUID.
+// You win a lollipop if UUID8 fails you in the meantime.
+extern uint32_t uuid_key(const uuid_t u)
+{
+    uint32_t v;
+    memcpy(&v, u, sizeof(v));
+    return ntohl(v);
+}
 
 /*****************************************************************************/
 
@@ -107,18 +114,14 @@ void DrawServ::Init() {
   _sessionidtable = new SessionIdTable(256);
   _compidtable = new CompIdTable(1024);
 
-  _sessionid = unique_sessionid();
-  uuid_generate(_sessionuuid);
-#if 0
-  _sessionid = 0xfff00000;  // for testing purposes
-#endif
+  create_unique_sessionid();
   char hostbuf[HOST_NAME_MAX];
   gethostname(hostbuf, HOST_NAME_MAX);
   char* username = getlogin();
   int pid = getpid();
   int hostid = gethostid();
-  SessionId* sid = new SessionId(_sessionid, _sessionid, pid, username, hostbuf, hostid);
-  _sessionidtable->insert(_sessionid, sid);
+  SessionId* sid = new SessionId(_sessionid, pid, username, hostbuf, hostid);
+  _sessionidtable->insert(uuid_key(_sessionid), sid);
 
   _comdraw_port = atoi(unidraw->GetCatalog()->GetAttribute("comdraw"));
 #endif /* HAVE_ACE */
@@ -142,34 +145,41 @@ DrawServ::~DrawServ ()
 }
 
 DrawLink* DrawServ::linkup(const char* hostname, int portnum, 
-		     int state, int local_id, int remote_id,
-		     ComTerp* comterp) {
+		     int state, uuid_t link_id,  ComTerp* comterp) {
+
+  if (comterp!=NULL) comterp->handler()->alt_fd(portnum);
+  
   if (state == DrawLink::new_link || state == DrawLink::one_way) {
+    
     DrawLink* link = new DrawLink(hostname, portnum, state);
-    link->remote_linkid(remote_id);
     if (state==DrawLink::one_way && comterp && comterp->handler()) {
       ((DrawServHandler*)comterp->handler())->drawlink(link);
       link->comhandler((DrawServHandler*)comterp->handler());
     }
-    if (link->open()==0 && link->ok()) {
+    if (state == DrawLink::new_link) {
+      uuid_generate(link->linkid());
+    } else {
+      uuid_copy(link->linkid(), link_id);
+    }
+    if (link->open(link->linkid())==0 && link->ok()) {  //
       _linklist->add_drawlink(link);
       return link;
     } else {
       delete link;
       return nil;
     }
-  } else {
+  } else if (state == DrawLink::two_way) {
 
     // search for existing link with matching local_id
     Iterator i;
     _linklist->First(i);
-    while(!_linklist->Done(i) && _linklist->GetDrawLink(i)->local_linkid()!=local_id)
+    while(!_linklist->Done(i) && uuid_compare(_linklist->GetDrawLink(i)->linkid(), link_id)!=0)
       _linklist->Next(i);
 
     /* if found, finalize linkup */
     if (!_linklist->Done(i)) {
       DrawLink* curlink = _linklist->GetDrawLink(i);
-      curlink->remote_linkid(remote_id);
+      curlink->linkid(link_id);
       curlink->althostname(hostname);
       curlink->state(DrawLink::two_way);
       if (comterp && comterp->handler()) {
@@ -178,14 +188,13 @@ DrawLink* DrawServ::linkup(const char* hostname, int portnum,
       }
       fprintf(stderr, "link up with %s(%s) via port %d\n", 
 	      curlink->hostname(), curlink->althostname(), portnum);
-      fprintf(stderr, "local id %d, remote id %d\n", curlink->local_linkid(), 
-	      curlink->remote_linkid());
+      fprintf(stderr, "link id %.8s\n", curlink->linkid_str());
 
       /* register all sessionid's with other DrawServ */
       sessionid_register(curlink);
       SendCmdString(curlink, "sid(:all)");
       char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "drawlink(:lid %d :rid %d :state 2)\n", curlink->remote_linkid(), curlink->local_linkid());
+      snprintf(buf, BUFSIZ, "drawlink(:linkid %.8s :state 2)\n", curlink->linkid_str());
       SendCmdString(curlink, buf);
 
       return curlink;
@@ -193,6 +202,9 @@ DrawLink* DrawServ::linkup(const char* hostname, int portnum,
       fprintf(stderr, "confirmation of two-way link\n");
       return nil;
     }
+  } else {
+    fprintf(stderr, "unexpected state of %d, nothing done\n", state);
+    abort();
   }
 }
 
@@ -205,23 +217,6 @@ int DrawServ::linkdown(DrawLink* link) {
     return 0;
   } else
     return -1;
-}
-
-DrawLink* DrawServ::linkget(int local_id, int remote_id) {
-  DrawLink* link = nil;
-  if (_linklist) {
-    Iterator(i);
-    _linklist->First(i);
-    while (!_linklist->Done(i) && !link) {
-      DrawLink* l = _linklist->GetDrawLink(i);
-      if (l->local_linkid()==local_id && remote_id==-1 ||
-	  local_id==-1 && l->remote_linkid()==remote_id ||
-	  l->local_linkid()==local_id && l->remote_linkid()==remote_id)
-	link = l;
-      _linklist->Next(i);
-    }
-  }
-  return link;
 }
 
 DrawLink* DrawServ::linkget(const char* hostname, int portnum) {
@@ -239,31 +234,34 @@ DrawLink* DrawServ::linkget(const char* hostname, int portnum) {
   return link;
 }
 
-DrawLink* DrawServ::linkget(unsigned int sessionid) {
+DrawLink* DrawServ::linkget(uuid_t sessionid) {
   void* ptr = nil;
-  if (sessionid>0) sessionidtable()->find(ptr, sessionid);
+  sessionidtable()->find(ptr, uuid_key(sessionid));
   return ptr ? ((SessionId*)ptr)->drawlink() : nil;
 }
 
 void DrawServ::linkdump(FILE* fptr) {
-  fprintf(fptr, "Host                            Alt.                            Port    LID  RID  State\n");
-  fprintf(fptr, "------------------------------  ------------------------------  ------  ---  ---  -----\n");
+  fprintf(fptr, "Host                            Alt.                            Port    LID       State\n");
+  fprintf(fptr, "------------------------------  ------------------------------  ------  --------  -----\n");
   if (_linklist) {
     Iterator i;
     _linklist->First(i);
     while(!_linklist->Done(i)) {
       DrawLink* link = _linklist->GetDrawLink(i);
-      fprintf(fptr, "%-30.30s  %-30.30s  %-6d  %-3d  %-3d  %-3d\n", 
+      fprintf(fptr, "%-30.30s  %-30.30s  %-6d  %.8s  %-3d\n", 
 	      link->hostname(), link->althostname(), link->portnum(),
-	      link->local_linkid(), link->remote_linkid(), link->state());
+	      link->linkid_str(), link->state());
       _linklist->Next(i);
     }
   }
 }
 
 void DrawServ::ExecuteCmd(Command* cmd) {
-  int sid = 0;
-  int grid = 0;
+  uuid_t sid;
+  uuid_t grid;
+  uuid_clear(sid);
+  uuid_clear(grid);
+  
   boolean original = false;
   
   if(!_linklist || _linklist->Number()==0) 
@@ -377,7 +375,7 @@ void DrawServ::DistributeCmdString(const char* cmdstring, DrawLink* orglink) {
 	fclose(fp);
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
-        fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, tv.tv_usec, link->portnum(), cmdstring);
+        fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, (int)link->portnum(), cmdstring);
 	link->ackhandler()->start_timer();
       }
     }
@@ -400,7 +398,7 @@ void DrawServ::SendCmdString(DrawLink* link, const char* cmdstring) {
       link->ackhandler()->start_timer();
       struct timeval tv;
       gettimeofday(&tv, NULL);
-      fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, tv.tv_usec, link->portnum(), cmdstring);
+      fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, link->portnum(), cmdstring);
     }
   }
 }
@@ -414,9 +412,10 @@ void DrawServ::sessionid_register(DrawLink* link) {
       SessionId* sessionid = (SessionId*)it.cur_value();
       if (sessionid && sessionid->drawlink() != link) {
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "sid(0x%08x 0x%08x :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", 
-		 sessionid->sid(), sessionid->osid(), 
-		 sessionid->pid(), sessionid->username(),
+	uuid_string_t sid_str;
+	uuid_unparse(sessionid->sid(), sid_str);
+	snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", 
+		 sid_str, sessionid->pid(), sessionid->username(),
 		 sessionid->hostname(), sessionid->hostid(), '\0');
 	SendCmdString(link, buf);
       }
@@ -427,88 +426,65 @@ void DrawServ::sessionid_register(DrawLink* link) {
 
 // handle request to register session id
 void DrawServ::sessionid_register_handle
-(DrawLink* link, unsigned int sid, unsigned osid, int pid, 
+(DrawLink* link, uuid_t sid, int pid, 
  const char* username, const char* hostname, int hostid) 
 {
   if (link) {
     SessionIdTable* sidtable = ((DrawServ*)unidraw)->sessionidtable();
-    unsigned int alt_id = sid;
-    if (!DrawServ::test_sessionid(sid)) 
-      alt_id = DrawServ::unique_sessionid();
-    SessionId* session_id = new SessionId(alt_id, osid, pid, username, hostname, hostid, link);
-    sidtable->insert(alt_id, session_id);
-    link->sid_insert(sid, alt_id);
-    if (sid != alt_id) {
-      char buffer[BUFSIZ];
-      snprintf(buffer, BUFSIZ, "sid(0x%08x 0x%08x :remap)%c", sid, alt_id, '\0');
-      SendCmdString(link, buffer);
-    }
+    SessionId* session_id = new SessionId(sid, pid, username, hostname, hostid, link);
+    sidtable->insert(uuid_key(sid), session_id);
 
     /* propagate */
-    sessionid_register_propagate(link, alt_id, osid, pid, username,
+    sessionid_register_propagate(link, sid, pid, username,
 				 hostname, hostid);
   }
 }
 
 // propagate request to register session id
 void DrawServ::sessionid_register_propagate
-(DrawLink* link, unsigned int sid, unsigned int osid, int pid, 
+(DrawLink* link, uuid_t sid, int pid, 
  const char* username, const char* hostname, int hostid)
 {
   Iterator it;
   _linklist->First(it);
+
+  uuid_string_t sid_str;
+  uuid_unparse(sid, sid_str);
+  
   while (!_linklist->Done(it)) {
     char buf[BUFSIZ];
     DrawLink* otherlink = _linklist->GetDrawLink(it);
     if (otherlink != link) {
-      snprintf(buf, BUFSIZ, "sid(0x%08x 0x%08x :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", sid, osid, pid, username, hostname, hostid, '\0');
+      snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", sid_str, pid, username, hostname, hostid, '\0');
       SendCmdString(otherlink, buf);
     }
     _linklist->Next(it);
   }
 }
 
-unsigned int DrawServ::unique_grid() {
-  if (!seed) {
-    seed = time(nil) & (time(nil) << 16);
-    srand(seed);
-  }
-  unsigned int retval;
-  do {
-    static int flip=0;
-    while ((retval=rand()&GraphicIdMask)<=1);
-
-  } while (!test_grid(retval));
-  return retval;
+void DrawServ::unique_grid(uuid_t uuid) {
+  uuid_generate(uuid);
 }
 
-int DrawServ::test_grid(unsigned int id) {
+int DrawServ::test_grid(uuid_t id) {
   GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
   void* ptr = nil;
-  table->find(ptr, id);
+  table->find(ptr, uuid_key(id));
   if (ptr) 
     return 0;
   else
     return 1;
 }
 
-unsigned int DrawServ::unique_sessionid() {
-  if (!seed) {
-    seed = time(nil) & (time(nil) << 16);
-    srand(seed);
-  }
-  int retval;
-  do {
-    while ((retval=rand()&SessionIdMask)==0);
-
-  } while (!test_sessionid(retval));
-  return retval;
+void DrawServ::create_unique_sessionid() {
+  uuid_generate(_sessionid);
+  uuid_unparse(_sessionid, _sessionid_str);
 }
 
-int DrawServ::test_sessionid(unsigned int id) {
+int DrawServ::test_sessionid(uuid_t id) {
   SessionIdTable* table = ((DrawServ*)unidraw)->sessionidtable();
   void* ptr = nil;
-  table->find(ptr, id);
+  table->find(ptr, uuid_key(id));
   if (ptr) 
     return 0;
   else
@@ -519,7 +495,7 @@ void DrawServ::grid_message(GraphicId* grid) {
   char buf[BUFSIZ];
   if (grid->selected()==LinkSelection::LocallySelected ||
       (grid->selector()==sessionid() && grid->selected()==LinkSelection::NotSelected)) {
-    snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :state %d )%c", grid->id(), grid->selector(), 
+    snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d )%c", grid->id(), grid->selectorstr(), 
 	     grid->selected()==LinkSelection::LocallySelected ? 
 	     LinkSelection::RemotelySelected : LinkSelection::NotSelected, '\0');
     DistributeCmdString(buf);
@@ -529,19 +505,19 @@ void DrawServ::grid_message(GraphicId* grid) {
     DrawLink* link = _linklist->find_drawlink(grid);
     
     if (link) {
-      snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :request chgid(0x%08x))%c", grid->id(), 
-	       grid->selector(), sessionid(), '\0');
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c", grid->id(), 
+	       grid->selectorstr(), sessionidstr(), '\0');
       SendCmdString(link, buf);
     }
   }
 }
   
 // handle reserve request from remote DrawLink.
-void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int selector, 
-				   int state, unsigned int newselector)
+void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector, 
+				   int state, uuid_t newselector)
 {
   void* ptr = nil;
-  gridtable()->find(ptr, id);
+  gridtable()->find(ptr, uuid_key(id));
   if (ptr) {
     GraphicId* grid = (GraphicId*)ptr;
 
@@ -557,7 +533,7 @@ void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int
 	  grid->selected(LinkSelection::NotSelected);
 	  grid->selector(newselector);
 	  char buf[BUFSIZ];
-	  snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :grant chgid(0x%08x))%c",
+	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\")%c",
 		   grid->id(), newselector, sessionid(), '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request granted\n");
@@ -566,7 +542,7 @@ void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int
 	  /* else deny it, because it is selected */
 	else {
 	  char buf[BUFSIZ];
-	  snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :state %d)%c",
+	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d)%c",
 		   grid->id(), sessionid(), LinkSelection::RemotelySelected, '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request denied, graphic locally selected\n");
@@ -577,7 +553,7 @@ void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int
       else {
 	fprintf(stderr, "grid: request passed along to current selector\n");
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :request chgid(0x%08x))%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c",
 		 grid->id(), grid->selector(), newselector, '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
@@ -592,7 +568,7 @@ void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int
 	grid->selector(selector);
 	grid->selected(state);
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :state %d)%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d)%c",
 		 grid->id(), grid->selector(), grid->selected(), '\0');
 	DistributeCmdString(buf, link);
       } 
@@ -601,7 +577,7 @@ void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int
       else {
 	fprintf(stderr, "grid:  request passed along to targeted selector\n");
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :request chgid(0x%08x))%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c",
 		 grid->id(), selector, newselector, '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
@@ -610,11 +586,11 @@ void DrawServ::grid_message_handle(DrawLink* link, unsigned int id, unsigned int
 }
 
 // handle callback from remote DrawLink.
-void DrawServ::grid_message_callback(DrawLink* link, unsigned int id, unsigned int selector, 
-				     int state, unsigned int oldselector)
+void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector, 
+				     int state, uuid_t oldselector)
 {
   void* ptr = nil;
-  gridtable()->find(ptr, id);
+  gridtable()->find(ptr, uuid_key(id));
   if (ptr) {
     GraphicId* grid = (GraphicId*)ptr;
 
@@ -631,7 +607,7 @@ void DrawServ::grid_message_callback(DrawLink* link, unsigned int id, unsigned i
     else {
       fprintf(stderr, "grid:  pass grant request along\n");
       char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "grid(chgid(0x%08x) chgid(0x%08x) :grant chgid(0x%08x))%c",
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\")%c",
 	       grid->id(), selector, oldselector, '\0');
       SendCmdString(linkget(selector), buf);
     }
@@ -647,11 +623,11 @@ void DrawServ::print_gridtable() {
     GraphicId* grid = (GraphicId*)it.cur_value();
     OverlayComp* comp = (OverlayComp*)grid->grcomp();
     const char* comptype = comp ? comp->GetClassName() : "nil";
-    uuid_string_t uuidstr;
-    uuid_unparse(grid->uuid(), uuidstr);
-    printf("0x%08x  %.8s %-20s  0x%08x  %s\n",
- 	   (unsigned int)it.cur_key(), uuidstr, comptype,
- 	   (unsigned int)grid->selector(), LinkSelection::selected_string(grid->selected()));
+    uuid_string_t idstr;
+    uuid_unparse(grid->id(), idstr);
+    printf("%.8s %-20s  %.8s  %s\n",
+ 	   idstr, comptype,
+ 	   grid->selectorstr(), LinkSelection::selected_string(grid->selected()));
     it.next();
   }
 }
@@ -659,14 +635,14 @@ void DrawServ::print_gridtable() {
 void DrawServ::print_sidtable() {
   SessionIdTable* table = sessionidtable();
   SessionIdTable_Iterator it(*table);
-  printf("sid         osid        &DrawLink   lid   rid   pid     hostid  user              host            \n");
-  printf("----------  ----------  ----------  ----  ----  ------  ------  ----              ----            \n");
+  printf("sid       linkid   pid    hostid user             host            \n");
+  printf("--------  -------- ------ ------ ----             ----            \n");
   while(it.more()) {
     SessionId* sid = (SessionId*)it.cur_value();
     DrawLink* link = sid->drawlink();
-    printf("0x%08x  0x%08x  0x%08lx  %4d  %4d  %6d  %6d  %16s  %16s\n", 
-	   sid->sid(), sid->osid(), (unsigned long)link, 
-	   link ? link->local_linkid() : 9999, link ? link->remote_linkid() : 9999, 
+    
+    printf("%.8s  %.8s %6d %6d %-16s %-16s\n", 
+	   sid->sidstr(), link ? link->linkid_str() : "00000000", 
 	   sid->pid(), sid->hostid(), sid->username(), sid->hostname());
     it.next();
   }
@@ -687,7 +663,7 @@ void DrawServ::remove_sids(DrawLink* link) {
   }
 }
 
-boolean DrawServ::cycletest(unsigned int sid, const char* host,
+boolean DrawServ::cycletest(uuid_t sid, const char* host,
 			    const char* user, int pid) 
 {
   boolean found = false;
@@ -695,7 +671,7 @@ boolean DrawServ::cycletest(unsigned int sid, const char* host,
   SessionIdTable_Iterator it(*table);
   while(it.more() && !found) {
     SessionId* sessionid = (SessionId*)it.cur_value();
-    if (sessionid->osid()==sid) {
+    if (sessionid->sid()==sid) {
       if (strcmp(host, sessionid->hostname())==0 && 
 	  strcmp(user, sessionid->username())==0 &&
 	  pid==sessionid->pid())
@@ -742,8 +718,8 @@ boolean DrawServ::PrintAttributeList(ostream& out, AttributeList* attrlist) {
 void DrawServ::SendAllToBackgroundEditor(DrawLink* link, DrawEditor* fged) {
 
     boolean original = false;
-    int grid = 0;
-    int sid = 0;
+    uuid_t grid; uuid_clear(grid);
+    uuid_t sid; uuid_clear(sid);
 
     // fged->GetSelection()->Clear();
     
@@ -793,8 +769,8 @@ void DrawServ::SendAllToBackgroundEditor(DrawLink* link, DrawEditor* fged) {
 void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
   
     boolean original = false;
-    int grid = 0;
-    int sid = 0;
+    uuid_t grid; uuid_clear(grid);
+    uuid_t sid; uuid_clear(sid);
     
     std::ostrstream sbuf;
     boolean oldflag = OverlayScript::ptlist_parens();
@@ -841,7 +817,7 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
     
 }
 
-boolean DrawServ::add_grid(OverlayComp* comp, int& grid, int& sid) {
+boolean DrawServ::add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid) {
     boolean original = false;
     static int grid_sym = symbol_add("grid");
     static int sid_sym = symbol_add("sid");
@@ -852,24 +828,23 @@ boolean DrawServ::add_grid(OverlayComp* comp, int& grid, int& sid) {
     if (al!=NULL) {
 	
 	AttributeValue *gridv = al->find(grid_sym);
-	if (gridv!=NULL) grid = gridv->uint_val();
+	if (gridv!=NULL && gridv->is_string()) {
+	  uuid_parse(gridv->string_ptr(), grid);
+	}
 	
 	AttributeValue *sidv = al->find(sid_sym);
-	if (sidv!=NULL) sid = sidv->uint_val();
-	
-	AttributeValue *uuidv = al->find(uuid_sym);
-	if (uuidv!=NULL) {
-	  uuid_parse(uuidv->string_ptr(), uuid);
+	if (sidv!=NULL && sidv->is_string()) {
+	  uuid_parse(sidv->string_ptr(), sid);
 	}
+	
 	
     }
     
     /* unique id already assigned */
-    if (grid != 0 && sid !=0) {
+    if (!uuid_is_null(grid) && !uuid_is_null(sid)) {
 	GraphicId* graphicid = new GraphicId();
 	graphicid->grcomp(comp);
 	graphicid->id(grid);
-	graphicid->uuid(uuid);
 	graphicid->selector(sid);
 	graphicid->selected(LinkSelection::NotSelected);
     } 
@@ -881,20 +856,19 @@ boolean DrawServ::add_grid(OverlayComp* comp, int& grid, int& sid) {
 	GraphicId* graphicid = new GraphicId(sessionid());
 	graphicid->grcomp(comp);
 	graphicid->selector(((DrawServ*)unidraw)->sessionid());
-	
-	AttributeValue* gridv = new AttributeValue(grid=graphicid->id(), AttributeValue::UIntType);
-	gridv->state(AttributeValue::HexState);
+
+	uuid_copy(grid, graphicid->id());
+	uuid_string_t grid_str;
+	uuid_unparse(grid, grid_str);
+	AttributeValue* gridv = new AttributeValue(grid_str);
 	al->add_attr(grid_sym, gridv);
 	
-	AttributeValue* sidv = new AttributeValue(sid=graphicid->selector(), AttributeValue::UIntType);
-	sidv->state(AttributeValue::HexState);
+	uuid_copy(sid, graphicid->selector());
+	uuid_string_t sid_str;
+	uuid_unparse(sid, sid_str);
+	AttributeValue* sidv = new AttributeValue(sid_str);
 	al->add_attr(sid_sym, sidv);
 
-	uuid_string_t uuid_str;
-	uuid_unparse(graphicid->uuid(), uuid_str);
-	AttributeValue* uuidv = new AttributeValue((const char*)uuid_str);
-	al->add_attr(uuid_sym, uuidv);
-	
      	Editor* ed = DrawKit::Instance()->GetEditor();
 	OverlaySelection* sel = (OverlaySelection*)ed->GetViewer()->GetSelection();
 	Iterator it;

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -32,9 +32,12 @@
 #include <strstream>
 #include <uuid/uuid.h>
 
+// utility function for grabbing key from uuid_t.
+extern uint32_t uuid_key(const uuid_t u);
+
 #include <OS/table.h>
-declareTable(GraphicIdTable,int,void*)
-declareTable(SessionIdTable,int,void*)
+declareTable(GraphicIdTable,uint32_t,void*)
+declareTable(SessionIdTable,uint32_t,void*)
 declareTable(CompIdTable,void*,void*);
      
 
@@ -68,8 +71,7 @@ public:
   
 #ifdef HAVE_ACE
   DrawLink* linkup(const char* hostname, int portnum, 
-		   int state, int local_id=-1, int remote_id=-1,
-		   ComTerp* comterp=nil);
+		   int state, uuid_t link_id=NULL, ComTerp* comterp=nil);
   // Create new link to remote drawserv, return -1 if error
   // state: 0==new_link, 1==one_way, 2==two_way.
   // Let DrawLink assign local_id by passing -1 for local_id.
@@ -79,13 +81,10 @@ public:
   int linkdown(DrawLink* link);
   // shut down existing link to remote drawserv
   
-  DrawLink* linkget(int local_id, int remote_id=-1);
-  // return pointer to existing DrawLink
-
   DrawLink* linkget(const char* hostname, int portnum);
   // return pointer to existing DrawLink
   
-  DrawLink* linkget(unsigned int sessionid);
+  DrawLink* linkget(uuid_t sessionid);
   // return pointer to existing DrawLink given a sessionid.
   
   void linkdump(FILE*);
@@ -121,21 +120,23 @@ public:
   void sessionid_register(DrawLink* link);
   // register all sessionid's used by this DrawServ with remote DrawServ
   
-  void sessionid_register_handle(DrawLink* link, unsigned int sid, 
-				 unsigned int osid, int pid, const char* user, 
+  void sessionid_register_handle(DrawLink* link, uuid_t sid,
+				 int pid, const char* user, 
 				 const char* host, int hostid);
   // handle request to register unique session id
   
-  void sessionid_register_propagate(DrawLink* link, unsigned int sid, 
-				    unsigned int osid, int pid, 
+  void sessionid_register_propagate(DrawLink* link, uuid_t sid, int pid, 
 				    const char* user, const char *host, int hostid);
   // propagate a newly registered session id to all other DrawLink's
   
-  unsigned int sessionid() { return _sessionid; }
-  // current unique session id.
+  uuid_t& sessionid() { return _sessionid; }
+  // get universally unique session id.
 
-  uuid_t& sessionuuid() { return _sessionuuid; }
-  // current unique session id.
+  const char* sessionidstr() { return (const char*) _sessionid_str; }
+  // get universally unique session id.
+
+  uint32_t sessionidkey() { int32_t key;memcpy(&key, _sessionid, sizeof(key)); return key; }
+  // get universally unique session id.
 
   void remove_sids(DrawLink*);
   // remove all SessionId's associated with this DrawLink
@@ -143,29 +144,24 @@ public:
   void grid_message(GraphicId* grid);
   // generate graphic id selection message
 
-  void grid_message_handle(DrawLink* link, unsigned int id, unsigned int selector, 
-			   int state, unsigned int newselector=0);
+  void grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector, 
+			   int state, uuid_t newselector=NULL);
   // handle graphic id selection message
 
-  void grid_message_callback(DrawLink* link, unsigned int id, unsigned int selector, 
-			     int state, unsigned int oldselector);
+  void grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector, 
+			     int state, uuid_t oldselector);
   // callback for graphic id selection message 
 
-#if 0
-  void grid_message_propagate(DrawLink* link, unsigned int id, unsigned int selector, 
-			      int state, unsigned int otherselector=0);
-  // propagate graphic id selection message
-#endif
-
-  static unsigned int unique_grid();
+  void unique_grid(uuid_t grid);
   // generate unique graphic id.
-  static int test_grid(unsigned int id);
+  
+  static int test_grid(uuid_t gid);
+  // test candidate graphic id for local uniqueness
+  static int test_sessionid(uuid_t sid);
   // test candidate graphic id for local uniqueness
   
-  unsigned int unique_sessionid();
-  // generate unique session id.
-  int test_sessionid(unsigned int id);
-  // test candidate session id for local uniqueness
+  void  create_unique_sessionid();
+  // generate and assign unique session id.
   
   static unsigned int GraphicIdMask;
   static unsigned int SessionIdMask;
@@ -179,7 +175,7 @@ public:
   int comdraw_port() { return _comdraw_port; }
   // return port used for comdraw command interpreter
 
-  boolean cycletest(unsigned int sid, const char* host, const char* user, int pid);
+  boolean cycletest(uuid_t sid, const char* host, const char* user, int pid);
   // test for new incoming link that would establish a cycle
 
   boolean selftest(const char* host, unsigned int portnum);
@@ -190,7 +186,7 @@ public:
   // returns false if really not there.
 
 protected:
-  boolean add_grid(OverlayComp* comp, int& grid, int& sid);
+  boolean add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid);
   
   DrawLinkList* _linklist;
   // DrawLink list
@@ -204,10 +200,11 @@ protected:
   // table of all GraphicComp's associated with a GraphicId.
   // maps from GraphicComp* to GraphicId*
   
-  int _sessionid;
-  // unique session id.
-  uuid_t _sessionuuid;
+  uuid_t _sessionid;
   // universally unique session id.
+  
+  uuid_string_t _sessionid_str;
+  // universally unique session id in string form.
   
   int _comdraw_port;
   // port used for comdraw command interpreter

--- a/src/DrawServ/grid.c
+++ b/src/DrawServ/grid.c
@@ -38,23 +38,22 @@
 
 /*****************************************************************************/
 
-GraphicId::GraphicId (unsigned int sessionid, uuid_t sessionuuid) 
+GraphicId::GraphicId (uuid_t sessionid) 
 {
 #ifdef HAVE_ACE
   _comp = nil;
-  if (sessionid != 0) {
+  if (!uuid_is_null(sessionid)) {
 
-    _id = DrawServ::unique_grid();
-    uuid_generate(_uuid);
+    ((DrawServ*)unidraw)->unique_grid(_id);
     
-    _sid = sessionid&DrawServ::SessionIdMask;
-    if (sessionuuid!=NULL) uuid_copy(_suuid, sessionuuid);
+    uuid_copy(_sid, sessionid);
     
     GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
-    table->insert(_id|_sid, this);
+    table->insert(uuid_key(_id), this);
     
   } else {
-    _id = _sid = 0;
+    uuid_clear(_id);
+    uuid_clear(_sid);
   }
 #endif
 }
@@ -63,30 +62,41 @@ GraphicId::~GraphicId ()
 {
 #ifdef HAVE_ACE
   GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
-  table->remove(_id|_sid);
+  table->remove(uuid_key(_id));
 #endif
 }
 
-void GraphicId::id(unsigned int id) {
+void GraphicId::id(uuid_t id) {
 #ifdef HAVE_ACE
   GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
-  if (id !=0 )
-    table->remove(id);
-  _id = id & DrawServ::GraphicIdMask;
-  _sid = id & DrawServ::SessionIdMask;
-  table->insert(id, this);
+
+  if (!uuid_is_null(id)) {
+    
+    void *ptr = NULL;
+    table->find(ptr, uuid_key(id));
+    if (ptr != NULL) {
+      fprintf(stderr, "UNEXPECTED COLLISION ON UUID8, NEED TO REWRITE TABLES FOR FULL UUID\n");
+      abort();
+    }
+    
+    table->remove(uuid_key(id));
+  }
+
+  
+  uuid_copy(_id, id);
+  table->insert(uuid_key(id), this);
 #endif
 }
 
-void GraphicId::uuid(uuid_t uuid) {
-#ifdef HAVE_ACE
-  uuid_copy(_uuid, uuid);
-#endif
+void GraphicId::selector(uuid_t sid) {
+  uuid_copy(_selector, sid);
+  uuid_parse(_selectorstr, _selector);
 }
+
 
 /*****************************************************************************/
 
-GraphicIds::GraphicIds(unsigned int sessionid, GraphicId* subids, int nsubs) : GraphicId (sessionid)
+GraphicIds::GraphicIds(uuid_t sessionid, GraphicId* subids, int nsubs) : GraphicId (sessionid)
 {
   if (nsubs>0) {
     _sublist = new GraphicIdList();
@@ -96,7 +106,7 @@ GraphicIds::GraphicIds(unsigned int sessionid, GraphicId* subids, int nsubs) : G
   Resource::ref(_sublist);
 }
 
-GraphicIds::GraphicIds(unsigned int sessionid, GraphicIdList* sublist) : GraphicId (sessionid)
+GraphicIds::GraphicIds(uuid_t sessionid, GraphicIdList* sublist) : GraphicId (sessionid)
 {
   if (!sublist) sublist = new GraphicIdList;
   _sublist = sublist;

--- a/src/DrawServ/grid.h
+++ b/src/DrawServ/grid.h
@@ -29,6 +29,7 @@
 
 #include <Unidraw/globals.h>
 #include <uuid/uuid.h>
+#include <cstdint>
 
 class DrawLink;
 class GraphicComp;
@@ -37,32 +38,23 @@ class GraphicIdList;
 //: object to encapsulate unique graphic id
 class GraphicId {
 public:
-  GraphicId(unsigned int sessionid=0, uuid_t sessionuuid=nil);
+  GraphicId(uuid_t sessionid=NULL);
   virtual ~GraphicId();
   
-  unsigned int id() { return _id|_sid; }
-  // get associated unique composite integer id
+  const uuid_t& id() { return _id; }
+  // get associated unique id
 
-  void id(unsigned int id);
-  // set associated unique composite integer id
+  void id(uuid_t id);
+  // set associated unique id
 
-  const uuid_t& uuid() { return _uuid; }
-  // get associated universally unique composite integer id
-
-  void uuid(uuid_t uuid);
-  // set associated universally unique composite integer id
-
-  unsigned int grid() { return _id; }
+  uuid_t& grid() { return _id; }
   // return graphic id portion of composite id
   // unique only to this process
 
-  unsigned int sessionid() { return _sid; }
-  // return session id portion of composite id
-
-  const uuid_t& sessionuuid() { return _suuid; }
+  const uuid_t& sessionid() { return _sid; }
   // get associated universally unique session
 
-  void sessionuuid(uuid_t uuid) { uuid_copy(_suuid, uuid); }
+  void sessionid(uuid_t id) { uuid_copy(_sid, id); }
   // set associated universally unique session id
 
   virtual int is_list() { return 0; }
@@ -77,10 +69,16 @@ public:
   GraphicComp* grcomp() { return _comp; }
   // get pointer to associated GraphicComp
 
-  void selector(unsigned int sid) { _selector = sid; }
+  void selector(uuid_t sid);
   // set session id of current selector
 
-  unsigned int selector() { return _selector; }
+  uuid_t& selector() { return _selector; }
+  // get session id of current selector
+
+  uint32_t selectorkey() { uint32_t key; memcpy(&key, _selector, sizeof(key)); return key; }
+  // get session id of current selector
+
+  const char* selectorstr() { return _selectorstr; }
   // get session id of current selector
 
   void selected(int state) { _selected = state; }
@@ -90,13 +88,11 @@ public:
   // get selected state
 
 protected:
-  unsigned int _id;
-  unsigned int _sid;
+  uuid_t _id;
+  uuid_t _sid;
   
-  uuid_t _uuid;
-  uuid_t  _suuid;
-  
-  unsigned int _selector;
+  uuid_t _selector;
+  uuid_string_t _selectorstr;
   int _selected;
   
   GraphicComp* _comp;
@@ -106,8 +102,8 @@ protected:
 //: object to encapsulate a set of graphic ids
 class GraphicIds : public GraphicId {
 public:
-  GraphicIds(unsigned int sessionid, GraphicId* subids, int nsubids); 
-  GraphicIds(unsigned int sessionid, GraphicIdList* sublist=nil);
+  GraphicIds(uuid_t sessionid, GraphicId* subids, int nsubids); 
+  GraphicIds(uuid_t sessionid, GraphicIdList* sublist=nil);
   virtual ~GraphicIds();
 
   virtual int is_list() { return 1; }

--- a/src/DrawServ/rcdialog.c
+++ b/src/DrawServ/rcdialog.c
@@ -89,7 +89,7 @@ RemoteConnectAction::RemoteConnectAction(StrEditDialog* dialog) : Action() {
 void RemoteConnectAction::execute() {
 
   if (_dialog && _dialog->text()) 
-    ((DrawServ*)unidraw)->linkup(_dialog->text(), 20002, 0);
+    ((DrawServ*)unidraw)->linkup(_dialog->text(), 99999/*20002*/, 0);
 
 }
 

--- a/src/DrawServ/sid.c
+++ b/src/DrawServ/sid.c
@@ -30,12 +30,12 @@
 
 /*****************************************************************************/
 
-SessionId::SessionId (unsigned int sid, unsigned int osid, int pid, 
+SessionId::SessionId (uuid_t sid, int pid, 
 		      const char* username, const char* hostname, 
 		      int hostid, DrawLink* link)
 {
-  _sid = sid;
-  _osid = osid;
+  uuid_copy(_sid, sid);
+  uuid_unparse(_sid, _sid_str);
   _pid = pid;
   _username = strnew(username);
   _hostname = strnew(hostname);

--- a/src/DrawServ/sid.h
+++ b/src/DrawServ/sid.h
@@ -28,19 +28,20 @@
 #define sid_h
 
 #include <Unidraw/globals.h>
+#include <uuid/uuid.h>
 
 //: object to encapsulate session member info
 class SessionId {
 public:
-  SessionId(unsigned int sid, unsigned int osid, int pid, 
+  SessionId(uuid_t sid, int pid,
 	    const char* username, const char* hostname, 
 	    int hostid, DrawLink* link = nil);
   virtual ~SessionId();
   
-  unsigned int sid() { return _sid; }
+  const char * sidstr() { return _sid_str; }
   // return session id
-  unsigned int osid() { return _osid; }
-  // return original session id
+  uuid_t& sid() { return _sid; }
+  // return session id
   unsigned int pid() { return _pid; }
   // return associated process id
   const char* username() { return _username; }
@@ -54,8 +55,8 @@ public:
   void drawlink(DrawLink* link) {_drawlink =  link; }
   // set associated DrawLink
 protected:
-  unsigned int _sid;
-  unsigned int _osid;
+  uuid_t _sid;
+  uuid_string_t _sid_str;
   int _pid;
   char* _username;
   char* _hostname;


### PR DESCRIPTION
## Summary
Replace the 32-bit composite session/graphic id scheme with UUIDs throughout
drawserv, eliminating the `:remap` collision resolution mechanism that was
causing distributed selection corruption on single-machine test setups.

## Changes

### UUID adoption
- `GraphicId`: `_id`, `_sid`, `_selector` all converted from `uint32_t` to
  `uuid_t`. Grid table keyed on first 8 bytes (`uuid_key()`) for compatibility
  with existing hash table infrastructure.  To be replaced but you win a 
  lollipop if you ever get a collision before that.
- `SessionId`: `_sid`/`_osid` pair replaced with single `uuid_t _sid` plus
  `uuid_string_t _sid_str` for logging. `osid` removed — no longer needed
  without collision remapping.
- `DrawLinkFunc`: `cycletest` and `linkup` updated to pass `uuid_t` sid.
  `:lid`/`:rid` keywords replaced with `:linkid` UUID.  `cycletest` not tested yet.
- `SessionIdFunc`: `:remap`/`osid` handling removed. `sid` arg now parsed
  as UUID string.
- `GraphicIdFunc`: `id` and `selector` args now parsed as UUID strings.

### :remap removal
- `sessionid_register_handle` no longer generates `:remap` commands or
  calls `sessionid_register_propagate` for collision cases — UUID collision
  probability is negligible.
- `ChangeIdFunc`/`chgid` command unregistered from editor — no longer needed
  without session id translation.
- `sid_change_inplace` machinery obsoleted.

### Logging improvements
- `ComterpHandler`: add `_alt_fd` to allow logging with port number instead
  of raw fd, making logs more readable.
- Timestamps on incoming command log lines.

## Notes
- `rcdialog.c`: port hardcoded to 99999 as placeholder — needs proper fix.
- `GraphicId::id()` setter has `abort()` on unexpected UUID8 collision as
  a panic guard during transition.
- Full 128-bit UUID table support is a follow-on — current implementation
  uses first 8 bytes as hash key.