### PR TITLE
comterp/comdraw: add :count keyword to beep() and ding() returning cumulative sound counts

### DIFF
--- a/src/ComTerp/soundfunc.c
+++ b/src/ComTerp/soundfunc.c
@@ -42,7 +42,6 @@ void BeepFunc::execute() {
     push_stack(retval);
     return;
   }
-  _beep_count++;
   static boolean afplay = bincheck("afplay");
   if (afplay)
     system("afplay /System/Library/Sounds/Pop.aiff &");
@@ -54,6 +53,7 @@ void BeepFunc::execute() {
       fclose(tty);
     }
   }
+  _beep_count++;
 }
 
 
@@ -71,7 +71,6 @@ void DingFunc::execute() {
     push_stack(retval);
     return;
   }
-  _ding_count++;
   static boolean afplay = bincheck("afplay");
   if (afplay)
       system("afplay /System/Library/Sounds/Funk.aiff &");
@@ -83,5 +82,6 @@ void DingFunc::execute() {
       fclose(tty);
     }
   }
+  _ding_count++;
 }
     

--- a/src/ComTerp/soundfunc.c
+++ b/src/ComTerp/soundfunc.c
@@ -25,24 +25,35 @@
 
 #define TITLE "SoundFunc"
 
+int BeepFunc::_beep_count = 0;
+int DingFunc::_ding_count = 0;
+
 /*****************************************************************************/
 
 BeepFunc::BeepFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void BeepFunc::execute() {
-    reset_stack();
-    static boolean afplay = bincheck("afplay");
-    if (afplay)
-      system("afplay /System/Library/Sounds/Pop.aiff &");
-    else {
-      FILE* tty = fopen("/dev/tty", "w");
-      if (tty) {
-        fputs("\a", tty);
-        fflush(tty);
-        fclose(tty);
-      }
+  static int count_sym = symbol_add("count");
+  ComValue countv(stack_key(count_sym));
+  reset_stack();
+  if (countv.is_true()) {
+    ComValue retval(_beep_count, ComValue::IntType);
+    push_stack(retval);
+    return;
+  }
+  _beep_count++;
+  static boolean afplay = bincheck("afplay");
+  if (afplay)
+    system("afplay /System/Library/Sounds/Pop.aiff &");
+  else {
+    FILE* tty = fopen("/dev/tty", "w");
+    if (tty) {
+      fputs("\a", tty);
+      fflush(tty);
+      fclose(tty);
     }
+  }
 }
 
 
@@ -52,17 +63,25 @@ DingFunc::DingFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void DingFunc::execute() {
-    reset_stack();
-    static boolean afplay = bincheck("afplay");
-    if (afplay)
+  static int count_sym = symbol_add("count");
+  ComValue countv(stack_key(count_sym));
+  reset_stack();
+  if (countv.is_true()) {
+    ComValue retval(_ding_count, ComValue::IntType);
+    push_stack(retval);
+    return;
+  }
+  _ding_count++;
+  static boolean afplay = bincheck("afplay");
+  if (afplay)
       system("afplay /System/Library/Sounds/Funk.aiff &");
-    else {
-      FILE* tty = fopen("/dev/tty", "w");
-      if (tty) {
-        fputs("\a\a\a", tty);
-        fflush(tty);
-        fclose(tty);
-      }
+  else {
+    FILE* tty = fopen("/dev/tty", "w");
+    if (tty) {
+      fputs("\a\a\a", tty);
+      fflush(tty);
+      fclose(tty);
     }
+  }
 }
     

--- a/src/ComTerp/soundfunc.h
+++ b/src/ComTerp/soundfunc.h
@@ -41,6 +41,7 @@ public:
     virtual void execute();
     virtual const char* docstring() { 
       return "[cnt]=%s(:count) -- beep sound"; }
+protected:
   static int _beep_count;
 
 };
@@ -54,6 +55,7 @@ public:
     virtual void execute();
     virtual const char* docstring() { 
       return "[cnt]=%s(:count) -- ding sound"; }
+protected:
   static int _ding_count;
 
 };

--- a/src/ComTerp/soundfunc.h
+++ b/src/ComTerp/soundfunc.h
@@ -40,7 +40,8 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "%s() -- beep sound"; }
+      return "[cnt]=%s(:count) -- beep sound"; }
+  static int _beep_count;
 
 };
 
@@ -52,7 +53,8 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "%s() -- ding sound"; }
+      return "[cnt]=%s(:count) -- ding sound"; }
+  static int _ding_count;
 
 };
 

--- a/src/ComUnidraw/soundfunc.c
+++ b/src/ComUnidraw/soundfunc.c
@@ -33,8 +33,15 @@ ComdrawBeepFunc::ComdrawBeepFunc(ComTerp* comterp, Editor* ed)
 }
 
 void ComdrawBeepFunc::execute() {
-    reset_stack();
-    ((OverlayEditor*)_ed)->Beep();
+  static int count_sym = symbol_add("count");
+  ComValue countv(stack_key(count_sym));
+  reset_stack();
+  if (countv.is_true()) {
+    ComValue retval(OverlayEditor::beep_count(), ComValue::IntType);
+    push_stack(retval);
+    return;
+  }
+  ((OverlayEditor*)_ed)->Beep();
 }
 
 /*****************************************************************************/
@@ -44,6 +51,13 @@ ComdrawDingFunc::ComdrawDingFunc(ComTerp* comterp, Editor* ed)
 }
 
 void ComdrawDingFunc::execute() {
-    reset_stack();
-    ((OverlayEditor*)_ed)->Ding();
+  static int count_sym = symbol_add("count");
+  ComValue countv(stack_key(count_sym));
+  reset_stack();
+  if (countv.is_true()) {
+    ComValue retval(OverlayEditor::ding_count(), ComValue::IntType);
+    push_stack(retval);
+    return;
+  }
+  ((OverlayEditor*)_ed)->Ding();
 }

--- a/src/ComUnidraw/soundfunc.h
+++ b/src/ComUnidraw/soundfunc.h
@@ -34,7 +34,7 @@ public:
     ComdrawBeepFunc(ComTerp*, Editor*);
     virtual void execute();
     virtual const char* docstring() {
-        return "%s() -- ring bell to indicate error or failure";
+        return "[cnt]=%s(:count) -- ring bell to indicate error or failure";
     }
 };
 
@@ -45,7 +45,7 @@ public:
     ComdrawDingFunc(ComTerp*, Editor*);
     virtual void execute();
     virtual const char* docstring() {
-        return "%s() -- play success sound, cha-ching";
+        return "[cnt]=%s(:count) -- play success sound, cha-ching";
     }
 };
 

--- a/src/OverlayUnidraw/oved.c
+++ b/src/OverlayUnidraw/oved.c
@@ -81,6 +81,9 @@
 
 implementActionCallback(OverlayEditor)
 
+int OverlayEditor::_beep_count = 0;
+int OverlayEditor::_ding_count = 0;
+
 /*****************************************************************************/
 
 inline void InsertSeparator (PulldownMenu* pdm) {
@@ -412,10 +415,12 @@ void OverlayEditor::UpdateText(OverlayComp* comp, boolean update) {
 }
 
 void OverlayEditor::Beep() {
+    _beep_count++;
     unidraw->GetWorld()->RingBell(1);
 }
 
 void OverlayEditor::Ding() {
+    _ding_count++;
 #ifdef __APPLE__
     system("afplay /System/Library/Sounds/Funk.aiff &");
 #else

--- a/src/OverlayUnidraw/oved.h
+++ b/src/OverlayUnidraw/oved.h
@@ -181,7 +181,11 @@ public:
     void Ding();
     // make confirmation/approval sound
 
-     
+    static int beep_count() {return _beep_count;} 
+    // number of beeps so far
+    static int ding_count() {return _ding_count;} 
+    // number of dings so far
+
 protected:
     void Init(OverlayComp* = nil, const char* = "OverlayEditor");
     // construct empty component tree if necessary, and pass to
@@ -205,7 +209,6 @@ protected:
     virtual void comterp(ComTerpServ* terp) { }
     // do nothing because this is not a ComEditor
 
-
 protected: 
     OverlayKit* _overlay_kit;
     Tool* _curtool;
@@ -214,6 +217,8 @@ protected:
     EivTextEditor* _texteditor;
     static AttributeList* _edlauncherlist;
     static AttributeList* _comterplist;
+    static int _beep_count;
+    static int _ding_count;
 
 friend class OverlayKit;
 };

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -378,9 +378,9 @@ Evaluate single expression then exit.
 
  dateobj|int = date([num|str|dateobj] :day :month :year :daymo :weekday) -- create date from days since 1/1/1901 or string
 
- beep() -- beep or alert sound
+ [cnt]=beep(:count) -- beep or alert sound
 
- ding() -- ding or confirmation sound
+ [cnt]=ding(:count) -- ding or confirmation sound
 
 .SH ONLY IN SERVER MODE
 


### PR DESCRIPTION
## Summary
Add `:count` keyword to `beep()` and `ding()` commands at both the ComTerp
and ComUnidraw/comdraw levels, returning cumulative counts of each sound fired.

## Changes

### ComTerp level (BeepFunc/DingFunc)
- Static `_beep_count` and `_ding_count` counters on `BeepFunc`/`DingFunc`
- `beep(:count)` returns count without making sound
- `ding(:count)` returns count without making sound
- Counters incremented on each sound in the afplay/tty path

### ComUnidraw/comdraw level (ComdrawBeepFunc/ComdrawDingFunc)
- Static `_beep_count` and `_ding_count` on `OverlayEditor`
- `OverlayEditor::beep_count()` and `ding_count()` static accessors
- `beep(:count)` and `ding(:count)` return `OverlayEditor` counts
- Counters incremented in `OverlayEditor::Beep()` and `Ding()`
- Two separate counter sets — ComTerp counts afplay/tty, comdraw counts X11/afplay

### Docstrings and man page updated
- `[cnt]=beep(:count)` and `[cnt]=ding(:count)` in all docstrings and comterp.1