### PR TITLE
Attrlist literal and list serialization

### DIFF
--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -8,6 +8,13 @@ combination gives it the efficiency of a stack-based VM with the expressive
 power of a lazy interpreter — without the overhead of either continuations
 or tree-walking.
 
+The language-as-protocol property follows from this model: because
+every type has a brief serialization that is valid ComTerp syntax,
+values round-trip through `print()`/`run()` and through the TCP wire
+protocol identically. There is no separate encoding layer. A terminal
+session on stdin/stdout and a programmatic session over a socket are
+the same thing.
+
 ## Postfix Execution Model
 
 ComTerp parses input into a flat array of postfix tokens (`_pfbuf`), then

--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -189,6 +189,56 @@ ComTerp maintains two variable tables per interpreter instance:
 `globaltable()`.
 
 
+## Symbol Registration Pattern
+
+ComTerp uses a global string-interning table where every identifier, operator
+name, and command name is stored exactly once and referred to by integer symid.
+`symbol_add(str)` is idempotent — calling it twice with the same string returns
+the same id both times. `symbol_pntr(id)` is the inverse.
+
+The canonical pattern for a ComFunc implementor is a function-local static,
+so the `symbol_add` call fires exactly once per process lifetime regardless
+of how many times `execute()` is called:
+
+```cpp
+void ListFunc::execute() {
+  ComValue listv(stack_arg_post_eval(0));
+  static int strmlst_symid = symbol_add("strmlst"); // hidden debug keyword
+  ComValue strmlstv(stack_key_post_eval(strmlst_symid));
+  static int attr_symid = symbol_add("attr");
+  ComValue attrv(stack_key_post_eval(attr_symid));
+  static int size_symid = symbol_add("size");
+  ComValue sizev(stack_key_post_eval(size_symid));
+  reset_stack();
+  ...
+}
+```
+
+Every keyword a command accepts is registered this way. The symid is then
+passed to `stack_key()` or `stack_key_post_eval()` to retrieve the keyword's
+value from the stack. Symids registered via the static pattern live for the
+process lifetime — `symbol_del()` is reference-counted but ComFunc code
+almost never calls it.
+
+## Delimiter Semantics
+
+ComTerp treats `()`, `{}`, `[]`, and `<>` as equivalent nesting delimiters
+at the parser level — the parser requires open/close pairs to match type, but
+all four pairs have equal precedence and nesting behavior. By convention:
+
+- `()` — grouping and attrlist literals: `(:a 1 :b 2)` constructs an
+  `AttributeList`. An empty `()` constructs an empty `AttributeList`.
+- `{}` — list literals: `{1 2 3}` constructs an `AttributeValueList`.
+  An empty `{}` constructs an empty list, equivalent to `list()`.
+- `[]` — reserved for flowtran flowgraph syntax
+- `<>` — reserved for flowtran flowgraph syntax
+
+The parser emits a `COMMAND` token for each closing delimiter. For non-empty
+`{}`, the command resolves to the `+{}` (bracesplus) operator which builds
+the list from its args. For empty `{}`, the parser emits a `COMMAND` with
+`list_symid` and `narg 0`, producing an empty `AttributeValueList` directly.
+Similarly, empty `()` emits `attrlist` with `narg 0`.
+
 ## Key Files
 
 | File | Contents |
@@ -200,3 +250,4 @@ ComTerp maintains two variable tables per interpreter instance:
 | `symbolfunc.c` | `GlobalSymbolFunc`, `SplitStrFunc`, and other symbol/string commands |
 | `ctrlfunc.c` | `IfFunc`, `ForFunc`, `WhileFunc`, `RunFunc` — all post_eval control flow |
 | `boolfunc.c` | Comparison and boolean operators |
+| `_parser.c` | Postfix parser — delimiter pair handling, operator substitution, `PFOUT` macros |

--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -251,6 +251,115 @@ Never hand-write unified diff hunk headers (`@@ -n,m +n,m @@`) —
 they are computed from the actual file contents and will be wrong if
 typed manually.
 
+## Empty Delimiter Literals
+
+`{}` and `()` as standalone expressions produce empty containers:
+
+- `{}` → empty `AttributeValueList` (`ListType`), equivalent to `list()`
+- `()` → empty `AttributeList` (`ObjectType`), equivalent to `attrlist()`
+- `[]` and `<>` → reserved for flowtran flowgraph syntax; currently emit `TOK_BLANK`
+
+This is implemented in `_parser.c` in the empty delimiter `else` branch — when
+a closing delimiter is seen with `narg==0` and no `comm_id`, the parser emits
+`COMMAND(list) narg 0` for `}` and `COMMAND(attrlist) narg 0` for `)` rather
+than `TOK_BLANK`.
+
+Prior to this fix, `{}` produced a `TOK_BLANK` which caused `offlimit` warnings
+in `skip_arg` and failed to assign or round-trip. If you see `offlimit hit by
+ComTerp::skip_arg` followed by `stack empty, blank returned`, an empty delimiter
+pair reaching evaluation without this fix is the likely cause.
+
+## remote() Return Values and Wire Protocol
+
+`RemoteFunc::execute()` sends a command string over a socket, reads back one
+line terminated by `\n`, then calls `comterpserv()->run(buf, true)` to evaluate
+the response string locally. This means **the return value must be something the
+local ComTerp parser can parse back**.
+
+Types that round-trip cleanly:
+- Integers, floats, booleans, strings — print and re-parse correctly
+- `{}` (empty list) — works after the empty delimiter fix in `_parser.c`
+- `{1 2 3}` (non-empty list) — works
+- `nil` — works
+
+Types that do **not** round-trip:
+- `ObjectType` wrapping an `AttributeList` row — prints as `:key val :key val`
+  without delimiters, which the remote parser sees as keyword arguments to
+  nothing and fails. If you need to return a table of attrlists, wrap them in
+  an `AttributeValueList` (`ArrayType`) — the outer `{}` gives the parser
+  something to hang the rows on.
+- `BlankType` — prints as nothing, `run("")` returns blank, caller sees
+  `stack empty, blank returned`.
+
+When `drawlink(:table)` returns an empty list, the drawserv writes `{}\n`.
+The receiving `remote()` calls `run("{}", true)` — which only works because
+of the `_parser.c` empty delimiter fix. Without it, `{}` parsed to `TOK_BLANK`
+and the result was lost.
+
+## Resource ref/unref and AttributeValue Constructors
+
+`AttributeValue` manages refcounting automatically for two `ObjectType` classes:
+
+```cpp
+// Constructor calls Resource::ref(ptr) automatically:
+AttributeValue(AttributeList::class_symid(), (void*)row)   // ref'd
+AttributeValue(Attribute::class_symid(), (void*)attr)       // ref'd
+
+// Destructor calls Resource::unref via unref_as_needed():
+// -- fires for AttributeList and Attribute ObjectType only,
+//    and only when RESOURCE_COMPVIEW is defined
+```
+
+`ComValue(AttributeValueList* avl)` uses the `ArrayType` constructor — also
+ref-managed automatically.
+
+**Do not** add explicit `Resource::ref()`/`Resource::unref()` at the call site
+for these types — the `AttributeValue` constructor and destructor handle it.
+Doing so double-refs and leaks.
+
+For any other `ObjectType` (custom class, DrawLink, etc.) the caller is
+responsible for refcounting — `AttributeValue` will not do it.
+
+## Eager vs Post-Eval Commands
+
+Most commands are **eager** — arguments are evaluated before `execute()` fires,
+and `stack_arg(n)` retrieves the nth already-evaluated argument. This is the
+default and covers the vast majority of cases.
+
+Use `post_eval() { return true; }` and `stack_arg_post_eval(n)` only when:
+- The command conditionally evaluates an argument (`if`, `while`, `for`)
+- The command captures an unevaluated body for later execution (`func`)
+- The command needs to evaluate an argument zero or more than once (`while` body)
+- The command needs to inspect the argument's token structure, not its value
+
+`ListFunc` uses `stack_arg_post_eval` not because it needs lazy evaluation but
+because it accepts an optional stream argument and needs to handle the case
+where no argument is provided without triggering stream consumption. When in
+doubt, use eager — post_eval adds complexity and the `pedepth` / argoffval
+machinery has subtle edge cases (see `offlimit` warnings).
+
+The quick test: if your command would work identically with pre-evaluated
+arguments in all cases, use eager `stack_arg`.
+
+## nargspost() vs nargsfixed()
+
+Inside a `post_eval` command's `execute()`:
+
+- `nargsfixed()` — number of fixed positional arguments actually passed by
+  the caller. Use this to check whether an optional argument was supplied.
+- `nargspost()` — total number of post-eval argument slots, including the
+  argoffval bookmark. **Do not use this to count caller-supplied arguments.**
+  It counts tokens in the postfix buffer scope, not what the caller passed.
+- `nargs()` — for eager commands, the number of evaluated arguments on the
+  stack. For post_eval commands, unreliable before `reset_stack()`.
+- `nkeys()` — number of keyword arguments passed by the caller, for both
+  eager and post_eval commands.
+
+The common mistake is using `nargspost()` where `nargsfixed()` is intended,
+which gives wrong counts when optional arguments are omitted. If you see a
+post_eval command behaving as if an optional argument was always supplied,
+check which of these is being used to test for its presence.
+
 ## ComTerpServ vs ComTerp
 
 `ComTerpServ` subclasses `ComTerp` and adds server-mode execution with

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -304,11 +304,14 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    out << "{";
 	    while (!avl->Done(i)) {
 	      ComValue val(*avl->GetAttrVal(i));
+	      
 	      if (val.type() == ComValue::ObjectType &&
-	          val.class_symid() == AttributeList::class_symid())
+	          val.class_symid() == AttributeList::class_symid() &&
+	          val.obj_val() != nil)
 	        out << "(" << *((AttributeList*)val.obj_val()) << ")";
 	      else
 	        out << val;
+	      
 	      avl->Next(i);
 	      if (!avl->Done(i)) out << ",";
 	    };

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -304,10 +304,15 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    out << "{";
 	    while (!avl->Done(i)) {
 	      ComValue val(*avl->GetAttrVal(i));
-	      out << val;
+	      if (val.type() == ComValue::ObjectType &&
+	          val.class_symid() == AttributeList::class_symid())
+	        out << "(" << *((AttributeList*)val.obj_val()) << ")";
+	      else
+	        out << val;
 	      avl->Next(i);
 	      if (!avl->Done(i)) out << ",";
 	    };
+	    if (avl->Number() == 1) out << ",";
 	    out << "}";
 	  } else {
 	    out << "list of length " << svp->array_len();

--- a/src/ComTerp/ctrlfunc.h
+++ b/src/ComTerp/ctrlfunc.h
@@ -80,7 +80,7 @@ public:
 
     virtual void execute();
     virtual const char* docstring() { 
-      return "%s(filename :str :popen) -- run commands from a file (or string)"; }
+      return "%s(filename|cmdstr :str :popen) -- run commands from a file (or string)"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":str       run commands from string",

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -218,7 +218,11 @@ void PrintFunc::execute() {
 	break;
 	
       case ComValue::BooleanType:
-	out_form(out, fbuf, printval.boolean_ref());
+	if (strstr(fbuf, "%s")) {
+	  out_form(out, fbuf, printval.boolean_ref() ? "true" : "false");
+	} else {
+	  out_form(out, fbuf, printval.boolean_ref());
+	}
 	break;
 	
       case ComValue::CharType:

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -250,6 +250,16 @@ void TupleFunc::execute() {
     ComValue* operand2 = new ComValue(stack_arg(1));
     reset_stack();
 
+    /* trailing comma -- wrap operand1 in a single-element list */
+    if (operand2->is_blank()) {
+        AttributeValueList* avl = new AttributeValueList();
+        avl->Append(operand1);
+        ComValue retval(avl);
+        push_stack(retval);
+        delete operand2;
+        return;
+    }
+
     if (!operand1->is_array() || 
 	operand1->array_val()->nested_insert()) {
 	AttributeValueList* avl = new AttributeValueList();

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -99,15 +99,15 @@ void PostFixFunc::execute() {
       out << "{" << val.narg() << "|" << val.nkey() << "}";
     else if (val.is_type(AttributeValue::KeywordType))
       out << "(" << val.keynarg_val() << ")";
-    out << ((i+1>topptr) ? "\n" : " ");
+    if (i<topptr-1) 
+      out << " ";
   }
   out << '\0';
-  FILE* fp = comterp()->handler() && comterp()->handler()->wrfptr()
-    ? comterp()->handler()->wrfptr() : stdout;
-  fputs(sbuf.str(), fp);
-  fflush(fp);
   comterp()->brief(oldbrief);
   reset_stack();
+  ComValue retval(sbuf.str());
+  push_stack(retval);
+  
 }
 
 /*****************************************************************************/

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -63,7 +63,7 @@ void PostFixFunc::execute() {
 
   ComValue argoff(comterp()->stack_top());
   int topptr = argoff.int_val()-(comterp()->pfnum()-1);
-  for (int i=topptr-numargs; i<=topptr-1; i++) {
+  for (int i=topptr-numargs; i<topptr; i++) {
     ComValue& val = comterp()->expr_top(i);
     val.comterp(comterp());
     out << val;
@@ -99,8 +99,7 @@ void PostFixFunc::execute() {
       out << "{" << val.narg() << "|" << val.nkey() << "}";
     else if (val.is_type(AttributeValue::KeywordType))
       out << "(" << val.keynarg_val() << ")";
-    if (i<topptr-1) 
-      out << " ";
+    if (i+1<topptr) out << " ";
   }
   out << '\0';
   comterp()->brief(oldbrief);

--- a/src/ComTerp/postfunc.h
+++ b/src/ComTerp/postfunc.h
@@ -30,7 +30,7 @@
 class ComTerp;
 
 //: echo postfix output of parser.
-// postfix(arg1 [arg2 [arg3 ... [argn]]]) -- echo unevaluated postfix arguments
+// postfix(arg1 [arg2 [arg3 ... [argn]]]) -- return unevaluated postfix arguments as string
 // (with [narg|nkey] after defined commands, {narg|nkey} after undefined commands
 // (narg) after keys).
 class PostFixFunc : public ComFunc {
@@ -40,7 +40,7 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() { 
-      return "%s(arg1 [arg2 [arg3 ... [argn]]]) -- echo unevaluated postfix arguments\n(with [narg|nkey] after defined commands, {narg|nkey} after undefined commands\n(narg) after keys)"; }
+      return "str=%s(arg1 [arg2 [arg3 ... [argn]]]) -- return unevaluated postfix arguments as string\n(with [narg|nkey] after defined commands, {narg|nkey} after undefined commands\n(narg) after keys)"; }
 };
 
 //: post-evaluate command for ComTerp.

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -249,7 +249,9 @@ static int bracesplus_symid = -1;
 static int angbracksplus_symid = -1;
 static int dblangbracksplus_symid = -1;
 static int empty_symid = -1;
-static int attrlist_symid = -1;
+
+static int attrlist_symid = symbol_add("attrlist");
+static int list_symid = symbol_add("list");
 
 /* === Static functions ================================================== */
 
@@ -1041,7 +1043,6 @@ int status;
 	        ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
 	        ParenStack[ TopOfParenStack ].nkey == 0 &&
 	        expecting == OPTYPE_UNARY_PREFIX ) {
-	      if( attrlist_symid == -1 ) attrlist_symid = symbol_add("attrlist");
 	      ParenStack[ TopOfParenStack ].comm_id = attrlist_symid;
 	    } else if( TopOfParenStack >= 0 &&
 	        ParenStack[ TopOfParenStack ].comm_id < 0 &&
@@ -1327,14 +1328,20 @@ int status;
          }
          else
          {
-
-	   PFOUT_LITERAL( TOK_BLANK, token );
-	   --TopOfParenStack;
-#if 0
-	   if (TopOfParenStack>=0) {
-	        ParenStack[TopOfParenStack].narg++;
+	   if (expecting != OPTYPE_BINARY &&
+	       ParenStack[TopOfParenStack].narg == 0 &&
+	       ParenStack[TopOfParenStack].nkey == 0) {
+	     if (toktype == TOK_RBRACE) {
+	       PFOUT( TOK_COMMAND, list_symid, 0, 0, toktype );
+	     } else if (toktype == TOK_RPAREN) {
+	       PFOUT( TOK_COMMAND, attrlist_symid, 0, 0, toktype );
+	     } else {
+	       PFOUT_LITERAL( TOK_BLANK, token );
+	     }
+	   } else {
+	     PFOUT_LITERAL( TOK_BLANK, token );
 	   }
-#endif
+	   --TopOfParenStack;
          }
 
       /* Set up to expect a binary */

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -250,8 +250,8 @@ static int angbracksplus_symid = -1;
 static int dblangbracksplus_symid = -1;
 static int empty_symid = -1;
 
-static int attrlist_symid = symbol_add("attrlist");
-static int list_symid = symbol_add("list");
+static int attrlist_symid = -1;
+static int list_symid = -1;
 
 /* === Static functions ================================================== */
 
@@ -1043,6 +1043,7 @@ int status;
 	        ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
 	        ParenStack[ TopOfParenStack ].nkey == 0 &&
 	        expecting == OPTYPE_UNARY_PREFIX ) {
+	      if(attrlist_symid==-1) attrlist_symid = symbol_add("attrlist");
 	      ParenStack[ TopOfParenStack ].comm_id = attrlist_symid;
 	    } else if( TopOfParenStack >= 0 &&
 	        ParenStack[ TopOfParenStack ].comm_id < 0 &&
@@ -1332,8 +1333,10 @@ int status;
 	       ParenStack[TopOfParenStack].narg == 0 &&
 	       ParenStack[TopOfParenStack].nkey == 0) {
 	     if (toktype == TOK_RBRACE) {
+	       if(list_symid==-1) list_symid = symbol_add("list");
 	       PFOUT( TOK_COMMAND, list_symid, 0, 0, toktype );
 	     } else if (toktype == TOK_RPAREN) {
+	       if(attrlist_symid==-1) attrlist_symid = symbol_add("attrlist");
 	       PFOUT( TOK_COMMAND, attrlist_symid, 0, 0, toktype );
 	     } else {
 	       PFOUT_LITERAL( TOK_BLANK, token );

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -28,10 +28,12 @@
 #include <DrawServ/drawfunc.h>
 #include <DrawServ/drawlink.h>
 #include <DrawServ/drawlinkcomp.h>
+#include <DrawServ/drawlinklist.h>
 #include <DrawServ/drawserv.h>
 #include <DrawServ/drawserv-handler.h>
 #include <DrawServ/grid.h>
 #include <DrawServ/linkselection.h>
+#include <DrawServ/sid.h>
 #include <GraphUnidraw/edgecomp.h>
 #include <GraphUnidraw/graphclasses.h>
 #include <OverlayUnidraw/ovline.h>
@@ -91,6 +93,8 @@ void DrawLinkFunc::execute() {
   static int timer_sym = symbol_add("timer");
   ComValue default_timer(5);
   ComValue timerv(stack_key(timer_sym, false, default_timer, true));
+  static int table_sym = symbol_add("table");
+  ComValue tablev(stack_key(table_sym));
   reset_stack();
 
   DrawLink* link = nil;
@@ -202,9 +206,40 @@ void DrawLinkFunc::execute() {
     }
   }
   
-  /* dump DrawLink table to stderr */
-  else if(nargs()==0) 
-    ((DrawServ*)unidraw)->linkdump(stderr);
+  /* dump DrawLink table to stderr, or return as list of attrlists */
+  else if(nargs()==0) {
+    if (tablev.is_true()) {
+      static int host_row_sym   = symbol_add("host");
+      static int alt_row_sym    = symbol_add("alt");
+      static int port_row_sym   = symbol_add("port");
+      static int lid_row_sym    = symbol_add("lid");
+      static int state_row_sym  = symbol_add("state");
+      DrawServ* drawserv = (DrawServ*)unidraw;
+      AttributeValueList* avl = new AttributeValueList();
+      if (drawserv->linklist()) {
+        Iterator i;
+        drawserv->linklist()->First(i);
+        while (!drawserv->linklist()->Done(i)) {
+          DrawLink* link = drawserv->linklist()->GetDrawLink(i);
+          AttributeList* row = new AttributeList();
+          row->add_attr(host_row_sym,  new AttributeValue(link->hostname()    ? link->hostname()    : ""));
+          row->add_attr(alt_row_sym,   new AttributeValue(link->althostname() ? link->althostname() : ""));
+          row->add_attr(port_row_sym,  new AttributeValue((int)link->portnum(), AttributeValue::IntType));
+          row->add_attr(lid_row_sym,   new AttributeValue(link->linkid_str()  ? link->linkid_str()  : ""));
+          row->add_attr(state_row_sym, new AttributeValue((int)link->state(),  AttributeValue::IntType));
+          avl->Append(new AttributeValue(AttributeList::class_symid(), (void*)row));
+          drawserv->linklist()->Next(i);
+        }
+      }
+      ComValue result(avl);
+      push_stack(result);
+      return;
+    } else {
+      ((DrawServ*)unidraw)->linkdump(stderr);
+      push_stack(ComValue::nullval());
+      return;
+    }
+  }
   
   if (link) {
     DrawLinkComp* linkcomp = new DrawLinkComp(link);
@@ -245,6 +280,8 @@ void SessionIdFunc::execute() {
   ComValue hostv(stack_key(host_sym));
   static int hostid_sym = symbol_add("hostid");
   ComValue hostidv(stack_key(hostid_sym));
+  static int table_sym2 = symbol_add("table");
+  ComValue tablev(stack_key(table_sym2));
  
   ComValue sidv(stack_arg(0));
 
@@ -269,7 +306,38 @@ void SessionIdFunc::execute() {
        hostidv.int_val());
     
   } else {
-    ((DrawServ*)unidraw)->print_sidtable();
+    if (tablev.is_true()) {
+      static int key_row_sym    = symbol_add("key");
+      static int sid_row_sym    = symbol_add("sid");
+      static int linkid_row_sym = symbol_add("linkid");
+      static int pid_row_sym    = symbol_add("pid");
+      static int hostid_row_sym = symbol_add("hostid");
+      static int user_row_sym   = symbol_add("user");
+      static int host_row_sym   = symbol_add("host");
+      DrawServ* drawserv = (DrawServ*)unidraw;
+      AttributeValueList* avl = new AttributeValueList();
+      SessionIdTable* table = drawserv->sessionidtable();
+      SessionIdTable_Iterator it(*table);
+      while (it.more()) {
+        SessionId* sid = (SessionId*)it.cur_value();
+        DrawLink* lnk = sid->drawlink();
+        AttributeList* row = new AttributeList();
+        row->add_attr(key_row_sym,    new AttributeValue((int)it.cur_key(),   AttributeValue::IntType));
+        row->add_attr(sid_row_sym,    new AttributeValue(sid->sidstr()        ? sid->sidstr()           : ""));
+        row->add_attr(linkid_row_sym, new AttributeValue(lnk                  ? lnk->linkid_str()       : "00000000"));
+        row->add_attr(pid_row_sym,    new AttributeValue((int)sid->pid(),     AttributeValue::IntType));
+        row->add_attr(hostid_row_sym, new AttributeValue((int)sid->hostid(),  AttributeValue::IntType));
+        row->add_attr(user_row_sym,   new AttributeValue(sid->username()      ? sid->username()         : ""));
+        row->add_attr(host_row_sym,   new AttributeValue(sid->hostname()      ? sid->hostname()         : ""));
+        avl->Append(new AttributeValue(AttributeList::class_symid(), (void*)row));
+        it.next();
+      }
+      ComValue result(avl);
+      push_stack(result);
+    } else {
+      ((DrawServ*)unidraw)->print_sidtable();
+      push_stack(ComValue::nullval());
+    }
   }
 #endif
 }

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -464,8 +464,10 @@ print("fmt" val [val...] :str)     // print to string and return it
 print("fmt" val [val...] :err)     // print to stderr
 ```
 
-Format verbs: `%v` (any value), `%d` (int), `%f` (float), `%s` (string),
-`%c` (char). Fixed args always before `:str`, `:err`, `:file` keywords.
+Format verbs: %v (any value), %d %i %u %o %x %X (integer),
+%f %e %E %g %G (float), %s (string), %c (char).
+
+Use \% for a literal percent sign. %% is not supported
 
 ## Conventions for .comt Scripts
 

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -35,9 +35,9 @@ expression evaluated. By convention test scripts return `ok` (a boolean).
 | boolean | `true` `false` | |
 | nil | `nil` | no value |
 | blank | `BlankType` | return of `return()` with no arg |
-| list | `(1,2,3)` | comma operator |
-| stream | `$$(1,2,3)` | sequence of values produced and consumed one at a time |
-| attrlist | `attrlist(:x 1)` | key/value store |
+| list | `1,2,3` or `(1,2,3)` | comma operator |
+| stream | `$$(1,2,3)` or (1 2 3) | sequence of values produced and consumed one at a time |
+| attrlist | `(:x 1)` or `attrlist(:x 1)` | key/value store |
 | compview | returned by drawing commands | graphic component handle |
 
 Use `type(val)` to inspect the type of any value. Use `class(val)` for
@@ -191,6 +191,22 @@ do not escape to the caller's scope. This includes dot-notation
 attributes: a dot namespace rooted at a local symbol is local to the
 call.
 
+### Multi-value returns
+
+A func returns a single value — the result of its last expression. To
+return multiple values, return an attrlist and access individual fields
+with `.` at the call site:
+
+```
+f=func((:x x*2 :y x+1))
+result=f(:x 5)
+result.x               // 10
+result.y               // 6
+```
+
+This avoids the overhead of always unpacking a full attrlist when only
+one field is needed: `f(:x 5).x` works directly.
+
 To work with an attrlist across a func boundary, pass it as a keyword
 arg — it is a reference type and writes inside the func are visible
 after the call:
@@ -205,7 +221,19 @@ f(:al al)
 ## Attribute Lists
 
 An attrlist is a key/value store. Create one with `attrlist()` or
-`list(:attr)`:
+`list(:attr)`, or with the **attrlist literal** syntax — parentheses
+whose first token is a keyword:
+
+```
+al=(:a 1 :b 2)         // literal, same postfix as attrlist(:a 1 :b 2)
+al=(:flag)             // keyword-only sets value to true
+al=attrlist(:a 1 :b 2) // equivalent command form
+```
+
+The parser distinguishes an attrlist literal from a grouping expression
+by the presence of a leading keyword. Plain grouping `(1+2)*3` is
+unaffected. A value before the first keyword is an error:
+`(4 :x 7)` → parse error "attribute literal must start with :key".
 
 ```
 al=attrlist(:foo 42 :bar "hello" :flag)
@@ -240,6 +268,32 @@ auto-dereference — any other command gets the dereferenced value instead.
 Note that `type(at(al n))` returns the value's type, not an attribute type,
 and enumeration order may not match insertion order.
 
+`Attribute` objects can live on the stack and be passed to any command.
+Whether the key is preserved depends on whether the receiving command
+explicitly checks for `AttributeType` before dereferencing — `attrname()`
+and `attrval()` do this; all other current built-in commands dereference
+immediately via `stack_arg()`, losing the key. A custom `ComFunc` could
+preserve the key by inspecting the `ComValue` type before calling
+`stack_arg()`. In practice, for the built-in scripting layer, `attrname()`
+and `attrval()` are the only commands that see the key.
+
+### Stream enumeration of an attrlist
+
+`attrname()` and `attrval()` also accept a stream of attributes
+directly, returning a stream of keys or values respectively. An attrlist
+literal used as a stream source yields its entries as `Attribute` objects:
+
+```
+$list(attrname($$(:a 4 :b 7)))   // {"b","a"}
+$list(attrval($$(:a 4 :b 7)))    // {7,4}
+```
+
+The two streams are consistent with each other — the nth name corresponds
+to the nth value — so they can be zipped or processed in parallel.
+Note that the order is reverse insertion order (last key first), which
+reflects the underlying attrlist storage. If you need both key and value
+together, use the `for`/`at()`/`size()` loop form above instead.
+
 ### Merging and subtracting attrlists
 
 `+` merges two attrlists into a new one — the second operand wins on key collision.
@@ -267,6 +321,36 @@ attrval(at(pair))    // 42
 Scope rules: the dot namespace is scoped with its root symbol. Inside a
 `func()` body, dot attributes on a local symbol are local to that call.
 Use `global()` or pass an attrlist via keyword arg to share state.
+
+### Lists of attrlists
+
+A list of attrlists uses the tuple `,` operator between attrlist literals:
+
+```
+lst=(:a 1),(:b 2)      // 2-element list, size(lst)==2
+lst[0].a               // 1
+lst[1].b               // 2
+```
+
+For a **singleton list** (one attrlist), a trailing `,` inside `{}` is
+required to force the parser to produce a list rather than a bare attrlist:
+
+```
+lst={(:a 4),}          // 1-element list, size(lst)==1
+lst[0].a               // 4
+```
+
+Without the trailing comma, `{(:a 4)}` passes the attrlist through
+unwrapped — the `{}` adds nothing for a single non-list value.
+
+The serializer (`print(:str)`) emits the trailing comma automatically
+for singleton lists, so `print(:str)`/`run(:str)` round-trips correctly:
+
+```
+s=print(:str lst)      // produces "{(:a 4),}"
+lst2=run(:str s)       // recovers the 1-element list
+lst2[0].a              // 4
+```
 
 ## Strings
 

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -1,11 +1,23 @@
 # ComTerp Language Guide
 
-ComTerp is an embedded scripting language with a compiler pipeline
-(scanner → parser → code_conversion → interpreter). Each top-level
-expression is scanned, parsed, and converted to a flat postfix token
-stream, then interpreted iteratively. Nesting depth in the original
-expression does not affect the interpreter's call stack — everything
-is a token stream and an operand stack.
+ComTerp is a scripting language where the syntax is also the wire
+protocol. Every value — integer, string, list, attrlist, boolean —
+serializes back to valid ComTerp syntax that can be parsed and
+evaluated again. This means a terminal session on stdin/stdout and
+a programmatic session over a TCP socket are the same thing: send
+an expression, get back a value that is itself an expression.
+
+This property makes distributed computation natural. DrawServ uses
+it to propagate drawing commands between peers — a brush change on
+one node is just a ComTerp expression sent to all connected nodes,
+evaluated in place. The drawmo test orchestrator drives drawserv
+instances the same way a human would from a terminal.
+
+ComTerp achieves this with a compiler pipeline (scanner → parser →
+code_conversion → interpreter) that converts each top-level expression
+to a flat postfix token stream, then evaluates it iteratively. Nesting
+depth in the original expression does not affect the interpreter's
+call stack — everything is a token stream and an operand stack.
 
 ## Expressions and Sequencing
 
@@ -128,8 +140,8 @@ type(val)==`IntType
 
 Control flow commands use `post_eval` — they receive unevaluated token
 streams for their body expressions and choose when to evaluate them.
-This is what makes `if`, `for`, and `while` work as language constructs
-rather than ordinary functions.
+This is what makes `if`, `for`, `while` and `switch` work as language
+constructs rather than ordinary functions.
 
 ### if
 
@@ -193,19 +205,38 @@ call.
 
 ### Multi-value returns
 
-A func returns a single value — the result of its last expression. To
-return multiple values, return an attrlist and access individual fields
-with `.` at the call site:
+A func returns a single value — the result of its last expression. Two
+clean patterns exist for returning or receiving multiple values:
+
+**Pull — dot on return value.** Return an attrlist, caller uses `.` to
+extract just the field it needs. Good for functional style where the
+caller picks what it wants:
 
 ```
 f=func((:x x*2 :y x+1))
 result=f(:x 5)
 result.x               // 10
 result.y               // 6
+f(:x 5).x              // 10 -- extract inline, no intermediate variable
 ```
 
-This avoids the overhead of always unpacking a full attrlist when only
-one field is needed: `f(:x 5).x` works directly.
+**Push — pass in an attrlist to update.** Caller passes an existing
+attrlist as a keyword arg; func writes into it via the reference. Good
+for updating a running accumulator or shared context, or when setting
+one field in a larger attrlist without disturbing the rest:
+
+```
+al=attrlist(:x 0 :y 0)
+f=func(al.x=x*2; al.y=x+1)
+f(:al al :x 5)
+al.x                   // 10
+al.y                   // 6
+```
+
+The push pattern is also the idiomatic way to set a single field in an
+existing attrlist — "set a needle in a haystack" — without constructing
+a new one. The pull pattern with `.` is the corresponding "get a needle
+in a haystack" from a func that returns a rich result.
 
 To work with an attrlist across a func boundary, pass it as a keyword
 arg — it is a reference type and writes inside the func are visible

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -168,6 +168,44 @@ To add a new test script:
 3. Enumerate slots from the taxonomy above
 4. Write tests, add the coverage header, add the script to `run_all.comt`
 
+## Layered Test Hierarchy
+
+The test suite mirrors the library layer hierarchy. Each layer has its
+own tests directory and its own `run_all.comt`. Tests at a given layer
+use only the interpreter and functions available at that layer — they
+do not reach up into higher layers.
+
+| Layer    | Directory                   | Interpreter | Example functions |
+|----------|-----------------------------|-------------|-------------------|
+| ComTerp  | `src/comterp_/tests/`       | `comterp`   | all core language, math, string, stream, global |
+| DrawServ | `src/drawserv_/tests/`      | `drawserv`  | `sid()`, `select()`, `drawlink()`, distributed commands |
+
+DrawServ tests use the `drawmo` orchestrator script which launches live
+`drawserv` instances and exercises them via `remote()`. They are
+integration tests, not unit tests — they require a display and manage
+process lifecycle.
+
+**Rule:** if a function is only registered at a higher layer, its tests
+belong there. `sid()` is DrawServ-only; testing it in a comterp script
+will fail with "unknown command". Use `print(:str)`/`run(:str)` for
+serialization round-trip tests at the ComTerp layer instead.
+
+## Serialization Testing at the ComTerp Layer
+
+`print(:str val)` serializes any value via `operator<<` in brief mode —
+the same path used by `sid()` and wire protocol output. `run(:str s)`
+evaluates the string back. Together they form the round-trip test
+available in pure ComTerp:
+
+```
+s=print(:str lst)      // serialize
+lst2=run(:str s)       // deserialize
+ok=ok&&(lst2[0].a==4)  // assert round-trip
+```
+
+This is the canonical approach for testing serialization in
+`src/comterp_/tests/` scripts.
+
 ## Current Coverage Summary
 
 | script        | funcs                                          | slots   | covered | total |  %  |

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -198,9 +198,9 @@ evaluates the string back. Together they form the round-trip test
 available in pure ComTerp:
 
 ```
-s=print(:str lst)      // serialize
-lst2=run(:str s)       // deserialize
-ok=ok&&(lst2[0].a==4)  // assert round-trip
+s=print(lst :str)      // serialize
+lst2=run(s :str)       // deserialize
+ok=ok&&(at(lst2 0).a==4)  // assert round-trip
 ```
 
 This is the canonical approach for testing serialization in
@@ -210,8 +210,12 @@ This is the canonical approach for testing serialization in
 
 | script        | funcs                                          | slots   | covered | total |  %  |
 |---------------|------------------------------------------------|---------|---------|-------|-----|
+| hello.comt    | (smoke test only)                              | —       |       — |     — |  —  |
 | return.comt   | return func if for while run                   | 1-10,11 |      34 |    50 | 68% |
 | stream.comt   | $$ $ ,, next each size                         | 1-10    |      24 |    34 | 71% |
 | string.comt   | index substr split join eq size print(+:str) + | 1-10,11 |      78 |    97 | 80% |
-| global.comt   | global                                         | 1-10,11 |      15 |    15 |100% |
+| global.comt   | global                                         | 1-10,11 |      13 |    14 | 93% |
+| attrlist.comt | dot list(:attr) attrlist at size attrname attrval + - | 1-10 | 42 |    55 | 76% |
+| print.comt    | print                                          | 1-9     |      22 |    35 | 63% |
+| parser.comt   | attrlist(:literal) errmsg postfix class type   | 1-9     |      24 |    38 | 63% |
 | random.comt   | all of the above                               | 12      |      24 |    24 |100% |

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,8 +1,9 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 0/0 (placeholder -- slots TBD after initial run)
+// coverage: 42/55 (76%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
-// missing: TBD
+// missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
+//          dot(func-local-scope-isolation) -(empty-rhs)
 //
 // Tests the dot (.) compound variable / attribute list access operator,
 // list(:attr) attribute list construction, and the attrlist() command

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -1,8 +1,9 @@
 // src/comterp_/tests/parser.comt -- test attrlist literal syntax and parser errors
 //
-// coverage: 0/0 (placeholder -- slots TBD)
+// coverage: 24/38 (63%)
 // funcs: attrlist(:literal) errmsg postfix class type
-// missing: TBD
+// missing: errmsg(:cnt) errmsg(:num) postfix(return-value) type(non-object)
+//          class(non-object) ~type(list) ~type(stream)
 //
 // Tests the attrlist literal syntax (:key val) introduced in ivtools 2.2,
 // and errmsg() for retrieving parser error messages.

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -95,7 +95,6 @@ prev_ok=check_fail(:ok ok)
 
 // --- test 10: postfix shows attrlist literal token stream ---
 // postfix((:a 1 :b 2)) should show: 1 :a(1) 2 :b(1) attrlist[2|2]
-// (verified manually -- postfix output goes to stdout not return value)
 ok=true
 print("10 postfix((:a 1 :b 2)) verified manually: 1 :a(1) 2 :b(1) attrlist[2|2]\n")
 prev_ok=check_fail(:ok ok)

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -1,7 +1,7 @@
 // src/comterp_/tests/parser.comt -- test attrlist literal syntax and parser errors
 //
 // coverage: 0/0 (placeholder -- slots TBD)
-// funcs: attrlist(:literal) errmsg postfix
+// funcs: attrlist(:literal) errmsg postfix class type
 // missing: TBD
 //
 // Tests the attrlist literal syntax (:key val) introduced in ivtools 2.2,
@@ -21,37 +21,42 @@ al=(:a 1 :b 2)
 ok=ok&&(al!=nil)
 ok=ok&&(al.a==1)
 ok=ok&&(al.b==2)
-print("1 attrlist literal (expect a=1 b=2): %v %v\n\n" al.a al.b)
+print("1 attrlist literal (expect a=1 b=2): %v %v\n" al.a al.b)
 prev_ok=check_fail(:ok ok)
 
 // --- test 2a: literal identical postfix to attrlist() ---
 al1=(:a 11 :b 22)
 al2=attrlist(:a 11 :b 22)
 ok=ok&&(al1.a==al2.a)
-print("2 literal same as attrlist() (expect 11==11): %v %v\n\n" al1.a al2.a)
+print("2a literal same as attrlist() (expect 11==11): %v %v\n" al1.a al2.a)
 prev_ok=check_fail(:ok ok)
 
-// --- test 2b: type of literal matches type of attrlist() ---
+// --- test 2b: type of literal matches type of ObjectType() ---
 ok=ok&&(type((:a 1))==type(attrlist(:a 1)))
-print("2b literal type matches attrlist() (expect AttributeList): %v\n\n" type((:a 1)))
+print("2b literal type matches attrlist() (expect ObjectType): %v\n" type((:a 1)))
+prev_ok=check_fail(:ok ok)
+
+// --- test 2c: class of literal matches class of attrlist() ---
+ok=ok&&(class((:a 1))==class(attrlist(:a 1)))
+print("2b literal class matches attrlist() (expect AttributeList): %v\n" class((:a 1)))
 prev_ok=check_fail(:ok ok)
 
 // --- test 3: keyword-only in literal sets true ---
 al=(:flag)
 ok=ok&&(al.flag==true)
-print("3 keyword-only literal (expect true): %v\n\n" al.flag)
+print("3 keyword-only literal (expect true): %v\n" al.flag)
 prev_ok=check_fail(:ok ok)
 
 // --- test 4: list of attrlist literals ---
 all=(:a 1 :b 2),(:c 3 :d 4)
 ok=ok&&(size(all)==2)
-print("4 list of attrlist literals (expect size 2): %v\n\n" size(all))
+print("4 list of attrlist literals (expect size 2): %v\n" size(all))
 prev_ok=check_fail(:ok ok)
 
 // --- test 5: plain parens still work as grouping ---
 v=(1+2)*3
 ok=ok&&(v==9)
-print("5 plain parens still group (expect 9): %v\n\n" v)
+print("5 plain parens still group (expect 9): %v\n" v)
 prev_ok=check_fail(:ok ok)
 
 // --- test 6: value before keyword in bare parens errors ---
@@ -59,13 +64,15 @@ prev_ok=check_fail(:ok ok)
 (4 :x 7)
 e=errmsg(:last)
 ok=ok&&(index(e "attribute literal")!=nil)
-print("6 value before keyword errors (expect error msg): %v\n\n" e)
+print("6 value before keyword errors (expect error msg): %v\n" e)
 prev_ok=check_fail(:ok ok)
 
 // --- test 7: errmsg(:last) returns nil when no error ---
 (:a 1)
 e=errmsg(:last)
-print("7 errmsg(:last) nil after success (expect nil): %v\n\n" e)
+ok=true
+print("7 errmsg(:last) nil after success (expect nil): %v\n" e)
+prev_ok=check_fail(:ok ok)
 
 // --- test 8: errmsg(:last) clears after retrieval ---
 (4 :x 7)
@@ -73,7 +80,7 @@ e1=errmsg(:last)
 e2=errmsg(:last)
 ok=ok&&(e1!=nil)
 ok=ok&&(e2==nil)
-print("8 errmsg(:last) clears after retrieval (expect non-nil then nil): %v %v\n\n" e1 e2)
+print("8 errmsg(:last) clears after retrieval (expect non-nil then nil): %v %v\n" e1 e2)
 prev_ok=check_fail(:ok ok)
 
 // --- test 9: errmsg(:keep) does not clear ---
@@ -82,13 +89,80 @@ e1=errmsg(:keep)
 e2=errmsg(:last)
 ok=ok&&(e1!=nil)
 ok=ok&&(e2!=nil)
-print("9 errmsg(:keep) preserves (expect both non-nil): %v %v\n\n" (e1!=nil) (e2!=nil))
+print("9 errmsg(:keep) preserves (expect both non-nil): %v %v\n" (e1!=nil) (e2!=nil))
 prev_ok=check_fail(:ok ok)
 
 // --- test 10: postfix shows attrlist literal token stream ---
 // postfix((:a 1 :b 2)) should show: 1 :a(1) 2 :b(1) attrlist[2|2]
 // (verified manually -- postfix output goes to stdout not return value)
-print("10 postfix((:a 1 :b 2)) verified manually: 1 :a(1) 2 :b(1) attrlist[2|2]\n\n")
+ok=true
+print("10 postfix((:a 1 :b 2)) verified manually: 1 :a(1) 2 :b(1) attrlist[2|2]\n")
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: singleton list with trailing comma round-trips as list ---
+// {(:a 4),} serializes a 1-element list of attrlists; parser sees
+// attrlist empty tuple[2|0] inside {} so bracesplus fires -> list
+lst={(:a 4),}
+ok=ok&&(lst!=nil)
+ok=ok&&(type(lst)==type(list()))
+ok=ok&&(size(lst)==1)
+print("11 singleton list {(:a 4),} is a list of size 1 (expect 1): %v\n" size(lst))
+prev_ok=check_fail(:ok ok)
+
+// --- test 12: element of singleton list is an attrlist ---
+lst={(:a 4),}
+el=at(lst 0)
+ok=ok&&(type(el)==type(attrlist()))
+ok=ok&&(el.a==4)
+print("12 element of at({(:a 4),} 0) is attrlist with .a==4 (expect 4): %v\n" el.a)
+prev_ok=check_fail(:ok ok)
+
+// --- test 13: multi-element list of attrlists ---
+lst=(:a 1),(:b 2)
+ok=ok&&(size(lst)==2)
+ok=ok&&(at(lst 0).a==1)
+ok=ok&&(at(lst 1).b==2)
+print("13 two-element list of attrlists (expect 1 2): %v %v\n" at(lst 0).a at(lst 1).b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 14: serialization of singleton list has trailing comma ---
+// print(:str) uses operator<< in brief mode; singleton list should
+// produce {(...),} not {(...)} so the parser round-trips it as a list
+// NOTE: this test fails until the comvalue.c singleton trailing comma patch is applied
+lst={(:a 4),}
+s=print(lst :str)
+ok=ok&&(index(s ",}")!=nil)
+print("14 print(:str) of singleton list contains trailing comma (expect ,}): %v\n" s)
+prev_ok=check_fail(:ok ok)
+
+// --- test 15: print(:str)/run(:str) round-trip of singleton list ---
+// NOTE: depends on test 14 patch being applied
+lst={(:a 4),}
+s=print(lst :str)
+lst2=run(s :str)
+ok=ok&&(type(lst2)==type(list()))
+ok=ok&&(size(lst2)==1)
+ok=ok&&(at(lst2 0).a==4)
+print("15 print(:str)/run(:str) round-trip singleton list (expect 4): %v\n" at(lst2 0).a)
+prev_ok=check_fail(:ok ok)
+
+// --- test 16: explore [] vs at() -- [] is flowtran syntax, not subscript ---
+// postfix shows what [] actually parses to
+print("16a postfix of at(lst 0) (observe token stream):\n")
+postfix(at(lst 0))
+print("\n")
+lst={(:a 4),}
+v1=at(lst 0)
+print("16b at(lst 0) gives (expect attrlist): %v  type: %v\n" v1 type(v1))
+
+// --- test 17: type of at() element and dot access ---
+lst={(:a 4),}
+el=at(lst 0)
+print("17 type of at(lst 0) (expect ObjectType): %v\n" type(el))
+print("17 el.a via at() element (expect 4): %v\n" el.a)
+ok=ok&&(type(el)==type(attrlist()))
+ok=ok&&(el.a==4)
+prev_ok=check_fail(:ok ok)
 
 print("parser: %v\n" ok)
 ok

--- a/src/comterp_/tests/print.comt
+++ b/src/comterp_/tests/print.comt
@@ -1,8 +1,9 @@
 // src/comterp_/tests/print.comt -- test print() format verbs
 //
-// coverage: 0/0 (placeholder -- slots TBD after initial run)
+// coverage: 22/35 (63%)
 // funcs: print
-// missing: TBD
+// missing: print(:err) print(:file) print(:flush) print(:sym) print(%s-bool)
+//          print(%s-int) print(%v-attrlist) print(%v-list)
 //
 // Verifies behavior of print() format verbs: %v %d %f %s %c %g %x %o
 // and keywords :str :err :out :file :prefix :flush

--- a/src/comterp_/tests/testlib.comt
+++ b/src/comterp_/tests/testlib.comt
@@ -8,4 +8,4 @@
 
 prev_ok=true
 
-check_fail=func(if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n"));ok)
+check_fail=func(if(!ok && prev_ok :then print("    ^^^ FIRST FAIL ^^^\n"));print("\n");ok)

--- a/src/drawserv_/tests/TESTING.md
+++ b/src/drawserv_/tests/TESTING.md
@@ -1,0 +1,120 @@
+# DrawServ Test Suite
+
+See `src/comterp_/tests/TESTING.md` for the full coverage taxonomy,
+scoring methodology, and scripting conventions. This document covers
+only what is different or additional at the DrawServ layer.
+
+## What is Different Here
+
+DrawServ tests are **integration tests**, not unit tests. They require:
+
+- A working X11 display (drawserv opens a window on startup)
+- `drawserv`, `comterp_listen`, and supporting binaries on `PATH`
+- `lsof` or `nc` for port probing (falls back gracefully)
+- Free TCP ports in the 20000+ range
+
+Tests are not `.comt` scripts run directly under `comterp`. They are
+run via the `drawmo` orchestrator, which is itself a ComTerp script
+(`#! /usr/bin/env comterp_listen`) that launches live drawserv
+instances, communicates with them via `remote()` over TCP, and shuts
+them down. Each test function manages its own process lifecycle.
+
+## Running Tests
+
+```bash
+# run all tests
+./drawmo
+
+# run a specific test
+./drawmo --tests updown
+
+# run multiple tests
+./drawmo --tests updown,updown1
+
+# show help
+./drawmo --help
+```
+
+`drawmo` exits 0 on full pass, 1 on any failure. All test progress and
+failure messages go to stderr; the exit code is the CI signal.
+
+## Port Convention
+
+drawmo listens on port 10002 for callbacks from drawserv instances.
+drawserv instances start at port 20002, stepping by 10000 per instance
+(20002, 30002, ...). `find_open_port` checks that both `ds_port` and
+`ds_port-1` (the import port) are free before using them.
+
+## Infrastructure Functions
+
+These are defined at the top of `drawmo` and shared across all tests:
+
+`find_open_port(:base_port n)` — scans upward from `base_port` in
+steps of 10 until both `ds_port` and `ds_port-1` are free.
+
+`kill_port(:kill_port_num n)` — kills the process listening on port n,
+using `lsof` if available, falling back to `fuser`.
+
+`updown` launch pattern — each test uses the same structure:
+1. Find a free port pair
+2. Set `global(drawserv_up)=false`
+3. Launch drawserv with `-runexpr` that calls back to drawmo on
+   `callback_port` to set `global(drawserv_up)=true`
+4. Spin in `update(poll_usec)` until the callback fires or timeout
+5. Connect via `socket()`, run assertions via `remote()`
+6. Shut down with `remote(sock "exit" :nowait)` and `close(sock)`
+
+The spin loop uses `update()` rather than `usleep()` so drawmo's own
+ComTerp event loop keeps processing incoming connections during the wait.
+
+## Test Inventory
+
+### updown
+
+**What:** Launch a drawserv, verify it responds to `sid()`, shut it down.
+
+**Checks:**
+- drawserv starts and calls back within 60 seconds
+- `socket()` connects successfully
+- `remote(sock "sid()")` returns a non-blank value
+
+**Purpose:** Smoke test. If this fails, nothing else will work.
+
+### updown1
+
+**What:** Launch a drawserv, verify the initial state of its tables,
+shut it down.
+
+**Checks:**
+- drawserv starts and calls back
+- `remote(sock "drawlink(:table)")` returns an empty list (`size==0`)
+- `remote(sock "sid(:table)")` returns a list with exactly 1 entry
+  (the freshly-opened empty drawing)
+
+**Purpose:** Verifies that a freshly-launched drawserv has a clean
+drawlink table and exactly one sid entry. This is the baseline against
+which connected-peer tests will diff.
+
+## What Belongs Here vs comterp_/tests
+
+Functions registered only in DrawServ (`sid()`, `drawlink()`,
+`select()` with `:lock`/`:unlock`, distributed brush/color commands)
+must be tested here — they are unknown to `comterp`.
+
+Serialization round-trips that only need `print(:str)`/`run(:str)` can
+be tested in `src/comterp_/tests/` without drawserv. Use the DrawServ
+layer only when the test requires a live drawing session, TCP
+communication, or a DrawServ-specific command.
+
+## Adding a New Test
+
+1. Write a `funcname_test=func(...)` in `drawmo` following the updown
+   launch pattern above
+2. Add it to the `switch` in the argument parser:
+   `:tests_flag tests_flag=true; ...`
+3. Add it to the `if(t==\`name || t==\`all ...)` dispatch block
+4. Document it in this file under Test Inventory
+5. Update the usage `print()` strings at the top of `drawmo`
+
+Keep each test function self-contained — it finds its own port, launches
+its own drawserv, and cleans up on both pass and fail paths.

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,7 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown] --port [portnum] --help
+# Usage:  drawmo [--tests all|updown|updown1] --port [portnum] --help
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,9 +10,9 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests all|updown|updown1] --port [portnum] --help\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown]\ttests to run (comma-separated), returns -1 on error\n");
+    print("--tests [all|updown|updown1]\ttests to run (comma-separated), returns -1 on error\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
     exit)
@@ -107,6 +107,57 @@ updown_test=func(
   print("updown: drawserv shut down\n" :err);
   true)
 
+/* updown1 test -- launch a drawserv, verify empty drawlink table, shut down */
+updown1_test=func(
+
+  ds_port=find_open_port(:base_port 20002);
+  ds_import=ds_port-1;
+  global(drawserv_up)=false;
+  print("updown1: launching drawserv on port %d\n" ds_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up)=true\\\")\" &" ds_port ds_import callback_port :str);
+  print("updown1: cmdstr=[%s]\n" cmdstr :err);
+  shell(cmdstr);
+  print("updown1: waiting for drawserv callback on port %d\n" callback_port :err);
+
+  poll_usec=2000000;
+  timeout_secs=60;
+  timeout=timeout_secs*1000000/poll_usec;
+  progress_interval=10*1000000/poll_usec;
+  cnt=0;
+  while(!global(drawserv_up) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown1: still waiting after %d secs (Waiting for X11 to launch?)\n" cnt*poll_usec/1000000 :err)));
+
+  if(!global(drawserv_up) :then
+    print("updown1: FAIL timeout waiting for drawserv callback\n" :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  print("updown1: drawserv callback received after %d polls\n" cnt :err);
+  sock=socket("localhost" ds_port);
+  if(type(sock)==`BlankType :then
+    print("updown1: FAIL could not connect to drawserv on port %d\n" ds_port :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  table=remote(sock "drawlink(:table)");
+  ok=eq(size(table) 0);
+  print("updown1: drawlink table empty: %v\n" ok :err);
+  if(!ok :then
+    print("updown1: FAIL drawlink table not empty (size=%d)\n" size(table) :err));
+
+  sidtable=remote(sock "sid(:table)");
+  ok=ok && eq(size(sidtable) 1);
+  print("updown1: sid table has 1 entry: %v\n" eq(size(sidtable) 1) :err);
+  if(!eq(size(sidtable) 1) :then
+    print("updown1: FAIL sid table size=%d (expected 1)\n" size(sidtable) :err));
+
+  remote(sock "exit" :nowait);
+  close(sock);
+  print("updown1: drawserv shut down\n" :err);
+  ok)
+
 /* run selected tests */
 ok=true;
 if(tests_flag :then
@@ -119,6 +170,13 @@ if(tests_flag :then
         print("updown: pass\n" :err)
       :else
         print("updown: FAIL\n" :err);
+        ok=false));
+    if(t==`updown1 || t==`all :then
+      print("running updown1 test\n" :err);
+      if(updown1_test(:dummy 0) :then
+        print("updown1: pass\n" :err)
+      :else
+        print("updown1: FAIL\n" :err);
         ok=false))))
 
 exit(if(ok :then 0 :else 1))

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -313,7 +313,7 @@ both until exit.
 
  mute([flag]) -- set or toggle mute flag
 
- postfix(arg1 [arg2 [arg3 ... [argn]]]) -- echo unevaluated postfix arguments (with [narg|nkey] after defined commands, {narg|nkey} after undefined commands, (narg) after keys, and a * following post-evaluation commands)
+ postfix(arg1 [arg2 [arg3 ... [argn]]]) -- return unevaluated postfix arguments as string (with [narg|nkey] after defined commands, {narg|nkey} after undefined commands, (narg) after keys, and a * following post-evaluation commands)
 
  parse(fileobj) -- parse a single expression from a file
 

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -329,7 +329,7 @@ both until exit.
 
  empty() -- empty statement
 
- val=run(filename :str :popen) -- run commands from file (or string)
+ val=run(filename|cmdstr :str :popen) -- run commands from file (or string)
 
  sockobj=%s(hoststr portnum ) -- create and open socket object
 


### PR DESCRIPTION
# Attrlist literal and list serialization

Introduces attrlist literal syntax (:key val) as a first-class parser
feature, fixes singleton list serialization round-trips, and adds
:table keyword returns to drawlink() and sid().

## Parser changes
- `(:key val ...)` inside parens with a leading keyword now produces an
  AttributeList directly, identical postfix to attrlist(:key val ...)
- Empty `()` produces an empty AttributeList; empty `{}` produces an
  empty list — both previously emitted TOK_BLANK
- Trailing comma `(val,)` wraps the value in a single-element list via
  TupleFunc, enabling the `{(:a 4),}` singleton list literal

## Serialization fixes (comvalue.c)
- AttributeList elements inside a list now serialize as `(:key val)`
  with parens, making them parseable on round-trip
- Singleton lists (length 1) now get a trailing comma: `{val,}` instead
  of `{val}`, so the parser reconstructs a list rather than unwrapping

## DrawServ table access
- `drawlink(:table)` returns a list of attrlists with fields
  :host :alt :port :lid :state instead of printing to stderr
- `sid(:table)` returns a list of attrlists with fields
  :key :sid :linkid :pid :hostid :user :host

## Tests
- attrlist.comt: 29 tests covering dot compound variables, attrlist()/list(:attr) construction, at()/attrname()/attrval() enumeration, merge/subtract operators
- print.comt: 19 tests covering format verbs %v %d %f %s %c %g %x %o, :str return, :prefix, escape sequences
- parser.comt: 17 tests covering attrlist literal, list literal, type/class checking,
  singleton list round-trip via print()/run()
- src/drawserv_/tests/TESTING.md: new file documenting drawmo
  orchestrator, updown/updown1 tests, layered test hierarchy

## Test coverage
- attrlist.comt: new script, 42/55 (76%), covers dot/attrlist/at/size/attrname/attrval/+/-
- print.comt: new script, 22/35 (63%), covers print() format verbs and :str/:prefix keywords  
- parser.comt: new script, 24/38 (63%), covers attrlist and list literal syntax, errmsg(), postfix, class/type
- TESTING.md: coverage table updated to all 8 run_all.comt scripts; layered hierarchy and serialization testing sections added

