### PR TITLE
comterp: support nested stream literals ((a b)(c d)) in _parser.c

### DIFF
--- a/APPENDIX-C-IVTOOLS-PROGRAMMING.md
+++ b/APPENDIX-C-IVTOOLS-PROGRAMMING.md
@@ -111,6 +111,76 @@ saved_offtop
 `skip_arg_in_expr()` skips one fixed-format argument expression.
 Both decrement the offset (scan toward lower indices).
 
+## Why the Pipeline Is So Clean: Fischer-LeBlanc and argoff
+
+Most language implementations interpose several layers between source
+text and execution: a parse tree (AST), a tree-walking or lowering pass
+to produce an intermediate representation, and then either compilation
+or interpretation of that IR. Each layer adds complexity and each
+crossing between layers requires a translation.
+
+ComTerp has none of that. The pipeline is:
+
+```
+source text → scanner → Fischer-LeBlanc parser → postfix token array → evaluator
+```
+
+The Fischer-LeBlanc parser (from the scanner/parser library developed
+at Triple Vision in the late 1980s, acquired by Scott Johnston at
+dissolution and carried forward into ComTerp) produces postfix-ordered
+tokens directly as it parses. There is no separately allocated AST. The tree structure is implicit
+in the postfix ordering — token sequence and argument counts
+(`[narg|nkey|nids]`) encode the full topology without ever
+materializing heap-allocated nodes with pointers. The "code conversion"
+step that would normally transform an explicit parse tree into an
+executable form is trivially thin — the parser is already building
+postfix order as it goes, and the postfix buffer it emits *is* the
+executable form.
+
+This has two consequences that compound each other:
+
+**The wire protocol is free.** Because the postfix buffer is the
+executable form, sending an expression over a socket and evaluating it
+locally are the same operation. There is no separate serialization
+layer, no marshalling, no protocol adapter. `remote()` sends the
+expression string, receives a ComTerp value string back, and evaluates
+it — one pipeline, both directions.
+
+**`argoff` unifies all lazy evaluation.** When the evaluator reaches a
+post-eval command in the postfix buffer, instead of having already
+evaluated and pushed all of the command's arguments onto the operand
+stack, it pushes a single integer: `argoff` — the offset into the
+static postfix buffer where the command's unevaluated arguments begin.
+
+The command receives `argoff` and can do whatever it likes with the
+buffer: evaluate one argument now and save the rest for later, evaluate
+an argument repeatedly (as `while` does for its condition and body),
+capture a slice as a `FuncObj` for deferred execution, or skip
+arguments entirely (as `if` does for the untaken branch).
+
+This is what makes `if`, `for`, `while`, `func`, stream literals, and
+`remote()` all work through the same mechanism rather than requiring
+special cases in the evaluator:
+
+- `if(:then :else)` — evaluates only the selected branch via `argoff`
+- `while(cond body)` — re-evaluates both from the buffer on each iteration
+- `func` — captures the body token buffer as a `FuncObj` via `argoff`
+- Stream literals — `StreamLiteralNextFunc` re-evaluates each element
+  token lazily via `comterpserv()->run(tokbuf+offset, cnt)`
+- `remote()` — the returned string is evaluated by the same pipeline
+
+In Lisp, special forms and macros achieve some of this, but each is
+baked into the evaluator as a special case. `argoff` is a uniform
+mechanism: any `ComFunc` subclass opts in by returning `true` from
+`post_eval()`, and the same `argoff` machinery handles it. No special
+cases in the evaluator, no privileged syntax.
+
+The simplicity compounds: the Fischer-LeBlanc parser encodes the tree
+implicitly in a flat buffer → the buffer is directly addressable by
+integer offset → `argoff` is just an integer → post-eval commands are
+just commands with one extra method → lazy evaluation, streaming, and
+distributed execution all fall out of the same mechanism.
+
 ## FuncObj and Lazy Evaluation
 
 `FuncObj` (defined in `postfunc.h`) is the mechanism for storing an
@@ -427,6 +497,35 @@ In all these cases the key facts to keep in mind:
 
 The stream literal implementation in `StreamFunc::execute_literal()` is
 the worked example of all four of these at once.
+
+## Generating Patches for git apply
+
+When producing a patch for `git apply`, the `---` and `+++` header lines
+must use `a/` and `b/` prefixes with paths relative to the repo root.
+Files uploaded to Claude land at `/mnt/user-data/uploads/` and patched
+copies are written to `/home/claude/`. Use `sed` to fix the paths:
+
+```bash
+diff -u /mnt/user-data/uploads/filename.c /home/claude/filename.c \
+  | sed 's|/mnt/user-data/uploads/filename.c|a/src/SubDir/filename.c|; \
+         s|/home/claude/filename.c|b/src/SubDir/filename.c|' \
+  > filename.patch
+```
+
+For `_parser.c` specifically:
+
+```bash
+diff -u /mnt/user-data/uploads/_parser.c /home/claude/_parser.c \
+  | sed 's|/mnt/user-data/uploads/_parser.c|a/src/ComUtil/_parser.c|; \
+         s|/home/claude/_parser.c|b/src/ComUtil/_parser.c|' \
+  > patch.patch
+```
+
+Apply with:
+
+```bash
+git apply patch.patch
+```
 
 ## See Also
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -66,8 +66,7 @@ a ComTerp command, but not every ComTerp command is a drawing Command.
 what uses it can be put to beyond those already discovered. Streams are
 lazy sequences — values produced and consumed one at a time. They
 compose with scalar operators, zip element-wise, concatenate, and
-terminate on nil. Stream literals `(0 1 2 3)` make it possible to
-describe dataflow graphs directly in the language.
+terminate on nil.
 
 Each stage of the system's development added one of three core ideas:
 commands-as-evaluation, streaming evaluation, and distributed state
@@ -169,12 +168,12 @@ language actually works rather than how it was intended to work.
 
 A note on that process: the documentation, test suite, design issues,
 and architectural writeups in this release were produced in
-collaboration with an LLM used as a programming and writing tool —
-the same way one might use a compiler or a debugger. The LLM found
-the same things surprising that a new human programmer would find
+collaboration with an LLM used as a programming and writing tool — the
+same way one might use a compiler or a debugger. The LLM found the
+same things surprising that a new human programmer would find
 surprising. The places where it needed correction were the places
-where the language most rewards attention. Those corrections became
-the documentation.
+where the language most rewards attention to simplicity. Those
+corrections became the documentation.
 
 It is as exciting as any marble run you can think of. You set up the
 tracks, release the marble, and watch where it goes. Sometimes it goes
@@ -230,7 +229,7 @@ makes sense in a way that most languages do not.
 
 ---
 
-## A note on the documentation
+## Continued Reading
 
 `src/comterp_/LANGUAGE.md` is the language reference. Start there for
 syntax, types, operators, control flow, streams, and functions.
@@ -243,8 +242,10 @@ the way it does.
 `src/ComTerp/HACKING.md` is for contributors — how to add a command,
 how to test, how to avoid the common mistakes.
 
-The test files in `src/comterp_/tests/` are the living specification.
-When the docs and the tests disagree, the tests are right.
+The test files in `src/comterp_/tests/` are the living specification
+of what the language does (`TESTING.md` in that directory describes
+the test procedures and coverage standards).  When the docs and the
+tests disagree, the tests are right.
 
 ---
 

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -1142,7 +1142,19 @@ int status;
 	 if( expecting == OPTYPE_BINARY ) {
 	   if( (!PROCEEDING_WHITESPACE( tokstart ) && !_detail_matched_delims) ||
 		 UNEXPECTED_NEW_EXPRESSION ) {
-		 UNEXPECTED_LPAREN_ERROR( toktype );
+		 /* stream literal: bare LPAREN, first element is also LPAREN */
+		 if( toktype == TOK_LPAREN &&
+		     TopOfParenStack >= 0 &&
+		     ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
+		     ParenStack[ TopOfParenStack ].comm_id == -1 &&
+		     ParenStack[ TopOfParenStack ].narg == 0 ) {
+		   if(stream_symid==-1) stream_symid = symbol_add("stream");
+		   ParenStack[ TopOfParenStack ].comm_id = stream_symid;
+		 /* nested paren is a valid element inside an existing stream literal */
+		 } else if( !(TopOfParenStack >= 0 &&
+		              ParenStack[ TopOfParenStack ].comm_id == stream_symid) ) {
+		   UNEXPECTED_LPAREN_ERROR( toktype );
+		 }
 	     }
 
              /* End of an argument                     */

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -870,7 +870,14 @@ int status;
 
 	    if( !PROCEEDING_WHITESPACE( tokstart ) ||
                 UNEXPECTED_NEW_EXPRESSION ) {
-	       /* stream literal: bare LPAREN, first value seen, second arriving */
+	      
+              /* stream literal: slip in stream_symid when a nested LPAREN arrives
+		 as the first element (narg==0, comm_id==-1).  This mirrors the
+		 scalar/identifier slip-in above and enables both all-stream
+		 ((a b)(c d)) and mixed scalar+stream (1 (2 3)) literals --
+		 the mixed case is consistent with how (a b) detects the stream
+		 on the second element with the first already on the stack. */
+
 	       if( TopOfParenStack >= 0 &&
 	           ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
 	           ParenStack[ TopOfParenStack ].comm_id == -1 &&

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -19,6 +19,62 @@ to a flat postfix token stream, then evaluates it iteratively. Nesting
 depth in the original expression does not affect the interpreter's
 call stack — everything is a token stream and an operand stack.
 
+### The REPL is the wire protocol
+
+"The syntax is the wire protocol" has a concrete meaning that goes
+beyond serialization. In most distributed systems there are two
+distinct layers: an expression language for local computation, and a
+separate serialization format (JSON, protobuf, XML) for sending values
+over the wire. ComTerp collapses these into one. The value returned by
+any expression is itself a valid ComTerp expression — so sending a
+value and sending an expression are the same act.
+
+This is demonstrated completely by `remote()`:
+
+```
+remote(hoststr|sockobj [portnum] cmdstr :nowait :str)
+```
+
+`remote()` sends `cmdstr` to another ComTerp instance over a TCP
+socket and — by default — waits for the response, evaluates it
+locally, and pushes the result onto the operand stack as a live
+ComTerp value:
+
+```
+// ask a remote node for its drawlink connection table, use it locally
+t=remote("peer" 9988 "drawlink(:table)")
+// t is a live list of attrlists -- at(t).host
+```
+
+That last step — evaluating the returned string and pushing it on the
+stack — is what makes the protocol self-consistent. The remote node
+doesn't return a serialized blob that needs to be deserialized by a
+separate layer. It returns a ComTerp expression that the local
+interpreter evaluates directly, because every ComTerp value round-trips
+through its own syntax.
+
+The `:str` keyword skips the local evaluation and returns the raw
+response string instead — useful when you want to inspect the wire
+traffic or defer evaluation:
+
+```
+raw=remote("peer" 9988 "drawlink(:table)" :str)
+// raw is something like "(:nlinks 2 :host0 \"peer2\" :port0 9988 ...)"
+// a ComTerp expression string -- parse or log it, or run() it later
+run(raw :str)   // evaluate it now -- same result as without :str
+```
+
+`:nowait` fires and forgets — sends the expression without waiting for
+a response. Used for one-way commands like brush propagation in
+DrawServ where the sender doesn't need the return value.
+
+The same property makes the `drawmo` test orchestrator work — it drives
+drawserv instances over stdin pipes using the same expressions a human
+would type at the REPL, and the responses come back as ComTerp values
+that the orchestrator can inspect, compare, and branch on. There is no
+separate test protocol, no mock layer, no serialization adapter. The
+REPL session and the wire session are the same thing.
+
 ## Expressions and Sequencing
 
 The basic unit of execution is an expression. Multiple expressions are
@@ -582,6 +638,64 @@ a=0; b=10; c=1000
 ss=(a..b)+c            // lazy -- not yet consumed
 list(ss)               // {1000,1001,...,1010}
 ```
+
+
+### Design Provenance and Prior Art
+
+The automatic scalar overdrive mechanism — where any scalar operator
+applies element-wise over a stream without the operator knowing anything
+about streams — is an original invention of Scott Johnston. The
+conceptual lineage traces to a SPIE paper in 1988 and the command
+interpreter work at Honeywell and Triple Vision that preceded ComTerp.
+The working `$$` stream mechanism with lazy evaluation and automatic
+scalar overdrive was developed and refined well into the 2000s and
+continues to be extended in the ivtools-2.x series.
+
+**What existed before:**
+
+- **APL/J/K** — automatic broadcasting over arrays, but eager and fully
+  materialized. The spirit is the same but the execution model is
+  opposite: arrays are computed all at once, not lazily on demand.
+- **MATLAB** — closest in surface syntax (`a*2` broadcasts over a
+  vector), but eager, and `*` vs `.*` means the programmer must
+  explicitly signal element-wise intent. Not automatic.
+- **Lucid (language, Wadge and Ashcroft, 1985)** — a dataflow language
+  where every variable is implicitly a stream and operators apply
+  element-wise. A whole-language commitment, not an embeddable
+  mechanism, and never became practical. Intellectually in the same
+  lineage as Karl Fant's NCL work which also influenced ComTerp.
+- **Haskell/Clojure** — lazy sequences, but explicit lifting required.
+  The programmer must write `fmap (*2) list` or `(map #(* % 2) coll)` —
+  the operator does not overdrive automatically.
+
+**What is distinctive about ComTerp's overdrive:**
+
+- **Automatic** — `(1..5)*2` just works. No `fmap`, no `.*`, no lifting.
+  The scalar operator `*` is oblivious to streams entirely.
+- **Lazy** — streams are single-pass and evaluate on demand. No full
+  materialization required.
+- **Post-eval flag** — a clean architectural separation between operators
+  that are overdriven by streams (scalar operators, non-post-eval
+  commands) and consumers that receive the stream intact (post-eval
+  commands like `list()`, `sum()`, `each()`). The flag is per-command
+  and controls the overdrive boundary.
+- **Three-level hierarchy** — scalar (fully overdriven), post-eval
+  (receives stream intact, consumes one level), deep (receives full
+  nested structure, traverses itself). This is a runtime dispatch
+  mechanism, not a type system feature.
+- **Embeddable** — ComTerp is a scripting layer on top of a C++
+  application framework. The stream algebra is available wherever
+  ComTerp expressions are evaluated, including over TCP sockets.
+- **nd by composition** — higher-dimensional array operations emerge
+  from composing zip (`,` overdriven by n streams) and cross product
+  (`for`/`while` overdriven by a stream in the body). No special nd
+  array type required.
+
+The combination of laziness, automatic overdrive without explicit
+lifting, the post-eval/deep distinction as an explicit architectural
+flag, and nd structure emerging from stream composition rather than
+being declared upfront — this specific architecture has no known prior
+art.
 
 ### Two-stream binary ops zip element-wise
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -174,6 +174,35 @@ setup in the comment above:
 print("10 sum via while/next($$(1..5)) (expect 15): %v\n" total)
 ```
 
+### Rules for LLM-assisted authoring
+
+When an LLM generates or edits a `.comt` test script, it must follow
+these four rules without exception. They are mechanical checklist items,
+not stylistic suggestions — violating any one of them produces a broken
+or misleading test file:
+
+1. **Update the test number in the version header and coverage comment.**
+   Every new test increments the count in `// coverage: N tests of ...`
+   and in `print("scriptname.comt version N\n")` if the version bumps.
+   Do not leave a stale count.
+
+2. **Move the final summary line to the very end.**
+   The `print("scriptname: %v\n" ok)` / `ok` footer must always be the
+   last two lines of the file. When appending new tests, remove the old
+   footer before appending, then re-add it after the new tests.
+
+3. **Update the coverage stats in the header.**
+   The `// coverage:`, `// funcs:`, and `// missing:` header lines must
+   reflect the new test count and any new functions exercised. If a
+   previously-missing slot is now covered, remove it from `// missing:`.
+
+4. **Embed the original ComTerp expression in the print label.**
+   The `print()` call for each test must show the actual expression being
+   tested as the first element of the label string, not just prose.
+   Followed by descriptive text if needed. This makes the test log
+   self-documenting. See the **Test label convention** section above for
+   examples.
+
 ## Adding Coverage
 
 To improve coverage on an existing script:

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -247,3 +247,24 @@ To add a new test script:
 | script      | funcs                                                                                                          | notes         |
 |-------------|----------------------------------------------------------------------------------------------------------------|---------------|
 | stream.comt | stream literal `(0 1 2 3)`, mixed `(0 :flag 1 :color red)`, keyword element detection via class()/attrname()/attrval() | see issue #94 |
+
+## The Self-Hosted Test Suite
+
+The ComTerp test suite is written in ComTerp. This is not just a
+convenience — it is the same bootstrap insight that underlies a C
+compiler compiling itself, or yacc processing its own grammar. You
+cannot use the test harness to test the test harness until the test
+harness works well enough to run. The scaffolding (`testlib.comt`,
+`run_all.comt`, `ok=ok&&(...)`, `check_fail()`) had to be bootstrapped
+from a working-enough ComTerp before it could test ComTerp.
+
+The payoff is that the test suite is also the most honest documentation
+of what the language actually does. Any discrepancy between prose docs
+and tests, the tests win — they run. And because the tests are written
+in ComTerp, reading them teaches ComTerp in a way no external test
+framework could. The test suite is also the tutorial.
+
+Most languages never achieve this. Their test suites are written in
+some other language, which means there is always a translation layer
+between "what the tests say" and "what the language means." ComTerp
+tests mean exactly what they say, in the language they are testing.

--- a/src/comterp_/tests/matrixmult.comt
+++ b/src/comterp_/tests/matrixmult.comt
@@ -1,0 +1,74 @@
+// matrixmult.comt version 5
+print("matrixmult.comt version 5\n")
+
+// Matrix multiplication C = A * B:
+//   C[i][j] = sum of A[i][r] * B[r][j] for r = 0..k-1
+//   Each element of C is a DOT PRODUCT of a row of A with a column of B.
+//
+// Key constraint: streams are single-pass. Reconstruct for each use.
+
+// A = [1 2; 3 4]  (2x2), B = [5 6; 7 8]  (2x2)
+// Expected C = [19 22; 43 50]
+
+A=list(1,2,3,4)
+B=list(5,6,7,8)
+
+// =========================================================
+// Approach 1: explicit -- streams must be reconstructed each use
+// =========================================================
+
+// c00 = row0(A) . col0(B) = (1,2).(5,7) = 5+14 = 19
+c00=sum(list((at(A 0) at(A 1))*(at(B 0) at(B 2))))
+c01=sum(list((at(A 0) at(A 1))*(at(B 1) at(B 3))))
+c10=sum(list((at(A 2) at(A 3))*(at(B 0) at(B 2))))
+c11=sum(list((at(A 2) at(A 3))*(at(B 1) at(B 3))))
+
+print("Approach 1: explicit stream literals (reconstruct each use)\n")
+print("C = [%v %v; %v %v]\n" c00 c01 c10 c11)
+print("Expected: [19 22; 43 50]\n\n")
+
+// =========================================================
+// Approach 2: matrow/matcol via list->stream
+// func has no formal argument list -- keywords from call site
+// become local variables in the body
+// =========================================================
+
+// matrow: keywords :M :k :i -- build list of row i, return as stream
+func matrow (r=list(); for(j=0 j<k j++ r=list(r,at(M,i*k+j))); $$r)
+
+// matcol: keywords :M :k :j -- build list of col j, return as stream
+func matcol (c=list(); for(i=0 i<k i++ c=list(c,at(M,j+i*k))); $$c)
+
+c00b=sum(list(matrow(:M A :k 2 :i 0)*matcol(:M B :k 2 :j 0)))
+c01b=sum(list(matrow(:M A :k 2 :i 0)*matcol(:M B :k 2 :j 1)))
+c10b=sum(list(matrow(:M A :k 2 :i 1)*matcol(:M B :k 2 :j 0)))
+c11b=sum(list(matrow(:M A :k 2 :i 1)*matcol(:M B :k 2 :j 1)))
+
+print("Approach 2: matrow/matcol funcs\n")
+print("C = [%v %v; %v %v]\n" c00b c01b c10b c11b)
+print("Expected: [19 22; 43 50]\n\n")
+
+// =========================================================
+// Approach 3: full matmul
+// keywords :A :B :m :k :n
+// =========================================================
+
+func matmul (
+  C=list();
+  for(i=0 i<m i++
+    for(j=0 j<n j++
+      C=list(C,sum(list(matrow(:M A :k k :i i)*matcol(:M B :k k :j j))))));
+  C)
+
+C=matmul(:A A :B B :m 2 :k 2 :n 2)
+print("Approach 3: matmul via nested for\n")
+print("C = [%v %v; %v %v]\n" at(C 0) at(C 1) at(C 2) at(C 3))
+print("Expected: [19 22; 43 50]\n\n")
+
+// =========================================================
+// Streaming algebra note:
+// The inner loop (dot product) is native streaming: row*col zips element-wise.
+// The outer loop (all i,j pairs) is a cross product -- currently requires
+// explicit for loops. Once stream overdrive through for/while lands,
+// the outer loop could become a stream too.
+// =========================================================

--- a/src/comterp_/tests/stream-literal.comt
+++ b/src/comterp_/tests/stream-literal.comt
@@ -1,11 +1,13 @@
-// stream-literal.comt version 1
-print("stream-literal.comt version 1\n")
+// stream-literal.comt version 3
+print("stream-literal.comt version 3\n")
 
 // src/comterp_/tests/stream-literal.comt -- stream literal syntax tests
 //
-// coverage: 14 parser tests of stream literal feature
-// funcs: postfix() errmsg() index()
-//
+// coverage: 17 tests of stream literal feature
+// funcs: postfix() errmsg() index() next() list() each() size() class()
+// tests 1-8:   parser tests (postfix inspection)
+// tests 9-14:  stream literal runtime behavior
+// tests 15-17: stream-of-streams construction and zip behavior
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/stream-literal.comt")
@@ -128,7 +130,7 @@ r3=next(s)
 ok=ok&&(r1!=empty())
 ok=ok&&(r2!=empty())
 ok=ok&&(r3!=empty())
-print("10 lazy eval (expect 3 rand values): %v %v %v\n" r1 r2 r3)
+print("10 (rand rand rand) lazy eval (expect 3 distinct rand values): %v %v %v\n" r1 r2 r3)
 prev_ok=check_fail(:ok ok)
 
 // --- test 11: nil in stream terminates early ---
@@ -138,7 +140,7 @@ s=(1 nil 3)
 v1=next(s); v2=next(s)
 ok=ok&&(v1==1)
 ok=ok&&(v2==nil)
-print("11 nil terminates stream (expect 1 then nil): %v %v\n" v1 v2)
+print("11 next() on (1 nil 3) -- nil terminates stream (expect 1 nil): %v %v\n" v1 v2)
 prev_ok=check_fail(:ok ok)
 
 // --- test 12: each() on stream literal returns count ---
@@ -157,7 +159,7 @@ ok=ok&&(v1==0)
 ok=ok&&(class(v2)==`AttributeList)
 ok=ok&&(v2.key==1)
 ok=ok&&(v3==nil)
-print("13 (0 :key 1) keyword element (expect 0 :key 1 nil): %v %v %v\n" v1 v2 v3)
+print("13 next() on (0 :key 1) -- keyword element as attrlist (expect 0 (:key 1) nil): %v %v %v\n" v1 v2 v3)
 prev_ok=check_fail(:ok ok)
 
 // --- test 14: stream literal and list duality ---
@@ -171,7 +173,56 @@ ok=ok&&(at(l1 0)==4)
 ok=ok&&(class(at(l1 1))==`AttributeList)
 ok=ok&&(at(l1 0)==at(l2 0))
 ok=ok&&(class(at(l2 1))==`AttributeList)
-print("14 list duality list((4 :b 3)) (expect {4,(:b 3)}): %v\n" l1)
+print("14 list((4 :b 3)) -- list duality (expect {4,(:b 3)}): %v\n" l1)
+prev_ok=check_fail(:ok ok)
+
+// =========================================================
+// PART 3: Stream-of-streams construction and zip behavior
+// =========================================================
+
+// --- test 15: nested stream literal syntax ((1 2 3)(4 5 6)) ---
+// BEFORE fix: parse error -- "Unexpected left parenthesis"
+// AFTER fix:  outer stream yields two independent inner StreamObjs lazily,
+//             next() on each inner stream gives {1,2,3} and {4,5,6}
+errmsg(:clear)
+ss=nil
+ss=((1 2 3)(4 5 6))
+e15=errmsg(:last)
+errmsg(:clear)
+ok15=(e15==nil)
+r0=next(ss); r1=next(ss); eot=next(ss)
+ok15=ok15&&(class(r0)==`StreamObj)
+ok15=ok15&&(class(r1)==`StreamObj)
+ok15=ok15&&(eot==nil)
+ok15=ok15&&(list(r0)==(1,2,3))
+ok15=ok15&&(list(r1)==(4,5,6))
+ok=ok&&ok15
+print("15 ((1 2 3)(4 5 6)) -- nested stream literal (expect StreamObj StreamObj nil): %v %v %v\n" r0 r1 eot)
+prev_ok=check_fail(:ok ok)
+
+// --- test 16: $$(1,2,3),$$(4,5,6) -- comma overdriven by two streams zips them ---
+// $$ binds tightly to next expr only; comma between two streams is overdriven
+// and produces a zip stream of paired elements, NOT a stream-of-rows.
+// This is the currently-working construction; result is a zip not nested streams.
+// ACTUAL: list() gives {{1,4},{2,5},{3,6}}
+ss2=$$(1,2,3),$$(4,5,6)
+l16=list(ss2)
+ok=ok&&(l16==((1,4),(2,5),(3,6)))
+print("16 $$(1,2,3),$$(4,5,6) -- zip via overdriven comma (expect {{1,4},{2,5},{3,6}}): %v\n" l16)
+prev_ok=check_fail(:ok ok)
+
+// --- test 17: double zipper -- known unexpected behavior ---
+// $$(($$(1,2,3),$$(4,5,6)),($$(11,12,13),$$(14,15,16)))
+// EXPECTED if double zip were symmetric: {{1,4,11,14},{2,5,12,15},{3,6,13,16}}
+// ACTUAL: {{1,4,{11,14}},{2,5,{12,15}},{3,6,{13,16}}}
+// Second group arrives as StreamObj and is appended as nested element
+// rather than being zipped peer-to-peer with the first group.
+// Root cause unknown -- preserved as regression/investigation anchor.
+ss3=$$(($$(1,2,3),$$(4,5,6)),($$(11,12,13),$$(14,15,16)))
+l17=list(ss3)
+ok17=(l17==((1,4,{11,14}),(2,5,{12,15}),(3,6,{13,16})))
+ok=ok&&ok17
+print("17 $$(($$(1,2,3),$$(4,5,6)),($$(11,12,13),$$(14,15,16))) -- double zipper (expect {{1,4,11,14},{2,5,12,15},{3,6,13,16}} actual {{1,4,{11,14}},...}): %v\n" l17)
 prev_ok=check_fail(:ok ok)
 
 print("stream-literal: %v\n" ok)


### PR DESCRIPTION
## comterp: support nested stream literals ((a b)(c d)) in _parser.c

Extends the stream literal parser patch to support nested stream literals,
where each element of an outer stream literal is itself a stream literal:

```comterp
((0 1 2)(3 4 5))   // outer stream yields two inner StreamObjs
```

Previously this threw "Unexpected left parenthesis" because the TOK_LPAREN
case in `_parser.c` did not recognize a nested `(` as a valid stream
element.

### Parser fix (`src/ComUtil/_parser.c`)

Two cases handled in the `TOK_LPAREN` / `expecting == OPTYPE_BINARY` branch:

1. **First element is `(`** — outer parens are bare (`comm_id == -1`,
   `narg == 0`), so slip in `stream_symid` immediately, same as the
   existing literal/identifier slip-in does for scalar first elements.

2. **Subsequent elements are `(`** — outer parens already have
   `comm_id == stream_symid`, so let the nested `(` through without
   error.

### Tests (`src/comterp_/tests/stream-literal.comt`)

Three new tests in Part 3 (stream-of-streams):

- **Test 15** — `((1 2 3)(4 5 6))`: verifies the outer stream yields two
  independent inner StreamObjs, each materializing correctly via `list()`.
- **Test 16** — `$$(1,2,3),$$(4,5,6)`: documents that comma overdriven by
  two streams produces a zip `{{1,4},{2,5},{3,6}}`, not stream-of-rows.
  Passes now; serves as a regression guard.
- **Test 17** — double zipper: documents known asymmetric zip behavior as
  a regression/investigation anchor. Passes with currently-incorrect behavior; 
update this expected value when the asymmetric zip is fixed.

`NextFunc` emits "Nested stream that could be further expanded, internal
type" when it encounters a stream-valued element — these are intentional
breadcrumbs marking where stream-of-streams overdrive logic will be added.

### Also in this PR

- `APPENDIX-C-IVTOOLS-PROGRAMMING.md` — new section "Why the Pipeline Is
  So Clean: Fischer-LeBlanc and argoff" documenting the architectural
  insight behind the flat postfix buffer, `argoff`, and why the wire
  protocol is free. Also adds patch generation conventions for `git apply`.
- `src/comterp_/LANGUAGE.md` — new section "The REPL is the wire
  protocol" with `remote()` example using `drawlink(:table)`. New section
  "Design Provenance and Prior Art" in the Streams chapter documenting the
  origins of automatic scalar overdrive. Also updates stream algebra
  sections for zip, cross product, and nd composition.
- `src/comterp_/tests/matrixmult.comt` — new test file demonstrating
  2×2 matrix multiply via stream literal dot products and keyword-argument
  funcs, with three approaches of increasing generality.