### PR TITLE
dot rhs bare identifier — suppress command dispatch, optable(:table) returns list of attrlists

### DIFF
--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -413,7 +413,7 @@ Fischer-LeBlanc compiler pipeline. Honeywell allowed Fant to take NCL
 when he left, and it became the basis of his subsequent work. The 1988
 paper was a crystallization of the language side of these ideas. See
 "Command Language for Developing Real-Time Signal and Image Processing
- Applications", Scott E. Johnston and Robert C. Fitch, SPIE Proceedings
+Applications", Scott E. Johnston and Robert C. Fitch, SPIE Proceedings
 on Automated Inspection and High Speed Vision Architectures II, vol.
 1004, November 1988.
 

--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -352,6 +352,51 @@ drives string concatenation to assemble parent-child connection
 expressions, producing a full tree description in a handful of
 expressions. The language consumes itself to generate programs.
 
+### Stream literals as wiring diagrams (ivtools-3.0)
+
+Stream literals make the flowgraph construction story more direct. Node
+indices are no longer threaded through arithmetic expressions — they are
+declared inline as a stream, and the stream drives the wiring:
+
+```
+// pipeline: connect nodes 0..3 in series
+nodes=(0 1 2 3)
+while((n=next(nodes))!=nil
+  run("pipe(node"+print(n :str)+" node"+print(n+1 :str)+")"))
+```
+
+The key property is that `(0 1 2 3)` reads as data — a description of
+what is to be wired — not as control flow. There is no loop counter, no
+index variable, no fence-post arithmetic visible at the call site. The
+stream literal *is* the wiring diagram; `next()` is the act of reading
+it.
+
+Note: `str()` is not stream-aware — integer-to-string conversion over a
+stream uses `print(v :str)` to convert each value as it is consumed.
+`"node"+(1..3)` produces char codes, not digit strings; the
+`print(v :str)` pattern inside `next()`/`while` is the correct idiom.
+
+With scalar overdrive the same pattern generalizes to arbitrary
+topologies. A stream of node indices drives string concatenation to
+assemble connection expressions for fan-out, fan-in, grid, or tree
+layouts without any additional bookkeeping:
+
+```
+// fan-out: connect source to nodes 1..4
+src=0
+result=list()
+s=(1 2 3 4)
+while((n=next(s))!=nil
+  result=list(result "fanout("+print(src :str)+" "+print(n :str)+")"))
+// {fanout(0 1), fanout(0 2), fanout(0 3), fanout(0 4)}
+```
+
+This is `setbuf` as syntax rather than API — the buffer contents are
+declared where they are used, the connections flow from the declaration,
+and the runtime executes what the stream describes. No visible control,
+no explicit graph object, no separate wiring step. The data flow *is*
+the program.
+
 The ComUtil package contains the Xgraph structure that was the original
 intended target for code generation from the Fischer-LeBlanc compiler
 pipeline. ComValues and ComFuncs were wired up as an interpreter

--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -90,6 +90,29 @@ postfix token), flags set on a specific `ComValue` in the array persist
 for the lifetime of the expression and are copied when that `ComValue` is
 pushed onto the eval stack.
 
+### nids() Values
+
+`nids()` is copied from `postfix_token.nids` into `ComValue` and has
+accumulated meaning over time:
+
+| nids | meaning |
+|------|---------|
+| `-1` | dot-rhs bare identifier — suppress `SymbolType` → `CommandType` promotion in `code_conversion()` (ivtools 2.2+) |
+| `0` | default/unset — used by `empty` (trailing comma sentinel) |
+| `1` | one argument list: `func(args)` — normal command |
+| `2-17` | multiple argument lists: `func(list1)(list2)` — number of paren-delimited groups following the command token; used for ipl and the Wave instruction set, and available for any domain needing multi-list dispatch |
+| `>= 18` | delimiter token type (`TOK_RPAREN`=18, `TOK_RBRACE`=22 etc.) for bracket-matching dispatch via `_delim_func` in `code_conversion()` |
+
+The `-1` convention was introduced to allow `a.type` to do a key lookup
+against an attrlist rather than dispatch the `type()` command. The
+parser emits `nids=-1` for bare identifiers on the rhs of `.`; the
+promotion guard in `code_conversion()` checks `sv->nids() != -1` before
+converting `SymbolType` to `CommandType`.
+
+The `2-17` range preserves the original intent of the field name —
+"number of ids" meaning number of argument lists. The `>= 18` overload
+and `-1` extension are the only departures from that original meaning.
+
 ## func() command for user written commands
 
 The func() command:
@@ -345,7 +368,7 @@ Fischer-LeBlanc compiler pipeline. Honeywell allowed Fant to take NCL
 when he left, and it became the basis of his subsequent work. The 1988
 paper was a crystallization of the language side of these ideas. See
 "Command Language for Developing Real-Time Signal and Image Processing
-Applications", Scott E. Johnston and Robert C. Fitch, SPIE Proceedings
+ Applications", Scott E. Johnston and Robert C. Fitch, SPIE Proceedings
 on Automated Inspection and High Speed Vision Architectures II, vol.
 1004, November 1988.
 

--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -204,6 +204,11 @@ ivtools. Use virtual dispatch instead.
 
 ## Naming Conventions
 
+- `comterp` (lowercase) — the interpreter: the binary, the `comterp_`
+  directory, `.comt` scripts, `comterp_listen`, the REPL. Use this in
+  user-facing docs, issue descriptions, and script comments.
+- `ComTerp` (PascalCase) — the C++ library: `src/ComTerp/`, class names
+  (`ComFunc`, `ComValue`, `ComTerp`), HACKING.md, ARCHITECTURE.md.
 - PascalCase for classes inherited from Unidraw/InterViews heritage
   (`ComValue`, `ComFunc`, `DrawServCmd`)
 - snake_case for newer additions (`dist_script()`, `make_brush_cmd()`,
@@ -250,6 +255,33 @@ EOF
 Never hand-write unified diff hunk headers (`@@ -n,m +n,m @@`) —
 they are computed from the actual file contents and will be wrong if
 typed manually.
+
+## Dot Operator Rhs — Symbol vs Command Dispatch
+
+On the rhs of `.`, the parser distinguishes bare identifiers from
+command calls with explicit parens:
+
+- **Bare identifier** (`a.type`, `a.exit`) — emits `TOK_COMMAND`
+  with nids set to -1  used as a key lookup against the attrlist.
+  Never dispatches as a command, even if the name is a registered
+  zero-arg command.
+- **Command with parens** (`a.type()`, `a.print("k_%v" n :sym)`) —
+  emits `TOK_COMMAND`, dispatches normally, result used as key.
+
+This is implemented in `_parser.c` at the bare identifier emission
+point (line ~1028): when the top of the operator stack is the `dot`
+operator and no left paren follows, emit `TOK_COMMANDL` with nids
+set to -1 instead of `TOK_COMMAND`. A `dot_symid` static
+(initialized lazily) identifies the dot operator by its command
+symid via `opr_tbl_commid()`.
+
+The chain form `a.type.class.exit` works automatically — each bare
+identifier after `.` hits the same emission point with dot on top of
+the operator stack.
+
+**Assignment to commands** is separately blocked in the evaluator:
+`false=7` produces a warning and returns nil. This is independent of
+the parser fix.
 
 ## Empty Delimiter Literals
 
@@ -369,3 +401,61 @@ behavior in `ComTerp::run()` or `ComTerp::runfile()`, check whether
 change. The two `runfile()` implementations are parallel but not
 identical — `ComTerpServ::runfile()` handles line-by-line buffering
 and has its own `err_str` call sites.
+
+## Deferred symbol_add in _parser.c
+
+Static symbol IDs in `_parser.c` that are needed during parsing must
+not be initialized at file scope with `symbol_add()` — the symbol table
+may not be ready yet at static init time. Instead initialize to `-1`
+and call `symbol_add()` lazily on first use:
+
+```c
+static int dot_symid = -1;
+// ...
+if (dot_symid == -1) dot_symid = symbol_add("dot");
+```
+
+This is the established pattern for all parser symbol IDs in that file:
+`attrlist_symid`, `list_symid`, `dot_symid`, and the delimiter symids.
+
+## String Return Values from Commands
+
+To return a string from a `ComFunc`, use:
+
+```cpp
+ComValue retval(mystr, ComValue::StringType);
+push_stack(retval);
+```
+
+`postfix()` is the canonical example — it captures its output in a
+`strstreambuf`, then pushes the result as `StringType` rather than
+writing to stdout. This makes the return value testable and composable
+with other string commands.
+
+## Commands Without Parentheses — Design Implications
+
+Some commands fire without parentheses: `exit`, `beep`, `true`,
+`false`, `nil`. This is intentional. The implications reach further
+than they might seem:
+
+**Zero-arg commands are symbolic constants.** `true`, `false`, `nil`
+are not keywords — they are registered commands that return values.
+Any zero-arg command can serve as a symbolic constant in an expression.
+
+**The dot operator creates a clean namespace boundary.** Because `.`
+suppresses command dispatch on its rhs for bare identifiers, attrlist
+keys can freely use any name — including command names like `type`,
+`class`, `exit`, `true`, `false`. The dot operator is a namespace
+escape hatch that makes attrlists safe to use as general-purpose
+key/value stores without collision.
+
+**Runtime operator table mutation makes this composable.** Because
+the operator table is mutable, new zero-arg commands could be registered
+as operators, extending the "symbolic constant" set in a domain-specific
+way. A boot script could define a vocabulary of named constants that
+look and behave like language keywords.
+
+**The lhs-of-assignment block is the safety valve.** The warning on
+`false=7` prevents accidental rebinding of constants. Combined with the
+dot-rhs symbol emission, the language has three well-defined contexts
+for bare identifiers with consistent, predictable behavior.

--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -270,7 +270,7 @@ command calls with explicit parens:
 
 This is implemented in `_parser.c` at the bare identifier emission
 point (line ~1028): when the top of the operator stack is the `dot`
-operator and no left paren follows, emit `TOK_COMMANDL` with nids
+operator and no left paren follows, emit `TOK_COMMAND` with nids
 set to -1 instead of `TOK_COMMAND`. A `dot_symid` static
 (initialized lazily) identifies the dot operator by its command
 symid via `opr_tbl_commid()`.

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -899,7 +899,8 @@ void ComTerp::token_to_comvalue(postfix_token* token, ComValue* sv) {
       localtable()->find(vptr, nil_symid);
     }
 
-    if (vptr && ((ComValue*)vptr)->type() == ComValue::CommandType) {
+    // convert to command if it has parens
+    if (vptr && ((ComValue*)vptr)->type() == ComValue::CommandType && sv->nids() >= 0) {
       sv->obj_ref() = ((ComValue*)vptr)->obj_ref();
       sv->type(ComValue::CommandType);
       sv->command_symid(command_symid);
@@ -943,8 +944,8 @@ void ComTerp::incr_stack() {
     ComValue& sv = stack_top();
 
     /* See if this really is a command with a ComFunc */
-    if (sv.type() == ComValue::SymbolType) {
-        void* vptr = nil;
+    if (sv.type() == ComValue::SymbolType && sv.nids() >= 0) {
+	void* vptr = nil;
 	localtable()->find(vptr, sv.int_val());
 	if (vptr && ((ComValue*)vptr)->type() == ComValue::CommandType) {
 	    sv.obj_ref() = ((ComValue*)vptr)->obj_ref();

--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -279,20 +279,60 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
   void OptableFunc::execute() {
-    
+
   static int bypri_symid = symbol_add("bypri");
   ComValue bypriflag(stack_key(bypri_symid));
   static int byopr_symid = symbol_add("byopr");
   ComValue byoprflag(stack_key(byopr_symid));
   static int bycom_symid = symbol_add("bycom");
   ComValue bycomflag(stack_key(bycom_symid));
-  
+  static int table_symid = symbol_add("table");
+  ComValue tableflag(stack_key(table_symid));
+
   reset_stack();
+
+  if (tableflag.is_true()) {
+    // return list of attrlists, one per operator entry
+    static int opr_symid = symbol_add("opr");
+    static int cmd_symid = symbol_add("cmd");
+    static int pri_symid = symbol_add("pri");
+    static int rtol_symid = symbol_add("rtol");
+    static int type_symid = symbol_add("type");
+    static int binary_symid = symbol_add("BINARY");
+    static int prefix_symid = symbol_add("UNARY PREFIX");
+    static int postfix_symid = symbol_add("UNARY POSTFIX");
+
+    AttributeValueList* avl = new AttributeValueList();
+    unsigned n = opr_tbl_numop_get();
+    for (unsigned i = 0; i < n; i++) {
+      AttributeList* al = new AttributeList();
+      AttributeValue opr_val((const char *)symbol_pntr(opr_tbl_operid(i)));
+      AttributeValue cmd_val((const char *)symbol_pntr(opr_tbl_commid(i)));
+      AttributeValue pri_val((int)opr_tbl_priority(i), AttributeValue::IntType);
+      AttributeValue rtol_val((boolean)opr_tbl_rtol(i), AttributeValue::BooleanType);
+      al->add_attr(opr_symid, opr_val);
+      al->add_attr(cmd_symid, cmd_val);
+      al->add_attr(pri_symid,  pri_val);
+      al->add_attr(rtol_symid, rtol_val);
+      int optype = opr_tbl_optype(i);
+      int type_symval = optype == OPTYPE_UNARY_POSTFIX ? postfix_symid
+                      : optype == OPTYPE_UNARY_PREFIX  ? prefix_symid
+                      : binary_symid;
+      AttributeValue type_val(type_symval, AttributeValue::SymbolType);
+      al->add_attr(type_symid, type_val);
+      AttributeValue* av = new AttributeValue(AttributeList::class_symid(), al);
+      avl->Append(av);
+    }
+    ComValue retval(avl);
+    push_stack(retval);
+    return;
+  }
+
   int sort = OPBY_PRIORITY;
   if (bycomflag.is_true()) { sort = OPBY_COMMAND; }
   if (byoprflag.is_true()) { sort = OPBY_OPERATOR; }
   if (bypriflag.is_true()) { sort = OPBY_PRIORITY; }
-  
+
   opr_tbl_print(stdout, sort);
   return;
 }

--- a/src/ComTerp/helpfunc.h
+++ b/src/ComTerp/helpfunc.h
@@ -62,12 +62,13 @@ public:
     virtual void execute();
 
     virtual const char* docstring() { 
-      return "%s(:bypri :byopr :bycom) -- print contents of operator table"; }
+      return "%s(:bypri :byopr :bycom :table) -- print contents of operator table\n(or return as list of attrlists with :table)"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":bypri     sort by priority",
 	":byopr     sort by operator name",
 	":bycom     sort by command name",
+	":table     return as list of attrlists (:opr :cmd :pri :rtol :type)",
 	nil
       };
       return keys;

--- a/src/ComTerp/listfunc.h
+++ b/src/ComTerp/listfunc.h
@@ -45,7 +45,7 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() { 
-      return "lst=%s([lst|strm|val] :strmlst :attr :size n) -- create list, copy list, or convert stream (unary $$)"; }
+      return "lst=%s([lst|strm|val] :strmlst :attr :size n) -- create list, copy list, or convert stream (unary $)"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":strmlst   return list inside stream for debug",

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -71,7 +71,7 @@ void PostFixFunc::execute() {
        (_detail_matched_delims && val.is_type(AttributeValue::SymbolType) && 
 	val.nids() >= TOK_RPAREN )) {
       if (!_detail_matched_delims) {
-	out << "[" << val.narg() << "|" << val.nkey() << "]";
+	out << "[" << val.narg() << "|" << val.nkey() << "|" << val.nids() << "]";
 	if (val.is_type(AttributeValue::CommandType)) {
   	  ComFunc* func = (ComFunc*)val.obj_val();
 	  if (func->post_eval()) out << "*";

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -54,7 +54,7 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() { 
-      return "strm=%s(strm|list|attrlist|val|fileobj|pipeobj) -- copy stream or convert list (unary $)"; }
+      return "strm=%s(strm|list|attrlist|val|fileobj|pipeobj) -- copy stream or convert list (unary $$)"; }
 
     CLASS_SYMID("StreamFunc");
 

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -252,6 +252,7 @@ static int empty_symid = -1;
 
 static int attrlist_symid = -1;
 static int list_symid = -1;
+static int dot_symid = -1;
 
 /* === Static functions ================================================== */
 
@@ -1025,7 +1026,15 @@ int status;
 	    else
             {
 	       expecting = OPTYPE_BINARY;
-  	       PFOUT( TOK_COMMAND, *(int *)token, 0, 0, 1 );
+	       if(dot_symid==-1) dot_symid = symbol_add("dot");
+	       if(TopOfOperStack >= 0 &&
+		  OperStack[TopOfOperStack].oper_type == OPERATOR &&
+		  opr_tbl_commid(OperStack[TopOfOperStack].id) == dot_symid) {
+		 PFOUT( TOK_COMMAND, *(int *)token, 0, 0, -1 );
+	       }
+	       else {
+  		 PFOUT( TOK_COMMAND, *(int *)token, 0, 0, 1 );
+	       }
 	    }
          }
 	 break;

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -47,7 +47,7 @@ expression evaluated. By convention test scripts return `ok` (a boolean).
 | boolean | `true` `false` | |
 | nil | `nil` | no value |
 | blank | `BlankType` | return of `return()` with no arg |
-| list | `1,2,3` or `(1,2,3)` | comma operator |
+| list | `1,2,3` or `(1,2,3)` or $1,2,3| comma operator |
 | stream | `$$(1,2,3)` or `(1 2 3)` *(ivtools-3.0)* | sequence of values produced and consumed one at a time |
 | attrlist | `(:x 1)` or `attrlist(:x 1)` | key/value store |
 | compview | returned by drawing commands | graphic component handle |

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -48,7 +48,7 @@ expression evaluated. By convention test scripts return `ok` (a boolean).
 | nil | `nil` | no value |
 | blank | `BlankType` | return of `return()` with no arg |
 | list | `1,2,3` or `(1,2,3)` | comma operator |
-| stream | `$$(1,2,3)` or (1 2 3) | sequence of values produced and consumed one at a time |
+| stream | `$$(1,2,3)` or `(1 2 3)` *(ivtools-3.0)* | sequence of values produced and consumed one at a time |
 | attrlist | `(:x 1)` or `attrlist(:x 1)` | key/value store |
 | compview | returned by drawing commands | graphic component handle |
 
@@ -589,7 +589,7 @@ symvar(key)=func(...)      // register handler for type
 ## Attribute Lists
 
 An attrlist is a key/value store. Create one with `attrlist()` or
-`list(:attr)`, or with the **attrlist literal** syntax — parentheses
+`list(:attr)`, or with the **attrlist literal** syntax *(ivtools-2.2)* — parentheses
 whose first token is a keyword:
 
 ```
@@ -733,3 +733,206 @@ at(lst2 0).a           // 4
 - Deferred/broken tests: comment out with `/* */`, reference the issue number
 - Return `ok` as the last expression for use by `run_all.comt`
 - Sub-scripts are not subject to coverage measurement
+
+---
+
+## Flowtran: Flowgraph Composition Language *(reserved, ivtools-4.0)*
+
+ComTerp is designed to evolve into a flowgraph composition language —
+**flowtran** — that can drive the
+[ipl simulator](https://ipl.sourceforge.net/ipl/IPL_Home.html) directly
+(when linked) and export executable
+[vectaport/flowgraph](https://github.com/vectaport/flowgraph) goroutines.
+
+The flowtran syntax is reserved in the current parser. This section
+documents the intended design.
+
+### Concepts
+
+A flowgraph is made up of **hubs** and **pipes**. A hub is a unit of
+computation; pipes are the typed channels connecting hubs. This maps
+directly to the `vectaport/flowgraph` Hub and Stream model and to the
+ipl (pipe|invo),connector model.  What was called first pipe, then
+invocation in ipl, became node and edge in vectaport/fgbase then Hub
+and Stream in vectaport/flowgraph.  In ipl it was realized that the
+nodes between edges were the place of buffering, so they were the
+pipe holding value.  You would think the edges/Stream should be the
+pipe but buffering is done at the node/Hub and edge/Stream is just
+the instantaneous interconnect, the wire.
+
+ComTerp streams (`..`, `**`, `$$`, `,,`) are a separate concept —
+they are evaluation-time value sequences within ComTerp expressions.
+Flowtran pipes are persistent communication channels between hubs in
+a running flowgraph. The two levels interact: ComTerp stream algebra
+is used to *construct* flowgraphs (replicating hubs and wiring pipes),
+while the flowgraph itself executes asynchronously once assembled.
+
+### Hub definition: `def()`
+
+```
+def(hubname[srclist][dstlist](hubbody))
+```
+
+Defines a hub type. `srclist` is the list of input pipes; `dstlist` is
+the list of output pipes. `hubbody` is a ComTerp expression that runs
+when the hub fires. A hub with no destinations has an empty `dstlist`.
+
+By convention, input pipes are named `a`, `b`, `c` and output pipes
+`x`, `y`, `z` in hub definitions — the Steve Johnson compiler tradition.
+At invocation sites, pipes are given names that make sense from both
+ends of the connection.
+
+Def's with no body must link to a language primitive and are just there to
+declare the API.   Otherwise def's can be a comterp expression that is a
+FuncObj to be fired when AllOf or OneOf is satisfied on inputs arriving,
+the result getting marshalled out on the destination list.  Or the body can
+be an ongoing nested declaration of a flowgraph connected up to the streams
+in the srclist and dstlist.  The primitives are flowtran's bottoming out,
+the comterp expressions are the comterp programmer's way of bottoming out,
+everything above that is a flowgraph.
+
+Any side effects from an embedded comterp fragment would not fit the model 
+so they will all be pre-evaluated down to the code fragment waiting for stream
+input.  For example:
+
+```
+def(area[r][a](a=pi()*r*r))
+```
+
+will get evaluated at "compile" time, and symbols not in the stream lists will
+be evaluated and stored in an internalized representation, i.e.:
+
+```
+area[r][a](a=3.141519*r*r)
+```
+
+A less useful but more illustrative example might be a hub that returned the
+date it was compiled forever:
+
+```
+datecompiled[][d](d=print("%v" date :str))
+```
+
+which becomes:
+
+```
+datecompiled[][d](d=" 6-Jun-2026")
+```
+
+The two canonical Invocation Language primitives illustrate the full syntax:
+
+```
+def(ARBIT[a | b][x](x=a||b))        // OneOf input, single output
+def(STRVAL[a b][x | y](if(a :then x=b :else y=b)))  // AllOf input, OneOf output
+```
+
+The `|` operator separates **firing groups** within a srclist or
+dstlist. Space separates pipes within a group (AllOf — all must be
+present). `|` separates groups (OneOf — any one group fires the hub).
+The rule "no bare values after keywords begin" applies within each
+group, as elsewhere in ComTerp.
+
+```
+def(sink[a][](print(a)))              // AllOf-1 input, no output
+def(double[a][x](x=a*2))             // AllOf-1 in, AllOf-1 out
+def(add[a b][x](x=a+b))              // AllOf-2 in, AllOf-1 out
+def(merge[a | b][x](x=a||b))         // OneOf-2 in (either fires), AllOf-1 out
+def(route[a b][x | y](if(a :then x=b :else y=b)))  // AllOf-2 in, OneOf-2 out
+```
+
+`|` between two sublists means the hub fires on whichever group
+arrives — useful for multiplexing normal data flow with a heartbeat
+or control path:
+
+```
+def(watchdog[data | heartbeat][x](x=data||heartbeat))
+// fires on normal data OR on the watchdog pulse, whichever arrives
+```
+
+Pipes in `srclist` and `dstlist` can include keywords for configuration
+values that are set at wiring time rather than flowing per-token:
+
+```
+def(scale[a :factor][x](x=a*factor))
+```
+
+### Hub invocation: `hubname[srclist][dstlist]`
+
+```
+hubname[srclist][dstlist]
+```
+
+Instantiates a hub and wires it into the flowgraph. The hub name leads
+— you read the topology as *what* fires, then what flows in, then what
+flows out. A stream symbol is created the first time it appears in any
+srclist or dstlist and updated as both ends become connected.
+
+The two NCL primitives invoked in a small flowgraph:
+
+```
+ARBIT[raw_a | raw_b][arbitrated]
+STRVAL[direction arbitrated][to_x | to_y]
+```
+
+`arbitrated` is the stream connecting `ARBIT`'s output to `STRVAL`'s
+input — named from the perspective of what it carries. `direction` is
+a control input; `to_x` and `to_y` are the two steered outputs.
+Reading top to bottom: arbitrate between two raw inputs, then steer
+the result based on a direction signal.
+
+A simple pipeline:
+
+```
+double[raw][scaled]
+sink[scaled][]
+```
+
+`scaled` is created as `double`'s output and simultaneously wired as
+`sink`'s input. Pipes are fully connected when both ends are bound.
+
+### Range replication: `<<` and `>>`
+
+`<<` and `>>` are added to the operator table as flowtran range
+operators, used to replicate hub names and pipe names across a range.
+Combined with ComTerp's `..` stream, they expand to indexed variants:
+
+```
+sink<<0..9>>=sink[input<<0..9>>][]
+```
+
+Expands to `sink0` through `sink9`, each wired to `input0` through
+`input9`. The ten input pipes are left unconnected on their source
+end — other hubs will wire into them. This is the `setbuf` pattern:
+declare the pipes where they are consumed, let the producer side wire
+to them later.
+
+`<<` and `>>` apply to any identifier in a hub or pipe position:
+
+```
+add<<0..3>>[a<<0..3>> b<<0..3>>][sum<<0..3>>]
+```
+
+Creates four `add` hubs, each with its own `a`, `b`, and `sum` pipes.
+
+### Relationship to existing reserved syntax
+
+The following are already reserved in the current parser and will
+be activated for flowtran:
+
+- `[]` — hub srclist and dstlist delimiters
+- `<>` — reserved (angle bracket template fill-in, complementing `<<`/`>>`)
+- `<<` / `>>` — added to the operator table as flowtran range operators
+
+It is hoped that not using `[` and ` ]` and `<<` and `>>` before now
+in the public use of comterp will make any conflicts between comterp and
+flowtran resolvable.
+
+### Target backends
+
+- **ipl simulator** — when ComTerp is linked with the ipl library,
+  `def()` and hub invocation compile to IPL node/arc creation calls
+  directly.
+- **vectaport/flowgraph** — hub definitions export to Go source
+  implementing the `flowgraph.Hub` interface, with pipes as
+  `flowgraph.Edge` channels. The exported package is runnable as
+  a standalone Go program.

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -204,3 +204,16 @@ To add a new test script:
 | parser.comt   | attrlist(:literal) errmsg postfix class type                 | 1-9     |      28 |    38 | 74% |
 | symbol.comt   | ` symadd symid symbol symstr symval symvar strref eq(:sym) lt gt switch cond | 1-9 |  36 |    42 | 86% |
 | random.comt   | (slot 12 stress: all funcs from return/stream/string/global) | 12      |      24 |    24 |100% |
+
+### Planned coverage (ivtools-2.2)
+
+| script        | funcs                                                                         | notes                                                      |
+|---------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
+| parser.comt   | attrlist(:literal) parse error lock-in via errmsg()                           | add errmsg() assertions for bare-value-after-keyword cases |
+| return.comt   | func() empty parens, func() positional varargs, arg(`sym) keyword lookup      | see issue #94                                              |
+
+### Planned coverage (ivtools-3.0)
+
+| script      | funcs                                                                                                          | notes         |
+|-------------|----------------------------------------------------------------------------------------------------------------|---------------|
+| stream.comt | stream literal `(0 1 2 3)`, mixed `(0 :flag 1 :color red)`, keyword element detection via class()/attrname()/attrval() | see issue #94 |

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -203,6 +203,7 @@ To add a new test script:
 | print.comt    | print                                                        | 1-9     |      22 |    35 | 63% |
 | parser.comt   | attrlist(:literal) errmsg postfix class type                 | 1-9     |      28 |    38 | 74% |
 | symbol.comt   | ` symadd symid symbol symstr symval symvar strref eq(:sym) lt gt switch cond | 1-9 |  36 |    42 | 86% |
+| help.comt     | help() help(:posteval) help(:top) help("op") optable(:table) optable(:bypri :byopr :bycom) | 1-14 | 14 | 14 |100% |
 | random.comt   | (slot 12 stress: all funcs from return/stream/string/global) | 12      |      24 |    24 |100% |
 
 ### Planned coverage (ivtools-2.2)

--- a/src/comterp_/tests/help.comt
+++ b/src/comterp_/tests/help.comt
@@ -1,0 +1,114 @@
+// src/comterp_/tests/help.comt -- test help() and optable()
+//
+// coverage: 13/13 (100%)
+// funcs: help() help(:posteval) help(:top) help("op")
+//        optable(:table) optable(:bypri) optable(:byopr) optable(:bycom)
+// optable(:table) returns list of attrlists (:opr :cmd :pri :rtol :type)
+// optable(:bypri :byopr :bycom) prints to stdout only
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/help.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: help(help) returns a string ---
+h=help(help)
+ok=ok&&(type(h)==`StringType)
+print("1 help(help) returns StringType (expect StringType): %v\n" type(h))
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: help(help) non-empty ---
+ok=ok&&(size(h)>0)
+print("2 help(help) non-empty (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: help of two commands returns longer string ---
+h2=help(help print)
+ok=ok&&(type(h2)==`StringType)
+ok=ok&&(size(h2)>size(h))
+print("3 help(help print) longer than help(help) (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: help(:posteval) returns non-empty string ---
+hp=help(:posteval)
+ok=ok&&(type(hp)==`StringType)
+ok=ok&&(size(hp)>0)
+print("4 help(:posteval) non-empty (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: help(:top) returns non-empty string ---
+ht=help(:top)
+ok=ok&&(type(ht)==`StringType)
+ok=ok&&(size(ht)>0)
+print("5 help(:top) non-empty (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: help("$$") returns non-empty string for operator given as string ---
+hstrm=help("$$")
+ok=ok&&(type(hstrm)==`StringType)
+ok=ok&&(size(hstrm)>0)
+print("6 help(\"$$\") non-empty string (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6b: help(optable) mentions :table keyword ---
+ho=help(optable)
+ok=ok&&(type(ho)==`StringType)
+ok=ok&&(size(ho)>0)
+print("6b help(optable) mentions :table (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: optable(:table) returns a list ---
+tbl=optable(:table)
+ok=ok&&(type(tbl)==`ListType)
+ok=ok&&(size(tbl)>0)
+print("7 optable(:table) returns non-empty list (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: each entry is an attrlist with :opr :cmd :pri :rtol :type ---
+al=at(tbl 0)
+ok=ok&&(class(al)==`AttributeList)
+ok=ok&&(al.opr!=nil)
+ok=ok&&(al.cmd!=nil)
+ok=ok&&(al.pri>0)
+ok=ok&&(al.rtol!=nil)
+ok=ok&&(al.type!=nil)
+print("8 optable entry has :opr :cmd :pri :rtol :type (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: known entries present -- "+" cmd "add" pri 60 ---
+found=false
+for(i=0 i<size(tbl) i++
+  if(at(tbl i).opr=="+" && at(tbl i).cmd=="add" :then found=true))
+ok=ok&&found
+print("9 optable has +:add:pri60 (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: "$$" entry is stream, rtol true, UNARY PREFIX ---
+found=false
+for(i=0 i<size(tbl) i++
+  if(at(tbl i).opr=="$$" && at(tbl i).cmd=="stream" :then found=true))
+ok=ok&&found
+print("10 optable has $$:stream (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: optable(:bypri) no crash ---
+optable(:bypri)
+ok=ok&&true
+print("11 optable(:bypri) no crash (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 12: optable(:byopr) no crash ---
+optable(:byopr)
+ok=ok&&true
+print("12 optable(:byopr) no crash (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 13: optable(:bycom) no crash ---
+optable(:bycom)
+ok=ok&&true
+print("13 optable(:bycom) no crash (expect true): %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+print("help: %v\n" ok)
+ok

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -169,5 +169,29 @@ ok=ok&&(type(el)==type(attrlist()))
 ok=ok&&(el.a==4)
 prev_ok=check_fail(:ok ok)
 
+// --- test 18: dot rhs bare name vs explicit parens should differ ---
+// a.type should emit rhs as SymbolType (key lookup intent)
+// a.type() should emit rhs as CommandType (call intent)
+// currently they are identical -- this test fails until _parser.c fix applied
+s_bare=postfix(a.type)
+s_call=postfix(a.type())
+ok=ok&&(s_bare!=s_call)
+print("18a postfix(a.type) (expect SymbolType rhs): %v\n" s_bare)
+print("18b postfix(a.type()) (expect CommandType rhs): %v\n" s_call)
+print("18c bare != call (expect true after fix, false before): %v\n" (s_bare!=s_call))
+prev_ok=check_fail(:ok ok)
+
+// --- test 19: dot rhs chained -- a.type.class.exit all rhs should be SymbolType ---
+// each bare name after . should emit as symbol, not command
+// a.type.class.exit() -- final explicit parens should still be CommandType
+s_chain=postfix(a.type.class.exit)
+s_chain_call=postfix(a.type.class.exit())
+ok=ok&&(index(s_chain "type{") != nil || index(s_chain "type ") != nil)
+print("19a postfix(a.type.class.exit) (expect all rhs as symbols): %v\n" s_chain)
+print("19b postfix(a.type.class.exit()) (expect exit as command): %v\n" s_chain_call)
+ok=ok&&(s_chain!=s_chain_call)
+print("19c chained bare != chained call (expect true after fix): %v\n" (s_chain!=s_chain_call))
+prev_ok=check_fail(:ok ok)
+
 print("parser: %v\n" ok)
 ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -41,5 +41,9 @@ if(run("./symbol.comt")
   :then print("pass: symbol\n")
   :else print("FAIL: symbol\n");ok=false)
 
+if(run("./help.comt")
+  :then print("pass: help\n")
+  :else print("FAIL: help\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -104,6 +104,7 @@ both until exit.
     -          minus          110         R-to-L      unary-prefix
     --         decr           110         R-to-L      unary-prefix
     --         decr_after     110         R-to-L      unary-postfix
+    $$         stream         100         R-to-L      unary-prefix
     **         repeat         90          L-to-R      binary
     ..         iterate        80          L-to-R      binary
     %          mod            70          L-to-R      binary
@@ -126,8 +127,7 @@ both until exit.
     ||         or             40          L-to-R      binary
     ,          tuple          35          L-to-R      binary
     ,,         stream concat  33          L-to-R      binary
-    $          stream         32          R-to-L      unary-prefix
-    $$         list           32          R-to-L      unary-prefix
+    $          list           32          R-to-L      unary-prefix
     %=         mod_assign     30          R-to-L      binary
     *=         mpy_assign     30          R-to-L      binary
     +=         add_assign     30          R-to-L      binary


### PR DESCRIPTION
## dot rhs bare identifier — suppress command dispatch, optable(:table) returns list of attrlists

`a.type` now does a key lookup against an attrlist rather than
dispatching the `type()` command. `a.type()` with explicit parens
still dispatches normally. The chain form `a.type.class.exit` works
correctly — each bare identifier after `.` is treated as a key.

### Implementation

**`_parser.c`** — when a bare identifier (no following parens) appears
on the rhs of `.`, emit `nids=-1` instead of `nids=1`:

```c
if (opr_tbl_commid(OperStack[TopOfOperStack].id) == dot_symid)
    PFOUT( TOK_COMMAND, *(int *)token, 0, 0, -1 );
```

**`comterp.c`** — guard `SymbolType` → `CommandType` promotion in
`code_conversion()` and `incr_stack()` with `sv->nids() >= 0`:

```cpp
if (vptr && ((ComValue*)vptr)->type() == ComValue::CommandType
    && sv->nids() >= 0) {
```

`nids=-1` is safe — `empty` uses `nids=0`, normal commands use
`nids=1`, delimiter dispatch uses `nids >= 18`.

## optable(:table)

`optable(:table)` returns a list of attrlists, one per operator entry,
with fields `:opr`, `:cmd`, `:pri`, `:rtol`, `:type`. Previously
`optable()` only printed to stdout.

## postfix() returns string with nids

`postfix()` now includes `nids` in bracket notation for commands:
`"a type dot[2|0|1]"`. This still doesn't makes the dot-rhs fix visible and testable from comterp scripts
(the type in this example has a nids of -1, the flag to say ignore the fact it is also a command, use it
as a symbol).

## Tests

- `parser.comt` tests 18/19: dot rhs bare vs parens differ in postfix
  output; chained form `a.type.class.exit` vs `a.type.class.exit()`

## Docs

- `ARCHITECTURE.md`: `nids()` values table with full history
- `HACKING.md`: dot operator rhs implementation, nids=-1 convention,
  naming conventions (`comterp` vs `ComTerp`), commands without parens