### PR TITLE
Finish replacement of integer  IDs with UUIDs for distributed graphic identity in DrawServ

### DIFF
--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -197,8 +197,9 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
       #else
       if (fd>0 && !comterp_->muted() ) { // && strncmp(inbuf, "ready", 5)!=0)
 	  struct timeval tv;
-	  ::gettimeofday(&tv, NULL);
-	  cerr << "[" << tv.tv_sec%100 << "." << tv.tv_usec << "] <" << (_alt_fd>-1 ? _alt_fd : fd) << ":  " << inbuf << "\n";
+	  log_command(inbuf, "<", (_alt_fd>-1 ? _alt_fd : fd));
+	  // ::gettimeofday(&tv, NULL);
+	  //cerr << "[" << tv.tv_sec%100 << "." << tv.tv_usec << "] <" << (_alt_fd>-1 ? _alt_fd : fd) << ":  " << inbuf << "\n";
       }
       #endif
 
@@ -278,6 +279,12 @@ REACTOR;
 
 ACE_Reactor* ComterpHandler::reactor_singleton() {
   return REACTOR::instance();
+}
+
+void ComterpHandler::log_command(const char* cmdstring, const char* fd_or_port_prefix, int fd_or_port) {
+  struct timeval tv;
+  ::gettimeofday(&tv, NULL);
+  fprintf(stderr, "[%ld.%06ld] %s%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, fd_or_port_prefix, fd_or_port, cmdstring);
 }
 
 #endif /* HAVE_ACE */

--- a/src/ComTerp/comhandler.h
+++ b/src/ComTerp/comhandler.h
@@ -123,6 +123,9 @@ public:
   void alt_fd(int num ) { _alt_fd = num; }
   // set number used to log command lines sent or received (default is fd)
 
+  void log_command(const char* cmdstring, const char* fd_or_port_prefix, int fd_or_port);
+  // utility function to log/timestamp outgoing or incoming command
+  
 protected:
   // = Demultiplexing hooks.
   virtual int handle_input (ACE_HANDLE);

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -55,7 +55,7 @@ public:
     GraphicIdFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(id :selector selector :state selected :request newselector :grant oldselector) -- command to send message between remote selections"; }
+	return "%s(id selector :state selected :request newselector :grant oldselector) -- command to send message between remote selections"; }
 };
 #endif /* defined(HAVE_ACE) */
 

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -55,7 +55,7 @@ public:
     GraphicIdFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(id selector :state selected :request newselector :grant oldselector) -- command to send message between remote selections"; }
+	return "%s(id :selector selector :state selected :request newselector :grant oldselector) -- command to send message between remote selections"; }
 };
 #endif /* defined(HAVE_ACE) */
 

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -213,7 +213,8 @@ void DrawLink::log_incoming_command(const char* cmdstring) {
 }
 
 void DrawLink::log_command(const char* cmdstring, const char* port_prefix) {
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  fprintf(stderr, "[%ld.%06ld] %s%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, port_prefix, portnum(), cmdstring);
+  if (_comhandler != NULL) {
+    _comhandler->log_command(cmdstring, port_prefix, port());
+  }
 }
+

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -100,7 +100,8 @@ int DrawLink::open(uuid_t linkid) {
 
     FILEBUF(obuf, fdopen(dup(_socket->get_handle()), "w"), ios_base::out);
     ostream out(&obuf);
-    out << "drawlink(\"";
+    std::ostrstream sbuf;
+    sbuf << "drawlink(\"";
     char buffer[HOST_NAME_MAX];
     gethostname(buffer, HOST_NAME_MAX);
     
@@ -114,16 +115,19 @@ int DrawLink::open(uuid_t linkid) {
     void* ptr = nil;
     ((DrawServ*)unidraw)->sessionidtable()->find(ptr, uuid_key(sid));
     SessionId* sessionid = (SessionId*)ptr;
-    out << buffer << "\"";
-    out << " :port " << ((DrawServ*)unidraw)->comdraw_port();
-    out << " :state " << _state+1;
-    out << " :sid " << "\"" << sid_str << "\"";
-    out << " :linkid " << "\"" << linkid_str << "\"";
+    sbuf << buffer << "\"";
+    sbuf << " :port " << ((DrawServ*)unidraw)->comdraw_port();
+    sbuf << " :state " << _state+1;
+    sbuf << " :sid " << "\"" << sid_str << "\"";
+    sbuf << " :linkid " << "\"" << linkid_str << "\"";
     if (sessionid) {
-      out << " :pid " << sessionid->pid();
-      out << " :user \"" << sessionid->username() << "\"";
+      sbuf << " :pid " << sessionid->pid();
+      sbuf << " :user \"" << sessionid->username() << "\"";
     }
-    out << ")\n";
+    sbuf << ")";
+    log_outgoing_command(sbuf.str());
+    sbuf << "\n";
+    out << sbuf.str();
     out.flush();
     _ok = true;
 
@@ -197,4 +201,18 @@ const char* DrawLink::linkid_str() {
     return _linkid_str;
   } else
     return "";
+}
+
+void DrawLink::log_outgoing_command(const char* cmdstring) {
+  log_command(cmdstring, ">");
+}
+
+void DrawLink::log_incoming_command(const char* cmdstring) {
+  log_command(cmdstring, "<");
+}
+
+void DrawLink::log_command(const char* cmdstring, const char* port_prefix) {
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  fprintf(stderr, "[%ld.%06ld] %s%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, port_prefix, portnum(), cmdstring);
 }

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -37,6 +37,7 @@
 #include <fstream.h>
 #include <unistd.h>
 #include <iostream>
+#include <sstream>
 
 using std::cout;
 using std::cerr;
@@ -100,7 +101,7 @@ int DrawLink::open(uuid_t linkid) {
 
     FILEBUF(obuf, fdopen(dup(_socket->get_handle()), "w"), ios_base::out);
     ostream out(&obuf);
-    std::ostrstream sbuf;
+    std::ostringstream sbuf;
     sbuf << "drawlink(\"";
     char buffer[HOST_NAME_MAX];
     gethostname(buffer, HOST_NAME_MAX);
@@ -125,9 +126,9 @@ int DrawLink::open(uuid_t linkid) {
       sbuf << " :user \"" << sessionid->username() << "\"";
     }
     sbuf << ")";
-    log_outgoing_command(sbuf.str());
+    log_outgoing_command(sbuf.str().c_str());
     sbuf << "\n";
-    out << sbuf.str();
+    out << sbuf.str().c_str();
     out.flush();
     _ok = true;
 

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -214,7 +214,7 @@ void DrawLink::log_incoming_command(const char* cmdstring) {
 
 void DrawLink::log_command(const char* cmdstring, const char* port_prefix) {
   if (_comhandler != NULL) {
-    _comhandler->log_command(cmdstring, port_prefix, port());
+    _comhandler->log_command(cmdstring, port_prefix, portnum());
   }
 }
 

--- a/src/DrawServ/drawlink.h
+++ b/src/DrawServ/drawlink.h
@@ -125,7 +125,17 @@ public:
     void dump_incomingsidtable(FILE*);
     // dump complete information on this DrawLink's IncomingSidTable
 
+    void log_outgoing_command(const char* cmd);
+    // log an outgoing command with timestamp
+
+    void log_incoming_command(const char* cmd);
+    // log an incoming command with timestamp
+
 protected:
+
+    void log_command(const char* cmd, const char* port_prefix);
+    // log an incoming or outgoing command with timestamp
+
     const char* _host;
     const char* _althost;
     int _port;

--- a/src/DrawServ/drawlinklist.c
+++ b/src/DrawServ/drawlinklist.c
@@ -62,6 +62,8 @@ void DrawLinkList::add_drawlink(DrawLink* new_link) {
 DrawLink* DrawLinkList::find_drawlink(GraphicId* grid) {
 #ifdef HAVE_ACE
   void* ptr = nil;
+  // fprintf(stderr, "searching into SID TABLE with uuid_key(sid) of 0x%x\n", grid->selectorkey());
+  //  fprintf(stderr, "COMPARED TO %.8s\n", grid->selectorstr());
   ((DrawServ*)unidraw)->sessionidtable()->find(ptr, grid->selectorkey());
   SessionId* sessionid = (SessionId*)ptr;
   return (DrawLink*) (sessionid ? sessionid->drawlink() : nil);

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -558,7 +558,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	fprintf(stderr, "grid: request passed along to current selector\n");
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c",
-		 grid->idstr(), grid->selectorstr(), newselector, '\0');
+		 grid->idstr(), grid->selectorstr(), newselector_str, '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
     }
@@ -566,7 +566,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
     /* else this request and/or simple state update should be passed along */
     else {
       /* if simple state, set the values here, and pass it on to everyone else */
-      if (newselector==0) {
+      if (((const char *)newselector)==NULL || uuid_is_null(newselector)) {
 	if (linklist()->Number()>1)
 	  fprintf(stderr, "grid: state change passed along to everyone else\n");
 	grid->selector(selector);
@@ -582,7 +582,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	fprintf(stderr, "grid:  request passed along to targeted selector\n");
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c",
-		 grid->idstr(), selector_str, newselector, '\0');
+		 grid->idstr(), selector_str, newselector_str, '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
     }
@@ -596,9 +596,11 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
   uuid_string_t selector_str;
-  uuid_unparse(selector, selector_str);
+  if (((const char*)selector)!= NULL) 
+    uuid_unparse(selector, selector_str);
   uuid_string_t oldselector_str;
-  uuid_unparse(oldselector, oldselector_str);
+  if (((const char*)oldselector)!= NULL) 
+    uuid_unparse(oldselector, oldselector_str);
   
   if (ptr) {
     GraphicId* grid = (GraphicId*)ptr;

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -66,7 +66,7 @@
 #include <Attribute/attrvalue.h>
 
 #include <fstream.h>
-#include <strstream>
+#include <sstream>
 #include <unistd.h>
 #include <iostream>
 #include <stdio.h>
@@ -272,7 +272,7 @@ void DrawServ::ExecuteCmd(Command* cmd) {
   else {
     
     /* indirect command execution, all by script */
-    std::ostrstream sbuf;
+    std::ostringstream sbuf;
     boolean oldflag = OverlayScript::ptlist_parens();
     OverlayScript::ptlist_parens(false);
     switch (cmd->GetClassId()) {
@@ -346,7 +346,7 @@ void DrawServ::ExecuteCmd(Command* cmd) {
     
     /* then send everywhere else */
     if (original || linklist()->Number()>0) 
-      DistributeCmdString(sbuf.str(), linkget(sid));
+      DistributeCmdString(sbuf.str().c_str(), linkget(sid));
     
     if (cmd->Reversible()) {
       cmd->Log();
@@ -428,7 +428,6 @@ void DrawServ::sessionid_register_handle
   if (link != NULL) {
     SessionIdTable* sidtable = ((DrawServ*)unidraw)->sessionidtable();
     SessionId* session_id = new SessionId(sid, pid, username, hostname, hostid, link);
-    fprintf(stderr, "inserting into SID TABLE with uuid_key(sid) of 0x%x\n", uuid_key(sid));
     sidtable->insert(uuid_key(sid), session_id);
 
     /* propagate */
@@ -598,9 +597,11 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
   uuid_string_t selector_str;
+  selector_str[0] = '\0';
   if (((const char*)selector)!= NULL) 
     uuid_unparse(selector, selector_str);
   uuid_string_t oldselector_str;
+  oldselector_str[0] = '\0';
   if (((const char*)oldselector)!= NULL) 
     uuid_unparse(oldselector, oldselector_str);
   
@@ -734,7 +735,7 @@ void DrawServ::SendAllToBackgroundEditor(DrawLink* link, DrawEditor* fged) {
 
     // fged->GetSelection()->Clear();
     
-    std::ostrstream sbuf;
+    std::ostringstream sbuf;
     boolean oldflag = OverlayScript::ptlist_parens();
     OverlayScript::ptlist_parens(false);
     boolean scripted = false;
@@ -772,7 +773,7 @@ void DrawServ::SendAllToBackgroundEditor(DrawLink* link, DrawEditor* fged) {
     /* then send to new background connection pasted in front */
     if (original || linklist()->Number()>1) {
 	sbuf << "\n";
-	SendCmdString(link, sbuf.str());
+	SendCmdString(link, sbuf.str().c_str());
     }
     
 }
@@ -783,7 +784,7 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
     uuid_t grid; uuid_clear(grid);
     uuid_t sid; uuid_clear(sid);
     
-    std::ostrstream sbuf;
+    std::ostringstream sbuf;
     boolean oldflag = OverlayScript::ptlist_parens();
     OverlayScript::ptlist_parens(false);
     boolean scripted = false;
@@ -823,7 +824,7 @@ void DrawServ::SendAllToForegroundEditor(DrawLink* link, DrawEditor* bged) {
     /* then send to new foreground connection pasted in front and moved to back */
     if (original || linklist()->Number()>1) {
 	sbuf << "\n";
-	SendCmdString(link, sbuf.str());
+	SendCmdString(link, sbuf.str().c_str());
     }
     
 }

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -516,9 +516,11 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
   uuid_string_t selector_str;
+  selector_str[0] = '\0';
   if (selector != NULL && !uuid_is_null(selector))
     uuid_unparse(selector, selector_str);
   uuid_string_t newselector_str;
+  newselector_str[0] = '\0';
   if ((newselector!= NULL) && !uuid_is_null(newselector))
     uuid_unparse(newselector, newselector_str);
   
@@ -852,7 +854,7 @@ boolean DrawServ::add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid) {
 	void *ptr = nil;
 	if (gridtable()->find(ptr, uuid_key(grid))) {
 	    GraphicId* graphicid = (GraphicId*)ptr;
-	    graphicid->selected(LinkSelection::WaitingToBeSelected);
+	    // graphicid->selected(LinkSelection::WaitingToBeSelected);
 	} else {
 	    GraphicId* graphicid = new GraphicId(sid);
 	    graphicid->grcomp(comp);

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -527,7 +527,8 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
     GraphicId* grid = (GraphicId*)ptr;
 
     /* if this request is aimed here */
-    if (uuid_compare(selector,sessionid())==0 && !uuid_is_null(newselector)) {
+    if (uuid_compare(selector,sessionid())==0 &&
+	newselector != NULL && !uuid_is_null(newselector)) {
 
       /* if graphic is still locally owned */
 	if (uuid_compare(grid->selector(), sessionid())==0) {

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -369,13 +369,11 @@ void DrawServ::DistributeCmdString(const char* cmdstring, DrawLink* orglink) {
     if (link && link != orglink && link->state()==DrawLink::two_way) {
       int fd = link->handle();
       if (fd>=0) {
+	link->log_outgoing_command(cmdstring);
 	FILE* fp=fdopen(dup(fd), "w");
 	fputs(cmdstring, fp);
 	fputs("\n", fp);
 	fclose(fp);
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-        fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, (int)link->portnum(), cmdstring);
 	link->ackhandler()->start_timer();
       }
     }
@@ -391,14 +389,12 @@ void DrawServ::SendCmdString(DrawLink* link, const char* cmdstring) {
   if (link) {
     int fd = link->handle();
     if (fd>=0) {
+      link->log_outgoing_command(cmdstring);
       FILE* fp=fdopen(dup(fd), "w");
       fputs(cmdstring, fp);
       fputs("\n", fp);
       fclose(fp);
       link->ackhandler()->start_timer();
-      struct timeval tv;
-      gettimeofday(&tv, NULL);
-      fprintf(stderr, "[%ld.%06ld] >%d: %s\n", tv.tv_sec%100, (long)tv.tv_usec, link->portnum(), cmdstring);
     }
   }
 }
@@ -432,6 +428,7 @@ void DrawServ::sessionid_register_handle
   if (link != NULL) {
     SessionIdTable* sidtable = ((DrawServ*)unidraw)->sessionidtable();
     SessionId* session_id = new SessionId(sid, pid, username, hostname, hostid, link);
+    fprintf(stderr, "inserting into SID TABLE with uuid_key(sid) of 0x%x\n", uuid_key(sid));
     sidtable->insert(uuid_key(sid), session_id);
 
     /* propagate */
@@ -494,8 +491,8 @@ int DrawServ::test_sessionid(uuid_t id) {
 void DrawServ::grid_message(GraphicId* grid) {
   char buf[BUFSIZ];
   if (grid->selected()==LinkSelection::LocallySelected ||
-      (grid->selector()==sessionid() && grid->selected()==LinkSelection::NotSelected)) {
-    snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d )%c", grid->id(), grid->selectorstr(), 
+      (uuid_compare(grid->selector(), sessionid())==0 && grid->selected()==LinkSelection::NotSelected)) {
+    snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d )%c", grid->idstr(), grid->selectorstr(), 
 	     grid->selected()==LinkSelection::LocallySelected ? 
 	     LinkSelection::RemotelySelected : LinkSelection::NotSelected, '\0');
     DistributeCmdString(buf);
@@ -505,7 +502,7 @@ void DrawServ::grid_message(GraphicId* grid) {
     DrawLink* link = _linklist->find_drawlink(grid);
     
     if (link) {
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c", grid->id(), 
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c", grid->idstr(), 
 	       grid->selectorstr(), sessionidstr(), '\0');
       SendCmdString(link, buf);
     }
@@ -518,14 +515,21 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 {
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
+  uuid_string_t selector_str;
+  if (selector != NULL && !uuid_is_null(selector))
+    uuid_unparse(selector, selector_str);
+  uuid_string_t newselector_str;
+  if ((newselector!= NULL) && !uuid_is_null(newselector))
+    uuid_unparse(newselector, newselector_str);
+  
   if (ptr) {
     GraphicId* grid = (GraphicId*)ptr;
 
     /* if this request is aimed here */
-    if (selector==sessionid() && newselector!=0) {
+    if (uuid_compare(selector,sessionid())==0 && !uuid_is_null(newselector)) {
 
       /* if graphic is still locally owned */
-      if (grid->selector()==sessionid()) {
+	if (uuid_compare(grid->selector(), sessionid())==0) {
 
 	/* if graphic is not actually selected */
 	if ((grid->selected()==LinkSelection::NotSelected || 
@@ -534,7 +538,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	  grid->selector(newselector);
 	  char buf[BUFSIZ];
 	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\")%c",
-		   grid->id(), newselector, sessionid(), '\0');
+		   grid->idstr(), newselector_str, sessionidstr(), '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request granted\n");
 	} 
@@ -543,7 +547,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	else {
 	  char buf[BUFSIZ];
 	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d)%c",
-		   grid->id(), sessionid(), LinkSelection::RemotelySelected, '\0');
+		   grid->idstr(), sessionidstr(), LinkSelection::RemotelySelected, '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request denied, graphic locally selected\n");
 	}	
@@ -554,7 +558,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	fprintf(stderr, "grid: request passed along to current selector\n");
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c",
-		 grid->id(), grid->selector(), newselector, '\0');
+		 grid->idstr(), grid->selectorstr(), newselector, '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
     }
@@ -569,7 +573,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	grid->selected(state);
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d)%c",
-		 grid->id(), grid->selector(), grid->selected(), '\0');
+		 grid->idstr(), grid->selectorstr(), grid->selected(), '\0');
 	DistributeCmdString(buf, link);
       } 
 
@@ -578,7 +582,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	fprintf(stderr, "grid:  request passed along to targeted selector\n");
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\")%c",
-		 grid->id(), selector, newselector, '\0');
+		 grid->idstr(), selector_str, newselector, '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
     }
@@ -591,11 +595,16 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
 {
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
+  uuid_string_t selector_str;
+  uuid_unparse(selector, selector_str);
+  uuid_string_t oldselector_str;
+  uuid_unparse(oldselector, oldselector_str);
+  
   if (ptr) {
     GraphicId* grid = (GraphicId*)ptr;
 
     /* if request is granted, add to selection */
-    if (grid->selected()==LinkSelection::WaitingToBeSelected && selector==sessionid()) {
+    if (grid->selected()==LinkSelection::WaitingToBeSelected && uuid_compare(selector, sessionid())==0) {
       grid->selector(selector);
       fprintf(stderr, "grid:  request granted, add to selection now\n");
       OverlayComp* comp = (OverlayComp*)grid->grcomp();
@@ -608,7 +617,7 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
       fprintf(stderr, "grid:  pass grant request along\n");
       char buf[BUFSIZ];
       snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\")%c",
-	       grid->id(), selector, oldselector, '\0');
+	       grid->idstr(), selector_str, oldselector_str, '\0');
       SendCmdString(linkget(selector), buf);
     }
   }
@@ -617,8 +626,8 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
 void DrawServ::print_gridtable() {
   GraphicIdTable* table = gridtable();
   GraphicIdTable_Iterator it(*table);
-  printf("grid     comptype              selector    selected\n");
-  printf("-------- --------------------  ----------  --------\n");
+  printf("grid     comptype              selector  selected\n");
+  printf("-------- --------------------  --------  --------\n");
   while(it.more()) {
     GraphicId* grid = (GraphicId*)it.cur_value();
     OverlayComp* comp = (OverlayComp*)grid->grcomp();
@@ -635,14 +644,14 @@ void DrawServ::print_gridtable() {
 void DrawServ::print_sidtable() {
   SessionIdTable* table = sessionidtable();
   SessionIdTable_Iterator it(*table);
-  printf("sid       linkid   pid    hostid user             host            \n");
-  printf("--------  -------- ------ ------ ----             ----            \n");
+  printf("key       sid       linkid   pid    hostid user             host            \n");
+  printf("--------- --------  -------- ------ ------ ----             ----            \n");
   while(it.more()) {
     SessionId* sid = (SessionId*)it.cur_value();
     DrawLink* link = sid->drawlink();
     
-    printf("%.8s  %.8s %6d %6d %-16s %-16s\n", 
-	   sid->sidstr(), link ? link->linkid_str() : "00000000", 
+    printf("%8x %.8s  %.8s %6d %6d %-16s %-16s\n", 
+	   it.cur_key(), sid->sidstr(), link ? link->linkid_str() : "00000000", 
 	   sid->pid(), sid->hostid(), sid->username(), sid->hostname());
     it.next();
   }
@@ -819,8 +828,6 @@ boolean DrawServ::add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid) {
     boolean original = false;
     static int grid_sym = symbol_add("grid");
     static int sid_sym = symbol_add("sid");
-    static int uuid_sym = symbol_add("uuid");
-    uuid_t uuid;
     
     AttributeList* al = comp->GetAttributeList();
     if (al!=NULL) {
@@ -840,18 +847,25 @@ boolean DrawServ::add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid) {
     
     /* unique id already assigned */
     if (!uuid_is_null(grid) && !uuid_is_null(sid)) {
-	GraphicId* graphicid = new GraphicId();
-	graphicid->grcomp(comp);
-	graphicid->id(grid);
-	graphicid->selector(sid);
-	graphicid->selected(LinkSelection::NotSelected);
+	void *ptr = nil;
+	if (gridtable()->find(ptr, uuid_key(grid))) {
+	    GraphicId* graphicid = (GraphicId*)ptr;
+	    graphicid->selected(LinkSelection::WaitingToBeSelected);
+	} else {
+	    GraphicId* graphicid = new GraphicId(sid);
+	    graphicid->grcomp(comp);
+	    graphicid->set_id(grid);
+	    graphicid->selector(sid);
+	    graphicid->selected(LinkSelection::NotSelected);
+	}
     } 
     
     /* generate unique id and add as attribute */
     /* also mark with selector id */
     else {
 	original = true;
-	GraphicId* graphicid = new GraphicId(sessionid());
+	GraphicId* graphicid = new GraphicId(((DrawServ*)unidraw)->sessionid());
+	grid = graphicid->generate_id();
 	graphicid->grcomp(comp);
 	graphicid->selector(((DrawServ*)unidraw)->sessionid());
 
@@ -867,7 +881,8 @@ boolean DrawServ::add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid) {
 	AttributeValue* sidv = new AttributeValue(sid_str);
 	al->add_attr(sid_sym, sidv);
 
-     	Editor* ed = DrawKit::Instance()->GetEditor();
+	#if 0
+	Editor* ed = DrawKit::Instance()->GetEditor();
 	OverlaySelection* sel = (OverlaySelection*)ed->GetViewer()->GetSelection();
 	Iterator it;
 	boolean is_selected = false;
@@ -879,7 +894,11 @@ boolean DrawServ::add_grid(OverlayComp* comp, uuid_t grid, uuid_t sid) {
 	    }
 	}
 	graphicid->selected(is_selected ? 
-			    (graphicid->selector() == sessionid() ? LinkSelection::LocallySelected : LinkSelection::WaitingToBeSelected) : 
-			    LinkSelection::NotSelected);    }
+			    (uuid_compare(graphicid->selector(),sessionid())==0 ? LinkSelection::LocallySelected : LinkSelection::WaitingToBeSelected) : 
+			    LinkSelection::NotSelected);
+	#endif
+	graphicid->selected(LinkSelection::LocallySelected);  // this assumes an initial paste that leaves the graphic in the clipboard
+    }
     return original;
 }
+    

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -599,18 +599,18 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
   gridtable()->find(ptr, uuid_key(id));
   uuid_string_t selector_str;
   selector_str[0] = '\0';
-  if (((const char*)selector)!= NULL) 
+  if (selector!= NULL) 
     uuid_unparse(selector, selector_str);
   uuid_string_t oldselector_str;
   oldselector_str[0] = '\0';
-  if (((const char*)oldselector)!= NULL) 
+  if (oldselector!= NULL) 
     uuid_unparse(oldselector, oldselector_str);
   
   if (ptr) {
     GraphicId* grid = (GraphicId*)ptr;
 
     /* if request is granted, add to selection */
-    if (grid->selected()==LinkSelection::WaitingToBeSelected && uuid_compare(selector, sessionid())==0) {
+    if (grid->selected()==LinkSelection::WaitingToBeSelected && selector != NULL && uuid_compare(selector, sessionid())==0) {
       grid->selector(selector);
       fprintf(stderr, "grid:  request granted, add to selection now\n");
       OverlayComp* comp = (OverlayComp*)grid->grcomp();

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -135,7 +135,7 @@ public:
   const char* sessionidstr() { return (const char*) _sessionid_str; }
   // get universally unique session id.
 
-  uint32_t sessionidkey() { int32_t key;memcpy(&key, _sessionid, sizeof(key)); return key; }
+  uint32_t sessionidkey() { return uuid_key(_sessionid); }
   // get universally unique session id.
 
   void remove_sids(DrawLink*);

--- a/src/DrawServ/grid.c
+++ b/src/DrawServ/grid.c
@@ -45,22 +45,11 @@ GraphicId::GraphicId (uuid_t sid)
   uuid_clear(_selector);
   memset(_selector_str, 0, sizeof(_selector_str));
   _selected = 0;
+  uuid_clear(_id);
+  memset(_id_str, 0, sizeof(_id_str));
   
   if (sid!=NULL && !uuid_is_null(sid)) {
-
-    uuid_t tempid;
-    ((DrawServ*)unidraw)->unique_grid(tempid);
-    id(tempid);
-    sessionid(sid);
-    
-  } else {
-    
-    uuid_clear(_id);
-    uuid_clear(_sid);
-    uuid_clear(_selector);
-    memset(_id_str, 0, sizeof(_id_str));
-    memset(_sid_str, 0, sizeof(_sid_str));
-    
+    selector(sid);
   }
 
 #endif
@@ -74,7 +63,7 @@ GraphicId::~GraphicId ()
 #endif
 }
 
-void GraphicId::id(uuid_t id) {
+void GraphicId::set_id(uuid_t id) {
 #ifdef HAVE_ACE
   GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
 
@@ -86,26 +75,42 @@ void GraphicId::id(uuid_t id) {
       fprintf(stderr, "UNEXPECTED COLLISION ON UUID8, NEED TO REWRITE TABLES FOR FULL UUID\n");
       abort();
     }
+    // table->remove(uuid_key(id));
     
-    table->remove(uuid_key(id));
   }
 
-  
   uuid_copy(_id, id);
   uuid_unparse(_id, _id_str);
   table->insert(uuid_key(id), this);
 #endif
 }
 
-void GraphicId::sessionid(uuid_t sid) {
-  uuid_copy(_sid, sid);
-  uuid_unparse(_sid, _sid_str);
+uuid_t& GraphicId::generate_id() {
+  GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
+
+  uuid_generate(_id);
+  
+  void *ptr = NULL;
+  table->find(ptr, uuid_key(_id));
+  if (ptr != NULL) {
+    // table->remove(uuid_key(id));
+    fprintf(stderr, "UNEXPECTED COLLISION ON UUID8, NEED TO REWRITE TABLES FOR FULL UUID\n");
+    abort();
+  }
+  uuid_unparse(_id, _id_str);
+  table->insert(uuid_key(_id), this);
+  return _id;
 }
 
 void GraphicId::selector(uuid_t selector) {
   uuid_copy(_selector, selector);
   uuid_unparse(_selector, _selector_str);
 }
+
+uint32_t GraphicId::selectorkey() {
+  return uuid_key(_selector);
+}
+
 
 
 /*****************************************************************************/

--- a/src/DrawServ/grid.c
+++ b/src/DrawServ/grid.c
@@ -86,6 +86,7 @@ void GraphicId::set_id(uuid_t id) {
 }
 
 uuid_t& GraphicId::generate_id() {
+#ifdef HAVE_ACE
   GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
 
   uuid_generate(_id);
@@ -99,6 +100,7 @@ uuid_t& GraphicId::generate_id() {
   }
   uuid_unparse(_id, _id_str);
   table->insert(uuid_key(_id), this);
+#endif
   return _id;
 }
 

--- a/src/DrawServ/grid.h
+++ b/src/DrawServ/grid.h
@@ -44,8 +44,11 @@ public:
   const uuid_t& id() { return _id; }
   // get associated unique id
 
-  void id(uuid_t id);
-  // set associated unique id
+  uuid_t& generate_id();
+  // generate unique id and assign it
+
+  void set_id(uuid_t id);
+  // sete unique id
 
   const char* idstr() { return _id_str; }
   // get associated unique id in string form
@@ -53,15 +56,6 @@ public:
   uuid_t& grid() { return _id; }
   // return graphic id portion of composite id
   // unique only to this process
-
-  const uuid_t& sessionid() {return _sid;};
-  // get associated universally unique session
-
-  void sessionid(uuid_t id);
-  // set associated universally unique session id
-
-  const char* sessionidstr() { return _sid_str; }
-  // get associated universally unique session id in string form
 
   virtual int is_list() { return 0; }
   // return true if can be cast to GraphicIds
@@ -81,8 +75,8 @@ public:
   uuid_t& selector() { return _selector; }
   // get session id of current selector
 
-  uint32_t selectorkey() { uint32_t key; memcpy(&key, _selector, sizeof(key)); return key; }
-  // get session id of current selector
+  uint32_t selectorkey();
+  // get key of session id of current selector
 
   const char* selectorstr() { return _selector_str; }
   // get session id of current selector
@@ -95,12 +89,11 @@ public:
 
 protected:
   uuid_t _id;
-  uuid_t _sid;
   uuid_string_t _id_str;
-  uuid_string_t _sid_str;
   
   uuid_t _selector;
   uuid_string_t _selector_str;
+  
   int _selected;
   
   GraphicComp* _comp;

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -146,8 +146,8 @@ void LinkSelection::Reserve() {
     table->find(ptr, (void*)comp);
     if (ptr) {
       GraphicId* grid = (GraphicId*)ptr;
-      if (grid->selector() && 
-	  ((DrawServ*)unidraw)->sessionid()!=grid->selector()) {
+      if (!uuid_is_null(grid->selector()) && 
+	  uuid_compare(((DrawServ*)unidraw)->sessionid(), grid->selector())) {
 	
 	Remove(it);
 	removed = true;
@@ -162,8 +162,10 @@ void LinkSelection::Reserve() {
 	
       } else {
 	if (grid->selected()!=LocallySelected) {
-	  grid->selected(LocallySelected);
+	  grid->selected(WaitingToBeSelected);
+	  // fprintf(stderr, ">>>>>>>>>>>>> CALLING GRID MESSAGE >>>>>>>>>>>>>>>>>\n");
 	  ((DrawServ*)unidraw)->grid_message(grid);
+	  // fprintf(stderr, ">>>>>>>>>>>>> DONE CALLING GRID MESSAGE >>>>>>>>>>>>>>>>>\n");
 	}
       }
       


### PR DESCRIPTION
## Description

Finishes converting DrawServ's distributed graphic identity mechanism from the old 
integer-based session ID scheme (with its sid/chgid remapping machinery) 
to UUID-based identity. Each graphic now gets a UUID at creation time that 
is globally unique across all connected peers, eliminating the need for ID 
remapping when editors connect.

The add_grid/grid/grid_message protocol now passes UUID strings over the 
wire. The selection locking protocol (grid request/grant/deny) has been 
updated to use uuid_compare() throughout.

Verified working for the basic case: two drawservs linked via drawlink, 
rectangle drawn on one side correctly propagates to the other with 
consistent grid table state (LocallySelected on creator, RemotelySelected 
on peer).
