### PR TITLE
drawserv: fix cycletest UUID comparison

### DIFF
--- a/src/DrawServ/.#drawfunc.c
+++ b/src/DrawServ/.#drawfunc.c
@@ -1,1 +1,0 @@
-scottjohnston@Scotts-MacBook-Pro.local.95863

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -663,15 +663,15 @@ void DrawServ::remove_sids(DrawLink* link) {
   }
 }
 
-boolean DrawServ::cycletest(uuid_t sid, const char* host,
-			    const char* user, int pid) 
+boolean DrawServ::cycletest(uuid_t sid, const char* host, const char* user, int pid) 
 {
   boolean found = false;
   SessionIdTable* table = sessionidtable();
   SessionIdTable_Iterator it(*table);
   while(it.more() && !found) {
     SessionId* sessionid = (SessionId*)it.cur_value();
-    if (sessionid->sid()==sid) {
+    uuid_t& ssid = sessionid->sid();
+    if (uuid_compare(ssid, sid)==0) {
       if (strcmp(host, sessionid->hostname())==0 && 
 	  strcmp(user, sessionid->username())==0 &&
 	  pid==sessionid->pid())

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -171,7 +171,7 @@ public:
   
   void print_sidtable();
   // print contents of table of SessionId's
-
+ 
   int comdraw_port() { return _comdraw_port; }
   // return port used for comdraw command interpreter
 


### PR DESCRIPTION
## Summary
Fix silent bug in drawlink cycle detection where uuid_t was compared
with == operator instead of uuid_compare(), and remove accidentally
committed Emacs lock file.

## Changes

### cycletest UUID comparison fix
- `cycletest()`: replace `sessionid->sid()==sid` with
  `uuid_compare(ssid, sid)==0` — uuid_t is a byte array, == performs
  pointer comparison not value comparison, so cycle detection never
  fired correctly after UUID migration

### Cleanup
- Remove `.#drawfunc.c` Emacs lock file from repository
- Minor whitespace fixes in `drawserv.h` and `cycletest` signature