### PR TITLE
Fix distributed selection state after grant in multi-editor setup

### DIFF
--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -614,10 +614,10 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
       grid->selector(selector);
       grid->selected(LinkSelection::LocallySelected);
       fprintf(stderr, "grid:  request granted, add to selection now\n");
-      grid_message(grid);
       OverlayComp* comp = (OverlayComp*)grid->grcomp();
       LinkSelection* sel = (LinkSelection*)DrawKit::Instance()->GetEditor()->GetSelection();
       sel->AddComp(comp);
+      grid_message(grid);
     }
 
     /* otherwise, pass the granting message along */

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -612,7 +612,9 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
     /* if request is granted, add to selection */
     if (grid->selected()==LinkSelection::WaitingToBeSelected && selector != NULL && uuid_compare(selector, sessionid())==0) {
       grid->selector(selector);
+      grid->selected(LinkSelection::LocallySelected);
       fprintf(stderr, "grid:  request granted, add to selection now\n");
+      grid_message(grid);
       OverlayComp* comp = (OverlayComp*)grid->grcomp();
       LinkSelection* sel = (LinkSelection*)DrawKit::Instance()->GetEditor()->GetSelection();
       sel->AddComp(comp);

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -78,6 +78,7 @@ void LinkSelection::Clear(Viewer* viewer) {
 #if 0
   fprintf(stderr, "LinkSelection::Clear\n");
 #endif
+#if 0  
   CompIdTable* table = ((DrawServ*)unidraw)->compidtable();
   Iterator it;
   First(it);
@@ -97,6 +98,7 @@ void LinkSelection::Clear(Viewer* viewer) {
     }
     Next(it);
   }
+#endif
   OverlaySelection::Clear(viewer);
   Reserve();
 }
@@ -163,9 +165,7 @@ void LinkSelection::Reserve() {
       } else {
 	if (grid->selected()!=LocallySelected) {
 	  grid->selected(WaitingToBeSelected);
-	  // fprintf(stderr, ">>>>>>>>>>>>> CALLING GRID MESSAGE >>>>>>>>>>>>>>>>>\n");
 	  ((DrawServ*)unidraw)->grid_message(grid);
-	  // fprintf(stderr, ">>>>>>>>>>>>> DONE CALLING GRID MESSAGE >>>>>>>>>>>>>>>>>\n");
 	}
       }
       

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -78,7 +78,7 @@ void LinkSelection::Clear(Viewer* viewer) {
 #if 0
   fprintf(stderr, "LinkSelection::Clear\n");
 #endif
-#if 0  
+#if 0
   CompIdTable* table = ((DrawServ*)unidraw)->compidtable();
   Iterator it;
   First(it);


### PR DESCRIPTION
## Fix distributed selection state after grant in multi-editor setup

### Problem
When a remote editor received a selection grant in a 3-way (or n-way) drawserv
setup, the granting editor and all other peers would show `NotSelected` instead
of `RemotelySelected` after the grant completed. The newly selected editor would
show `WaitingToBeSelected` instead of `LocallySelected`.

### Root Causes

**1. `grid_message_callback` — missing `LocallySelected` and `grid_message` call**

After receiving a grant, the callback correctly identified the graphic as
locally owned but never set `LocallySelected` on the grid entry, leaving it
stuck at `WaitingToBeSelected`. And since `grid_message` was never called,
no `:state 2` (RemotelySelected) was distributed to peers — so all other
editors remained at `NotSelected` with a stale selector.

**2. `LinkSelection::Clear` — redundant grid message distribution**

`Clear` was independently sending grid state messages that `Reserve` (called
at the end of `Clear`) already handles. This caused double `:state 0` messages
to all peers on deselection, which could confuse the state machine. The
redundant block is now disabled with `#if 0`.

**3. Stale debug comments removed from `Reserve`**

Leftover commented-out debug `fprintf` calls around `grid_message` in
`Reserve` cleaned up.

### Fix
- Set `LocallySelected` before `AddComp` in `grid_message_callback`
- Call `grid_message` immediately after to distribute `:state 2` to all peers
- Disable redundant grid message block in `LinkSelection::Clear`

### Testing
Verified with 2-way and 3-way drawserv setups:
- Draw rect on 20002 → correct `LocallySelected`/`RemotelySelected` on all peers
- Deselect on 20002 → single `:state 0` to peers, no double send
- Select-all on 30002 → correct grant/request chain, `LocallySelected` on 30002,
  `RemotelySelected` on 20002 and 40002
- Select-all on 40002 after 30002 owns → multi-hop request/grant works correctly