### PR TITLE
comdraw: add -runfile, -runexpr, --help, and improved usage output

### DIFF
--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -413,20 +413,24 @@ int main (int argc, char** argv) {
 
 	fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
 	XSync(unidraw->GetWorld()->display()->rep()->display_,false);
-
+	
 	/* execute -runfile or -runexpr after editor is fully initialized */
 	ComTerpServ* terp = ed->GetComTerp();
 	if (terp) {
 	    const char* runfile = catalog->GetAttribute("runfile");
-	    if (runfile && *runfile)
-	        terp->runfile(runfile);
+	    if (runfile && *runfile) {
+		if (terp->runfile(runfile) < 0)
+		    cerr << "comdraw: error running script file: " << runfile << "\n";
+	    }
 	    const char* runexpr = catalog->GetAttribute("runexpr");
 	    if (runexpr && *runexpr) {
-	      int bufsize;
-	      char* runexpr_nl = restore_escapes(runexpr, bufsize);
-	      strncat(runexpr_nl, "\n", bufsize - strlen(runexpr_nl) - 1);
-	      terp->run(runexpr_nl);
-	      delete [] runexpr_nl;
+	        int bufsize;
+	        char* runexpr_nl = restore_escapes(runexpr, bufsize);
+	        strncat(runexpr_nl, "\n", bufsize - strlen(runexpr_nl) - 1);
+	        ComValue result = terp->run(runexpr_nl);
+	        if (result.is_null())
+	            cerr << "comdraw: error running expression: " << runexpr << "\n";
+	        delete [] runexpr_nl;
 	    }
 	}
 	unidraw->Run();

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -297,8 +297,10 @@ any idraw parameter is also accepted (see idraw man page)";
 
 /* restore escape sequences converted to ASCII by shell/option parser */
 /* so downstream interpreters can do their own correct conversion */
-static char* restore_escapes(const char* str) {
-    char* dst = new char[strlen(str)*2+2];
+/* returns allocated buffer and its size via bufsize */
+static char* restore_escapes(const char* str, int& bufsize) {
+    bufsize = strlen(str)*2+2;
+    char* dst = new char[bufsize];
     char* dptr = dst;
     const char* src = str;
     while (*src) {
@@ -420,13 +422,13 @@ int main (int argc, char** argv) {
 	        terp->runfile(runfile);
 	    const char* runexpr = catalog->GetAttribute("runexpr");
 	    if (runexpr && *runexpr) {
-	        char* runexpr_nl = restore_escapes(runexpr);
-	        strcat(runexpr_nl, "\n");
-	        terp->run(runexpr_nl);
-	        delete [] runexpr_nl;
+	      int bufsize;
+	      char* runexpr_nl = restore_escapes(runexpr, bufsize);
+	      strncat(runexpr_nl, "\n", bufsize - strlen(runexpr_nl) - 1);
+	      terp->run(runexpr_nl);
+	      delete [] runexpr_nl;
 	    }
 	}
-
 	unidraw->Run();
     }
 

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -48,6 +48,9 @@
 #include <AceDispatch/ace_dispatcher.h>
 #endif
 
+#include <ComTerp/comterpserv.h>
+#include <ComTerp/comvalue.h>
+
 #include <stream.h>
 #include <string.h>
 #include <math.h>
@@ -178,6 +181,8 @@ static PropertyData properties[] = {
     { "*wbport",        "20002" },
 #endif
     { "*help",          "false"  },
+    { "*runfile",       ""  },
+    { "*runexpr",       ""  },
     { "*font",          "-adobe-helvetica-medium-r-normal--14-140-75-75-p-77-iso8859-1"  },
     { nil }
 };
@@ -223,29 +228,97 @@ static OptionDesc options[] = {
     { "-wbport", "*wbport", OptionValueNext },
 #endif
     { "-help", "*help", OptionValueImplicit, "true" },
+    { "--help", "*help", OptionValueImplicit, "true" },
     { "-font", "*font", OptionValueNext },
+    { "-runfile", "*runfile", OptionValueNext },
+    { "-runexpr", "*runexpr", OptionValueNext },
     { nil }
 };
 
 #ifdef HAVE_ACE
 static const char usage[] =
-"Usage: comdraw [any idraw parameter] [-comdraw port] [-color5]\n\
- [-color6] [-import portnum] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc]\n\
-[-rampsize n ] [-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
-[-stripped] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile] [-twidth|-tw n]\n\
-[-wbhost host] [-wbmaster] [-wbslave] [-wbport port] [-zoomer_off|-zoff] [file]";
+"comdraw  drawing editor with comterp scripting\n\
+Usage:  comdraw [file] [options]\n\n\
+-comdraw port               port number for comdraw command socket\n\
+-import portnum             port number for import socket\n\
+-color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
+-gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
+-opaque_off | -opoff        disable opaque moving/reshaping\n\
+-pagecols | -ncols n        number of page columns in tiled view\n\
+-pagerows | -nrows n        number of page rows in tiled view\n\
+-panner_off | -poff         disable panner\n\
+-panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
+                            panner alignment\n\
+-rampsize n                 size of color ramp\n\
+-scribble_pointer | -scrpt  enable scribble pointer\n\
+-slider_off | -soff         disable slider\n\
+-stdin_off                  disable stdin command socket\n\
+-stripped                   stripped-down tool palette\n\
+-toolbarloc | -tbl r|l      toolbar location left or right\n\
+-theight | -th n            tile height in pixels\n\
+-tile                       enable tiled page view\n\
+-twidth | -tw n             tile width in pixels\n\
+-wbhost host                whiteboard host to connect to\n\
+-wbmaster                   run as whiteboard master\n\
+-wbslave                    run as whiteboard slave\n\
+-wbport port                whiteboard port number\n\
+-zoomer_off | -zoff         disable zoomer\n\
+-runfile file               run script file after startup\n\
+-runexpr cmdstr             run command string after startup\n\n\
+any idraw parameter is also accepted (see idraw man page)";
 #else
-static char usage[] =
-"Usage: comdraw [any idraw parameter] [-color5] [-color6] \n\
-[-gray5] [-gray6] [-gray7] [-opaque_off|-opoff] \n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff] \n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc] \n\
-[-rampsize n ] [-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
-[-stripped] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
-[-twidth|-tw n] [-zoomer_off|-zoff] [file]";
+static const char usage[] =
+"comdraw  drawing editor with comterp scripting\n\
+Usage:  comdraw [file] [options]\n\n\
+-color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
+-gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
+-opaque_off | -opoff        disable opaque moving/reshaping\n\
+-pagecols | -ncols n        number of page columns in tiled view\n\
+-pagerows | -nrows n        number of page rows in tiled view\n\
+-panner_off | -poff         disable panner\n\
+-panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
+                            panner alignment\n\
+-rampsize n                 size of color ramp\n\
+-scribble_pointer | -scrpt  enable scribble pointer\n\
+-slider_off | -soff         disable slider\n\
+-stdin_off                  disable stdin command socket\n\
+-stripped                   stripped-down tool palette\n\
+-toolbarloc | -tbl r|l      toolbar location left or right\n\
+-theight | -th n            tile height in pixels\n\
+-tile                       enable tiled page view\n\
+-twidth | -tw n             tile width in pixels\n\
+-zoomer_off | -zoff         disable zoomer\n\
+-runfile file               run script file after startup\n\
+-runexpr cmdstr             run command string after startup\n\n\
+any idraw parameter is also accepted (see idraw man page)";
 #endif
+
+/*****************************************************************************/
+
+/* restore escape sequences converted to ASCII by shell/option parser */
+/* so downstream interpreters can do their own correct conversion */
+static char* restore_escapes(const char* str) {
+    char* dst = new char[strlen(str)*2+2];
+    char* dptr = dst;
+    const char* src = str;
+    while (*src) {
+        if (*src == '\n') {
+            *dptr++ = '\\';
+            *dptr++ = 'n';
+        } else if (*src == '\t') {
+            *dptr++ = '\\';
+            *dptr++ = 't';
+        } else if (*src == '\r') {
+            *dptr++ = '\\';
+            *dptr++ = 'r';
+        } else {
+            *dptr++ = *src;
+        }
+        src++;
+    }
+    *dptr = '\0';
+    return dst;
+}
 
 /*****************************************************************************/
 
@@ -338,6 +411,22 @@ int main (int argc, char** argv) {
 
 	fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
 	XSync(unidraw->GetWorld()->display()->rep()->display_,false);
+
+	/* execute -runfile or -runexpr after editor is fully initialized */
+	ComTerpServ* terp = ed->GetComTerp();
+	if (terp) {
+	    const char* runfile = catalog->GetAttribute("runfile");
+	    if (runfile && *runfile)
+	        terp->runfile(runfile);
+	    const char* runexpr = catalog->GetAttribute("runexpr");
+	    if (runexpr && *runexpr) {
+	        char* runexpr_nl = restore_escapes(runexpr);
+	        strcat(runexpr_nl, "\n");
+	        terp->run(runexpr_nl);
+	        delete [] runexpr_nl;
+	    }
+	}
+
 	unidraw->Run();
     }
 

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -433,6 +433,7 @@ int main (int argc, char** argv) {
 	        delete [] runexpr_nl;
 	    }
 	}
+	
 	unidraw->Run();
     }
 

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -188,6 +188,12 @@ graphical object assigned to an interpreter variable.
 
 .SH OPTIONS
 
+.B \-runfile filename  
+file of comdraw commands to run at startup.
+
+.B \-runexpr expression
+string of comdraw commands to run at startup.
+
 .B \-port n,  
 specifies the port number to accept command interpreter
 connections on.


### PR DESCRIPTION
## comdraw: add `-runfile`, `-runexpr`, `--help`, and improved usage output

### Changes

**New flags:**
- `-runfile file` — run a `.comt` script file after the editor is fully
  initialized, then leave the editor running normally
- `-runexpr cmdstr` — run a comterp command string after the editor is fully
  initialized, then leave the editor running normally

**`restore_escapes()`** — new static utility function that undoes the escape
sequence conversion (e.g. `\n` → ASCII 10) performed by the InterViews option
parser before the string reaches the comterp scanner, so the scanner can do
its own correct conversion. Handles `\n`, `\t`, and `\r`.

**Improved `--help`** — replaces the dense single-block flag list with a
csvfilt-style per-flag description format. `--help` accepted in addition to
`-help`.

**Man page** — adds `-runfile` and `-runexpr` to the OPTIONS section of
`comdraw.1`.

### Notes

- Both `-runfile` and `-runexpr` execute after `unidraw->Open(ed)` and ACE
  handler setup, so the editor and its comterp instance are fully initialized
- `-runexpr` is the mechanism `drawmo` will use to have a freshly launched
  drawserv call back to the orchestrator on startup
- `restore_escapes()` only applies to the `-runexpr` path and does not touch
  any other comterp input path (socket, stdin, runfile)