### PR TITLE
comterp: fix offset/order of mixed-width positionals in stream literals

### DIFF
--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -197,15 +197,35 @@ void StreamFunc::execute_literal() {
     skip_key_in_expr(rescan, argcnt);
   }
 
-  /* fixed-format (positional) args first */
+  /* fixed-format (positional) args first.
+     skip_arg_in_expr walks the postfix buffer BACKWARD from the command,
+     so pi=0 discovers the LAST source positional, pi=1 the second-to-last,
+     etc -- discovery order is the reverse of source order.  tokbuf (from
+     copy_post_eval_expr) is in FORWARD source order, so a naive running
+     elem_offset assigns (offset,count) pairs as if discovery order matched
+     tokbuf order -- correct only when all positionals are the same width
+     (e.g. (10 20 30), or ((1 2 3)(4 5 6)) where both elements are width 3),
+     and silently wrong for mixed-width elements like (1 (2 3)).
+
+     Fix: collect each pi's size, then compute true forward offsets via a
+     reverse-accumulation pass, and append to the AVL in reverse-pi order
+     so AVL element 0 corresponds to source positional 0. */
+  int* possizes = npositionals>0 ? new int[npositionals] : nil;
   for (int pi = 0; pi < npositionals; pi++) {
     argcnt = 0;
     skip_arg_in_expr(rescan, argcnt);
-    avl->Append(new AttributeValue(elem_offset, AttributeValue::IntType));
-    avl->Append(new AttributeValue(argcnt, AttributeValue::IntType));
-    elem_offset += argcnt;
+    possizes[pi] = argcnt;
+  }
+  int posoffsets_running = 0;
+  for (int pi = npositionals-1; pi >= 0; pi--) {
+    int off = posoffsets_running;
+    posoffsets_running += possizes[pi];
+    avl->Append(new AttributeValue(off, AttributeValue::IntType));
+    avl->Append(new AttributeValue(possizes[pi], AttributeValue::IntType));
     nelem++;
   }
+  elem_offset = posoffsets_running;
+  delete [] possizes;
 
   /* keywords second */
   rescan = keys_start;

--- a/src/comterp_/tests/stream-literal.comt
+++ b/src/comterp_/tests/stream-literal.comt
@@ -1,13 +1,13 @@
-// stream-literal.comt version 3
-print("stream-literal.comt version 3\n")
+// stream-literal.comt version 4
+print("stream-literal.comt version 4\n")
 
 // src/comterp_/tests/stream-literal.comt -- stream literal syntax tests
 //
-// coverage: 17 tests of stream literal feature
-// funcs: postfix() errmsg() index() next() list() each() size() class()
+// coverage: 18 tests of stream literal feature
+// funcs: postfix() errmsg() index() next() list() each() size() class() trace()
 // tests 1-8:   parser tests (postfix inspection)
 // tests 9-14:  stream literal runtime behavior
-// tests 15-17: stream-of-streams construction and zip behavior
+// tests 15-18: stream-of-streams construction, zip behavior, mixed elements
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/stream-literal.comt")
@@ -223,6 +223,35 @@ l17=list(ss3)
 ok17=(l17==((1,4,{11,14}),(2,5,{12,15}),(3,6,{13,16})))
 ok=ok&&ok17
 print("17 $$(($$(1,2,3),$$(4,5,6)),($$(11,12,13),$$(14,15,16))) -- double zipper (expect {{1,4,11,14},{2,5,12,15},{3,6,13,16}} actual {{1,4,{11,14}},...}): %v\n" l17)
+prev_ok=check_fail(:ok ok)
+
+// --- test 18: mixed scalar + nested stream literal ---
+// (1 (2 3) :key 4) -- a stream containing a scalar, an inner stream
+// literal, and a keyword element, in that source order.
+// next() yields 1, then StreamObj{2,3}, then (:key 4), then nil.
+//
+// Previously this corrupted the stack ("func next pushed more than a
+// single value on stack", leaving {1,2,3}).  Root cause: execute_literal()
+// discovers positionals via backward postfix traversal (pi=0 = LAST source
+// element), but assigned (offset,count) pairs as if discovery order
+// matched tokbuf's forward order.  Correct only when all positionals are
+// the same width -- (10 20 30) and ((1 2 3)(4 5 6)) (tests 9, 15) are both
+// uniform-width and worked "by coincidence".  Fixed by collecting sizes
+// then assigning offsets via reverse accumulation, appended in reverse-pi
+// order so AVL element 0 = source positional 0.
+errmsg(:clear)
+s18=(1 (2 3) :key 4)
+ok18=(class(s18)==`StreamObj)
+r18a=next(s18)
+ok18=ok18&&(r18a==1)
+r18b=next(s18)
+ok18=ok18&&(class(r18b)==`StreamObj)&&(list(r18b)==(2,3))
+r18c=next(s18)
+ok18=ok18&&(class(r18c)==`AttributeList)
+r18d=next(s18)
+ok18=ok18&&(r18d==nil)
+ok=ok&&ok18
+print("18 next((1 (2 3) :key 4)) -- mixed scalar+stream+keyword (expect 1 StreamObj{2,3} (:key 4) nil): %v %v %v %v\n" r18a r18b r18c r18d)
 prev_ok=check_fail(:ok ok)
 
 print("stream-literal: %v\n" ok)


### PR DESCRIPTION
## Fix mixed-width positional offset/order in stream literal hidden list

`StreamFunc::execute_literal()` discovers positional elements via
backward postfix traversal (`skip_arg_in_expr` walks from the command
backward, so pi=0 discovers the LAST source positional, pi=1 the
second-to-last, etc). tokbuf (from `copy_post_eval_expr`) is in forward
source order.

The recording loop assigned `(offset,count)` pairs using a running
`elem_offset` in *discovery* order, implicitly assuming discovery order
matches tokbuf order. This is correct only when all positionals are the
same token-width:

- `(10 20 30)` -- three width-1 elements (test 9, passes)
- `((1 2 3)(4 5 6))` -- two width-3 elements (test 15, passes)

and silently wrong for mixed-width elements:

- `(1 (2 3))` -- width-1 then width-3 -- `(offset,count)` pairs pointed
  at the wrong token ranges entirely, causing `next()` to evaluate
  garbage token slices and corrupt the stack: