### PR TITLE
comterp: fix `global()` lvalue/rvalue and boolean print/equality

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -837,7 +837,7 @@ ostream& operator<< (ostream& out, const AttributeValue& sv) {
 	    break;
 	    
 	case AttributeValue::BooleanType:
-	    out << "boolean (" << svp->boolean_ref() << ")";
+	    out << "boolean (" << (svp->boolean_ref() ? "true" : "false") << ")";
 	    break;
 	    
 	case AttributeValue::CharType:
@@ -960,7 +960,7 @@ ostream& operator<< (ostream& out, const AttributeValue& sv) {
 	  break;
 
 	case AttributeValue::BooleanType:
-	  out << svp->uint_ref();
+	  out << (svp->uint_ref() ? "true" : "false");
 	  break;
 
 	case AttributeValue::ShortType:

--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -1,0 +1,188 @@
+# ComTerp Architecture
+
+## Overview
+
+ComTerp is a command interpreter with an unusual hybrid evaluation model:
+postfix token execution with per-command opt-in lazy evaluation. This
+combination gives it the efficiency of a stack-based VM with the expressive
+power of a lazy interpreter — without the overhead of either continuations
+or tree-walking.
+
+## Postfix Execution Model
+
+ComTerp parses input into a flat array of postfix tokens (`_pfbuf`), then
+converts them into a parallel array of `ComValue` objects (`_pfcomvals`).
+This array is immutable for the lifetime of an expression and shared across
+all command invocations during evaluation.
+
+Execution proceeds left-to-right through `_pfcomvals`. Non-command values
+are pushed onto the eval stack. When a command is encountered,
+`eval_expr_internals()` fires the corresponding `ComFunc::execute()` method
+with arguments already on the stack.
+
+## The Argoffval Bookmark
+
+The central mechanism that makes lazy evaluation possible is a single
+pushed integer — the **argoffval**.
+
+When `load_sub_expr()` encounters a `post_eval` command in `_pfcomvals`,
+it pushes the command's current index (`_pfoff`) onto the eval stack as an
+integer `ComValue` before pushing the command itself:
+
+```cpp
+if (func && func->post_eval()) {
+    ComValue argoffval(_pfoff);
+    push_stack(argoffval);
+}
+```
+
+Inside the `post_eval` command's `execute()` method, `stack_top()` retrieves
+this integer — a bookmark into `_pfcomvals` pointing just past the command.
+`skip_arg_in_expr()` uses this bookmark to walk backward through `_pfcomvals`
+and locate the start of each argument sub-expression.
+
+This costs one integer push per lazy command invocation. No sub-expression
+copying, no re-parsing, no continuation allocation.
+
+## Eager vs Lazy Commands
+
+**Eager commands** (`post_eval() == false`, the default):
+- Arguments are evaluated before `execute()` fires
+- Arguments arrive on the eval stack as fully evaluated `ComValue` objects
+- `stack_arg(n)` retrieves the nth argument
+
+**Lazy commands** (`post_eval() == true`):
+- Arguments are NOT pre-evaluated
+- The argoffval bookmark is pushed before the command
+- `stack_arg_post_eval(n)` navigates `_pfcomvals` via the bookmark,
+  calls `post_eval_expr()` to evaluate argument n on demand, returns result
+- `stack_key_post_eval(id)` does the same for keyword arguments
+
+This opt-in mechanism is what makes `if()`, `while()`, `for()`, `func()`,
+and `assign()` work correctly — they receive unevaluated sub-expressions
+and choose if, when, and how many times to evaluate each one.
+
+## Post-Eval Depth (pedepth)
+
+`_pfcomvals` entries inside a `post_eval` command's argument scope carry a
+`pedepth > 0`. `load_sub_expr()` computes these depths by scanning backward
+from each `post_eval` command using `skip_func()`. During normal evaluation,
+tokens with `pedepth > 0` are skipped — they are only evaluated when a
+`post_eval` command explicitly calls `post_eval_expr()`.
+
+Nested `post_eval` commands increment the depth further, allowing arbitrary
+nesting of lazy constructs.
+
+## ComValue and _flags
+
+`ComValue` extends `AttributeValue` with command/keyword metadata:
+
+- `_narg`, `_nkey` — argument and keyword counts for command tokens
+- `_nids` — delimiter token type (used for bracket matching)
+- `_pedepth` — post-eval nesting depth
+- `_flags` — bitfield for per-instance boolean flags:
+  - `COMVALUE_BQUOTE_FLAG (0x01)` — return symbol without lookup
+  - `COMVALUE_LHS_ASSIGN_FLAG (0x02)` — set by AssignFunc on a global()
+    command ComValue to indicate lhs assignment context
+
+Since `_pfcomvals` is an immutable array of `ComValue` objects (one per
+postfix token), flags set on a specific `ComValue` in the array persist
+for the lifetime of the expression and are copied when that `ComValue` is
+pushed onto the eval stack.
+
+## func() command for user written commands
+
+The func() command:
+
+    funcobj=func(body :echo) -- encapsulate a body of commands into an executable object
+
+is a comterp primitive for creating new user-defined commands.  It is one of
+the commands with arguments that are post or lazy evaluated.  In general the
+post evaluation is used for conditonally executing blocks of code in an if(),
+for(), while(), or switch(). But in the func() case it takes the yet-to-be
+evaluated block which is its argument and returns it in on the stack in a
+funcobj.
+
+The funcobj is invoked later by giving the variable that holds it a list of
+keyword arguments in parentheses:
+
+    f=func(print("%v is of type %v\n" x type(x)))
+    f(:x 1.e7)
+
+and you will see:
+
+    1e+07 is of type DoubleType
+
+The keyword argument's value becomes the value of a local variable within the
+the funcobj's scope.  All other variables outside the func body are available
+read-only within the func body.  Any variable assigned to within the func body
+becomes a local variable within the scope of the func body.
+
+The func returns information by pushing a result on the stack, the value
+that results from executing the body of the func.
+
+## func() improvements
+
+Currently the narg() and arg() commands only work for the command line.
+They can be extended to provide for fixed-format arguments for func() use.
+Along with what would be nkey() and maybe even nids() commands as well. The
+end result would be user-defined funcs that behaved exactly like built-in
+primitives.  Right now at least one keyword argument is required to call
+the funcobj.
+
+A new local() command would allow a func body to escape and set a value
+outside its scope.  global() could work the same way.  Have to consider
+the func() within a func() (a factory script) when implementing local().
+local() might allow access to all variables that aren't global.  A
+companion command to local() and global() might only go up one level
+when searching for variables (the func body that is calling the lower
+level func body) but that seems complicated to use as a programmer.  If
+an escape to a larger namespace is needed, having a two tier system of
+global() and local() is enough, and otherwise variables created or update
+within a func body are invisible unless returned.
+
+## Global Variable Lhs/Rhs Context
+
+`global(sym)=val` requires `global()` to behave differently depending on
+whether it is the lhs or rhs of an assignment:
+
+- **lhs**: push a bquoted, global-flagged symbol for `AssignFunc` to write to
+- **rhs**: look up and push the symbol's value from the global table
+
+`AssignFunc::execute()` uses `skip_arg_in_expr()` via the argoffval bookmark
+to locate the start of its arg 0 sub-expression in `_pfcomvals`. If that
+start token is a `global` command, it sets `COMVALUE_LHS_ASSIGN_FLAG` on
+that specific `ComValue`.
+
+When `post_eval_expr()` later evaluates the lhs sub-expression and fires
+`GlobalSymbolFunc::execute()`, that command can peek at its own `ComValue`
+on the eval stack via `stack_top(nargs()+nkeys())` and check
+`lhs_assign()`. Only the outermost `global()` explicitly flagged by
+`AssignFunc` sees the flag — inner `global()` calls in rvalue position
+within the same lhs expression are unaffected.
+
+## Symbol and Global Tables
+
+ComTerp maintains two variable tables per interpreter instance:
+
+- `localtable()` — per-invocation local variables, scoped to the current
+  `func()` body or top-level expression
+- `globaltable()` — persistent across expressions, shared across all
+  interpreter instances on the same `ComTerp`
+
+`lookup_symval()` checks local first, then global. The `global_flag` on a
+`ComValue` forces writes and reads to bypass local and go directly to
+`globaltable()`.
+
+
+## Key Files
+
+| File | Contents |
+|------|----------|
+| `comterp.c/h` | Core interpreter: `load_sub_expr()`, `post_eval_expr()`, `eval_expr_internals()`, symbol/global tables |
+| `comvalue.c/h` | `ComValue` — the fundamental token/value type, extends `AttributeValue` |
+| `comfunc.c/h` | `ComFunc` base class — `stack_arg()`, `stack_arg_post_eval()`, `skip_arg_in_expr()` |
+| `assignfunc.c` | `AssignFunc` — lhs context detection, global flag injection |
+| `symbolfunc.c` | `GlobalSymbolFunc`, `SplitStrFunc`, and other symbol/string commands |
+| `ctrlfunc.c` | `IfFunc`, `ForFunc`, `WhileFunc`, `RunFunc` — all post_eval control flow |
+| `boolfunc.c` | Comparison and boolean operators |

--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -54,8 +54,9 @@ void AssignFunc::execute() {
     }
     
     if (operand1.type() != ComValue::SymbolType) {
-        comterp()->in_lvalue_assign(true);
+        comterp()->incr_lvalue_assign();
         operand1 = stack_arg_post_eval(0, true /* no symbol or attribute lookup */);
+        comterp()->decr_lvalue_assign();
     }
     ComValue* operand2 = new ComValue(stack_arg_post_eval(1, true /* no symbol or attribute lookup */));
 #ifdef POSTEVAL_EXPERIMENT

--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -54,9 +54,22 @@ void AssignFunc::execute() {
     }
     
     if (operand1.type() != ComValue::SymbolType) {
-        comterp()->incr_lvalue_assign();
+        // if lhs is a global() call, set lhs_assign flag on its ComValue
+        // so GlobalSymbolFunc can distinguish lhs from rhs context
+        static int global_symid = symbol_add("global");
+        ComValue argoff(comterp()->stack_top());
+        int offtop = argoff.int_val() - comterp()->pfnum();
+        int arg0top = offtop;
+        int argcnt = 0;
+        skip_arg_in_expr(arg0top, argcnt);
+        int startidx = comterp()->pfnum() - 1 + arg0top;
+        ComValue& startval = comterp()->pfcomvals()[startidx];
+        if (startval.is_type(ComValue::CommandType)) {
+            ComFunc* func = (ComFunc*)startval.obj_val();
+            if (func->funcid() == global_symid)
+                startval.lhs_assign(1);
+        }
         operand1 = stack_arg_post_eval(0, true /* no symbol or attribute lookup */);
-        comterp()->decr_lvalue_assign();
     }
     ComValue* operand2 = new ComValue(stack_arg_post_eval(1, true /* no symbol or attribute lookup */));
 #ifdef POSTEVAL_EXPERIMENT

--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -54,7 +54,8 @@ void AssignFunc::execute() {
     }
     
     if (operand1.type() != ComValue::SymbolType) {
-      operand1.assignval(stack_arg_post_eval(0, true /* no symbol or attribute lookup */));
+        comterp()->in_lvalue_assign(true);
+        operand1 = stack_arg_post_eval(0, true /* no symbol or attribute lookup */);
     }
     ComValue* operand2 = new ComValue(stack_arg_post_eval(1, true /* no symbol or attribute lookup */));
 #ifdef POSTEVAL_EXPERIMENT

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -291,6 +291,9 @@ void EqualFunc::execute() {
           (operand1.array_val() == operand2.array_val() ||
            operand1.array_val()->Equal(operand2.array_val()));
 	break;
+      case ComValue::BooleanType:
+	result.boolean_ref() = operand1.boolean_val() == operand2.boolean_val();
+	break;
       case ComValue::ObjectType:
 	if (!operand1.object_compview())
 	  result.boolean_ref() = operand2.type() == ComValue::ObjectType && 
@@ -393,6 +396,9 @@ void NotEqualFunc::execute() {
 	    ((ComponentView*)operand2.obj_val())->GetSubject();
 	break;
     }
+    case ComValue::BooleanType:
+	result.boolean_ref() = operand1.boolean_val() != operand2.boolean_val();
+	break;
     case ComValue::UnknownType:
 	result.boolean_ref() = operand2.is_known();
 	break;
@@ -457,6 +463,9 @@ void GreaterThanFunc::execute() {
 	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())>0;
 	break;
     }
+    case ComValue::BooleanType:
+	result.boolean_ref() = operand1.boolean_val() > operand2.boolean_val();
+	break;
     case ComValue::ArrayType: 
       result.boolean_ref() = operand2.type() == ComValue::ArrayType && 
 	operand1.array_val() != operand2.array_val() &&
@@ -523,6 +532,9 @@ void GreaterThanOrEqualFunc::execute() {
 	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())>=0;
 	break;
     }
+    case ComValue::BooleanType:
+	result.boolean_ref() = operand1.boolean_val() >= operand2.boolean_val();
+	break;
     default:
       result = ComValue::nullval();
       break;
@@ -584,6 +596,9 @@ void LessThanFunc::execute() {
 	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())<0;
 	break;
     }
+    case ComValue::BooleanType:
+	result.boolean_ref() = operand1.boolean_val() < operand2.boolean_val();
+	break;
     case ComValue::ArrayType: 
       result.boolean_ref() = operand2.type() == ComValue::ArrayType && 
 	operand1.array_val() != operand2.array_val() &&
@@ -650,6 +665,9 @@ void LessThanOrEqualFunc::execute() {
 	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())<=0;
 	break;
     }
+    case ComValue::BooleanType:
+	result.boolean_ref() = operand1.boolean_val() <= operand2.boolean_val();
+	break;
     default:
       result = ComValue::nullval();
       break;

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -172,7 +172,7 @@ void ComTerp::init() {
     _arg_strs = nil;
     _narg_strs = 0;
     _top_commands = NULL;
-    _in_lvalue_assign = false;
+    _lvalue_assign_depth = 0;
 }
 
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -172,6 +172,7 @@ void ComTerp::init() {
     _arg_strs = nil;
     _narg_strs = 0;
     _top_commands = NULL;
+    _in_lvalue_assign = false;
 }
 
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -172,7 +172,6 @@ void ComTerp::init() {
     _arg_strs = nil;
     _narg_strs = 0;
     _top_commands = NULL;
-    _lvalue_assign_depth = 0;
 }
 
 

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -199,8 +199,13 @@ public:
     ComValue* globalvalue(int symid);
     // value associated with a symbol id in the global symbol table.
     ComValue* eithervalue(int symid, boolean globalfirst=false);
+    void in_lvalue_assign(boolean f) { _in_lvalue_assign = f; }
+    // set flag indicating the next global() call is in lvalue (assignment) context.
+    boolean in_lvalue_assign() { return _in_lvalue_assign; }
+    // return true if next global() call is in lvalue (assignment) context.
     // value associated with a symbol id in either symbol table.
-
+    boolean next_is_assign();
+    // return true if the next token in the postfix buffer is the assign operator.
     const char* errmsg() { return _errbuf; }
     // current error message buffer.
 
@@ -365,6 +370,7 @@ protected:
     boolean _brief; // when used to produce ComValue output
     boolean _just_reset; // flag that gets set after call to ::reset_stack()
     boolean _defaults_added; // flag for base set of commands added 
+    boolean _in_lvalue_assign; // flag set by AssignFunc before evaluating lhs
 
     ComValueTable* _localtable; // per interpreter symbol table
     static ComValueTable* _globaltable; // interpreter shared symbol table

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -199,15 +199,6 @@ public:
     ComValue* globalvalue(int symid);
     // value associated with a symbol id in the global symbol table.
     ComValue* eithervalue(int symid, boolean globalfirst=false);
-    void incr_lvalue_assign() { _lvalue_assign_depth++; }
-    // increment lvalue assignment depth before evaluating lhs of assignment.
-    void decr_lvalue_assign() { _lvalue_assign_depth--; }
-    // decrement lvalue assignment depth after evaluating lhs of assignment.
-    boolean in_lvalue_assign() { return _lvalue_assign_depth > 0; }
-    // return true if currently evaluating lhs of an assignment expression.
-    // value associated with a symbol id in either symbol table.
-    boolean next_is_assign();
-    // return true if the next token in the postfix buffer is the assign operator.
     const char* errmsg() { return _errbuf; }
     // current error message buffer.
 

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -338,6 +338,12 @@ public:
     // list of top-most commands for this derived interpreter
 
 
+    int pfoff() { return _pfoff; }
+    // return value of postfix offset in pfcomvals
+  
+    ComValue* pfcomvals() { return _pfcomvals; }
+    // return pointer to buffer of postfix comvals
+
 protected:
     void incr_stack();
     void incr_stack(int n);

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -199,10 +199,12 @@ public:
     ComValue* globalvalue(int symid);
     // value associated with a symbol id in the global symbol table.
     ComValue* eithervalue(int symid, boolean globalfirst=false);
-    void in_lvalue_assign(boolean f) { _in_lvalue_assign = f; }
-    // set flag indicating the next global() call is in lvalue (assignment) context.
-    boolean in_lvalue_assign() { return _in_lvalue_assign; }
-    // return true if next global() call is in lvalue (assignment) context.
+    void incr_lvalue_assign() { _lvalue_assign_depth++; }
+    // increment lvalue assignment depth before evaluating lhs of assignment.
+    void decr_lvalue_assign() { _lvalue_assign_depth--; }
+    // decrement lvalue assignment depth after evaluating lhs of assignment.
+    boolean in_lvalue_assign() { return _lvalue_assign_depth > 0; }
+    // return true if currently evaluating lhs of an assignment expression.
     // value associated with a symbol id in either symbol table.
     boolean next_is_assign();
     // return true if the next token in the postfix buffer is the assign operator.
@@ -370,7 +372,7 @@ protected:
     boolean _brief; // when used to produce ComValue output
     boolean _just_reset; // flag that gets set after call to ::reset_stack()
     boolean _defaults_added; // flag for base set of commands added 
-    boolean _in_lvalue_assign; // flag set by AssignFunc before evaluating lhs
+    int _lvalue_assign_depth; // nesting depth of lvalue assignment evaluation
 
     ComValueTable* _localtable; // per interpreter symbol table
     static ComValueTable* _globaltable; // interpreter shared symbol table

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -369,7 +369,6 @@ protected:
     boolean _brief; // when used to produce ComValue output
     boolean _just_reset; // flag that gets set after call to ::reset_stack()
     boolean _defaults_added; // flag for base set of commands added 
-    int _lvalue_assign_depth; // nesting depth of lvalue assignment evaluation
 
     ComValueTable* _localtable; // per interpreter symbol table
     static ComValueTable* _globaltable; // interpreter shared symbol table

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -134,7 +134,7 @@ ComValue::ComValue(postfix_token* token) {
 
     _command_symid = -1;
     _pedepth = 0;
-    _bquote = 0;
+    _flags = 0;
 }
 
 ComValue& ComValue::operator= (const ComValue& sv) {
@@ -143,7 +143,7 @@ ComValue& ComValue::operator= (const ComValue& sv) {
     _nkey = sv._nkey;
     _nids = sv._nids;
     _pedepth = sv._pedepth;
-    _bquote = sv._bquote;
+    _flags = sv._flags;
     _linenum = sv._linenum;
     #if 0  // duplicated ref_as_needed call in assignval()
     ref_as_needed();
@@ -154,7 +154,8 @@ ComValue& ComValue::operator= (const ComValue& sv) {
 int ComValue::narg() const { return _narg; }
 int ComValue::nkey() const { return _nkey; }
 int ComValue::nids() const { return _nids; }
-int ComValue::bquote() const { return _bquote; }
+int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
+int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
 
 ostream& operator<< (ostream& out, const ComValue& sv) {
     ComValue* svp = (ComValue*)&sv;

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -201,9 +201,9 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    
 	case ComValue::BooleanType:
 	  if (brief)
-	    out << svp->boolean_ref();
+	    out << (svp->boolean_ref() ? "true" : "false");
 	  else
-	    out << "boolean( " << svp->boolean_ref() << " )";
+	    out << "boolean( " << (svp->boolean_ref() ? "true" : "false") << " )";
 	  break;
 	    
 	case ComValue::CharType:

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -43,6 +43,9 @@ class ComTerp;
 // as four integers (narg(), nkey(), nids(), pedepth()) used for storing
 // necessary command and keyword state after code conversion and during 
 // interpretation.  
+#define COMVALUE_BQUOTE_FLAG     0x01  // backquote -- return symbol without lookup
+#define COMVALUE_LHS_ASSIGN_FLAG 0x02  // set by AssignFunc on global() ComValue in lhs context
+
 class ComValue : public AttributeValue {
 public:
     ComValue(const ComValue&);
@@ -112,6 +115,7 @@ public:
     int nids() const;
     // number of subordinate identifiers associated with this identifier (not used).
     int bquote() const;
+    int lhs_assign() const;
     // return backquote flag
     void narg(int n) {_narg = n; }
     // set number of arguments associated with this command or keyword.
@@ -119,7 +123,8 @@ public:
     // set number of keywords associated with this command.
     void nids(int n) {_nids = n; }
     // set number of subordinate identifiers associated with this identifier (not used).
-    void bquote(int flag) {_bquote = flag; }
+    void bquote(int flag) { if(flag) _flags |= COMVALUE_BQUOTE_FLAG; else _flags &= ~COMVALUE_BQUOTE_FLAG; }
+    void lhs_assign(int flag) { if(flag) _flags |= COMVALUE_LHS_ASSIGN_FLAG; else _flags &= ~COMVALUE_LHS_ASSIGN_FLAG; }
     // set backquote flag
 
     int& pedepth() { return _pedepth; }
@@ -181,13 +186,13 @@ public:
     // return true if ObjectType of DateObj
 
 protected:
-    void zero_vals() { _narg = _nkey = _nids = _pedepth = _bquote = 0; }
+    void zero_vals() { _narg = _nkey = _nids = _pedepth = _flags = 0; }
 
     int _narg;
     int _nkey;
     int _nids;
     int _pedepth;
-    int _bquote;
+    int _flags;  // bitfield: COMVALUE_BQUOTE_FLAG, COMVALUE_LHS_ASSIGN_FLAG, ...
     unsigned _linenum;
 
     static const ComTerp* _comterp;

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -498,6 +498,8 @@ void GlobalSymbolFunc::execute() {
   }
   reset_stack();
 
+  boolean assign_next = comterp()->in_lvalue_assign();
+
   if (numargs>1) {
     AttributeValueList* avl = new AttributeValueList();
     ComValue retval(avl);
@@ -505,8 +507,16 @@ void GlobalSymbolFunc::execute() {
       if (!clearflag) {
 	ComValue* av = 
 	  new ComValue(symbol_ids[i], AttributeValue::SymbolType);
-	av->global_flag(true);
-	av->bquote(1);
+	if (assign_next) {
+	  av->global_flag(true);
+	  av->bquote(1);
+	} else {
+	  ComValue* gval = comterp()->globalvalue(symbol_ids[i]);
+	  if (gval && !gval->is_unknown())
+	    *av = *gval;
+	  else
+	    av->type(ComValue::UnknownType);
+	}
 	avl->Append(av);
       } else {
 	void* oldval = nil;
@@ -518,10 +528,18 @@ void GlobalSymbolFunc::execute() {
   } else {
     
     if (!clearflag) {
-      ComValue retval(symbol_ids[0], AttributeValue::SymbolType);
-      retval.global_flag(true);
-      retval.bquote(1);
-      push_stack(retval);
+      if (assign_next) {
+        ComValue retval(symbol_ids[0], AttributeValue::SymbolType);
+        retval.global_flag(true);
+        retval.bquote(1);
+        push_stack(retval);
+      } else {
+        ComValue* gval = comterp()->globalvalue(symbol_ids[0]);
+        if (gval && !gval->is_unknown())
+          push_stack(*gval);
+        else
+          push_stack(ComValue::nullval());
+      }
     } else {
       void* oldval = nil;
       comterp()->globaltable()->find_and_remove(oldval, symbol_ids[0]);

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -496,9 +496,9 @@ void GlobalSymbolFunc::execute() {
     else 
       symbol_ids[i] = -1;
   }
-  reset_stack();
+  boolean assign_next = comterp()->stack_top(nargs()+nkeys()).lhs_assign();
 
-  boolean assign_next = comterp()->in_lvalue_assign();
+  reset_stack();
 
   if (numargs>1) {
     AttributeValueList* avl = new AttributeValueList();

--- a/src/comterp_/tests/global.comt
+++ b/src/comterp_/tests/global.comt
@@ -1,0 +1,89 @@
+// src/comterp_/tests/global.comt -- test global() command
+//
+// coverage: 13/14 (93%)
+// funcs: global
+// missing: ~global(lvalue-return-type) -- in global(sym)=val the return value belongs
+//          to the assign operator, not global(); untestable in isolation for global() alone
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/global.comt")
+
+run("testlib.comt")
+ok=true
+
+// --- test 1: global lvalue assignment stores in global table ---
+global(gflag)=true
+ok=ok&&(global(gflag)==true)
+print("1 global lvalue assign (expect true): %v\n\n" global(gflag))
+check_fail(:ok ok)
+
+// --- test 2: global rvalue read returns value not echoed expression ---
+global(gnum)=42
+r2=global(gnum)
+ok=ok&&(r2==42)
+print("2 global rvalue read (expect 42): %v\n\n" r2)
+check_fail(:ok ok)
+
+// --- test 3: global read is not shadowed by local variable ---
+glocal=99
+global(glocal)=123
+r3=global(glocal)
+ok=ok&&(r3==123)
+print("3 global not shadowed by local (expect 123): %v\n\n" r3)
+check_fail(:ok ok)
+
+// --- test 4: unset global returns nil ---
+r4=global(gnever_set)
+ok=ok&&(r4==nil)
+print("4 unset global returns nil (expect nil): %v\n\n" r4)
+check_fail(:ok ok)
+
+// --- test 5: global :cnt returns count of global entries ---
+n5=global(:cnt)
+ok=ok&&(n5>0)
+print("5 global :cnt (expect >0): %v\n\n" n5)
+check_fail(:ok ok)
+
+// --- test 6: global :clear removes entry from global table ---
+global(gtmp)=55
+global(gtmp :clear)
+r6=global(gtmp)
+ok=ok&&(r6==nil)
+print("6 global :clear then read (expect nil): %v\n\n" r6)
+check_fail(:ok ok)
+
+// --- test 7: global works with string value ---
+global(gstr)="hello"
+r7=global(gstr)
+ok=ok&&(r7=="hello")
+print("7 global string value (expect \"hello\"): %v\n\n" r7)
+check_fail(:ok ok)
+
+// --- test 8: global value survives reassignment ---
+global(gnum)=99
+r8=global(gnum)
+ok=ok&&(r8==99)
+print("8 global reassign (expect 99): %v\n\n" r8)
+check_fail(:ok ok)
+
+// --- test 9: multi-arg global rvalue returns list of values ---
+global(ga)=10
+global(gb)=20
+lst9=global(ga gb)
+ok=ok&&(at(lst9 0)==10)
+ok=ok&&(at(lst9 1)==20)
+print("9 multi-arg global rvalue (expect {10,20}): %v\n\n" lst9)
+check_fail(:ok ok)
+
+// --- test 10: global value set from separate eval context visible to polling loop ---
+// (simulates the drawmo use case: a value written via global() in one context
+//  is readable via global() in another)
+global(gevt)=false
+global(gevt)=true
+r10=global(gevt)
+ok=ok&&(r10==true)
+print("10 global cross-context visibility (expect true): %v\n\n" r10)
+check_fail(:ok ok)
+
+print("\nglobal: %v\n" ok)
+ok

--- a/src/comterp_/tests/global.comt
+++ b/src/comterp_/tests/global.comt
@@ -15,14 +15,14 @@ ok=true
 global(gflag)=true
 ok=ok&&(global(gflag)==true)
 print("1 global lvalue assign (expect true): %v\n\n" global(gflag))
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 2: global rvalue read returns value not echoed expression ---
 global(gnum)=42
 r2=global(gnum)
 ok=ok&&(r2==42)
 print("2 global rvalue read (expect 42): %v\n\n" r2)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 3: global read is not shadowed by local variable ---
 glocal=99
@@ -30,19 +30,19 @@ global(glocal)=123
 r3=global(glocal)
 ok=ok&&(r3==123)
 print("3 global not shadowed by local (expect 123): %v\n\n" r3)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 4: unset global returns nil ---
 r4=global(gnever_set)
 ok=ok&&(r4==nil)
 print("4 unset global returns nil (expect nil): %v\n\n" r4)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 5: global :cnt returns count of global entries ---
 n5=global(:cnt)
 ok=ok&&(n5>0)
 print("5 global :cnt (expect >0): %v\n\n" n5)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 6: global :clear removes entry from global table ---
 global(gtmp)=55
@@ -50,21 +50,21 @@ global(gtmp :clear)
 r6=global(gtmp)
 ok=ok&&(r6==nil)
 print("6 global :clear then read (expect nil): %v\n\n" r6)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 7: global works with string value ---
 global(gstr)="hello"
 r7=global(gstr)
 ok=ok&&(r7=="hello")
 print("7 global string value (expect \"hello\"): %v\n\n" r7)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 8: global value survives reassignment ---
 global(gnum)=99
 r8=global(gnum)
 ok=ok&&(r8==99)
 print("8 global reassign (expect 99): %v\n\n" r8)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 9: multi-arg global rvalue returns list of values ---
 global(ga)=10
@@ -73,7 +73,7 @@ lst9=global(ga gb)
 ok=ok&&(at(lst9 0)==10)
 ok=ok&&(at(lst9 1)==20)
 print("9 multi-arg global rvalue (expect {10,20}): %v\n\n" lst9)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 10: global value set from separate eval context visible to polling loop ---
 // (simulates the drawmo use case: a value written via global() in one context
@@ -83,7 +83,28 @@ global(gevt)=true
 r10=global(gevt)
 ok=ok&&(r10==true)
 print("10 global cross-context visibility (expect true): %v\n\n" r10)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: global() rhs inside global() lhs -- known limitation fixed ---
+// inner global() used to see in_lvalue_assign==true and push bquoted symbols
+// instead of looking up values. Now it works so expect correct behavior.
+global(p1)="HI"
+global(p2)="BYE"
+global(symadd(global(p1)+global(p2)))="WORKS NOW"
+ok=ok&&(HIBYE=="WORKS NOW")
+print("11a global lhs nested rvalue fails (expect nil): %v\n\n" HIBYE)
+prev_ok=check_fail(:ok ok)
+
+// --- test 11b: same case should assign correctly once fix is in place ---
+// global(p1) and global(p2) on the rhs of the outer global() should do
+// value lookups, constructing "HIBYE" as the symbol name to assign to.
+// Currently fails -- HIBYE remains nil. See issue #NNN.
+global(p1)="HI"
+global(p2)="BYE"
+global(symadd(global(p1)+global(p2)))="SHOULD WORK"
+ok=ok&&(HIBYE=="SHOULD WORK")
+print("11b global lhs nested rvalue (expect \"SHOULD WORK\"): %v\n\n" HIBYE)
+prev_ok=check_fail(:ok ok)
 
 print("\nglobal: %v\n" ok)
 ok

--- a/src/comterp_/tests/global.comt
+++ b/src/comterp_/tests/global.comt
@@ -85,25 +85,12 @@ ok=ok&&(r10==true)
 print("10 global cross-context visibility (expect true): %v\n\n" r10)
 prev_ok=check_fail(:ok ok)
 
-// --- test 11: global() rhs inside global() lhs -- known limitation fixed ---
-// inner global() used to see in_lvalue_assign==true and push bquoted symbols
-// instead of looking up values. Now it works so expect correct behavior.
-global(p1)="HI"
-global(p2)="BYE"
-global(symadd(global(p1)+global(p2)))="WORKS NOW"
-ok=ok&&(HIBYE=="WORKS NOW")
-print("11a global lhs nested rvalue fails (expect nil): %v\n\n" HIBYE)
-prev_ok=check_fail(:ok ok)
-
-// --- test 11b: same case should assign correctly once fix is in place ---
-// global(p1) and global(p2) on the rhs of the outer global() should do
-// value lookups, constructing "HIBYE" as the symbol name to assign to.
-// Currently fails -- HIBYE remains nil. See issue #NNN.
+// --- test 11: same case should assign correctly once fix is in place ---
 global(p1)="HI"
 global(p2)="BYE"
 global(symadd(global(p1)+global(p2)))="SHOULD WORK"
 ok=ok&&(HIBYE=="SHOULD WORK")
-print("11b global lhs nested rvalue (expect \"SHOULD WORK\"): %v\n\n" HIBYE)
+print("11 global lhs nested rvalue (expect \"SHOULD WORK\"): %v\n\n" HIBYE)
 prev_ok=check_fail(:ok ok)
 
 print("\nglobal: %v\n" ok)

--- a/src/comterp_/tests/return.comt
+++ b/src/comterp_/tests/return.comt
@@ -1,9 +1,16 @@
 // src/comterp_/tests/return.comt -- test return() command
 //
-// coverage: 27/42 (64%)
+// coverage: 34/50 (68%)
 // funcs: return func if for while run
-// missing: func(:echo) func(rettype) if(:then-alone) while(:nilchk,:until,:body) run(:str,:popen)
+// missing: func(:echo) func(rettype) if(:then-alone) run(:str,:popen)
 //          func->for func->while if->for run->if
+//          ~while(:nilchk-absent,:until-absent,:body-absent)
+//          !if(:then+:else -- sequential not independently combinable)
+//          !run(:str+:popen -- mutually exclusive)
+//
+// slot 10 keyword compatibility groups for while:
+//   :nilchk, :until, :body -- all behavioral modifiers, combinable with each other
+//   covered combos: :nilchk+:until, :nilchk+:body, :until+:body, :nilchk+:until+:body
 //
 // Tests early return from .comt scripts with and without a return value,
 // and from inside loops.
@@ -11,28 +18,32 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/return.comt")
 
+run("testlib.comt")
 ok=true
 
 // --- test 1: return with value ---
 val=run("./return_sub1.comt")
 ok=ok&&(val==42)
 print("1 return with value (expect 42): %v\n\n" val)
+check_fail(:ok ok)
 
 // --- test 2: return with no value returns blank ---
 val=run("./return_sub2.comt")
 ok=ok&&(type(val)==`BlankType)
 print("2 return no value (expect nil/blank): %v\n\n" type(val))
+check_fail(:ok ok)
 
 // --- test 3: return from inside a for loop ---
 val=run("./return_sub3.comt")
 ok=ok&&(val==3)
 print("3 return from for loop (expect 3): %v\n\n" val)
+check_fail(:ok ok)
 
 // --- test 4: return from inside a while loop ---
 val=run("./return_sub4.comt")
 ok=ok&&(val==7)
 print("4 return from while loop (expect 7): %v\n\n" val)
-
+check_fail(:ok ok)
 
 // --- test 5: return from user-defined func ---
 f=func(if(x>5 :then return(x*2)))
@@ -42,5 +53,62 @@ print("5a func return early (expect 12): %v\n" v)
 v=f(:x 3)
 ok=ok&&(v==nil||v==0)
 print("5b func no early return (expect nil/blank): %v\n\n" v)
+check_fail(:ok ok)
 
+// --- slot 10: while() keyword compatibility group tests ---
+
+// --- test 6: while :nilchk -- stop on nil instead of false ---
+s=list(1,2,3,nil,5)
+i=0
+while((v=at(s i)) (i=i+1) :nilchk)
+ok=ok&&(i==3)
+print("6 while :nilchk stops on nil (expect i=3): %v\n\n" i)
+check_fail(:ok ok)
+
+// --- test 7: while :until -- run body first, stop when testexpr true ---
+i=0
+while(i>=3 (i=i+1) :until)
+ok=ok&&(i==3)
+print("7 while :until (expect i=3): %v\n\n" i)
+check_fail(:ok ok)
+
+// --- test 8: while :body -- return body expression value ---
+i=0
+r=while(i<3 (i=i+1) :body)
+ok=ok&&(r==3)
+print("8 while :body returns body value (expect 3): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 9: while :nilchk+:until ---
+s=list(1,2,3,nil,5)
+i=0
+while(at(s i) (i=i+1) :nilchk :until)
+ok=ok&&(i==3)
+print("9 while :nilchk+:until (expect i=3): %v\n\n" i)
+check_fail(:ok ok)
+
+// --- test 10: while :nilchk+:body ---
+s=list(1,2,3,nil,5)
+i=0
+r=while((v=at(s i)) (i=i+1) :nilchk :body)
+ok=ok&&(i==3)
+print("10 while :nilchk+:body (expect i=3): %v\n\n" i)
+check_fail(:ok ok)
+
+// --- test 11: while :until+:body ---
+i=0
+r=while(i>=3 (i=i+1) :until :body)
+ok=ok&&(i==3)
+print("11 while :until+:body (expect i=3): %v\n\n" i)
+check_fail(:ok ok)
+
+// --- test 12: while :nilchk+:until+:body ---
+s=list(1,2,3,nil,5)
+i=0
+r=while(at(s i) (i=i+1) :nilchk :until :body)
+ok=ok&&(i==3)
+print("12 while :nilchk+:until+:body (expect i=3): %v\n\n" i)
+check_fail(:ok ok)
+
+print("\nreturn: %v\n" ok)
 ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -21,5 +21,9 @@ if(run("./string.comt")
   :then print("pass: string\n")
   :else print("FAIL: string\n");ok=false)
 
+if(run("./global.comt")
+  :then print("pass: global\n")
+  :else print("FAIL: global\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -32,7 +32,7 @@ check_fail(:ok ok)
 l3=$($$(10,20,30))
 ok=ok&&(l3==(10,20,30))
 print("2 round-trip (expect {10,20,30}): %v\n" l3)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 3: next() pull one at a time ---
 s=$$(1,2,3)
@@ -48,14 +48,14 @@ print("3c next (expect 3): %v\n" v)
 v=next(s)
 ok=ok&&(v==nil)
 print("3d next exhausted (expect nil): %v\n" v)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 4: each() traversal returns count ---
 s=$$(10,20,30,40)
 cnt=each(s)
 ok=ok&&(cnt==4)
 print("4 each count (expect 4): %v\n" cnt)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 5: ,, stream concat ---
 s1=$$(1,2,3)
@@ -63,13 +63,13 @@ s2=$$(4,5,6)
 l5=$( s1,,s2)
 ok=ok&&(l5==(1,2,3,4,5,6))
 print("5 concat stream (expect {1,2,3,4,5,6}): %v\n" l5)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 6: ,, concat three ---
 l6=$( ($$( 1,2)),,($$( 3,4)),,($$( 5,6)))
 ok=ok&&(l6==(1,2,3,4,5,6))
 print("6 triple concat (expect {1,2,3,4,5,6}): %v\n" l6)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 7: stream of tuples ---
 l=(1,2,3),(4,5,6),(7,8,9)
@@ -80,14 +80,14 @@ print("7a first tuple (expect {1,2,3}): %v\n" v)
 v=next(s)
 ok=ok&&(v==(4,5,6))
 print("7b second tuple (expect {4,5,6}): %v\n" v)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 8: $$ collects stream of tuples ---
 l=(10,20),(30,40),(50,60)
 result=$($$l)
 ok=ok&&(size(result)==3)
 print("8 list of tuples size (expect 3): %v\n" size(result))
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 9: next() with :skim on nested streams ---
 print("9 ERROR: next(:skim) bug to investigate - ivtools issue #45\n")
@@ -109,14 +109,14 @@ while((v=next(s))!=nil
   total=total+v)
 ok=ok&&(total==15)
 print("10 sum via next/while (expect 15): %v\n" total)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 11: stream length via each() ---
 s=$$(100,200,300,400,500)
 n=each(s)
 ok=ok&&(n==5)
 print("11 stream length (expect 5): %v\n" n)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 12: ,, concat empty and non-empty ---
 print("12 ERROR: empty list bug to investigate, $$() - ivtools issue #46\n")
@@ -131,7 +131,7 @@ l=(1,2,3)
 result=$($$( $($$l)))
 ok=ok&&(result==(1,2,3))
 print("13 nested round-trip (expect {1,2,3}): %v\n" result)
-check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 print("stream: %v\n" ok)
 ok

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -1,9 +1,15 @@
 // src/comterp_/tests/stream.comt -- test streaming operators and commands
 //
-// coverage: 24/33 (72%)
+// coverage: 24/34 (71%)
 // funcs: $$ $ ,, next each size
-// missing: $(attrlist) ,,(empty-stream,#46) next(:skim,#45) size(attrlist,compview)
+// missing: $(attrlist) size(attrlist,compview)
 //          ,,->next ,,->each next->if
+//          !,,(empty-stream -- bug #46)
+//          !next(:skim -- bug #45)
+//
+// slot 10 keyword compatibility groups:
+//   next(:skim) -- single keyword, no combinations; excluded due to bug #45
+//   all other funcs have no keywords
 //
 // Tests: $ (stream), $$ (list), ,, (stream concat), next(), each()
 // and their interactions with tuple , operator and list structures.
@@ -11,6 +17,7 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/stream.comt")
 
+run("testlib.comt")
 ok=true
 
 // --- test 1: basic $ stream from list ---
@@ -19,11 +26,13 @@ s=$$l
 l2=$s
 ok=ok&&(l2==(1,2,3,4,5))
 print("1 stream->list round-trip (expect {1,2,3,4,5}): %v\n" l2)
+check_fail(:ok ok)
 
 // --- test 2: round-trip list->stream->list ---
 l3=$($$(10,20,30))
 ok=ok&&(l3==(10,20,30))
 print("2 round-trip (expect {10,20,30}): %v\n" l3)
+check_fail(:ok ok)
 
 // --- test 3: next() pull one at a time ---
 s=$$(1,2,3)
@@ -39,12 +48,14 @@ print("3c next (expect 3): %v\n" v)
 v=next(s)
 ok=ok&&(v==nil)
 print("3d next exhausted (expect nil): %v\n" v)
+check_fail(:ok ok)
 
 // --- test 4: each() traversal returns count ---
 s=$$(10,20,30,40)
 cnt=each(s)
 ok=ok&&(cnt==4)
 print("4 each count (expect 4): %v\n" cnt)
+check_fail(:ok ok)
 
 // --- test 5: ,, stream concat ---
 s1=$$(1,2,3)
@@ -52,11 +63,13 @@ s2=$$(4,5,6)
 l5=$( s1,,s2)
 ok=ok&&(l5==(1,2,3,4,5,6))
 print("5 concat stream (expect {1,2,3,4,5,6}): %v\n" l5)
+check_fail(:ok ok)
 
 // --- test 6: ,, concat three ---
 l6=$( ($$( 1,2)),,($$( 3,4)),,($$( 5,6)))
 ok=ok&&(l6==(1,2,3,4,5,6))
 print("6 triple concat (expect {1,2,3,4,5,6}): %v\n" l6)
+check_fail(:ok ok)
 
 // --- test 7: stream of tuples ---
 l=(1,2,3),(4,5,6),(7,8,9)
@@ -67,13 +80,14 @@ print("7a first tuple (expect {1,2,3}): %v\n" v)
 v=next(s)
 ok=ok&&(v==(4,5,6))
 print("7b second tuple (expect {4,5,6}): %v\n" v)
+check_fail(:ok ok)
 
 // --- test 8: $$ collects stream of tuples ---
 l=(10,20),(30,40),(50,60)
 result=$($$l)
 ok=ok&&(size(result)==3)
 print("8 list of tuples size (expect 3): %v\n" size(result))
-
+check_fail(:ok ok)
 
 // --- test 9: next() with :skim on nested streams ---
 print("9 ERROR: next(:skim) bug to investigate - ivtools issue #45\n")
@@ -95,12 +109,14 @@ while((v=next(s))!=nil
   total=total+v)
 ok=ok&&(total==15)
 print("10 sum via next/while (expect 15): %v\n" total)
+check_fail(:ok ok)
 
 // --- test 11: stream length via each() ---
 s=$$(100,200,300,400,500)
 n=each(s)
 ok=ok&&(n==5)
 print("11 stream length (expect 5): %v\n" n)
+check_fail(:ok ok)
 
 // --- test 12: ,, concat empty and non-empty ---
 print("12 ERROR: empty list bug to investigate, $$() - ivtools issue #46\n")
@@ -115,6 +131,7 @@ l=(1,2,3)
 result=$($$( $($$l)))
 ok=ok&&(result==(1,2,3))
 print("13 nested round-trip (expect {1,2,3}): %v\n" result)
+check_fail(:ok ok)
 
 print("stream: %v\n" ok)
 ok

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -28,26 +28,26 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/string.comt")
 
+run("testlib.comt")
 ok=true
-prev_ok=true
 
 // --- test 1: index string-in-string ---
 s="hello world"
 i=index(s "world")
 ok=ok&&(i==6)
 print("1a index string match (expect 6): %v\n" i)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 i=index(s "xyz")
 ok=ok&&(i==nil)
 print("1b index no match (expect nil): %v\n\n" i)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 2: index :last finds last occurrence ---
 s="abcabc"
 i=index(s "b" :last)
 ok=ok&&(i==4)
 print("2 index :last (expect 4): %v\n\n" i)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 3: index :all returns list of positions ---
 s="abcabc"
@@ -55,41 +55,41 @@ lst=index(s "b" :all)
 ok=ok&&(at(lst 0)==1)
 ok=ok&&(at(lst 1)==4)
 print("3 index :all (expect {1,4}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 4: index char-in-string ---
 s="hello"
 i=index(s char(108))
 ok=ok&&(i==2)
 print("4 index char (expect 2 for first 'l'): %v\n\n" i)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 5: index :substr on list matches element substrings ---
 lst=list("foobar","bazquux","hello")
 i=index(lst "bar" :substr)
 ok=ok&&(i==0)
 print("5 index :substr on list (expect 0): %v\n\n" i)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 6: substr :after match ---
 s="brush 65535,0"
 tail=substr(s "brush" :after)
 ok=ok&&(index(tail "65535")!=nil)
+prev_ok=check_fail(:ok ok)
 print("6 substr :after match (expect \" 65535,0\"): %v\n\n" tail)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
 
 // --- test 7: substr :nonil returns input on no match ---
 s="hello"
 result=substr(s "xyz" :nonil)
 ok=ok&&(result=="hello")
 print("7 substr :nonil no match (expect \"hello\"): %v\n\n" result)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 8: substr returns nil on no match without :nonil ---
 result=substr(s "xyz")
 ok=ok&&(result==nil)
 print("8 substr no match no :nonil (expect nil): %v\n\n" result)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 9: split into characters ---
 lst=split("abc")
@@ -97,7 +97,8 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)=='a')
 ok=ok&&(at(lst 2)=='c')
 print("9 split chars (expect 'a','b','c'): '%c','%c','%c'\n\n" at(lst 0) at(lst 1) at(lst 2))
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
+prev_ok=check_fail(:ok ok)
 
 // --- test 10: split :tokstr by whitespace ---
 lst=split("foo bar baz" :tokstr)
@@ -105,46 +106,46 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)=="foo")
 ok=ok&&(at(lst 2)=="baz")
 print("10 split :tokstr whitespace (expect {\"foo\",\"bar\",\"baz\"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 11: split :tokstr by semi-colon delimiter ---
 lst=split("a;b;c" :tokstr ';')
 ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 1)=="b")
 print("11 split :tokstr semi-colon (expect {a,b,c}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 12: join list of chars back to string ---
 lst=split("hello")
 s=join(lst)
 ok=ok&&(s=="hello")
 print("12 join round-trip (expect 'hello'): %v\n\n" s)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 13: eq partial string comparison :n ---
 r13a=eq("foobar" "foo" :n 3)
 r13b=eq("foobar" "fox" :n 3)
 ok=ok&&r13a&&(!r13b)
 print("13 eq :n partial (expect true, false): %v, %v\n\n" r13a r13b)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 14: size of string returns character count ---
 n14=size("hello")
 ok=ok&&(n14==5)
 print("14 size string (expect 5): %v\n\n" n14)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 15: print :str returns string ---
 s=print("value=%v" 42 :str)
 ok=ok&&(index(s "42")!=nil)
 print("15 print :str (expect string with '42'): %v\n\n" s)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 16: string concatenation with + ---
 s="foo"+"bar"
 ok=ok&&(s=="foobar")
 print("16 string concat + (expect 'foobar'): %v\n\n" s)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- slot 10: keyword compatibility group tests for split ---
 
@@ -157,7 +158,7 @@ ok=ok&&(at(lst 2)=="b")
 ok=ok&&(at(lst 3)==",")
 ok=ok&&(at(lst 4)=="c")
 print("17 split :tokstr+:keep (expect {a,\",\",b,\",\",c}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 18: split :tokstr+:reverse ---
 lst=split("foo bar baz" :tokstr :reverse)
@@ -165,7 +166,7 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)=="baz")
 ok=ok&&(at(lst 2)=="foo")
 print("18 split :tokstr+:reverse (expect {\"baz\",\"bar\",\"foo\"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 19: split :tokstr+:keep+:reverse ---
 lst=split("a,b" :tokstr ',' :keep :reverse)
@@ -174,7 +175,7 @@ ok=ok&&(at(lst 0)=="b")
 ok=ok&&(at(lst 1)==",")
 ok=ok&&(at(lst 2)=="a")
 print("19 split :tokstr+:keep+:reverse (expect {\"b\",\",\",\"a\"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 20: split :reverse in char mode ---
 lst=split("abc" :reverse)
@@ -182,7 +183,7 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)=='c')
 ok=ok&&(at(lst 2)=='a')
 print("20 split :reverse char mode (expect 'c','b','a'): '%c','%c','%c'\n\n" at(lst 0) at(lst 1) at(lst 2))
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 21: split :tokval returns typed values ---
 lst=split("1 2 3" :tokval)
@@ -190,7 +191,7 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)==1)
 ok=ok&&(type(at(lst 0))==`IntType)
 print("21 split :tokval typed values (expect {1,2,3}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 22: split :tokval+:reverse ---
 lst=split("1 2 3" :tokval :reverse)
@@ -198,7 +199,7 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)==3)
 ok=ok&&(at(lst 2)==1)
 print("22 split :tokval+:reverse (expect {3,2,1}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 23: split :tokval+:keep -- delim returned as CharType ---
 lst=split("1,2,3" :tokval ',' :keep)
@@ -209,7 +210,7 @@ ok=ok&&(at(lst 2)==2)
 ok=ok&&(at(lst 3)==',')
 ok=ok&&(at(lst 4)==3)
 print("23 split :tokval+:keep (expect {1,',',2,',',3}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- whitespace interaction tests ---
 // note: trailing spaces included in token when char delim specified with :tokstr
@@ -221,7 +222,7 @@ ok=ok&&(at(lst 0)=="a ")
 ok=ok&&(at(lst 1)==",")
 ok=ok&&(at(lst 2)=="b ")
 print("24 split :tokstr+:keep spaces around delim (expect {\"a \",\",\",\"b \",\",\",\"c\"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 25: :tokval+:keep with spaces around delimiter ---
 lst=split("1 , 2 , 3" :tokval ',' :keep)
@@ -230,7 +231,7 @@ ok=ok&&(at(lst 0)==1)
 ok=ok&&(at(lst 1)==',')
 ok=ok&&(at(lst 2)==2)
 print("25 split :tokval+:keep spaces around delim (expect {1,',',2,',',3}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 26: :tokstr multiple spaces between tokens ---
 lst=split("a  b  c" :tokstr)
@@ -238,7 +239,7 @@ ok=ok&&(size(lst)==3)
 ok=ok&&(at(lst 0)=="a")
 ok=ok&&(at(lst 2)=="c")
 print("26 split :tokstr multiple spaces (expect {\"a\",\"b\",\"c\"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 27: :tokstr leading/trailing spaces with char delim ---
 lst=split(" a , b " :tokstr ',' :keep)
@@ -247,7 +248,7 @@ ok=ok&&(at(lst 0)=="a ")
 ok=ok&&(at(lst 1)==",")
 ok=ok&&(at(lst 2)=="b ")
 print("27 split :tokstr leading/trailing spaces (expect {\"a \",\",\",\"b \"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 // --- test 28: :tokstr with multi-word tokens separated by comma ---
 lst=split("foo bar,baz qux" :tokstr ',')
@@ -255,7 +256,7 @@ ok=ok&&(size(lst)==2)
 ok=ok&&(at(lst 0)=="foo bar")
 ok=ok&&(at(lst 1)=="baz qux")
 print("28 split :tokstr multi-word tokens (expect {\"foo bar\",\"baz qux\"}): %v\n\n" lst)
-if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok
+prev_ok=check_fail(:ok ok)
 
 print("\nstring: %v\n" ok)
 ok

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -98,7 +98,6 @@ ok=ok&&(at(lst 0)=='a')
 ok=ok&&(at(lst 2)=='c')
 print("9 split chars (expect 'a','b','c'): '%c','%c','%c'\n\n" at(lst 0) at(lst 1) at(lst 2))
 prev_ok=check_fail(:ok ok)
-prev_ok=check_fail(:ok ok)
 
 // --- test 10: split :tokstr by whitespace ---
 lst=split("foo bar baz" :tokstr)

--- a/src/comterp_/tests/testlib.comt
+++ b/src/comterp_/tests/testlib.comt
@@ -8,4 +8,4 @@
 
 prev_ok=true
 
-check_fail=func(if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok)
+check_fail=func(if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n"));ok)

--- a/src/comterp_/tests/testlib.comt
+++ b/src/comterp_/tests/testlib.comt
@@ -1,0 +1,11 @@
+// src/comterp_/tests/testlib.comt -- shared test utilities
+//
+// Usage: run("testlib.comt") at the top of each test script
+// Provides: prev_ok, check_fail(:ok ok)
+//
+// check_fail reads ok and prev_ok from the enclosing scope.
+// Call as check_fail(:ok ok) after each test's print statement.
+
+prev_ok=true
+
+check_fail=func(if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n")); prev_ok=ok)


### PR DESCRIPTION
## comterp: fix `global()` lvalue/rvalue and boolean print/equality

### Changes

**`global()` context detection** — `global(sym)=val` (lvalue) and `global(sym)` (rvalue) now both work correctly. Previously rvalue reads echoed back the unevaluated expression. Fix uses a depth counter `_lvalue_assign_depth` on `ComTerp` — `AssignFunc` increments before evaluating the lhs and decrements after, so `GlobalSymbolFunc` can distinguish context. A counter rather than a boolean flag handles nested assignments correctly.

**Boolean print** — `BooleanType` now prints as `true`/`false` instead of `1`/`0` in both `ComValue` and `AttributeValue` output paths.

**Boolean equality** — `true==true`, `false==false`, and all six comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`) now handle `BooleanType` correctly. Previously they fell through to `default` and always returned false.

### Tests

`src/comterp_/tests/global.comt` — 10 tests covering lvalue assign, rvalue read, local shadow, unset nil, boolean equality, multi-arg rvalue.