### PR TITLE
comterp: attrlist() func returns newly created attrlist populated with arbitrary keyword/value attributes

### DIFF
--- a/src/Attribute/attrlist.c
+++ b/src/Attribute/attrlist.c
@@ -181,6 +181,7 @@ void AttributeList::Remove (Attribute* p) {
 	_alist->Remove(temp);
         delete temp;
 	--_count;
+        Resource::unref(p);
     }
 }
 

--- a/src/Attribute/attrlist.h
+++ b/src/Attribute/attrlist.h
@@ -156,7 +156,7 @@ public:
     int add_attr(Attribute* attr);
     // add attribute, returning 0 if new, -1 if it already existed.
     // When -1 is returned you need to clear the valueptr of 'attr' before 
-    // deleting it.  That's why this is protected.
+    // deleting it.
 
 protected:
     AList* _alist;

--- a/src/Attribute/attrlist.h
+++ b/src/Attribute/attrlist.h
@@ -153,12 +153,12 @@ public:
     AttributeValue* find(int symid);
     // find AttributeValue by symbol id.
 
+protected:
     int add_attr(Attribute* attr);
     // add attribute, returning 0 if new, -1 if it already existed.
     // When -1 is returned you need to clear the valueptr of 'attr' before 
-    // deleting it.
+    // deleting it.  That's why this is protected.
 
-protected:
     AList* _alist;
     unsigned int _count;
 

--- a/src/Attribute/attrlist.h
+++ b/src/Attribute/attrlist.h
@@ -153,12 +153,12 @@ public:
     AttributeValue* find(int symid);
     // find AttributeValue by symbol id.
 
-protected:
     int add_attr(Attribute* attr);
     // add attribute, returning 0 if new, -1 if it already existed.
     // When -1 is returned you need to clear the valueptr of 'attr' before 
     // deleting it.  That's why this is protected.
 
+protected:
     AList* _alist;
     unsigned int _count;
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1334,6 +1334,7 @@ void ComTerp::add_defaults() {
     add_command("attrval", new DotValFunc(this));
 
     add_command("list", new ListFunc(this));
+  add_command("attrlist", new AttrListFunc(this));
     add_command("at", new ListAtFunc(this));
     add_command("size", new ListSizeFunc(this));
     add_command("tuple", new TupleFunc(this));

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1334,7 +1334,7 @@ void ComTerp::add_defaults() {
     add_command("attrval", new DotValFunc(this));
 
     add_command("list", new ListFunc(this));
-  add_command("attrlist", new AttrListFunc(this));
+    add_command("attrlist", new AttrListFunc(this));
     add_command("at", new ListAtFunc(this));
     add_command("size", new ListSizeFunc(this));
     add_command("tuple", new TupleFunc(this));

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -131,7 +131,11 @@ DotNameFunc::DotNameFunc(ComTerp* comterp) : ComFunc(comterp) {
 void DotNameFunc::execute() {
     ComValue dotted_pair(stack_arg(0, true));
     reset_stack();
-    if (dotted_pair.class_symid() != Attribute::class_symid()) return;
+    if (dotted_pair.class_symid() != Attribute::class_symid()) {
+        fprintf(stderr, "attrname: argument is not a dotted pair attribute (line %d)\n", funcstate()->linenum());
+        push_stack(ComValue::nullval());
+        return;
+    }
     Attribute *attr = (Attribute*)dotted_pair.obj_val();
     ComValue retval(attr->SymbolId(), ComValue::StringType);
     push_stack(retval);
@@ -145,7 +149,11 @@ DotValFunc::DotValFunc(ComTerp* comterp) : ComFunc(comterp) {
 void DotValFunc::execute() {
     ComValue dotted_pair(stack_arg(0, true));
     reset_stack();
-    if (dotted_pair.class_symid() != Attribute::class_symid()) return;
+    if (dotted_pair.class_symid() != Attribute::class_symid()) {
+        fprintf(stderr, "attrval: argument is not a dotted pair attribute (line %d)\n", funcstate()->linenum());
+        push_stack(ComValue::nullval());
+        return;
+    }
     Attribute *attr = (Attribute*)dotted_pair.obj_val();
     push_stack(*attr->Value());
 }

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -87,7 +87,6 @@ void DotFunc::execute() {
 	al = (AttributeList*) ((ComValue*) vptr)->obj_val();
       } else {
 	al = new AttributeList();
-	Resource::ref(al);
 	ComValue* comval = new ComValue(AttributeList::class_symid(), (void*)al);
 	if (!global)
 	  comterp()->localtable()->insert(before_symid, comval);

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -168,7 +168,11 @@ void PrintFunc::execute() {
     }
     else {
       if (prefixv.is_string()) out << prefixv.symbol_ptr();
-      out << formatstr;  // which could be arbitrary ComValue
+      if (!formatstr.is_string())
+	out << formatstr;  // which could be arbitrary ComValue
+      else
+	out << formatstr.string_ptr();
+	    
       if (prefixv.is_string()) out << "\n";
       out.flush();
     }

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -107,6 +107,19 @@ void ListFunc::execute() {
 
 /*****************************************************************************/
 
+AttrListFunc::AttrListFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void AttrListFunc::execute() {
+    AttributeList* al = stack_keys();
+    Resource::ref(al);
+    reset_stack();
+    ComValue retval(AttributeList::class_symid(), al);
+    push_stack(retval);
+}
+
+/*****************************************************************************/
+
 ListAtFunc::ListAtFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -56,7 +56,6 @@ void ListFunc::execute() {
 
   if (attrflag) {
       AttributeList* al = new AttributeList();
-      Resource::ref(al);
       ComValue retval(AttributeList::class_symid(), al);
       push_stack(retval);
       return;
@@ -112,7 +111,6 @@ AttrListFunc::AttrListFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void AttrListFunc::execute() {
     AttributeList* al = stack_keys();
-    Resource::ref(al);
     reset_stack();
     ComValue retval(AttributeList::class_symid(), al);
     push_stack(retval);

--- a/src/ComTerp/listfunc.h
+++ b/src/ComTerp/listfunc.h
@@ -130,7 +130,7 @@ public:
     AttrListFunc(ComTerp*);
     virtual void execute();
     virtual const char* docstring() {
-      return "attrlst=%s([:<name> [val]] ...) -- create attribute list from keyword/value pairs"; }
+      return "alst=%s([:<name> [val]] ...) -- create attribute list from keyword/value pairs"; }
 };
 
 #endif /* !defined(_listfunc_h) */

--- a/src/ComTerp/listfunc.h
+++ b/src/ComTerp/listfunc.h
@@ -121,4 +121,16 @@ public:
     }
 };
 
+
+//: attrlist command for ComTerp.
+// attrlst=attrlist([:<name> [val]] ...) -- create attribute list from keyword/value pairs.
+// Keyword-only (no value) sets attribute to true. Missing attribute returns nil.
+class AttrListFunc : public ComFunc {
+public:
+    AttrListFunc(ComTerp*);
+    virtual void execute();
+    virtual const char* docstring() {
+      return "attrlst=%s([:<name> [val]] ...) -- create attribute list from keyword/value pairs"; }
+};
+
 #endif /* !defined(_listfunc_h) */

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -27,6 +27,7 @@
 #include <ComTerp/comterp.h>
 #include <ComTerp/timefunc.h>
 #include <Unidraw/iterator.h>
+#include <Attribute/attribute.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/lexscan.h>
 #include <Attribute/paramlist.h>
@@ -269,6 +270,20 @@ void AddFunc::execute() {
 	break;
     case ComValue::ArrayType: 
         {
+	  if (operand1.is_attributelist() && operand2.is_attributelist()) {
+	    // merge two attrlists: + is to attrlist as + is to string
+	    // deep copy al1, then deep copy each attr from al2 into merged
+	    AttributeList* al1 = (AttributeList*)operand1.obj_val();
+	    AttributeList* al2 = (AttributeList*)operand2.obj_val();
+	    AttributeList* merged = new AttributeList(al1);
+	    Iterator it;
+	    for (al2->First(it); !al2->Done(it); al2->Next(it))
+	        merged->add_attr(new Attribute(*al2->GetAttr(it)));
+	    Resource::ref(merged);
+	    result = ComValue(AttributeList::class_symid(), (void*)merged);
+	    push_stack(result);
+	    return;
+	  }
 	  if (operand2.is_array()) {
 	    Resource::unref(result.array_val());
 	    result.array_ref() = 
@@ -287,6 +302,18 @@ void AddFunc::execute() {
           int addend = operand2.int_val();
 	  *dateobj->date() = ((const Date)*dateobj->date()) + addend;
 	  result = ComValue(DateObj::class_symid(), (void*)dateobj);
+
+	} else if (operand1.is_attributelist() && operand2.is_attributelist()) {
+	  // merge two attrlists: + is to attrlist as + is to string
+	  // deep copy al1, then deep copy each attr from al2 into merged
+	  AttributeList* al1 = (AttributeList*)operand1.obj_val();
+	  AttributeList* al2 = (AttributeList*)operand2.obj_val();
+	  AttributeList* merged = new AttributeList(al1);
+	  Iterator it;
+	  for (al2->First(it); !al2->Done(it); al2->Next(it))
+	      merged->add_attr(new Attribute(*al2->GetAttr(it)));
+	  result = ComValue(AttributeList::class_symid(), (void*)merged);
+
 	} else {
 	  fprintf(stderr, "Unhandled add operand1 of class %s (line %d)\n", operand1.class_name(), funcstate()->linenum());
 	}
@@ -368,21 +395,35 @@ void SubFunc::execute() {
 	break;
     case ComValue::ObjectType:
       {
-        if (operand1.is_dateobj() && operand2.is_int()) {
+	if (operand1.is_dateobj() && operand2.is_int()) {
 	  DateObj *dateobj = new DateObj((DateObj*)operand1.geta(DateObj::class_symid()));
-          int subtrahend = operand2.int_val();
+	  int subtrahend = operand2.int_val();
 	  *dateobj->date() = ((const Date)*dateobj->date()) - subtrahend;
 	  result = ComValue(DateObj::class_symid(), (void*)dateobj);
+	  
+	} else if (operand1.is_attributelist() && operand2.is_attributelist()) {
+	  // subtract attrlist: remove from al1 any keys present in al2
+	  AttributeList* al1 = (AttributeList*)operand1.obj_val();
+	  AttributeList* al2 = (AttributeList*)operand2.obj_val();
+	  AttributeList* result_al = new AttributeList(al1);
+	  Iterator it;
+	  for (al2->First(it); !al2->Done(it); al2->Next(it)) {
+	    Attribute* attr = al2->GetAttr(it);
+	    Attribute* found = result_al->GetAttr(attr->Name());
+	    if (found) result_al->Remove(found);
+	  }
+	  result = ComValue(AttributeList::class_symid(), (void*)result_al);
+	  
 	} else {
 	  fprintf(stderr, "Unhandled subtraction operand1 of class %s (line %d)\n", operand1.class_name(), funcstate()->linenum());
 	}
       }
+      
       break;
-
     default: {
-        fprintf(stderr, "Unhandled subtraction operand1 type %s (line %d)\n", operand1.type_name(), funcstate()->linenum());
-        }
-        break;
+      fprintf(stderr, "Unhandled subtraction operand1 type %s (line %d)\n", operand1.type_name(), funcstate()->linenum());
+    }
+      break;
     }
     reset_stack();
     push_stack(result);

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -270,20 +270,6 @@ void AddFunc::execute() {
 	break;
     case ComValue::ArrayType: 
         {
-	  if (operand1.is_attributelist() && operand2.is_attributelist()) {
-	    // merge two attrlists: + is to attrlist as + is to string
-	    // deep copy al1, then deep copy each attr from al2 into merged
-	    AttributeList* al1 = (AttributeList*)operand1.obj_val();
-	    AttributeList* al2 = (AttributeList*)operand2.obj_val();
-	    AttributeList* merged = new AttributeList(al1);
-	    Iterator it;
-	    for (al2->First(it); !al2->Done(it); al2->Next(it))
-	        merged->add_attr(new Attribute(*al2->GetAttr(it)));
-	    Resource::ref(merged);
-	    result = ComValue(AttributeList::class_symid(), (void*)merged);
-	    push_stack(result);
-	    return;
-	  }
 	  if (operand2.is_array()) {
 	    Resource::unref(result.array_val());
 	    result.array_ref() = 
@@ -313,7 +299,6 @@ void AddFunc::execute() {
 	  for (al2->First(it); !al2->Done(it); al2->Next(it))
 	      merged->add_attr(new Attribute(*al2->GetAttr(it)));
 	  result = ComValue(AttributeList::class_symid(), (void*)merged);
-
 	} else {
 	  fprintf(stderr, "Unhandled add operand1 of class %s (line %d)\n", operand1.class_name(), funcstate()->linenum());
 	}

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -297,7 +297,7 @@ void AddFunc::execute() {
 	  AttributeList* merged = new AttributeList(al1);
 	  Iterator it;
 	  for (al2->First(it); !al2->Done(it); al2->Next(it))
-	      merged->add_attr(new Attribute(*al2->GetAttr(it)));
+	      merged->add_attribute(new Attribute(*al2->GetAttr(it)));
 	  result = ComValue(AttributeList::class_symid(), (void*)merged);
 	} else {
 	  fprintf(stderr, "Unhandled add operand1 of class %s (line %d)\n", operand1.class_name(), funcstate()->linenum());

--- a/src/ComTerp/numfunc.h
+++ b/src/ComTerp/numfunc.h
@@ -52,7 +52,8 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "+ is the add operator for numerics and matrices, the concatenation operator for strings, and the merge operator for attrlists"; }
+      return "+ is the add operator for numerics and matrices, the concatenation operator for strings,\n\
+and the merge operator for attrlists (second operand wins on key collision)"; }
 
     AttributeValueList* matrix_add(AttributeValueList*, AttributeValueList*);
 
@@ -65,7 +66,8 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "- is the minus operator for numerics and matrices, and the key-removal operator for attrlists"; }
+      return "- is the minus operator for numerics and matrices, and the key-removal operator for attrlists\n\
+(removes keys present in second operand)"; }
 
 };
 

--- a/src/ComTerp/numfunc.h
+++ b/src/ComTerp/numfunc.h
@@ -52,7 +52,7 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "+ is the add operator for numerics and matrices, and the concatenation operator for strings"; }
+      return "+ is the add operator for numerics and matrices, the concatenation operator for strings, and the merge operator for attrlists"; }
 
     AttributeValueList* matrix_add(AttributeValueList*, AttributeValueList*);
 
@@ -65,7 +65,7 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "- is the minus operator"; }
+      return "- is the minus operator for numerics and matrices, and the key-removal operator for attrlists"; }
 
 };
 

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -52,9 +52,8 @@ x=42
 s="hello"
 ```
 
-Variables can be reassigned to any type at any time. A symbol bound to
-a registered command (built-in or added via `comterp->add_command()`)
-cannot be reassigned.
+Variables can be reassigned to any type at any time. A symbol bound to a registered command cannot be reassigned.
+See `ARCHITECTURE.md` for how commands are registered.
 
 ### Global variables
 
@@ -73,7 +72,7 @@ interpreters (e.g. UI and network interpreters in drawserv).
 
 Every ComTerp command accepts fixed positional arguments followed by
 keyword arguments. This ordering is enforced and consistent across all
-commands:
+commands — unlike Unix shell commands:
 
 ```
 print("value=%v" 42 :str)     // correct
@@ -84,8 +83,9 @@ Keywords come in two forms:
 - `:keyword` — flag (presence is meaningful, value is `true`)
 - `:keyword value` — keyword with an associated value
 
-[Unknown keywords are silently ignored by `reset_stack()`, which enables
-layered keyword extension across the library hierarchy.]
+Unknown keywords are silently ignored, which enables layered keyword
+extension across the library hierarchy. See `ARCHITECTURE.md` for how
+this works internally.
 
 ## Operators
 
@@ -221,6 +221,34 @@ attrlist on first use:
 ```
 point.x=10
 point.y=20
+```
+
+### Enumerating an attrlist
+
+Use `size()`, `at()`, `attrname()`, and `attrval()` to enumerate:
+
+```
+al=attrlist(:x 1 :y 2 :z 3)
+for(i=0 i<size(al) i++
+  print("%v=%v
+" attrname(at(al i)) attrval(at(al i))))
+```
+
+`at(attrlist n)` is the escape mechanism into the raw `Attribute` layer.
+`attrname()` and `attrval()` are the only commands that receive it before
+auto-dereference — any other command gets the dereferenced value instead.
+Note that `type(at(al n))` returns the value's type, not an attribute type,
+and enumeration order may not match insertion order.
+
+### Portable key/value pairs
+
+A single-element attrlist is the idiomatic portable key/value pair —
+it passes anywhere as a first-class value:
+
+```
+pair=attrlist(:foo 42)
+attrname(at(pair))   // "foo"
+attrval(at(pair))    // 42
 ```
 
 Scope rules: the dot namespace is scoped with its root symbol. Inside a

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -1,0 +1,336 @@
+# ComTerp Language Guide
+
+ComTerp is an embedded scripting language with a compiler pipeline
+(scanner → parser → code_conversion → interpreter). Each top-level
+expression is scanned, parsed, and converted to a flat postfix token
+stream, then interpreted iteratively. Nesting depth in the original
+expression does not affect the interpreter's call stack — everything
+is a token stream and an operand stack.
+
+## Expressions and Sequencing
+
+The basic unit of execution is an expression. Multiple expressions are
+sequenced with `;` (the sequence operator):
+
+```
+x=1; y=2; x+y
+```
+
+The value of a sequence is the value of its last expression.
+
+A script file (`.comt`) is a sequence of top-level expressions consumed
+one at a time. The return value of the script is the value of the last
+expression evaluated. By convention test scripts return `ok` (a boolean).
+
+## Types
+
+| Type | Example | Notes |
+|------|---------|-------|
+| int | `42` | |
+| float | `3.14` | |
+| double | `3.14` | |
+| string | `"hello"` | double-quoted |
+| symbol | `` `foo `` | backquote suppresses lookup |
+| char | `'a'` | single-quoted, format with `%c` |
+| boolean | `true` `false` | |
+| nil | `nil` | no value |
+| blank | `BlankType` | return of `return()` with no arg |
+| list | `(1,2,3)` | comma operator |
+| stream | `$$(1,2,3)` | sequence of values produced and consumed one at a time |
+| attrlist | `attrlist(:x 1)` | key/value store |
+| compview | returned by drawing commands | graphic component handle |
+
+Use `type(val)` to inspect the type of any value. Use `class(val)` for
+object types.
+
+## Variables
+
+Variables are local to the current ComTerp instance by default:
+
+```
+x=42
+s="hello"
+```
+
+Variables can be reassigned to any type at any time. A symbol bound to
+a registered command (built-in or added via `comterp->add_command()`)
+cannot be reassigned.
+
+### Global variables
+
+Declare a variable global with `global()` to share it across all
+ComTerp instances in the process:
+
+```
+global(counter)
+counter=0
+```
+
+Global variables persist across script runs and are visible to all
+interpreters (e.g. UI and network interpreters in drawserv).
+
+## Arguments: Fixed Before Keywords — Always
+
+Every ComTerp command accepts fixed positional arguments followed by
+keyword arguments. This ordering is enforced and consistent across all
+commands:
+
+```
+print("value=%v" 42 :str)     // correct
+print(:str "value=%v" 42)     // wrong
+```
+
+Keywords come in two forms:
+- `:keyword` — flag (presence is meaningful, value is `true`)
+- `:keyword value` — keyword with an associated value
+
+[Unknown keywords are silently ignored by `reset_stack()`, which enables
+layered keyword extension across the library hierarchy.]
+
+## Operators
+
+Standard arithmetic, comparison, and logical operators work as expected.
+String concatenation uses `+`.
+
+### Streaming operators
+
+| Operator | Description |
+|----------|-------------|
+| `,` | tuple / list construction |
+| `$$` | create stream from list |
+| `$` | collect stream into list |
+| `,,` | stream concatenation |
+| `..` | iterate / range |
+| `**` | repeat |
+
+### Dot operator
+
+`.` accesses attributes on a compound variable or attrlist:
+
+```
+foo.bar=42
+foo.bar          // returns 42
+```
+
+The dot namespace rooted at a symbol is scoped with that symbol — see
+**Attribute Lists** below.
+
+### Backquote
+
+`` ` `` (backquote) returns a symbol without looking it up:
+
+```
+`foo             // the symbol foo, not its value
+type(val)==`IntType
+```
+
+## Control Flow
+
+Control flow commands use `post_eval` — they receive unevaluated token
+streams for their body expressions and choose when to evaluate them.
+This is what makes `if`, `for`, and `while` work as language constructs
+rather than ordinary functions.
+
+### if
+
+```
+if(testexpr :then trueexpr :else falseexpr)
+```
+
+`:else` is optional. `if` returns the value of the branch taken.
+
+### for
+
+```
+for(i=0 i<10 i++
+  print("%v\n" i))
+```
+
+Positional args: init, while-test, next, body. `:body expr` is an
+explicit keyword form for the body.
+
+### while
+
+```
+while(i<10
+  print("%v\n" i); i++)
+```
+
+Keywords: `:nilchk` (test for nil instead of false), `:until` (test
+after body), `:body expr` (explicit body keyword).
+
+### return, break, continue
+
+```
+return([retval])   // return from func or script, optional value
+break([retval])    // break out of for/while
+continue           // skip to next iteration
+```
+
+`return()` with no argument returns `BlankType`. The `_returnflag`
+propagates through `SeqFunc`, `ForFunc`, `WhileFunc`, and `runfile()`.
+
+## Functions
+
+Define a function with `func()`:
+
+```
+f=func(body)
+```
+
+The body is the first positional argument. Call with keyword args:
+
+```
+f=func(if(x>5 :then return(x*2)))
+v=f(:x 6)          // returns 12
+v=f(:x 3)          // returns nil (no early return taken)
+```
+
+Function body assignments are local — variables assigned inside a func
+do not escape to the caller's scope. This includes dot-notation
+attributes: a dot namespace rooted at a local symbol is local to the
+call.
+
+To work with an attrlist across a func boundary, pass it as a keyword
+arg — it is a reference type and writes inside the func are visible
+after the call:
+
+```
+al=attrlist(:x 0)
+f=func(al.x=99)
+f(:al al)
+// al.x is now 99
+```
+
+## Attribute Lists
+
+An attrlist is a key/value store. Create one with `attrlist()` or
+`list(:attr)`:
+
+```
+al=attrlist(:foo 42 :bar "hello" :flag)
+al.foo             // 42
+al.bar             // "hello"
+al.flag            // true (keyword-only sets true)
+al.missing         // nil
+```
+
+Dot notation on any symbol creates a compound variable backed by an
+attrlist on first use:
+
+```
+point.x=10
+point.y=20
+```
+
+Scope rules: the dot namespace is scoped with its root symbol. Inside a
+`func()` body, dot attributes on a local symbol are local to that call.
+Use `global()` or pass an attrlist via keyword arg to share state.
+
+## Strings
+
+String literals use double-quotes. Escape sequences: `\"` for a literal
+double-quote, `\n` for newline, `\t` for tab, `\\` for a literal
+backslash before `n`, `r`, or `t`.
+
+Key string commands:
+
+```
+index(str fragment)           // 0-based position of fragment, nil if not found
+index(str fragment :last)     // last occurrence
+index(str fragment :all)      // list of all positions
+index(lst val :substr)        // strstr match on list elements
+substr(str match :after)      // string after match
+substr(str match :nonil)      // return input string if no match (instead of nil)
+split("a;b;c" :tokstr ';')    // split by single-char delimiter (single-quoted)
+split("foo bar" :tokstr)      // split by whitespace
+split("abc")                  // list of char codes
+join(lst)                     // join list of chars back to string
+eq(str1 str2 :n len)          // partial string comparison
+size("hello")                 // 5
+"foo"+"bar"                   // "foobar"
+print("val=%v" 42 :str)       // returns formatted string
+```
+
+Note: `:substr` is only needed when the first arg to `index` is a list.
+When both args are strings, substring search is the default behavior.
+
+Single-quoted literals are chars, not strings: `'a'`, printed with `%c`.
+
+## Streams
+
+A stream is a sequence of values produced and consumed one at a time, rather than all at once. Unlike a list which holds all its values in memory, a stream yields the next value only when asked — via `next()` or `each()`. This makes streams suitable for processing large or unbounded sequences without materializing the whole thing.
+
+The streaming algebra:
+
+```
+s=$$(1,2,3,4,5)    // create stream
+l=$s                // collect stream into list
+s1,,s2              // concatenate two streams
+next(s)             // pull next value, nil when exhausted
+each(s)             // traverse stream, return count
+```
+
+Round-trip: `$($$(1,2,3))` returns `(1,2,3)`.
+
+Drive a loop with `next`:
+
+```
+total=0
+s=$$(1,2,3,4,5)
+while((v=next(s))!=nil
+  total=total+v)
+```
+
+## Running Scripts
+
+```
+run("path/to/script.comt")         // run from file
+run("path/to/script.comt" :str)    // run from string
+```
+
+**Path resolution:** when running interactively, relative paths in
+`run()` resolve relative to the directory of the calling script. When
+invoking `comterp run script.comt` from the command line, `./`-relative
+paths resolve relative to the process working directory, not the script
+directory. Run interactively with a full path to avoid this:
+
+```
+// from inside comterp:
+run("src/comterp_/tests/run_all.comt")
+```
+
+## print()
+
+```
+print("fmt" val [val...])          // print to stdout
+print("fmt" val [val...] :str)     // print to string and return it
+print("fmt" val [val...] :err)     // print to stderr
+```
+
+Format verbs: `%v` (any value), `%d` (int), `%f` (float), `%s` (string),
+`%c` (char). Fixed args always before `:str`, `:err`, `:file` keywords.
+
+## Conventions for .comt Scripts
+
+- Use `print()` not `printf()`
+- Fixed args always before keyword args
+- Single-quoted char literals: `'a'`, `';'`
+- Double-quoted string literals: `"hello"`
+- Test accumulator: `ok=ok&&(result==expected)`
+- Deferred/broken tests: comment out with `/* */`, reference the issue number
+- Return `ok` as the last expression for use by `run_all.comt`
+- Sub-scripts are not subject to coverage measurement
+
+## help()
+
+```
+help(funcname)       // help for one command
+help(:all)           // help for every registered command
+help(:top)           // help for top-level commands in this program
+help(:posteval)      // help for post_eval commands
+```
+
+`help()` is the primary reference for command signatures. The docstring
+format is: `retval=name(arg [optarg] :keyword :keyword value) -- description`.
+Square brackets indicate optional fixed args.

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -240,6 +240,19 @@ auto-dereference — any other command gets the dereferenced value instead.
 Note that `type(at(al n))` returns the value's type, not an attribute type,
 and enumeration order may not match insertion order.
 
+### Merging and subtracting attrlists
+
+`+` merges two attrlists into a new one — the second operand wins on key collision.
+`-` removes from the first attrlist any keys present in the second. Both operands
+are unchanged; a new attrlist is returned:
+
+```
+al1=attrlist(:a 1 :b 2)
+al2=attrlist(:b 99 :c 3)
+merged=al1+al2       // :a 1 :b 99 :c 3  (al2's :b wins)
+diff=al1-al2         // :a 1              (:b removed)
+```
+
 ### Portable key/value pairs
 
 A single-element attrlist is the idiomatic portable key/value pair —

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -292,7 +292,7 @@ int main(int argc, char *argv[]) {
       if (S_ISREG(buf.st_mode) || S_ISFIFO(buf.st_mode))
 	terp->disable_prompt();
       else
-	fprintf(stderr, "ivtools-%s comterp: type help for more info\n%s", VersionString, get_command_prompt());
+	fprintf(stdout, "ivtools-%s comterp: type help for more info\n%s", VersionString, get_command_prompt());
       return terp->run();
     } else {
 

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -292,7 +292,7 @@ int main(int argc, char *argv[]) {
       if (S_ISREG(buf.st_mode) || S_ISFIFO(buf.st_mode))
 	terp->disable_prompt();
       else
-	fprintf(stderr, "ivtools-%s comterp: type help for more info\n", VersionString);
+	fprintf(stderr, "ivtools-%s comterp: type help for more info\n%s", VersionString, get_command_prompt());
       return terp->run();
     } else {
 
@@ -334,8 +334,9 @@ int main(int argc, char *argv[]) {
 #endif
         if (S_ISREG(buf.st_mode) || S_ISFIFO(buf.st_mode))
 	  terp->disable_prompt();
-	else
-	  fprintf(stderr, "ivtools-%s comterp:  type help for more info\n", VersionString);
+	else {
+	  fprintf(stdout, "ivtools-%s comterp:  type help for more info\n%s", VersionString, get_command_prompt());
+	}
 	return terp->run();
       }
     }

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -198,7 +198,7 @@ ok=ok&&(total==6)
 print("26 enumerate attrlist sum (expect 6): %v\n\n" total)
 prev_ok=check_fail(:ok ok)
 
-// --- test 27: + merges two attrlists into a new one ---
+// --- test 27a: + merges two attrlists into a new one ---
 al1=attrlist(:a 1 :b 2)
 al2=attrlist(:c 3 :d 4)
 merged=al1+al2
@@ -207,9 +207,23 @@ ok=ok&&(merged.a==1)
 ok=ok&&(merged.d==4)
 ok=ok&&(size(al1)==2)
 ok=ok&&(size(al2)==2)
-print("27 attrlist + merge (expect size 4, a=1, d=4, operands unchanged): %v %v %v %v %v\n\n" size(merged) merged.a merged.d size(al1) size(al2))
+print("27a attrlist + merge (expect size 4, a=1, d=4, operands unchanged): %v %v %v %v %v\n\n" size(merged) merged.a merged.d size(al1) size(al2))
 prev_ok=check_fail(:ok ok)
 
+// --- test 27b: + merges two overlapping attrlists into a new one ---
+al1=attrlist(:a 1 :b 2)
+al2=attrlist(:b 7 :c 3 :d 4)
+merged=al1+al2
+ok=ok&&(size(merged)==4)
+ok=ok&&(merged.a==1)
+ok=ok&&(merged.d==4)
+ok=ok&&(size(al1)==2)
+ok=ok&&(size(al2)==3)
+ok=ok&&(merged.b==7)
+print("27b attrlist + overlapping merge (expect size 4, a=1, d=4, operands unchanged): %v %v %v %v %v\n\n" size(merged) merged.a merged.d size(al1) size(al2))
+prev_ok=check_fail(:ok ok)
+
+// --- test 28: - removes keys from attrlist ---
 // --- test 28: - removes keys from attrlist ---
 al1=attrlist(:a 1 :b 2 :c 3)
 al2=attrlist(:b 0 :c 0)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,0 +1,151 @@
+// src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
+//
+// coverage: 0/0 (placeholder -- slots TBD after initial run)
+// funcs: dot list(:attr) attrlist
+// missing: TBD
+//
+// Tests the dot (.) compound variable / attribute list access operator,
+// list(:attr) attribute list construction, and the attrlist() command
+// introduced in PR #85 (closes #82).
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/attrlist.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: attrlist() creates an attribute list ---
+al=attrlist(:foo 42 :bar "hello")
+ok=ok&&(al!=nil)
+print("1 attrlist() creates attrlist (expect non-nil): %v\n\n" al)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: dot access retrieves keyword value ---
+al=attrlist(:foo 42 :bar "hello")
+ok=ok&&(al.foo==42)
+print("2 dot access :foo (expect 42): %v\n\n" al.foo)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: dot access retrieves string value ---
+al=attrlist(:foo 42 :bar "hello")
+ok=ok&&(al.bar=="hello")
+print("3 dot access :bar (expect \"hello\"): %v\n\n" al.bar)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: keyword-only arg sets attribute to true ---
+al=attrlist(:flag)
+ok=ok&&(al.flag==true)
+print("4 keyword-only sets true (expect true): %v\n\n" al.flag)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: missing attribute returns nil ---
+al=attrlist(:foo 42)
+ok=ok&&(al.missing==nil)
+print("5 missing attribute (expect nil): %v\n\n" al.missing)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: dot assignment sets attribute value ---
+al=attrlist(:foo 1)
+al.foo=99
+ok=ok&&(al.foo==99)
+print("6 dot assignment (expect 99): %v\n\n" al.foo)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: dot creates new attribute on existing attrlist ---
+al=attrlist(:foo 1)
+al.bar=42
+ok=ok&&(al.bar==42)
+print("7 dot creates new attr (expect 42): %v\n\n" al.bar)
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: list(:attr) creates an attribute list ---
+al=list(:attr)
+ok=ok&&(al!=nil)
+print("8 list(:attr) creates attrlist (expect non-nil): %v\n\n" al)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: list(:attr) attrlist is writable via dot ---
+al=list(:attr)
+al.x=10
+ok=ok&&(al.x==10)
+print("9 list(:attr) dot assign (expect 10): %v\n\n" al.x)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: dot compound variable created on first use ---
+foo.bar=55
+ok=ok&&(foo.bar==55)
+print("10 dot compound variable first use (expect 55): %v\n\n" foo.bar)
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: dot compound variable second attribute on same symbol ---
+foo.baz=77
+ok=ok&&(foo.bar==55)
+ok=ok&&(foo.baz==77)
+print("11 dot two attrs on same symbol (expect 55, 77): %v, %v\n\n" foo.bar foo.baz)
+prev_ok=check_fail(:ok ok)
+
+// --- test 12: plain var becomes attrlist when dot attr is assigned ---
+// assigning plain=99 then plain.x=1 converts plain to attrlist, losing 99
+plain=99
+plain.x=1
+print("12 plain var becomes attrlist after dot assign (plain=%v plain.x=%v):\n\n" plain plain.x)
+prev_ok=check_fail(:ok ok)
+
+// --- test 13: dot inside func() on attrlist passed as keyword arg ---
+// func body can access dot attrs on a symbol passed in as keyword
+f=func(al.val=42; al.val)
+v=f(:al attrlist())
+ok=ok&&(v==42)
+print("13 dot inside func via keyword arg (expect 42): %v\n\n" v)
+prev_ok=check_fail(:ok ok)
+
+// --- test 14: dot on free symbol inside func bleeds to outer scope ---
+// inner.x=99 inside func with no :inner keyword modifies the shared 'inner' symbol
+f=func(inner.x=99)
+f()
+print("14 dot free symbol bleeds to outer scope (expect 99): %v\n\n" inner.x)
+prev_ok=check_fail(:ok ok)
+
+// --- test 15: global dot variable shared across uses ---
+global(gobj)
+gobj.count=0
+gobj.count=gobj.count+1
+ok=ok&&(gobj.count==1)
+print("15 global dot variable (expect 1): %v\n\n" gobj.count)
+prev_ok=check_fail(:ok ok)
+
+// --- test 16: two funcs sharing same free dot symbol get shared state ---
+// myns.v without :myns keyword arg shares the same outer 'myns' symbol
+f1=func(myns.v=1; myns.v)
+f2=func(myns.v=2; myns.v)
+f1(:dummy 0)
+f2(:dummy 0)
+ok=ok&&(myns.v==2)
+print("16 two funcs share free dot symbol (expect final myns.v=2): %v\n\n" myns.v)
+prev_ok=check_fail(:ok ok)
+
+// --- test 17: attrlist() round-trip via dot access ---
+al=attrlist(:x 1 :y 2 :z 3)
+ok=ok&&(al.x+al.y+al.z==6)
+print("17 attrlist round-trip sum (expect 6): %v\n\n" (al.x+al.y+al.z))
+prev_ok=check_fail(:ok ok)
+
+// --- test 18: attrlist() multiple types ---
+al=attrlist(:n 7 :s "abc" :b true)
+ok=ok&&(al.n==7)
+ok=ok&&(al.s=="abc")
+ok=ok&&(al.b==true)
+print("18 attrlist multiple types (expect 7, abc, true): %v, %v, %v\n\n" al.n al.s al.b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 19: list(:attr) vs attrlist() produce compatible results ---
+al1=list(:attr)
+al2=attrlist()
+al1.x=1
+al2.x=1
+ok=ok&&(al1.x==al2.x)
+print("19 list(:attr) vs attrlist() compatible (expect 1==1): %v %v\n\n" al1.x al2.x)
+prev_ok=check_fail(:ok ok)
+
+print("attrlist: %v\n" ok)
+ok

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,7 +1,7 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
 // coverage: 0/0 (placeholder -- slots TBD after initial run)
-// funcs: dot list(:attr) attrlist
+// funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: TBD
 //
 // Tests the dot (.) compound variable / attribute list access operator,
@@ -145,6 +145,89 @@ al1.x=1
 al2.x=1
 ok=ok&&(al1.x==al2.x)
 print("19 list(:attr) vs attrlist() compatible (expect 1==1): %v %v\n\n" al1.x al2.x)
+prev_ok=check_fail(:ok ok)
+
+
+// --- test 20: size() on attrlist returns attribute count ---
+al=attrlist(:foo 42 :bar "hello" :baz true)
+ok=ok&&(size(al)==3)
+print("20 size of attrlist (expect 3): %v\n\n" size(al))
+prev_ok=check_fail(:ok ok)
+
+// --- test 21: at() on attrlist returns nth dotted pair ---
+al=attrlist(:foo 42 :bar "hello")
+attr=at(al 0)
+ok=ok&&(attr!=nil)
+print("21 at(attrlist 0) returns dotted pair (expect non-nil): %v\n\n" attr)
+prev_ok=check_fail(:ok ok)
+
+// --- test 22: attrname() returns name of dotted pair ---
+al=attrlist(:foo 42 :bar "hello")
+n=attrname(at(al 1))
+ok=ok&&(n==`foo)
+print("22 attrname (expect foo): %v\n\n" n)
+prev_ok=check_fail(:ok ok)
+
+// --- test 23: attrval() returns value of dotted pair ---
+al=attrlist(:foo 42 :bar "hello")
+v=attrval(at(al 1))
+ok=ok&&(v==42)
+print("23 attrval (expect 42): %v\n\n" v)
+prev_ok=check_fail(:ok ok)
+
+// --- test 24: at() second element name and value ---
+al=attrlist(:foo 42 :bar "hello")
+ok=ok&&(attrname(at(al 0))==`bar)
+ok=ok&&(attrval(at(al 0))=="hello")
+print("24 at(1) name/val (expect bar, hello): %v, %v\n\n" attrname(at(al 0)) attrval(at(al 0)))
+prev_ok=check_fail(:ok ok)
+
+// --- test 25: at(:set) modifies nth attribute value ---
+al=attrlist(:foo 42 :bar "hello")
+at(al 0 :set 99)
+ok=ok&&(attrval(at(al 0))==99)
+print("25 at(:set) modifies value (expect 99): %v\n\n" attrval(at(al 0)))
+prev_ok=check_fail(:ok ok)
+
+// --- test 26: enumerate attrlist via size/at/attrname/attrval ---
+al=attrlist(:x 1 :y 2 :z 3)
+total=0
+for(i=0 i<size(al) i++
+  total=total+attrval(at(al i)))
+ok=ok&&(total==6)
+print("26 enumerate attrlist sum (expect 6): %v\n\n" total)
+prev_ok=check_fail(:ok ok)
+
+// --- test 27: + merges two attrlists into a new one ---
+al1=attrlist(:a 1 :b 2)
+al2=attrlist(:c 3 :d 4)
+merged=al1+al2
+ok=ok&&(size(merged)==4)
+ok=ok&&(merged.a==1)
+ok=ok&&(merged.d==4)
+ok=ok&&(size(al1)==2)
+ok=ok&&(size(al2)==2)
+print("27 attrlist + merge (expect size 4, a=1, d=4, operands unchanged): %v %v %v %v %v\n\n" size(merged) merged.a merged.d size(al1) size(al2))
+prev_ok=check_fail(:ok ok)
+
+// --- test 28: - removes keys from attrlist ---
+al1=attrlist(:a 1 :b 2 :c 3)
+al2=attrlist(:b 0 :c 0)
+diff=al1-al2
+ok=ok&&(size(diff)==1)
+ok=ok&&(diff.a==1)
+ok=ok&&(diff.b==nil)
+ok=ok&&(size(al1)==3)
+print("28 attrlist - remove keys (expect size 1, a=1, b=nil, al1 unchanged size 3): %v %v %v %v\n\n" size(diff) diff.a diff.b size(al1))
+prev_ok=check_fail(:ok ok)
+
+// --- test 29: + operands are unchanged (deep copy verified) ---
+al1=attrlist(:x 10)
+al2=attrlist(:y 20)
+merged=al1+al2
+merged.x=99
+ok=ok&&(al1.x==10)
+print("29 + operands unchanged after merge (expect al1.x still 10): %v\n\n" al1.x)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -179,7 +179,7 @@ prev_ok=check_fail(:ok ok)
 al=attrlist(:foo 42 :bar "hello")
 ok=ok&&(attrname(at(al 0))==`bar)
 ok=ok&&(attrval(at(al 0))=="hello")
-print("24 at(1) name/val (expect bar, hello): %v, %v\n\n" attrname(at(al 0)) attrval(at(al 0)))
+print("24 at(0) name/val (expect bar, hello): %v, %v\n\n" attrname(at(al 0)) attrval(at(al 0)))
 prev_ok=check_fail(:ok ok)
 
 // --- test 25: at(:set) modifies nth attribute value ---

--- a/src/comterp_/tests/global.comt
+++ b/src/comterp_/tests/global.comt
@@ -8,7 +8,7 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/global.comt")
 
-run("testlib.comt")
+run("./testlib.comt")
 ok=true
 
 // --- test 1: global lvalue assignment stores in global table ---

--- a/src/comterp_/tests/print.comt
+++ b/src/comterp_/tests/print.comt
@@ -1,0 +1,130 @@
+// src/comterp_/tests/print.comt -- test print() format verbs
+//
+// coverage: 0/0 (placeholder -- slots TBD after initial run)
+// funcs: print
+// missing: TBD
+//
+// Verifies behavior of print() format verbs: %v %d %f %s %c %g %x %o
+// and keywords :str :err :out :file :prefix :flush
+//
+// Key question: does %v print strings with or without surrounding quotes?
+// Does %s strip quotes that %v adds?
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/print.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: %v with int ---
+s=print("%v" 42 :str)
+ok=ok&&(s=="42")
+print("1 %s int (expect 42): %v\n\n" "%v" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: %v with float ---
+s=print("%v" 3.14 :str)
+ok=ok&&(index(s "3.14")!=nil)
+print("2 \%v float (expect 3.14): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: %v with string -- does it add quotes? ---
+s=print("%v" "hello" :str)
+print("3 \%v string (observe -- quoted or bare?): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: %s with string -- does it strip quotes? ---
+s=print("%s" "hello" :str)
+print("4 \%s string (observe -- quoted or bare?): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: %v with boolean ---
+s=print("%v" true :str)
+ok=ok&&(s=="true")
+print("5 \%v bool (expect true): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: %v with nil ---
+s=print("%v" nil :str)
+print("6 \%v nil (observe): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: %d with int ---
+s=print("%d" 42 :str)
+ok=ok&&(s=="42")
+print("7 \%d int (expect 42): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: %f with float ---
+s=print("%f" 3.14 :str)
+ok=ok&&(index(s "3.14")!=nil)
+print("8 \%f float (expect contains 3.14): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: %g with float ---
+s=print("%g" 3.14 :str)
+ok=ok&&(index(s "3.14")!=nil)
+print("9 \%g float (expect contains 3.14): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: %c with char ---
+s=print("%c" 'a' :str)
+ok=ok&&(s=="a")
+print("10 \%c char (expect a): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: %x hex format ---
+s=print("%x" 255 :str)
+ok=ok&&(s=="ff")
+print("11 \%x hex (expect ff): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 12: %o octal format ---
+s=print("%o" 8 :str)
+ok=ok&&(s=="10")
+print("12 \%o octal (expect 10): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 13: multiple values in one print ---
+s=print("%v %v %v" 1 2 3 :str)
+ok=ok&&(s=="1 2 3")
+print("13 multiple values (expect 1 2 3): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 14: \n in format string produces newline ---
+s=print("a\nb" :str)
+ok=ok&&(size(s)==3)
+print("14 \\n produces newline (expect size 3): %v\n\n" size(s))
+prev_ok=check_fail(:ok ok)
+
+// --- test 15: \t in format string produces tab ---
+s=print("a\tb" :str)
+ok=ok&&(size(s)==3)
+print("15 \\t produces tab (expect size 3): %v\n\n" size(s))
+prev_ok=check_fail(:ok ok)
+
+// --- test 16: \% produces literal percent ---
+s=print("\%" :str)
+ok=ok&&(s=="%")
+print("16 \\\% produces \% (expect \%): %v\n\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 17: :str returns string not nil ---
+s=print("hello" :str)
+ok=ok&&(s!=nil)
+ok=ok&&(type(s)==`StringType)
+print("17 :str return type (expect StringType): %v\n\n" type(s))
+prev_ok=check_fail(:ok ok)
+
+// --- test 18: print without :str returns nil or blank ---
+v=print("hello\n")
+print("18 print without :str return (observe): %v\n\n" v)
+prev_ok=check_fail(:ok ok)
+
+// --- test 19: :prefix inserts prefix and newline ---
+print("hello" :prefix "PREFIX")
+print("19 :prefix (observe above line -- should show PREFIX then newline):\n\n")
+prev_ok=check_fail(:ok ok)
+
+print("print: %v\n" ok)
+ok

--- a/src/comterp_/tests/print.comt
+++ b/src/comterp_/tests/print.comt
@@ -25,12 +25,12 @@ prev_ok=check_fail(:ok ok)
 // --- test 2: %v with float ---
 s=print("%v" 3.14 :str)
 ok=ok&&(index(s "3.14")!=nil)
-print("2 \%v float (expect 3.14): %v\n\n" s)
+print("2 %s float (expect 3.14): %v\n\n" "%v" s)
 prev_ok=check_fail(:ok ok)
 
 // --- test 3: %v with string -- does it add quotes? ---
 s=print("%v" "hello" :str)
-print("3 \%v string (observe -- quoted or bare?): %v\n\n" s)
+print("3 %s string (observe -- quoted or bare?): %v\n\n" "%v" s)
 prev_ok=check_fail(:ok ok)
 
 // --- test 4: %s with string -- does it strip quotes? ---
@@ -41,12 +41,12 @@ prev_ok=check_fail(:ok ok)
 // --- test 5: %v with boolean ---
 s=print("%v" true :str)
 ok=ok&&(s=="true")
-print("5 \%v bool (expect true): %v\n\n" s)
+print("5 %s bool (expect true): %v\n\n" "%v" s)
 prev_ok=check_fail(:ok ok)
 
 // --- test 6: %v with nil ---
 s=print("%v" nil :str)
-print("6 \%v nil (observe): %v\n\n" s)
+print("6 %s nil (observe): %v\n\n" "%v" s)
 prev_ok=check_fail(:ok ok)
 
 // --- test 7: %d with int ---
@@ -122,8 +122,9 @@ print("18 print without :str return (observe): %v\n\n" v)
 prev_ok=check_fail(:ok ok)
 
 // --- test 19: :prefix inserts prefix and newline ---
-print("hello" :prefix "PREFIX")
-print("19 :prefix (observe above line -- should show PREFIX then newline):\n\n")
+v=print("hello" :prefix "PREFIX" :str)
+ok=ok&&(v=="PREFIXhello\n")
+print("19 :prefix (expect PREFIXhello\\n): %v\n\n" v)
 prev_ok=check_fail(:ok ok)
 
 print("print: %v\n" ok)

--- a/src/comterp_/tests/random.comt
+++ b/src/comterp_/tests/random.comt
@@ -22,7 +22,7 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/random.comt")
 
-run("testlib.comt")
+run("./testlib.comt")
 ok=true
 seed=int(date()*1000%1000000)
 srand(seed)

--- a/src/comterp_/tests/return.comt
+++ b/src/comterp_/tests/return.comt
@@ -18,7 +18,7 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/return.comt")
 
-run("testlib.comt")
+run("./testlib.comt")
 ok=true
 
 // --- test 1: return with value ---

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -25,5 +25,13 @@ if(run("./global.comt")
   :then print("pass: global\n")
   :else print("FAIL: global\n");ok=false)
 
+if(run("./attrlist.comt")
+  :then print("pass: attrlist\n")
+  :else print("FAIL: attrlist\n");ok=false)
+
+if(run("./print.comt")
+  :then print("pass: print\n")
+  :else print("FAIL: print\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -17,7 +17,7 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/stream.comt")
 
-run("testlib.comt")
+run("./testlib.comt")
 ok=true
 
 // --- test 1: basic $ stream from list ---

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -28,7 +28,7 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/string.comt")
 
-run("testlib.comt")
+run("./testlib.comt")
 ok=true
 
 // --- test 1: index string-in-string ---

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -68,7 +68,7 @@ updown_test=func(
   global(drawserv_up)=false;
   print("updown: launching drawserv on port %d\n" ds_port :err);
   cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up)=true\\\")\" &" ds_port ds_import callback_port :str);
-  print("updown: cmdstr=[%s]\n" cmdstr);
+  print("updown: cmdstr=[%s]\n" cmdstr :err);
   shell(cmdstr);
   print("updown: waiting for drawserv callback on port %d\n" callback_port :err);
   

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -289,7 +289,7 @@ both until exit.
 
 .SH ATTRIBUTE COMMANDS
 
- attrlst=attrlist([:<name> [val]] ...) -- create attribute list from keyword/value pairs; keyword-only sets attribute to true, missing attribute returns nil
+ alst=attrlist([:<name> [val]] ...) -- create attribute list from keyword/value pairs; keyword-only sets attribute to true, missing attribute returns nil
 
  sym=attrname(attribute) -- return name field of dotted pair
 

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -289,6 +289,8 @@ both until exit.
 
 .SH ATTRIBUTE COMMANDS
 
+ attrlst=attrlist([:<name> [val]] ...) -- create attribute list from keyword/value pairs; keyword-only sets attribute to true, missing attribute returns nil
+
  sym=attrname(attribute) -- return name field of dotted pair
 
  val=attrval(attribute) -- return value field of dotted pair


### PR DESCRIPTION
## comterp: attrlist() func returns newly created attrlist populated with arbitrary keyword/value attributes

Closes #82

## Summary

Adds `attrlist()` to comterp — a new command that constructs an `AttributeList` populated from arbitrary keyword/value argument pairs and returns it as a first-class `ComValue`.

## Implementation

`AttrListFunc::execute()` calls `stack_keys()` to harvest all keyword arguments into a new `AttributeList`, refs it for memory management, wraps it in a `ComValue` typed as `AttributeList::class_symid()`, and pushes it onto the stack.

- `src/ComTerp/listfunc.h` — `AttrListFunc` class declaration with docstring
- `src/ComTerp/listfunc.c` — `AttrListFunc::execute()` implementation
- `src/ComTerp/comterp.c` — registers `attrlist` command alongside `list` in `add_defaults()`
- `src/man/man1/comterp.1` — added to ATTRIBUTE COMMANDS section

Also fixes a minor debug print in `drawmo` `updown_test` — the launch cmdstr was going to stdout instead of stderr.

## Usage

```comterp
attrlst=attrlist(:foo 42 :bar "hello" :flag)
```

- keyword/value pairs become attributes
- keyword-only (no value) sets the attribute to `true`
- accessing a missing attribute returns `nil`

## Additional Work

This PR also changes the behavior of "," (tuple()) to put two attribute lists in a list, and migrates its old behavior of attribute list concatenation to "+".  At the same time "-" was implemented which removes attributes in the lhs attribute list that exist in the rhs attribute list.