### PR TITLE
drawserv: add :deny to grid command for explicit request denial, ringbell on RemotelySelected selection attempt

### DIFF
--- a/src/DrawServ/.#drawfunc.c
+++ b/src/DrawServ/.#drawfunc.c
@@ -1,0 +1,1 @@
+scottjohnston@Scotts-MacBook-Pro.local.95863

--- a/src/DrawServ/.#drawfunc.c
+++ b/src/DrawServ/.#drawfunc.c
@@ -1,1 +1,0 @@
-scottjohnston@Scotts-MacBook-Pro.local.95863

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -270,7 +270,7 @@ void GraphicIdFunc::execute() {
   uuid_t id;
   if (idv.is_string()) uuid_parse(idv.string_ptr(), id); else uuid_clear(id);
   uuid_t selector;
-  if (selectorv.is_string()) uuid_parse(idv.string_ptr(), id); else uuid_clear(selector);
+  if (selectorv.is_string()) uuid_parse(selectorv.string_ptr(), selector); else uuid_clear(selector);
 
   if (denyv.is_true()) {
     void* ptr = nil;

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -269,9 +269,9 @@ void GraphicIdFunc::execute() {
 
   if (denyv.is_true()) {
     uuid_t id;
-    uuid_parse(idv.string_ptr(), id);
+    if (id != NULL) uuid_parse(idv.string_ptr(), id) else uuid_clear(id);
     uuid_t sid;
-    uuid_parse(selectorv.string_ptr(), sid);
+    if (sid != NULL) uuid_parse(idv.string_ptr(), id) else uuid_clear(sid);
     
     void* ptr = nil;
     ((DrawServ*)unidraw)->gridtable()->find(ptr, uuid_key(id));

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -30,6 +30,8 @@
 #include <DrawServ/drawlinkcomp.h>
 #include <DrawServ/drawserv.h>
 #include <DrawServ/drawserv-handler.h>
+#include <DrawServ/grid.h>
+#include <DrawServ/linkselection.h>
 #include <GraphUnidraw/edgecomp.h>
 #include <GraphUnidraw/graphclasses.h>
 #include <OverlayUnidraw/ovline.h>
@@ -257,12 +259,31 @@ void GraphicIdFunc::execute() {
   ComValue grantv(stack_key(grant_sym));
   static int state_sym = symbol_add("state");
   ComValue statev(stack_key(state_sym));
-
+  static int deny_sym = symbol_add("deny");
+  ComValue denyv(stack_key(deny_sym));
+ 
   ComValue idv(stack_arg(0));
   ComValue selectorv(stack_arg(1));
 
   reset_stack();
 
+  if (denyv.is_true()) {
+    uuid_t id;
+    uuid_parse(idv.string_ptr(), id);
+    uuid_t sid;
+    uuid_parse(selectorv.string_ptr(), sid);
+    
+    void* ptr = nil;
+    ((DrawServ*)unidraw)->gridtable()->find(ptr, uuid_key(id));
+    if (ptr) {
+      GraphicId* grid = (GraphicId*)ptr;
+      grid->selected(LinkSelection::RemotelySelected);
+      grid->selector(sid);
+      fprintf(stderr, "grid: request denied, ringing bell\n");
+    }
+    return;
+  }
+  
   DrawServHandler* handler = comterp() ? (DrawServHandler*)comterp()->handler() : nil;
   DrawLink* link = handler ? (DrawLink*)handler->drawlink() : nil;
 

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -267,18 +267,18 @@ void GraphicIdFunc::execute() {
 
   reset_stack();
 
+  uuid_t id;
+  if (idv.is_string()) uuid_parse(idv.string_ptr(), id); else uuid_clear(id);
+  uuid_t selector;
+  if (selectorv.is_string()) uuid_parse(idv.string_ptr(), id); else uuid_clear(selector);
+
   if (denyv.is_true()) {
-    uuid_t id;
-    if (id != NULL) uuid_parse(idv.string_ptr(), id) else uuid_clear(id);
-    uuid_t sid;
-    if (sid != NULL) uuid_parse(idv.string_ptr(), id) else uuid_clear(sid);
-    
     void* ptr = nil;
     ((DrawServ*)unidraw)->gridtable()->find(ptr, uuid_key(id));
     if (ptr) {
       GraphicId* grid = (GraphicId*)ptr;
       grid->selected(LinkSelection::RemotelySelected);
-      grid->selector(sid);
+      grid->selector(selector);
       fprintf(stderr, "grid: request denied\n");
     }
     return;
@@ -288,24 +288,19 @@ void GraphicIdFunc::execute() {
   DrawLink* link = handler ? (DrawLink*)handler->drawlink() : nil;
 
   if (idv.is_known() && selectorv.is_known()) {
-    uuid_t id;
-    uuid_parse(idv.string_ptr(), id);
-    
-    uuid_t sid;
-    uuid_parse(selectorv.string_ptr(), sid);
     
     if (grantv.is_unknown()) {
       
       if (requestv.is_unknown())  {
 	((DrawServ*)unidraw)->grid_message_handle
-	  (link, id, sid, statev.int_val());
+	  (link, id, selector, statev.int_val());
       }
       
       else {
 	uuid_t rid;
 	uuid_parse(requestv.string_ptr(), rid);
 	((DrawServ*)unidraw)->grid_message_handle
-	  (link, id, sid, statev.int_val(), rid);
+	  (link, id, selector, statev.int_val(), rid);
       }
       
     } else {
@@ -313,7 +308,7 @@ void GraphicIdFunc::execute() {
       uuid_parse(grantv.string_ptr(), gid);
       
       ((DrawServ*)unidraw)->grid_message_callback
-	(link, id, sid, statev.int_val(), gid);
+	(link, id, selector, statev.int_val(), gid);
     }
     
   } else if (idv.is_unknown()) {

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -279,7 +279,7 @@ void GraphicIdFunc::execute() {
       GraphicId* grid = (GraphicId*)ptr;
       grid->selected(LinkSelection::RemotelySelected);
       grid->selector(sid);
-      fprintf(stderr, "grid: request denied, ringing bell\n");
+      fprintf(stderr, "grid: request denied\n");
     }
     return;
   }

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -55,7 +55,7 @@ public:
     GraphicIdFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(id selector :state selected :request newselector :grant oldselector) -- command to send message between remote selections"; }
+	return "%s(id selector :state selected :request newselector :grant oldselector :deny) -- command to send message between remote selections"; }
 };
 #endif /* defined(HAVE_ACE) */
 

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -548,8 +548,8 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	  /* else deny it, because it is selected */
 	else {
 	  char buf[BUFSIZ];
-	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d)%c",
-		   grid->idstr(), sessionidstr(), LinkSelection::RemotelySelected, '\0');
+	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny)%c",
+		   grid->idstr(), sessionidstr(), '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request denied, graphic locally selected\n");
 	}	

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -42,6 +42,8 @@
 #include <Attribute/attrlist.h>
 #include <Attribute/attrvalue.h>
 
+#include <IV-2_6/InterViews/world.h>
+
 #include <stdio.h>
 
 GraphicIdList* LinkSelection::_locally_selected = nil;
@@ -152,6 +154,9 @@ void LinkSelection::Reserve() {
 	Remove(it);
 	removed = true;
 	
+	if (grid->selected()==RemotelySelected)
+	  unidraw->GetWorld()->RingBell(1);
+
 	if (grid->selected()==NotSelected) {
 	  
 	  /* make a request to select this in the future */
@@ -163,9 +168,7 @@ void LinkSelection::Reserve() {
       } else {
 	if (grid->selected()!=LocallySelected) {
 	  grid->selected(WaitingToBeSelected);
-	  // fprintf(stderr, ">>>>>>>>>>>>> CALLING GRID MESSAGE >>>>>>>>>>>>>>>>>\n");
 	  ((DrawServ*)unidraw)->grid_message(grid);
-	  // fprintf(stderr, ">>>>>>>>>>>>> DONE CALLING GRID MESSAGE >>>>>>>>>>>>>>>>>\n");
 	}
       }
       


### PR DESCRIPTION
## Summary
Add explicit `:deny` keyword to the `grid` command for request denials,
and ring the system bell when a user attempts to select a remotely owned
graphic.

## Changes

### `:deny` keyword on grid command
- `grid_message_handle`: replace `:state 2` denial response with `:deny`
  for explicit semantic distinction between a denial and a generic state
  update
- `GraphicIdFunc::execute()`: handle `:deny` by setting `RemotelySelected`
  on the graphic and logging the denial — cleaner than inferring denial
  from a `:state 2` arriving after a `:request`
- Docstring updated to include `:deny`

### Bell on RemotelySelected selection attempt
- `LinkSelection::Reserve()`: ring bell via `unidraw->GetWorld()->RingBell(1)`
  when a user tries to select a graphic that is already `RemotelySelected`
  — distinguishes genuine user rejection from automatic paste-time
  handshake settling (which leaves graphics in `NotSelected` or
  `WaitingToBeSelected`, not `RemotelySelected`)
- `RingBell` placed on `World` rather than `Editor` — already accessible
  via `unidraw->GetWorld()` without needing a cast

### Cleanup
- Remove stale commented-out debug `fprintf` calls around `grid_message`
  in `Reserve()`
- Add missing includes for `grid.h` and `linkselection.h` in `drawfunc.c`