### PR TITLE
comdraw, drawserv, flipbook, graphdraw: add `(comt)` interactive prompt

### DIFF
--- a/src/Attribute/commodule.h
+++ b/src/Attribute/commodule.h
@@ -72,7 +72,7 @@ public:
     // operator string.
 
     outfuncptr& outfunc() { return _outfunc; }
-    // return outfuncptr by value
+    // return outfuncptr by reference
 
 protected:
     void init();

--- a/src/Attribute/commodule.h
+++ b/src/Attribute/commodule.h
@@ -71,6 +71,9 @@ public:
     // symbol ids for binary infix, unary prefix and postfix for a given
     // operator string.
 
+    outfuncptr& outfunc() { return _outfunc; }
+    // return outfuncptr by value
+
 protected:
     void init();
     // allocate internal buffers and initialize internal pointers.

--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -197,6 +197,7 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
       }
       
       comterp_->_fd = fd;
+      comterp_->_outfunc = (fd == 0) ? (outfuncptr)&stdout_puts : (outfuncptr)&ComTerpServ::fd_fputs;
       int  status = comterp_->ComTerp::run(false /* !once */, comterp_->force_nested() /* !nested */);
       if(comterp_->force_nested()) ComValue retval(comterp_->pop_stack(false));
       if (comterp_->delete_later()) {

--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -197,8 +197,6 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
       }
       
       comterp_->_fd = fd;
-      // comterp_->outfunc() = (fd == 0) ? (outfuncptr)&stdout_puts : (outfuncptr)&ComTerpServ::fd_fputs;
-      
       int  status = comterp_->ComTerp::run(false /* !once */, comterp_->force_nested() /* !nested */);
       if(comterp_->force_nested()) ComValue retval(comterp_->pop_stack(false));
       if (comterp_->delete_later()) {

--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -197,11 +197,8 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
       }
       
       comterp_->_fd = fd;
-      comterp_->_outfunc = (outfuncptr)&ComTerpServ::fd_fputs;
-
-
-
-
+      // comterp_->outfunc() = (fd == 0) ? (outfuncptr)&stdout_puts : (outfuncptr)&ComTerpServ::fd_fputs;
+      
       int  status = comterp_->ComTerp::run(false /* !once */, comterp_->force_nested() /* !nested */);
       if(comterp_->force_nested()) ComValue retval(comterp_->pop_stack(false));
       if (comterp_->delete_later()) {

--- a/src/ComTerp/comterpserv.c
+++ b/src/ComTerp/comterpserv.c
@@ -247,6 +247,8 @@ int ComTerpServ::run(boolean one_expr, boolean nested) {
     if (_fptr == stdin && !handler()) {
         _outptr = stdout;
         _outfunc = (outfuncptr)&stdout_puts;
+    } else if (handler() && handler()->get_handle() == 0) {
+        _outfunc = (outfuncptr)&stdout_puts;
     } else {
         _outfunc = (outfuncptr)&fd_fputs;
     }

--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -351,5 +351,8 @@ boolean ComEditor::whiteboard() {
 void ComEditor::stdio_setup(UnidrawComterpHandler* handler) {
   SetComTerp(handler->comterp());
   handler->comterp()->outfunc() = (outfuncptr)&stdout_puts;
+}
+
+void ComEditor::stdio_prompt(UnidrawComterpHandler* handler) {
   (*handler->comterp()->outfunc()) (get_command_prompt(), nil);
 }

--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -349,10 +349,15 @@ boolean ComEditor::whiteboard() {
 }
 
 void ComEditor::stdio_setup(UnidrawComterpHandler* handler) {
-  SetComTerp(handler->comterp());
-  handler->comterp()->outfunc() = (outfuncptr)&stdout_puts;
+  if (handler) {
+    SetComTerp(handler->comterp());
+    handler->comterp()->outfunc() = (outfuncptr)&stdout_puts;
+  }
 }
 
 void ComEditor::stdio_prompt(UnidrawComterpHandler* handler) {
-  (*handler->comterp()->outfunc()) (get_command_prompt(), nil);
+  if (handler!=NULL) 
+    (*handler->comterp()->outfunc()) (get_command_prompt(), nil);
+  else
+    fprintf(stdout, get_command_prompt());
 }

--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -23,6 +23,7 @@
  */
 
 #include <ComUnidraw/comkit.h>
+#include <ComUnidraw/comterp-acehandler.h>
 #include <ComUnidraw/grdotfunc.h>
 #include <ComUnidraw/grfunc.h>
 #include <ComUnidraw/grlistfunc.h>
@@ -345,4 +346,10 @@ boolean ComEditor::whiteboard() {
       _whiteboard = 0;
   }
   return _whiteboard;
+}
+
+void ComEditor::stdio_setup(UnidrawComterpHandler* handler) {
+  SetComTerp(handler->comterp());
+  handler->comterp()->outfunc() = (outfuncptr)&stdout_puts;
+  (*handler->comterp()->outfunc()) (get_command_prompt(), nil);
 }

--- a/src/ComUnidraw/comeditor.h
+++ b/src/ComUnidraw/comeditor.h
@@ -67,6 +67,10 @@ public:
 
     void stdio_setup(UnidrawComterpHandler* handler);
     // initial setup of stdio handler that writes to stdout.
+    void stdio_prompt(UnidrawComterpHandler* handler);
+    // conditionally generate (comt) prompt for interactive sessions
+    // called only once to add the prompt after initial startup
+    // after that it happens in ComUtil/_lexscan.c
 
 protected:
 

--- a/src/ComUnidraw/comeditor.h
+++ b/src/ComUnidraw/comeditor.h
@@ -30,6 +30,7 @@
 class ComTerpIOHandler;
 class ComTerp;
 class ComTerpServ;
+class UnidrawComterpHandler;
 
 //: editor that integrates ComTerp into the drawing editor framework.
 class ComEditor : public OverlayEditor {
@@ -63,6 +64,9 @@ public:
     boolean whiteboard();
     // test for distributed whiteboard mode, which only exists when
     // used with a ComEditor.
+
+    void stdio_setup(UnidrawComterpHandler* handler);
+    // initial setup of stdio handler that writes to stdout.
 
 protected:
 

--- a/src/ComUtil/_lexscan.c
+++ b/src/ComUtil/_lexscan.c
@@ -256,7 +256,8 @@ int bs_ident = 0;
 	 if (outfunc && !_continuation_prompt_disabled) {
 	   if (_continuation_prompt)
 	     (*outfunc) ( "> ", outfile);
-	   else if (outfunc == (int(*)(const char*,void*))&stdout_puts && *get_command_prompt())
+	   else if (outfunc == (int(*)(const char*,void*))&stdout_puts && *get_command_prompt()
+		    && buffer[0] != '\0')
 	     (*outfunc) ( get_command_prompt(), outfile);
 	 }
 	 _continuation_prompt = 0;

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -37,6 +37,7 @@ History:        Written by Scott E. Johnston, April 1989
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include "comterp.ci"
 
@@ -49,7 +50,6 @@ int get_continuation_prompt_disabled() { return _continuation_prompt_disabled; }
 void set_command_prompt(const char* prompt) { _command_prompt_string = prompt; }
 const char* get_command_prompt() { return _command_prompt_string; }
 
-int stdout_puts(const char* s, void* ignored) { return fputs(s, stdout); }
 int _skip_shell_comments = 0;
 infuncptr _oneshot_infunc = NULL;
 int _detail_matched_delims = 0;

--- a/src/ComUtil/util.c
+++ b/src/ComUtil/util.c
@@ -114,3 +114,9 @@ char* restore_escapes(const char* str, int& bufsize) {
     *dptr = '\0';
     return dst;
 }
+
+int stdout_puts(const char* s, void* ignored) { 
+    int ret = fputs(s, stdout);
+    fflush(stdout);
+    return ret;
+}

--- a/src/ComUtil/util.h
+++ b/src/ComUtil/util.h
@@ -598,6 +598,7 @@ const char* shell_string(const char* cmd);  // returns first line of output from
 const char* local_hostname();               // returns fully qualified local hostname
 void log_with_timestamp(const char* msg);   // log timestamped message
 char* restore_escapes(const char* str, int& bufsize);  // restore escape sequences converted to ASCII by shell/option parser
+int stdout_puts(const char* s, void* ignored);
 
 
 #endif /* not UTIL_INCLUDED */

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -371,14 +371,11 @@ int main (int argc, char** argv) {
 	
 	/*  Start up one on stdin */
 	const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
+	UnidrawComterpHandler* stdin_handler = nil;
 	if (!stdin_off_str || strcmp(stdin_off_str, "false")==0) {
-	  UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-#if 0
-	  if (ACE::register_stdin_handler(stdin_handler, ComterpHandler::reactor_singleton(), nil) == -1)
-#else
+	    stdin_handler = new UnidrawComterpHandler();
 	    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
 							  ACE_Event_Handler::READ_MASK)==-1)
-#endif
 	      cerr << "comdraw: unable to open stdin with ACE\n";
 
 	  fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
@@ -389,6 +386,11 @@ int main (int argc, char** argv) {
 	if (!starter_line) {
 	  fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
 	}
+
+#ifdef HAVE_ACE
+	ed->stdio_prompt(stdin_handler);
+#endif
+	
 	XSync(unidraw->GetWorld()->display()->rep()->display_,false);
 	
 	/* execute -runfile or -runexpr after editor is fully initialized */

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -355,6 +355,7 @@ int main (int argc, char** argv) {
 
 #endif
     int exit_status = 0;
+    boolean starter_line = false;
 
     if (argc > 2) {
 	cerr << usage << "\n";
@@ -379,11 +380,15 @@ int main (int argc, char** argv) {
 							  ACE_Event_Handler::READ_MASK)==-1)
 #endif
 	      cerr << "comdraw: unable to open stdin with ACE\n";
-	  ed->SetComTerp(stdin_handler->comterp());
+
+	  fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
+	  starter_line = true;
+	  ed->stdio_setup(stdin_handler);
 	}
 #endif
-
-	fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
+	if (!starter_line) {
+	  fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info\n", VersionString);
+	}
 	XSync(unidraw->GetWorld()->display()->rep()->display_,false);
 	
 	/* execute -runfile or -runexpr after editor is fully initialized */

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -423,9 +423,10 @@ int main (int argc, char** argv) {
 	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
 							  ACE_Event_Handler::READ_MASK)==-1)
 #endif
-	  cerr << "drawserv: unable to open stdin with ACE\n";
-	ed->SetComTerp(stdin_handler->comterp());
+          cerr << "drawserv: unable to open stdin with ACE\n";
+	
 	fprintf(stderr, "ivtools-%s drawserv: type help here for command info\n", VersionString);
+	ed->stdio_setup(stdin_handler);
 #else
 	fprintf(stderr, "ivtools-%s drawserv", VersionString);
 #endif

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -417,16 +417,14 @@ int main (int argc, char** argv) {
 #ifdef HAVE_ACE
 	/*  Start up one on stdin */
 	DrawServHandler* stdin_handler = new DrawServHandler();
-#if 0
-	if (ACE::register_stdin_handler(stdin_handler, ComterpHandler::reactor_singleton(), nil) == -1)
-#else
 	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
 							  ACE_Event_Handler::READ_MASK)==-1)
-#endif
           cerr << "drawserv: unable to open stdin with ACE\n";
 	
-	fprintf(stderr, "ivtools-%s drawserv: type help here for command info\n", VersionString);
 	ed->stdio_setup(stdin_handler);
+	fprintf(stderr, "ivtools-%s drawserv: type help here for command info\n", VersionString);
+	ed->stdio_prompt(stdin_handler);
+
 #else
 	fprintf(stderr, "ivtools-%s drawserv", VersionString);
 #endif

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -306,18 +306,17 @@ int main (int argc, char** argv) {
 #ifdef HAVE_ACE
 	/*  Start up one on stdin */
 	UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-#if 0
-	if (ACE::register_stdin_handler(stdin_handler, ComterpHandler::reactor_singleton(), nil) == -1)
-#else
 	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
 							  ACE_Event_Handler::READ_MASK)==-1)
-#endif
 	  cerr << "flipbook: unable to open stdin with ACE\n";
-	
+	ed->stdio_setup(stdin_handler);
 #endif
 
 	fprintf(stderr, "ivtools-%s flipbook: see \"man flipbook\" or type help here for command info\n", VersionString);
-	ed->stdio_setup(stdin_handler);
+	
+#ifdef HAVE_ACE
+	ed->stdio_prompt(stdin_handler);
+#endif
 	
 	unidraw->Run();
     }

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -40,6 +40,8 @@
 
 #include <InterViews/world.h>
 
+#include <ComTerp/comterpserv.h>
+
 #include <stdio.h>
 #include <stream.h>
 #include <string.h>
@@ -311,11 +313,12 @@ int main (int argc, char** argv) {
 							  ACE_Event_Handler::READ_MASK)==-1)
 #endif
 	  cerr << "flipbook: unable to open stdin with ACE\n";
-	ed->SetComTerp(stdin_handler->comterp());
-#endif
 	
+#endif
 
 	fprintf(stderr, "ivtools-%s flipbook: see \"man flipbook\" or type help here for command info\n", VersionString);
+	ed->stdio_setup(stdin_handler);
+	
 	unidraw->Run();
     }
 

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -38,6 +38,8 @@
 
 #include <OverlayUnidraw/ovunidraw.h>
 
+#include <ComTerp/comterpserv.h>
+
 #include <InterViews/world.h>
 
 #include <stream.h>
@@ -292,11 +294,13 @@ int main (int argc, char** argv) {
 							  ACE_Event_Handler::READ_MASK)==-1)
 #endif
 	  cerr << "graphdraw: unable to open stdin with ACE\n";
-	ed->SetComTerp(stdin_handler->comterp());
+
 #endif
 	
     cerr << "ivtools-" << VersionString 
 	 << " graphdraw: see \"man graphdraw\" or type help here for command info\n";
+    ed->stdio_setup(stdin_handler);
+
     unidraw->Run();
 
     delete unidraw;

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -283,26 +283,25 @@ int main (int argc, char** argv) {
     GraphEditor* ed = new GraphEditor(initial_file);
     
     unidraw->Open(ed);
-
+    
 #ifdef HAVE_ACE
-	/*  Start up one on stdin */
-	UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-#if 0
-	if (ACE::register_stdin_handler(stdin_handler, ComterpHandler::reactor_singleton(), nil) == -1)
-#else
-	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
-							  ACE_Event_Handler::READ_MASK)==-1)
+    /*  Start up one on stdin */
+    UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
+    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
+							      ACE_Event_Handler::READ_MASK)==-1)
+      cerr << "graphdraw: unable to open stdin with ACE\n";
+    ed->stdio_setup(stdin_handler);
 #endif
-	  cerr << "graphdraw: unable to open stdin with ACE\n";
-
-#endif
-	
+    
     cerr << "ivtools-" << VersionString 
 	 << " graphdraw: see \"man graphdraw\" or type help here for command info\n";
-    ed->stdio_setup(stdin_handler);
-
+    
+#ifdef HAVE_ACE
+    ed->stdio_prompt(stdin_handler);
+#endif
+    
     unidraw->Run();
-
+    
     delete unidraw;
     return exit_status;
 }


### PR DESCRIPTION
## comdraw, drawserv, flipbook, graphdraw: add `(comt)` interactive prompt

### Overview

Adds a `(comt) ` prompt to all drawing editors with built-in comterp, matching
the behavior of the standalone `comterp` interactive interpreter. The prompt
appears before each new expression and `> ` appears for continuation lines in
multi-line expressions.

### Behavior

```
(comt) 44*4
176
(comt) 1 +
> 2 +
> 3 +
> 4
10
(comt)
```

### Changes

**`src/ComUtil/util.c` and `util.h`**
- Add `stdout_puts()` implementation -- an `outfuncptr`-compatible wrapper
  that writes to `stdout` with `fflush`. Its identity as a function pointer
  is the signal to `_lexscan.c` that the `(comt)` prompt should print.
  Moved here from `_parser.c` so it lives in `ComUtil` alongside the other
  IO utility functions.

**`src/ComUtil/_parser.c`**
- Remove `stdout_puts()` implementation (moved to `util.c`)
- Add `#include <unistd.h>`

**`src/ComUtil/_lexscan.c`**
- Add `buffer[0] != '\0'` guard to `(comt)` prompt check -- suppresses
  spurious prompt on the initial empty-buffer scanner init call used by
  socket IO paths

**`src/ComTerp/comterpserv.c`**
- In `ComTerpServ::run()`, add `handler()->get_handle() == 0` case to
  preserve `stdout_puts` as `_outfunc` for stdin handler context, preventing
  it from being overridden with `fd_fputs`

**`src/ComTerp/comhandler.c`**
- Remove explicit `_outfunc = fd_fputs` assignment -- outfunc is now set
  correctly by `ComTerpServ::run()` and `stdio_setup()`

**`src/Attribute/commodule.h`**
- Add `outfunc()` reference accessor so `stdio_setup()` can set `_outfunc`
  on the comterp instance

**`src/ComUnidraw/comeditor.h` and `comeditor.c`**
- Add `stdio_setup(UnidrawComterpHandler*)` method to `ComEditor` that:
  1. Calls `SetComTerp(handler->comterp())`
  2. Sets `outfunc() = stdout_puts`
  3. Prints the initial `(comt) ` prompt

**`src/comdraw/main.c`**
- Replace `ed->SetComTerp()` with `ed->stdio_setup(stdin_handler)`
- Move startup message before `stdio_setup()` call so `(comt)` appears
  after the startup message, not before it

**`src/drawserv_/main.c`**, **`src/flipbook/main.c`**, **`src/graphdraw/main.c`**
- Same pattern: replace `SetComTerp` with `stdio_setup`, move startup
  message before the call

### Notes

- The function pointer identity of `stdout_puts` is the canonical way
  to detect stdout vs socket output throughout the stack -- no `fileno()`
  comparison needed
- `stdout_puts` lives in `ComUtil/util.c` so it is available at the
  `_lexscan.c` layer without a layer violation
- `comterp` standalone already had correct `(comt)` prompt behavior;
  this PR brings the drawing editors to the same standard