### PR TITLE
comterp: comterp: attrlist literal syntax — resolves #83

### DIFF
--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -55,7 +55,11 @@ public:
 ```
 
 The `%s` in `docstring()` is replaced with the command name by
-`help()`. Square brackets denote optional args.
+`help()`. Square brackets denote optional fixed arguments. Keyword
+arguments (`:keyword`) are never wrapped in brackets — they are always
+optional by nature and the brackets would be redundant and misleading.
+Only fixed positional arguments need brackets when optional, e.g.
+`func(arg [optarg] :keyword)`.
 
 ### Registration
 

--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -1,0 +1,258 @@
+# Hacking on ComTerp
+
+This document covers what you need to know to write, patch, and debug
+C++ code in the ComTerp/ComUtil layer of ivtools. It complements
+`ARCHITECTURE.md` (which explains the evaluation model) and
+`LANGUAGE.md` (which covers the scripting language from the user side).
+
+## Adding a New Command
+
+A command is a subclass of `ComFunc` with an `execute()` method. The
+pattern is the same for every command:
+
+```cpp
+void MyFunc::execute() {
+    // 1. Capture all args and keywords BEFORE reset_stack()
+    ComValue arg0(stack_arg(0));
+    ComValue arg1(stack_arg(1));
+    static int foo_symid = symbol_add("foo");
+    ComValue foov(stack_key(foo_symid));
+    boolean fooflag = foov.is_true();
+
+    // 2. reset_stack() always before doing any work
+    reset_stack();
+
+    // 3. Do work, push exactly one return value
+    ComValue retval(42, ComValue::IntType);
+    push_stack(retval);
+}
+```
+
+**Critical:** `stack_arg()`, `nargs()`, and `stack_key()` are invalid
+after `reset_stack()`. Capture everything by value first.
+
+**Return value:** always push exactly one value. Use
+`push_stack(ComValue::nullval())` if there is nothing meaningful to
+return.
+
+### Header boilerplate
+
+```cpp
+class MyFunc : public ComFunc {
+public:
+    MyFunc(ComTerp*);
+    virtual void execute();
+    virtual const char* docstring() {
+        return "retval=%s(arg [:foo]) -- one-line description"; }
+    virtual const char** dockeys() {
+        static const char* keys[] = {
+            ":foo       what :foo does",
+            nil
+        };
+        return keys;
+    }
+};
+```
+
+The `%s` in `docstring()` is replaced with the command name by
+`help()`. Square brackets denote optional args.
+
+### Registration
+
+Register in `ComTerp::add_defaults()` in `comterp.c`, at the bottom
+of the existing block, following the established order:
+
+```cpp
+add_command("mycommand", new MyFunc(this));
+```
+
+Commands registered here are available in all interpreters — comterp,
+comdraw, drawserv. Commands that require a graphical editor context
+belong in `ComUnidraw` or higher layers instead.
+
+### Docstring extension for higher layers
+
+If a lower-layer command needs DrawServ-specific keyword documentation,
+use the alternate docstring form rather than modifying the lower layer:
+
+```cpp
+comterp->add_command("select", func, nil, docstring2);
+```
+
+This replaces the dockeys in `help()` output without a layer violation.
+
+## Keyword Arguments
+
+Keywords are looked up by symbol id, cached as a `static int`:
+
+```cpp
+static int keep_symid = symbol_add("keep");
+ComValue keepv(stack_key(keep_symid));
+boolean keepflag = keepv.is_true();
+```
+
+`:keyword` (flag form) — `keepv.is_true()` returns true if present.
+`:keyword value` — use `keepv.int_val()`, `keepv.string_ptr()`, etc.
+
+Unknown keywords are silently ignored by `reset_stack()` — this is
+intentional and enables layered keyword extension up the library
+hierarchy. Do not add error checking for unknown keywords.
+
+## Error State: _errbuf and _errbuf2
+
+`ComTerp` maintains two error buffers:
+
+- `_errbuf` — the current error string, filled by `this->err_str()`
+  and cleared immediately after use
+- `_errbuf2` — the last reported error, saved automatically whenever
+  `_errbuf` is non-empty; persists until explicitly cleared
+
+**Always use the instance method wrappers**, not the raw ComUtil C
+functions, inside `ComTerp` member functions:
+
+```cpp
+this->err_str(_errbuf, BUFSIZ, "comterp");   // fills _errbuf, saves to _errbuf2
+this->err_print(stderr, "comterp");           // saves to _errbuf2, prints, clears
+```
+
+Calling `::err_str()` or `::err_print()` directly bypasses the
+`_errbuf2` save and breaks `errmsg(:last)`.
+
+### Why _errbuf2 exists
+
+In batch script execution (`comterp run script.comt`), parse and eval
+errors are detected, printed, and cleared by the `run()`/`runfile()`
+loop before any subsequent expression can call `errmsg()`. `_errbuf2`
+is the persistence layer that makes `errmsg(:last)` work in that
+context.
+
+### errmsg() from scripts
+
+```
+e=errmsg()         -- current error (cleared after retrieval)
+e=errmsg(:last)    -- last saved error from _errbuf2 (cleared after retrieval)
+e=errmsg(:keep)    -- current error, not cleared
+e=errmsg(:last :keep) -- last saved error, not cleared
+n=errmsg(:cnt)     -- number of errors on stack
+n=errmsg(:num)     -- error number
+```
+
+## Adding a New Error Code
+
+Two files must be updated together:
+
+**`src/ComUtil/comterp.err`** — add the `#define` and comment:
+
+```c
+#define ERR_MY_NEW_ERROR    1317
+/* "(%d) descriptive message for this error" */
+```
+
+**`src/ComUtil/errsys.c`** — add to the `default_errmsgs` table in
+numeric order:
+
+```c
+{1317, "(%d) descriptive message for this error"},
+```
+
+The `(%d)` receives the line number via `COMERR_SET1(errcode, linenum)`.
+Use `COMERR_SET2` for errors that also embed a string token.
+
+## extern Declarations for ComUtil Functions
+
+`debugfunc.c` and other files that call ComUtil C functions directly
+need explicit `extern` declarations since there is no C++ header that
+covers them all:
+
+```cpp
+extern void err_str(char*, int, const char*);
+extern void err_clear();
+extern int err_cnt();
+extern int comerr_get();
+```
+
+These go near the top of the `.c` file, after the `#include` block.
+Do not add them to headers — they are implementation details of the
+files that need them.
+
+## Layer Hierarchy and Violations
+
+The library layers from bottom to top are:
+
+```
+ComUtil → ComTerp → OverlayUnidraw → ComUnidraw → FrameUnidraw|GraphUnidraw → DrawServ
+```
+
+A lower layer must never `#include` a header from a higher layer.
+When lower-layer code needs behavior that only exists in a higher layer,
+use a virtual no-op method in the lower layer overridden in the higher:
+
+```cpp
+// In ComTerp (lower):
+virtual void on_something() {}   // no-op
+
+// In DrawServ (higher):
+virtual void on_something() { /* real implementation */ }
+```
+
+The same rule applies to `dynamic_cast` — it is not used anywhere in
+ivtools. Use virtual dispatch instead.
+
+## Naming Conventions
+
+- PascalCase for classes inherited from Unidraw/InterViews heritage
+  (`ComValue`, `ComFunc`, `DrawServCmd`)
+- snake_case for newer additions (`dist_script()`, `make_brush_cmd()`,
+  `last_errmsg()`)
+- New methods and members go at the **bottom** of the header and source
+  file, not interspersed with existing code
+- Test scripts use `.comt` extension; see `TESTING.md` for conventions
+
+## Patch Workflow
+
+`git apply` requires exact context matches. The safest way to generate
+a patch for this codebase is with Python `difflib` against fresh copies
+of the files:
+
+```python
+import difflib
+with open('original.c') as f: orig = f.readlines()
+# ... make changes to a copy ...
+diff = difflib.unified_diff(orig, new,
+    fromfile='a/src/ComTerp/foo.c',
+    tofile='b/src/ComTerp/foo.c')
+with open('my.patch', 'w') as f: f.writelines(diff)
+```
+
+Then apply with:
+
+```bash
+git apply ~/Downloads/my.patch
+```
+
+For multi-line commit messages, use `git commit -F -` with a heredoc
+to avoid shell quoting issues:
+
+```bash
+git commit -F - << 'EOF'
+subject line
+
+Body paragraph one.
+
+Body paragraph two.
+EOF
+```
+
+Never hand-write unified diff hunk headers (`@@ -n,m +n,m @@`) —
+they are computed from the actual file contents and will be wrong if
+typed manually.
+
+## ComTerpServ vs ComTerp
+
+`ComTerpServ` subclasses `ComTerp` and adds server-mode execution with
+its own `runfile()`. When updating error handling or execution loop
+behavior in `ComTerp::run()` or `ComTerp::runfile()`, check whether
+`ComTerpServ::runfile()` in `comterpserv.c` also needs the same
+change. The two `runfile()` implementations are parallel but not
+identical — `ComTerpServ::runfile()` handles line-by-line buffering
+and has its own `err_str` call sites.

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -152,6 +152,8 @@ void ComTerp::init() {
 #endif
 
     _errbuf = new char[BUFSIZ];
+    _errbuf2 = new char[BUFSIZ];
+    _errbuf2[0] = '\0';
 
     _alist = nil;
     _brief = true;
@@ -1155,7 +1157,7 @@ int ComTerp::run(boolean one_expr, boolean nested) {
 
       if (returnflag()) {
         returnflag(false);  // return() at prompt: clear and ignore
-        err_str(_errbuf, BUFSIZ, "comterp");  // clear any error state
+        this->err_str(_errbuf, BUFSIZ, "comterp");  // clear any error state
         _errbuf[0] = '\0';
         if (one_expr) break;
         continue;
@@ -1163,7 +1165,7 @@ int ComTerp::run(boolean one_expr, boolean nested) {
 
       if (top_before == _stack_top)
 	status = 2;
-      err_str( _errbuf, BUFSIZ, "comterp" );
+      this->err_str( _errbuf, BUFSIZ, "comterp" );
       errno = 0;
       if (strlen(_errbuf)==0) {
 	if (quitflag()) {
@@ -1225,7 +1227,7 @@ int ComTerp::run(boolean one_expr, boolean nested) {
 	_errbuf[0] = '\0';
       }
     } else {
-      err_str( _errbuf, BUFSIZ, "comterp" );
+      this->err_str( _errbuf, BUFSIZ, "comterp" );
       if (strlen(_errbuf)>0) {
 	errorflag = true;
 	#ifdef USE_FDSTREAMS
@@ -1381,6 +1383,7 @@ void ComTerp::add_defaults() {
     add_command("help", new HelpFunc(this));
     add_command("optable", new OptableFunc(this));
     add_command("trace", new ComterpTraceFunc(this));
+    add_command("errmsg", new ErrMsgFunc(this));
     add_command("pause", new ComterpPauseFunc(this));
     add_command("step", new ComterpStepFunc(this));
     add_command("stackheight", new ComterpStackHeightFunc(this));
@@ -1483,7 +1486,7 @@ int ComTerp::runfile(const char* filename, boolean popen_flag) {
     while( fptr && !feof(fptr)) {
 	if (read_expr()) {
 	    if (eval_expr(true)) {
-	        err_print( stderr, "comterp" );
+	        this->err_print( stderr, "comterp" );
 		FILEBUF(obuf, stdout, ios_base::out);
 		ostream ostr(&obuf);
 		ostr << "err\n";
@@ -1915,3 +1918,20 @@ void ComTerp::set_args(const char* argstr) {
   return;
 }
 
+
+void ComTerp::err_str(char* buf, int bufsiz, const char* cmd) {
+    ::err_str(buf, bufsiz, cmd);
+    if (strlen(buf) > 0)
+        strncpy(_errbuf2, buf, BUFSIZ-1);
+}
+
+void ComTerp::err_print(FILE* out, const char* cmd) {
+    char buf[BUFSIZ];
+    buf[0] = '\0';
+    ::err_str(buf, BUFSIZ, cmd);
+    if (strlen(buf) > 0) {
+        strncpy(_errbuf2, buf, BUFSIZ-1);
+        fprintf(out, "%s\n", buf);
+        ::err_clear();
+    }
+}

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1921,8 +1921,10 @@ void ComTerp::set_args(const char* argstr) {
 
 void ComTerp::err_str(char* buf, int bufsiz, const char* cmd) {
     ::err_str(buf, bufsiz, cmd);
-    if (strlen(buf) > 0)
+    if (strlen(buf) > 0) {
         strncpy(_errbuf2, buf, BUFSIZ-1);
+	_errbuf2[BUFSIZ-1] = '\0';
+    }
 }
 
 void ComTerp::err_print(FILE* out, const char* cmd) {
@@ -1931,7 +1933,8 @@ void ComTerp::err_print(FILE* out, const char* cmd) {
     ::err_str(buf, BUFSIZ, cmd);
     if (strlen(buf) > 0) {
         strncpy(_errbuf2, buf, BUFSIZ-1);
-        fprintf(out, "%s\n", buf);
+	_errbuf2[BUFSIZ-1] = '\0';
+	fprintf(out, "%s\n", buf);
         ::err_clear();
     }
 }

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -200,6 +200,12 @@ public:
     // value associated with a symbol id in the global symbol table.
     ComValue* eithervalue(int symid, boolean globalfirst=false);
     const char* errmsg() { return _errbuf; }
+    const char* last_errmsg() { return _errbuf2; }
+    void clear_last_errmsg() { _errbuf2[0] = '\0'; }
+    void err_str(char* buf, int bufsiz, const char* cmd);
+    // wrap ComUtil err_str, saving result to _errbuf2.
+    void err_print(FILE* out, const char* cmd);
+    // wrap ComUtil err_print, saving result to _errbuf2.
     // current error message buffer.
 
     void set_attributes(AttributeList*);

--- a/src/ComTerp/debugfunc.c
+++ b/src/ComTerp/debugfunc.c
@@ -39,6 +39,11 @@ using std::vector;
 
 #define TITLE "DebugFunc"
 
+extern void err_str(char*, int, const char*);
+extern void err_clear();
+extern int err_cnt();
+extern int comerr_get();
+
 /*****************************************************************************/
 
 ComterpTraceFunc::ComterpTraceFunc(ComTerp* comterp) : ComFunc(comterp) {
@@ -198,7 +203,61 @@ void ComterpMallInfoFunc::execute() {
 #endif
 }
 
+/*****************************************************************************/
 
+ErrMsgFunc::ErrMsgFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
 
+void ErrMsgFunc::execute() {
+    static int keep_symid = symbol_add("keep");
+    ComValue keepv(stack_key(keep_symid));
+    boolean keepflag = keepv.is_true();
+    static int last_symid = symbol_add("last");
+    ComValue lastv(stack_key(last_symid));
+    boolean lastflag = lastv.is_true();
+    static int num_symid = symbol_add("num");
+    ComValue numv(stack_key(num_symid));
+    boolean numflag = numv.is_true();
+    static int cnt_symid = symbol_add("cnt");
+    ComValue cntv(stack_key(cnt_symid));
+    boolean cntflag = cntv.is_true();
+    reset_stack();
 
+    if (cntflag) {
+        ComValue retval(err_cnt(), ComValue::IntType);
+        push_stack(retval);
+        return;
+    }
 
+    if (numflag) {
+        ComValue retval((int)comerr_get(), ComValue::IntType);
+        push_stack(retval);
+        return;
+    }
+
+    char errbuf[BUFSIZ];
+    errbuf[0] = '\0';
+
+    if (lastflag) {
+        // :last -- read _errbuf2 directly, bypass current error state
+        strncpy(errbuf, comterp()->last_errmsg(), BUFSIZ-1);
+        if (!keepflag)
+            comterp()->clear_last_errmsg();
+    } else {
+        // check current error first, fall back to last reported error
+        err_str(errbuf, BUFSIZ, "comterp");
+        if (strlen(errbuf) == 0)
+            strncpy(errbuf, comterp()->last_errmsg(), BUFSIZ-1);
+        if (!keepflag) {
+            err_clear();
+            comterp()->clear_last_errmsg();
+        }
+    }
+
+    if (strlen(errbuf) > 0) {
+        int symid = symbol_add(errbuf);
+        ComValue retval(symid, ComValue::StringType);
+        push_stack(retval);
+    } else
+        push_stack(ComValue::nullval());
+}

--- a/src/ComTerp/debugfunc.h
+++ b/src/ComTerp/debugfunc.h
@@ -95,4 +95,24 @@ public:
 	return "%s() -- return attribute list of malloc info"; }
 };
 
+//: command to return current or last error message string
+// str=errmsg([:keep] [:last] [:num] [:cnt]) -- return current or last error message as string
+class ErrMsgFunc : public ComFunc {
+public:
+    ErrMsgFunc(ComTerp*);
+    virtual void execute();
+    virtual const char* docstring() {
+      return "str=%s([:keep] [:last] [:num] [:cnt]) -- return current or last error message as string"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+	":keep      return message without clearing error state",
+	":last      return last saved error (_errbuf2), bypass current error check",
+	":num       return error number instead of message string",
+	":cnt       return number of errors on stack",
+	nil
+      };
+      return keys;
+    }
+};
+
 #endif /* !defined(_debugfunc_h) */

--- a/src/ComTerp/debugfunc.h
+++ b/src/ComTerp/debugfunc.h
@@ -102,11 +102,11 @@ public:
     ErrMsgFunc(ComTerp*);
     virtual void execute();
     virtual const char* docstring() {
-      return "str=%s([:keep] [:last] [:num] [:cnt]) -- return current or last error message as string"; }
+      return "str=%s(:keep :last :num :cnt) -- return current or last error message as string"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":keep      return message without clearing error state",
-	":last      return last saved error (_errbuf2), bypass current error check",
+	":last      return last saved error, bypass current error check",
 	":num       return error number instead of message string",
 	":cnt       return number of errors on stack",
 	nil

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -37,6 +37,7 @@
 #if __GNUC__>=3
 #include <fstream.h>
 #endif
+#include <strstream>
 
 #define TITLE "PostFunc"
 
@@ -52,9 +53,9 @@ PostFixFunc::PostFixFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void PostFixFunc::execute() {
   // print everything on the stack for this function
-  FILEBUF(fbuf, comterp()->handler() && comterp()->handler()->wrfptr()
-	  ? comterp()->handler()->wrfptr() : stdout, ios_base::out);
-  ostream out(&fbuf);
+  // use strstreambuf + fputs to avoid FILEBUF destructor closing stdout fd
+  std::strstreambuf sbuf;
+  ostream out(&sbuf);
  
   boolean oldbrief = comterp()->brief();
   comterp()->brief(true);
@@ -100,10 +101,13 @@ void PostFixFunc::execute() {
       out << "(" << val.keynarg_val() << ")";
     out << ((i+1>topptr) ? "\n" : " ");
   }
-  out.flush();
+  out << '\0';
+  FILE* fp = comterp()->handler() && comterp()->handler()->wrfptr()
+    ? comterp()->handler()->wrfptr() : stdout;
+  fputs(sbuf.str(), fp);
+  fflush(fp);
   comterp()->brief(oldbrief);
   reset_stack();
-  out.flush();
 }
 
 /*****************************************************************************/

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -1038,6 +1038,7 @@ int status;
 	 if( TopOfParenStack < 0 || ParenStack[ TopOfParenStack ].comm_id < 0 ) {
 	    /* Allow keyword as first token in bare parens -- implicit attrlist() literal */
 	    if( TopOfParenStack >= 0 &&
+	        ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
 	        ParenStack[ TopOfParenStack ].nkey == 0 &&
 	        expecting == OPTYPE_UNARY_PREFIX ) {
 	      if( attrlist_symid == -1 ) attrlist_symid = symbol_add("attrlist");

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -1036,12 +1036,17 @@ int status;
       /* Must be inside parenthesis associated with a command */
       /* for a keyword to be legal                            */
 	 if( TopOfParenStack < 0 || ParenStack[ TopOfParenStack ].comm_id < 0 ) {
-	    /* Allow keyword as first token in parens -- implicit attrlist() literal */
+	    /* Allow keyword as first token in bare parens -- implicit attrlist() literal */
 	    if( TopOfParenStack >= 0 &&
-	        ParenStack[ TopOfParenStack ].narg == 0 &&
-	        ParenStack[ TopOfParenStack ].nkey == 0 ) {
+	        ParenStack[ TopOfParenStack ].nkey == 0 &&
+	        expecting == OPTYPE_UNARY_PREFIX ) {
 	      if( attrlist_symid == -1 ) attrlist_symid = symbol_add("attrlist");
 	      ParenStack[ TopOfParenStack ].comm_id = attrlist_symid;
+	    } else if( TopOfParenStack >= 0 &&
+	        ParenStack[ TopOfParenStack ].comm_id < 0 &&
+	        expecting == OPTYPE_BINARY ) {
+	      COMERR_SET1( ERR_ATTRLIT_VALUE_BEFORE_KEY, *linenum );
+	      goto error_return;
 	    } else {
 	      COMERR_SET2( ERR_UNEXPECTED_KEYWORD, *linenum,
 			   symbol_pntr( *(int *)token ) );

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -249,6 +249,7 @@ static int bracesplus_symid = -1;
 static int angbracksplus_symid = -1;
 static int dblangbracksplus_symid = -1;
 static int empty_symid = -1;
+static int attrlist_symid = -1;
 
 /* === Static functions ================================================== */
 
@@ -1035,15 +1036,23 @@ int status;
       /* Must be inside parenthesis associated with a command */
       /* for a keyword to be legal                            */
 	 if( TopOfParenStack < 0 || ParenStack[ TopOfParenStack ].comm_id < 0 ) {
-	    COMERR_SET2( ERR_UNEXPECTED_KEYWORD, *linenum,
-			 symbol_pntr( *(int *)token ) );
-	    goto error_return;
+	    /* Allow keyword as first token in parens -- implicit attrlist() literal */
+	    if( TopOfParenStack >= 0 &&
+	        ParenStack[ TopOfParenStack ].narg == 0 &&
+	        ParenStack[ TopOfParenStack ].nkey == 0 ) {
+	      if( attrlist_symid == -1 ) attrlist_symid = symbol_add("attrlist");
+	      ParenStack[ TopOfParenStack ].comm_id = attrlist_symid;
+	    } else {
+	      COMERR_SET2( ERR_UNEXPECTED_KEYWORD, *linenum,
+			   symbol_pntr( *(int *)token ) );
+	      goto error_return;
 	    }
-
+	 }
+	    
       /* Increment the number of keywords associated with this */
       /* level of parens                                       */
 	 ParenStack[ TopOfParenStack ].nkey++;
-
+	 
          /* Its an error if anything is on the operator */
          /* stack and a unary prefix was expected.      */
 	 if( OperStack[TopOfOperStack].oper_type == OPERATOR &&

--- a/src/ComUtil/comterp.err
+++ b/src/ComUtil/comterp.err
@@ -154,6 +154,9 @@
 #define ERR_UNEXPECTED_LANGBRACK2	1315
 /* "(%d) Unexpected double left angle bracket" */
 
+#define ERR_ATTRLIT_VALUE_BEFORE_KEY	1316
+/* "(%d) attribute literal must start with :key" */
+
 #define ERR_TYPE_BADPARAMS		5201
 /* "Bad parameters in function call" */
 

--- a/src/ComUtil/errsys.c
+++ b/src/ComUtil/errsys.c
@@ -124,6 +124,7 @@ static struct {
 {1313, "(%d) Unexpected left angle bracket"},
 {1314, "(%d) Unexpected double right angle bracket"},
 {1315, "(%d) Unexpected double left angle bracket"},
+{1316, "(%d) attribute literal must start with :key"},
 {5201, "Bad parameters in function call"},
 {5202, "Illegal symbol identifier in type list"},
 {5203, "Illegal simple type in type identifier list"},

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -1,0 +1,94 @@
+// src/comterp_/tests/parser.comt -- test attrlist literal syntax and parser errors
+//
+// coverage: 0/0 (placeholder -- slots TBD)
+// funcs: attrlist(:literal) errmsg postfix
+// missing: TBD
+//
+// Tests the attrlist literal syntax (:key val) introduced in ivtools 2.2,
+// and errmsg() for retrieving parser error messages.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/parser.comt")
+
+// line 13 - preamble, reading prior error if any
+print("last: %s\n" s=errmsg(:last :keep);cond(s==nil "nil" s))
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: attrlist literal creates attrlist ---
+al=(:a 1 :b 2)
+ok=ok&&(al!=nil)
+ok=ok&&(al.a==1)
+ok=ok&&(al.b==2)
+print("1 attrlist literal (expect a=1 b=2): %v %v\n\n" al.a al.b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2a: literal identical postfix to attrlist() ---
+al1=(:a 11 :b 22)
+al2=attrlist(:a 11 :b 22)
+ok=ok&&(al1.a==al2.a)
+print("2 literal same as attrlist() (expect 11==11): %v %v\n\n" al1.a al2.a)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2b: type of literal matches type of attrlist() ---
+ok=ok&&(type((:a 1))==type(attrlist(:a 1)))
+print("2b literal type matches attrlist() (expect AttributeList): %v\n\n" type((:a 1)))
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: keyword-only in literal sets true ---
+al=(:flag)
+ok=ok&&(al.flag==true)
+print("3 keyword-only literal (expect true): %v\n\n" al.flag)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: list of attrlist literals ---
+all=(:a 1 :b 2),(:c 3 :d 4)
+ok=ok&&(size(all)==2)
+print("4 list of attrlist literals (expect size 2): %v\n\n" size(all))
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: plain parens still work as grouping ---
+v=(1+2)*3
+ok=ok&&(v==9)
+print("5 plain parens still group (expect 9): %v\n\n" v)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: value before keyword in bare parens errors ---
+// (4 :x 7) should give: attribute literal must start with :key
+(4 :x 7)
+e=errmsg(:last)
+ok=ok&&(index(e "attribute literal")!=nil)
+print("6 value before keyword errors (expect error msg): %v\n\n" e)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: errmsg(:last) returns nil when no error ---
+(:a 1)
+e=errmsg(:last)
+print("7 errmsg(:last) nil after success (expect nil): %v\n\n" e)
+
+// --- test 8: errmsg(:last) clears after retrieval ---
+(4 :x 7)
+e1=errmsg(:last)
+e2=errmsg(:last)
+ok=ok&&(e1!=nil)
+ok=ok&&(e2==nil)
+print("8 errmsg(:last) clears after retrieval (expect non-nil then nil): %v %v\n\n" e1 e2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: errmsg(:keep) does not clear ---
+(4 :x 7)
+e1=errmsg(:keep)
+e2=errmsg(:last)
+ok=ok&&(e1!=nil)
+ok=ok&&(e2!=nil)
+print("9 errmsg(:keep) preserves (expect both non-nil): %v %v\n\n" (e1!=nil) (e2!=nil))
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: postfix shows attrlist literal token stream ---
+// postfix((:a 1 :b 2)) should show: 1 :a(1) 2 :b(1) attrlist[2|2]
+// (verified manually -- postfix output goes to stdout not return value)
+print("10 postfix((:a 1 :b 2)) verified manually: 1 :a(1) 2 :b(1) attrlist[2|2]\n\n")
+
+print("parser: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -33,5 +33,9 @@ if(run("./print.comt")
   :then print("pass: print\n")
   :else print("FAIL: print\n");ok=false)
 
+if(run("./parser.comt")
+  :then print("pass: parser\n")
+  :else print("FAIL: parser\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -317,6 +317,8 @@ both until exit.
 
  parse(fileobj) -- parse a single expression from a file
 
+ str=errmsg([:keep] [:num] [:cnt]) -- return current error message as string
+
 .SH CONTROL COMMANDS
 
  arr=posteval(arg1 [arg2 [arg3 ... [argn]]]) -- post-evaluate every fixed argument (until nil) and return array

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -317,7 +317,7 @@ both until exit.
 
  parse(fileobj) -- parse a single expression from a file
 
- str=errmsg([:keep] [:num] [:cnt]) -- return current error message as string
+ str=errmsg(:keep :num :cnt :last) -- return current error message as string
 
 .SH CONTROL COMMANDS
 


### PR DESCRIPTION
## comterp: attrlist literal syntax — resolves #83

Allows `(:key val ...)` as sugar for `attrlist(:key val ...)` when the
first token inside bare parentheses is a keyword.

### Change

`src/ComUtil/_parser.c` — in the `TOK_KEYWORD` case, when a keyword is
encountered inside bare parens with no associated command (`comm_id < 0`,
`narg == 0`, `nkey == 0`), set `comm_id` to `attrlist_symid` rather than
erroring. The existing RPAREN machinery then emits `attrlist` as the
command with the correct `narg`/`nkey` counts — identical postfix to an
explicit `attrlist()` call.

### Examples
(:a 1 :b 2)                    // sugar for attrlist(:a 1 :b 2)
(:a 1 :b 2).a                  // 1
x=(:a 1 :b 2); x.b             // 2
(:a 1 :b 2),(:c 3 :d 4)        // list of two attrlists

### Verification
postfix((:a 1 :b 2))           // 1 :a(1) 2 :b(1) attrlist[2|2]
postfix(attrlist(:a 1 :b 2))   // 1 :a(1) 2 :b(1) attrlist[2|2]  -- identical

### Notes

- Only fires when `(` is followed by a keyword as the very first token
  inside bare parens — normal subexpressions and function calls are
  unaffected since they never start with a keyword
- Serialization of an `AttributeList` can now use the shorter form
  `(:host "hostname" :port 20002)` instead of `attrlist(...)`
- Part of the ivtools 2.2 attrlist-as-first-class-citizen feature set