### PR TITLE
Add info() stream introspection command, stream-info.comt suite, and postfix/stream design docs

### DIFF
--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -487,7 +487,7 @@ site.
 
 ```
 // correct -- func returns a FuncObj, assigned to a symbol with =:
-matrow=func(r=list(); for(j=0 j<k j++ r,at(M i*k+j)); $$r)
+matrow=func(r=list(); for(j=0 j<n j++ r,at(M i*n+j)); $$r)
 
 // wrong -- this is C/Scheme declaration syntax; there is no such form.
 // `matrow` is not a name slot here; the FuncObj is never bound to it,
@@ -497,8 +497,8 @@ func matrow (r=list(); for(...); $$r)
 
 Note what is *not* present in the correct form:
 
-- **No formal argument list.** `M`, `k`, `i` are never declared. They
-  appear as locals when the call passes `:M ... :k ... :i ...`. See the
+- **No formal argument list.** `M`, `n`, `i` are never declared. They
+  appear as locals when the call passes `:M ... :n ... :i ...`. See the
   Keyword Arguments section — keyword names become body-local variables.
 - **No name in the `func` call.** The binding is the outer `=`. `func`
   itself only ever produces an anonymous `FuncObj`.

--- a/src/ComTerp/POSTFIX-INDEXING.md
+++ b/src/ComTerp/POSTFIX-INDEXING.md
@@ -1,0 +1,244 @@
+# Postfix indexing & arity: ground truth
+
+What the source says about how the postfix buffer is laid out, how arity counts
+work, how the buffer is traversed, and how stream-literal consumption is built on
+top of it. Established by reading `comterp.c`, `comfunc.c`, `comfunc.h`,
+`comvalue.h`, and `strmfunc.c`; line numbers refer to those files.
+
+## 1. Two arity families on two different objects
+
+Look-alike names with different meanings; conflating them is the core hazard.
+
+### ComValue token counts — in the postfix token
+
+`narg()`, `nkey()`, `nids()`, `pedepth()` are four integers baked into each
+postfix token at code-conversion (parse) time and carried in the pfbuf
+(`ComValue(postfix_token*)`). **The buffer walk reads these.**
+
+- `narg()` — non-keyword args of this token, **including args that follow
+  keywords**. It is *not* "args before keywords."
+- `nkey()` — keyword args of this token.
+- `nids()` — the header comment says "(not used)", but that comment is stale: it
+  is read at `comterp.c:297` (`sv.nids()!=1`) on the delim/dot path. Treat it as
+  live.
+- `pedepth()` — post-eval scope depth, set by the backward pre-pass (§2).
+
+### ComFunc / ComFuncState invocation counts — runtime state
+
+Pushed on the `_fsstack` when a command executes; read by `execute()` bodies via
+`stack_arg` etc. (Documented in HACKING `## nargspost() vs nargsfixed()`.)
+
+- `nargs()` — non-keyword args incl. post-keyword. For post_eval, unreliable
+  before `reset_stack()`.
+- `nkeys()` — keyword args.
+- `nargskey()` — args that *follow* keywords (post-keyword positionals),
+  `<= nkeys()`.
+- `nargsfixed() = nargs() - nargskey()` — the pre-keyword, order-dependent
+  positionals. **This** is the "args before keywords" count, not `nargs()`.
+- `nargstotal() = nargs() + nkeys()` — everything.
+- `nargspost()` — post-eval token-scope count; **includes the argoffval
+  bookmark**. Not a caller-supplied-arg count.
+
+The three meanings people attach to "nargs" are three *different members* —
+`nargstotal` (all whitespace-separated incl. keywords), `nargs` (all non-keyword
+incl. post-keyword), `nargsfixed` (pre-keyword only) — not three readings of one
+call. The walk reads the *token* family; `execute()` bodies read the *funcstate*
+family.
+
+## 2. The pfbuf is stored reversed; the walk has two passes
+
+`load_sub_expr` (`comterp.c:490`) runs in both directions, for different jobs:
+
+- **Backward pre-pass** (`j = _pfnum-1 .. 0`) computes `pedepth` for each token,
+  using `skip_func` to find how far each post-eval command's scope reaches. This
+  is a lookahead: a token's operands appear *before* the command in postfix, so
+  you can only know a token is inside a post-eval region after seeing the
+  post-eval command that follows it — which forces a backward pass.
+- **Forward push pass** (`_pfoff = 0 .. _pfnum`) pushes operands onto the stack
+  until a CommandType/funcobj at depth 0 is hit.
+
+So storage is reversed, but both directions are in use, and the backward pass is
+the forward pass's precomputed lookahead — not a competing traversal.
+
+## 3. The arity-aware traversal exists and is linear
+
+`ComTerp::skip_func` / `skip_key` / `skip_arg` (`comterp.c:693-`) is a correct,
+mutually-recursive, arity-aware skip over the reversed buffer. `skip_func` reads
+the token's `narg`/`nkey`, steps `offset` backward, and recurses to consume each
+operand's whole subtree. Within one span it visits each token once: it is
+**linear, not quadratic**.
+
+### The `narg`-meaning correction lives inside skip_func
+
+`skip_func` (lines 702-712): `nargs = sv->narg()` (incl. post-keyword); the loop
+decrements `nkeys` on a keyword and `nargs` on a non-keyword, with
+`nargs -= tokcnt ? 1 : 0` discounting a post-keyword positional that a keyword
+already consumed (so it isn't double-counted against `narg`). This line is the
+"`narg` includes post-keyword args" subtlety encoded as a correction. It is the
+place a mis-walk would hide, and it can only be validated by probing across
+keyword arrangements (positional-only, trailing keywords, interleaved keywords,
+keyword-with-value) via `postfix()`, not by eye.
+
+## 4. The quadratic cost is in the accessors, not the traversal
+
+The traversal is linear. The quadratic cost is the access pattern in the
+`stack_arg_post_eval*` family (`comfunc.c:129-311`), which is **stateless across
+calls**:
+
+```
+recover offtop from the argoff anchor (argoff.int_val() - _pfnum)
+skip ALL keywords        (for i < nkeys())
+skip from nargsfixed() down to n   (for j = nargsfixed(); j > n; j--)
+read argument n
+```
+
+Reading args `0..nargsfixed-1` re-skips the keyword block plus all later
+positionals on every fetch: `nargsfixed + (nargsfixed-1) + ... + 1` skip passes —
+O(n²). The shape is "re-derive position from a fixed anchor on each access"
+rather than "advance a saved cursor." A side effect of this shape: the *first*
+argument fetched (`n=0`) is the most expensive (`nargsfixed` skips down) and each
+later one is cheaper, so a consumer reading `0,1,2,...` starts slow and speeds
+up.
+
+`stack_arg_post_eval`, `stack_arg_post`, `stack_arg_post_eval_size`,
+`print_stack_arg_post_eval`, and `copy_stack_arg_post_eval` all use this shape.
+
+### The linear template already exists, used by one method
+
+`stack_arg_post_eval_nargsfixed` (`comfunc.c:212`) walks **once**,
+`j = nargsfixed() .. 1`, caching `offtopbuf[j-1]`/`argcntbuf[j-1]` for every
+positional in a single descent, then consumes from the cache. The fix for the
+quadratic methods is to share one descent the way this method does — not to write
+a new traversal.
+
+## 5. What this says about the argoff anchor
+
+The argoff anchor and the per-access re-scan are load-bearing together: the
+accessors recover position from `argoff.int_val() - _pfnum` precisely because
+they keep no cursor between calls. So the universal argoff push is not
+compensating for a *missing* traversal — the traversal exists — it exists because
+the post-eval accessors are anchor-relative by construction. The accessor O(n²)
+is removable by migrating to the single-descent cache pattern above, independent
+of whether the push is later narrowed to post-eval-only.
+
+## 6. Broadcast documents the discovery-order hazard
+
+`strmfunc.c:200-212` (broadcast literal construction) contains an in-source
+comment recording the discovery-order hazard directly: `skip_arg_in_expr` walks
+the buffer **backward**, so positional `pi=0` is the *last* source arg, while
+`copy_post_eval_expr`'s tokbuf is in **forward** order. A naive running
+`elem_offset` is correct only when all positionals are the same width and
+silently wrong for mixed-width elements like `(1 (2 3))`. The code fixes this by
+collecting `possizes[pi]` and doing a reverse-accumulation pass (lines 213-228).
+
+Takeaways:
+- The mixed-width / discovery-order bug is real; any rewrite must preserve the
+  reverse-accumulation rather than regress to a running offset.
+- It confirms `nargsfixed()` is the right positional count here (line 168-169
+  comment), consistent with §1.
+- `possizes` is `new int[npositionals]` only when `npositionals>0`; the reverse
+  loop and `delete[]` are guarded correctly, but the `npositionals==0` path (pure
+  keyword call) should be confirmed to leave `nelem`/`elem_offset` sane.
+
+## 7. How stream literals are laid out in the postfix
+
+Reading `postfix()` of a literal shows the structure directly:
+
+- `postfix((0 1 ... 39))` → 29 element tokens **in source order**, then a single
+  `stream[29|0|1]*` command token. Elements are stored contiguously, forward;
+  nothing needs to be searched for to *find* them.
+- `postfix((... 100*4/33 ... a=0*3000 ... 3*xxx++ ...))` shows compound elements
+  (`100 4 mpy 33 div`, `a 0 3000 mpy assign*`) sitting flush among bare ints. So
+  **element stride is variable, not 1** — element boundaries are an arity-balance
+  property, not a fixed position. Splitting the buffer into elements is a
+  paren-matching / stack-depth computation (what `skip_arg` does), not a pattern
+  match.
+- The trailing `*` on a command token marks it **post-eval** (e.g. `assign*`,
+  `stream*`). This is how post-eval status is read off the postfix.
+
+## 8. Stream-literal representation and consumption (as built)
+
+`StreamLiteralNextFunc::execute` (`strmfunc.c:834-924`), `execute_literal`, and
+the `NextFunc::execute_impl` driver (`strmfunc.c:525`) together implement lazy
+stream literals as follows.
+
+### Construction: reverse-built directory, traversal paid once
+
+`execute_literal` copies the whole literal's token region once into a `FuncObj`
+(`copy_post_eval_expr(total, offtop)` → `FuncObj(tokbuf, total)`,
+`strmfunc.c:178-182`), then builds a **directory** over it in a single backward
+pass (the `possizes` + reverse-accumulation, 213-228). The directory is an
+`AttributeValueList`:
+
+```
+[0]    FuncObj(tokbuf, ntoks)        -- the copied token buffer
+[1]    nremaining                    -- starts at element count
+[2..]  per-element entries           -- positional = (offset,count) = 2 slots;
+                                         keyword = KeywordType marker [+ off,count]
+```
+
+The variable-stride work (§7) is therefore done **once**, at construction, and
+stored. This is the key cost decision: you pay the postfix traversal either once
+(reverse-build the directory) or as a triangular per-element cost at consumption
+time. Paying it once, against the token copy you are already making, is the right
+trade.
+
+The FuncObj copy is also what decouples the **parser rate** from the lazy
+consumer: the parser fills the buffer ahead of consumption and moves on, so a
+lazy stream cannot alias the live parse region. The copy is the bounded, once-up-
+front buffer the cursor drains; it is not a live producer/consumer queue. Because
+every stream literal owns its FuncObj copy, the stream never aliases the volatile
+REPL `_pfbuf`, so lifetime needs no escape-on-assignment trigger — the copy is
+paid once, uniformly, at construction.
+
+### Consumption: cheap head removal to exhaustion
+
+`next()` evaluates one element by handing its precomputed `(offset,count)` span to
+`comterpserv()->run(tokbuf + offset, cnt)` (line 913) — the evaluator runs the
+element's tokens in place. Because each span is precomputed, `next()` cannot land
+mid-subtree; the boundary invariant is established once at construction, not
+recomputed per call.
+
+The directory **diminishes**: each `next()` removes the consumed front entries
+and decrements `nremaining` (lines 874-922). Removal of a positioned element is
+O(1) (`AttributeValueList::Remove(ALIterator&)` splices a node), and the live
+front stays shallow, so the per-call cost is constant. After each removal the
+code re-navigates from the list head (`First(); Next(); Next()`) rather than
+holding an iterator across calls. This re-navigation is intentional and correct:
+it is O(few) because removal keeps the front shallow, and — crucially — it never
+carries a live iterator across the lazy boundary, where an interleaved consumer or
+a fork could invalidate it. A saved iterator would work in the single-consumer
+case and corrupt silently under interleaving, which is exactly the cross-product /
+fork scenario streams must support. Cheap-and-robust is preferred over
+cheaper-and-fragile.
+
+### Copy forks at the current position
+
+Because consumption physically removes entries, the remaining directory *is* the
+stream's position. `$$s` / `stream(s)` therefore copies a stream at its current
+state of consumption: it deep-copies the **remaining** directory (the
+`AttributeValueList` copy ctor does `Append(new AttributeValue(...))` per entry,
+`attrlist.c`), giving the fork an independent diminishing directory, while the
+FuncObj token buffer at `[0]` is shared. Draining one fork does not disturb the
+other. This is why **removal is the correct design** rather than an immutable
+directory plus a cursor index: under removal, "copy at current position" is just a
+deep copy of what remains; an immutable-directory design would instead have to
+copy a cursor value, a different mechanism. The two are the same decision viewed
+from opposite ends, and copy-at-current-position is the one the stream contract
+requires.
+
+(For the FuncObj at `[0]` to be safely shared across forks rather than leaked or
+double-freed, it must be reference-counted. See the ObjectType Resource-by-contract
+work, which makes every ObjectType payload — FuncObj included — a `Resource`.)
+
+`stream-info.comt` (tests 7-10) exercises this end to end: the raw directory
+shrinks on `next()`, exhaustion yields nil, and a mid-stream `$$` fork continues
+from the current position independently.
+
+## 9. Stale-doc fixes to make alongside
+
+- `comvalue.h` `nids()` "(not used)" comment — it is used (`comterp.c:297`).
+- HACKING `## nargspost() vs nargsfixed()` documents only the funcstate family.
+  Add the ComValue token family (`narg/nkey/nids/pedepth`) and state plainly that
+  the *walk* reads the token family while `execute()` bodies read the funcstate
+  family.

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1332,6 +1332,7 @@ void ComTerp::add_defaults() {
     add_command("repeat", new RepeatFunc(this));
     add_command("iterate", new IterateFunc(this));
     add_command("next", new NextFunc(this));
+    add_command("info", new InfoFunc(this));
     add_command("each", new EachFunc(this));
     add_command("filter", new FilterFunc(this));
 

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -1026,13 +1026,13 @@ void InfoFunc::execute() {
   while (pos < avl->Number()) {
     AttributeValue* entry = (AttributeValue*)avl->Get(pos);
     if (entry->is_type(ComValue::KeywordType)) {
+      /* keyword-with-value needs two trailing slots; stop before adding
+         anything so a short tail leaves no orphaned key entry */
+      if (entry->keynarg_val() > 0 && pos+2 >= avl->Number()) break;
       snprintf(keybuf, sizeof(keybuf), "key%d", nelem);
       ComValue kv(entry->keyid_val(), ComValue::SymbolType);
       al->add_attr(symbol_add(keybuf), kv);
       if (entry->keynarg_val() > 0) {
-        /* keyword-with-value needs two trailing slots; stop on a short tail */
-        if (pos+2 >= avl->Number()) break;
-        snprintf(keybuf, sizeof(keybuf), "key%d_off", nelem);
         ComValue kov(*((AttributeValue*)avl->Get(pos+1)));
         al->add_attr(symbol_add(keybuf), kov);
         snprintf(keybuf, sizeof(keybuf), "key%d_cnt", nelem);

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -922,3 +922,139 @@ void StreamLiteralNextFunc::execute() {
     nremval->int_ref()--;
     push_stack(result);
 }
+
+/*****************************************************************************/
+
+int InfoFunc::_symid = -1;
+
+InfoFunc::InfoFunc(ComTerp* comterp) : StrmFunc(comterp) {
+}
+
+void InfoFunc::execute() {
+  /* attrlst=info(streamobj [:raw]) -- inspect a stream's internal directory.
+
+     Directory layout for StreamLiteralNextFunc-backed streams (the current
+     diminishing-directory design):
+       [0]    FuncObj(tokbuf, ntoks)
+       [1]    nremaining  (starts at element count, decremented as consumed)
+       [2..]  element entries: positional = (offset,count) = 2 slots;
+              keyword = KeywordType marker [+ (offset,count) if it has a value]
+
+     :raw returns the raw internal list directly -- layout-agnostic, so it works
+     unchanged as the directory evolves and is the probe used by regression
+     tests.  Without :raw, a named-field AttributeList is returned describing the
+     directory in the layout above.  Non-literal streams report (:mode "external"
+     :func `funcname) since their list layouts differ. */
+
+  /* fetch :raw from the post-eval region BEFORE reset_stack() clears it.
+     InfoFunc is post_eval, so the keyword lives in the post-eval buffer. */
+  static int raw_symid = symbol_add("raw");
+  ComValue rawv(stack_key_post_eval(raw_symid));
+  boolean rawflag = rawv.is_true();
+
+  ComValue streamv(stack_arg_post_eval(0));
+  reset_stack();
+
+  if (!streamv.is_stream()) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+
+  AttributeValueList* avl = streamv.stream_list();
+
+  /* :raw -- return the raw internal list directly */
+  if (rawflag) {
+    if (avl) {
+      ComValue retval(avl);
+      push_stack(retval);
+    } else {
+      push_stack(ComValue::nullval());
+    }
+    return;
+  }
+
+  /* identify a literal-backed stream; others have different list layouts */
+  static int slnf_symid = -1;
+  if (slnf_symid == -1) slnf_symid = symbol_add("streamliteralnext");
+  ComFunc* sfunc = streamv.stream_func() ? (ComFunc*)streamv.stream_func() : nil;
+  boolean is_literal = sfunc && sfunc->funcid() == slnf_symid;
+
+  if (!avl || !is_literal) {
+    AttributeList* al = new AttributeList();
+    static int mode_sym = symbol_add("mode");
+    static int func_sym = symbol_add("func");
+    int sfunc_symid = sfunc ? sfunc->funcid() : symbol_add("unknown");
+    ComValue modeval(is_literal ? "internal" : "external");
+    ComValue funcval(sfunc_symid, ComValue::SymbolType);
+    funcval.bquote(1);
+    al->add_attr(mode_sym, modeval);
+    al->add_attr(func_sym, funcval);
+    ComValue retval(AttributeList::class_symid(), (void*)al);
+    push_stack(retval);
+    return;
+  }
+
+  /* field-aware report for the literal directory layout */
+  AttributeList* al = new AttributeList();
+  static int func_sym2  = symbol_add("func");
+  static int ntoks_sym  = symbol_add("ntoks");
+  static int nrem_sym   = symbol_add("nremaining");
+  static int nelem_sym  = symbol_add("nelem");
+
+  /* func name of the backing NextFunc -- back-quoted symbol */
+  int sfunc_symid2 = sfunc ? sfunc->funcid() : symbol_add("unknown");
+  ComValue* funcnamev = new ComValue(sfunc_symid2, ComValue::SymbolType);
+  funcnamev->bquote(1);
+  al->add_attr(func_sym2, funcnamev);
+
+  /* [0] FuncObj -> ntoks */
+  FuncObj* fo = avl->Number() > 0
+    ? (FuncObj*)((AttributeValue*)avl->Get(0))->obj_val() : nil;
+  ComValue ntoksv(fo ? fo->ntoks() : 0);
+  al->add_attr(ntoks_sym, ntoksv);
+
+  /* [1] nremaining */
+  if (avl->Number() > 1) {
+    ComValue nremv(*((AttributeValue*)avl->Get(1)));
+    al->add_attr(nrem_sym, nremv);
+  }
+
+  /* [2..] element entries */
+  int nelem = 0;
+  int pos = 2;
+  char keybuf[64];
+  while (pos < avl->Number()) {
+    AttributeValue* entry = (AttributeValue*)avl->Get(pos);
+    if (entry->is_type(ComValue::KeywordType)) {
+      snprintf(keybuf, sizeof(keybuf), "key%d", nelem);
+      ComValue kv(entry->keyid_val(), ComValue::SymbolType);
+      al->add_attr(symbol_add(keybuf), kv);
+      if (entry->keynarg_val() > 0) {
+        snprintf(keybuf, sizeof(keybuf), "key%d_off", nelem);
+        ComValue kov(*((AttributeValue*)avl->Get(pos+1)));
+        al->add_attr(symbol_add(keybuf), kov);
+        snprintf(keybuf, sizeof(keybuf), "key%d_cnt", nelem);
+        ComValue kcv(*((AttributeValue*)avl->Get(pos+2)));
+        al->add_attr(symbol_add(keybuf), kcv);
+        pos += 3;
+      } else {
+        pos += 1;
+      }
+    } else {
+      snprintf(keybuf, sizeof(keybuf), "elem%d_off", nelem);
+      ComValue ov(*entry);
+      al->add_attr(symbol_add(keybuf), ov);
+      snprintf(keybuf, sizeof(keybuf), "elem%d_cnt", nelem);
+      ComValue cv(*((AttributeValue*)avl->Get(pos+1)));
+      al->add_attr(symbol_add(keybuf), cv);
+      pos += 2;
+    }
+    nelem++;
+  }
+
+  ComValue nelemv(nelem);
+  al->add_attr(nelem_sym, nelemv);
+
+  ComValue retval(AttributeList::class_symid(), (void*)al);
+  push_stack(retval);
+}

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -1030,6 +1030,8 @@ void InfoFunc::execute() {
       ComValue kv(entry->keyid_val(), ComValue::SymbolType);
       al->add_attr(symbol_add(keybuf), kv);
       if (entry->keynarg_val() > 0) {
+        /* keyword-with-value needs two trailing slots; stop on a short tail */
+        if (pos+2 >= avl->Number()) break;
         snprintf(keybuf, sizeof(keybuf), "key%d_off", nelem);
         ComValue kov(*((AttributeValue*)avl->Get(pos+1)));
         al->add_attr(symbol_add(keybuf), kov);
@@ -1041,6 +1043,8 @@ void InfoFunc::execute() {
         pos += 1;
       }
     } else {
+      /* positional needs one trailing slot (count); stop on a short tail */
+      if (pos+1 >= avl->Number()) break;
       snprintf(keybuf, sizeof(keybuf), "elem%d_off", nelem);
       ComValue ov(*entry);
       al->add_attr(symbol_add(keybuf), ov);

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -62,11 +62,12 @@ public:
 };
 
 //: info command for stream objects.
-// attrlst=info(streamobj :raw) -- inspect a stream's internal directory list.
-// Step 1 (this commit) implements only the :raw path, which returns the raw
-// internal AVL directly and is layout-agnostic -- usable as a structural probe
-// for regression tests regardless of the directory layout.  Field-aware
-// reporting is added with the directory rewrite it describes.
+// attrlst=info(streamobj)      -- AttributeList describing a literal stream's
+//                                 directory: func, ntoks, nremaining,
+//                                 elemN_off/elemN_cnt..., nelem.  Non-literal
+//                                 streams report (:mode :func).
+// lst=info(streamobj :raw) -- the raw internal directory list, layout-
+//                                 agnostic; the probe used by regression tests.
 class InfoFunc : public StrmFunc {
 public:
     InfoFunc(ComTerp*);
@@ -74,7 +75,7 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "attrlst=%s(strm :raw) -- return raw internal list of a stream"; }
+      return "attrlst|lst=%s(strm :raw) -- return internal list of a stream"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
         ":raw       return raw internal list directly",

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -61,6 +61,30 @@ public:
 
 };
 
+//: info command for stream objects.
+// attrlst=info(streamobj :raw) -- inspect a stream's internal directory list.
+// Step 1 (this commit) implements only the :raw path, which returns the raw
+// internal AVL directly and is layout-agnostic -- usable as a structural probe
+// for regression tests regardless of the directory layout.  Field-aware
+// reporting is added with the directory rewrite it describes.
+class InfoFunc : public StrmFunc {
+public:
+    InfoFunc(ComTerp*);
+
+    virtual void execute();
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "attrlst=%s(strm :raw) -- return raw internal list of a stream"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+        ":raw       return raw internal list directly",
+        nil };
+      return keys; }
+
+    CLASS_SYMID("InfoFunc");
+
+};
+
 //: hidden func used by next command for stream command
 class StreamNextFunc : public StrmFunc {
 public:

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -76,6 +76,83 @@ that the orchestrator can inspect, compare, and branch on. There is no
 separate test protocol, no mock layer, no serialization adapter. The
 REPL session and the wire session are the same thing.
 
+## Background: how ComTerp got its streams
+
+ComTerp's design did not start where it ended. It began with a dream,
+set the dream aside to build something tractable, and only years later
+discovered that the tractable thing had quietly become the foundation
+the dream required. The order matters, because it explains why the
+implementation looks the way it does — much of the machinery that powers
+streams was built for other purposes first.
+
+**The original dream: stream-overdriven operators.** The starting vision
+was dataflow all the way down — operators like `*` and `+` as inherently
+stream operators, operands flowing through them. This traces to the
+NCL/dataflow lineage (Karl Fant, Honeywell) and the command-interpreter
+work at Honeywell IRL and Triple Vision. But an operator cannot flow
+operands through itself until there is a defined notion of what an
+operand *is* — its type, its evaluation, its timing. The dream was set
+aside, not abandoned. It was waiting for a substrate.
+
+**Layer 1 — the expression interpreter.** What got built instead was a
+sober, C-like expression evaluator on a Fischer-LeBlanc scanner/parser
+pipeline: postfix, arity-counted, evaluated left to right. The governing
+rule — *everything is a C-like expression; there are no declarations* —
+is this layer. Unglamorous next to the dataflow dream, but it is bedrock:
+a stream element turns out to be nothing more than a *deferred
+expression*, and you cannot defer an expression you cannot first
+evaluate definitely.
+
+**Layer 2 — post-eval control commands.** Control flow (`if`, `for`,
+`while`, conditional and lazy evaluation — the post_eval mechanism
+synthesized from the lazy-vs-eager evaluation literature) required
+commands that receive their operands *unevaluated* and drive evaluation
+themselves. That deferral machinery — hold the operand's tokens,
+evaluate them when and how it chooses — is exactly what a lazy stream
+needs. A stream literal's `next()` *is* a post-eval: it holds an
+element's token span and evaluates one element on demand. The post-eval
+apparatus (the argoff bookmark, the backward span-finding walk) was built
+for control flow and turned out to be stream infrastructure under another
+name.
+
+**Layer 3 — the duck-typed value model.** A single `ComValue` type
+carrying any value (int, float, string, symbol, list, attrlist, object,
+command, stream) via a `void*`/`interface{}`-style union with runtime
+`isa`/`geta` dispatch. Streams are heterogeneous and polymorphic — an
+element may be an int, a list, an attrlist, a FuncObj, or another stream.
+Without a uniform any-value type, "a stream of whatever" is not
+expressible, and `next()` could not return a value without the iteration
+machinery knowing its type.
+
+**Layer 4 — builtin primitives and user functions.** `func` is a command
+that returns a `FuncObj` you bind with `=` (there is no function
+*declaration* — see the function section). The `FuncObj` carries its own
+copy of the postfix token buffer. This is the last brick, and it is the
+one that finally made streams first-class: a stream that outlives the
+expression that created it needs an owned, reference-counted, lifetime-
+managed copy of its tokens — which is precisely what `FuncObj` already
+was, built for user functions. A first-class stream literal *is* a
+`FuncObj` wrapping a token buffer plus a consumption cursor.
+
+**Why it took so long to make streams first-class.** A first-class stream
+is the intersection of all four layers at once: a `FuncObj` (layer 4)
+holding deferred token spans (layer 2) of arbitrary expressions (layer 1)
+that yield any-typed values (layer 3), flowed through ordinary operators
+(the original dream). Four of the five things a stream is made of did not
+exist when the dream was first conceived. The foundation got built by
+solving four other problems that each looked unrelated at the time, and
+the streams could only become first-class once all four were in place.
+
+The dream was not compromised — it was *deferred*, fittingly the same
+move as post-eval: the stream-operator idea was held unevaluated until a
+substrate that could evaluate it existed. Today, `((1,2,3),)*((4,),(5,),(6,))`
+performing a matrix multiply through the ordinary `*` operator is that
+original dream finally running, on top of the four layers it needed.
+
+For how the resulting overdrive compares to APL, Lucid, MATLAB, and
+Haskell — and what is genuinely without prior art — see *Design
+Provenance and Prior Art* under Streams below.
+
 ## Expressions and Sequencing
 
 The basic unit of execution is an expression. Multiple expressions are
@@ -511,6 +588,50 @@ memory, a stream yields the next value only when asked. This makes
 streams suitable for processing large or unbounded sequences without
 materializing the whole thing.
 
+### The stream contract
+
+A stream is a **monotonic, nil-terminated, forkable** sequence. These are
+not three separate features; they are one shape stated three ways, and
+together they define what it means to be a stream in ComTerp.
+
+- **Monotonic** — consumption only moves forward. `next()` advances the
+  position; there is no rewind or seek in the contract. (A backing source
+  may happen to be seekable, but the stream abstraction does not expose
+  it.) To replay, reassign the stream.
+
+- **Nil-terminated** — the forward motion has a defined end. An exhausted
+  stream yields `nil` from `next()` and stays exhausted. `nil` is the
+  universal terminator; it is what makes a stream finite *in contract*
+  even when the underlying source is unbounded.
+
+- **Forkable** — at any position a stream can be split (`$$s` /
+  `stream(s)`) into independent continuations, each of which is itself a
+  monotonic, nil-terminated, forkable stream. Forkability is part of the
+  definition, not an added feature: a sequence that cannot be forked is
+  not a stream.
+
+The contract is **closed**: a fork of a stream is a stream, and a fork of
+a fork is a stream, all the way down.
+
+**The mechanism that delivers forkability** is a shared growing-shrinking
+buffer of elements. A fork copies the stream's *current* position (see
+*Stream copy forks at the current position*), and the buffer retains
+exactly those elements that some forks have consumed but not yet all —
+freeing each element once every fork has passed it. This lets any
+streamable source satisfy the fork contract regardless of its nature:
+
+- a **stream literal**'s buffer is born full and only shrinks as it is
+  consumed (the degenerate case — all production happened up front);
+- a **file or pipe** stream's buffer both grows at the front as elements
+  are produced and shrinks at the back as the slowest fork advances,
+  bounded by the spread between the fastest and slowest fork.
+
+The literal mechanism and the file/pipe mechanism are therefore the same
+structure at different settings: a shared ordered buffer with per-fork
+positions and front-reclamation by the slowest fork. (File/pipe stream
+forking is specified in a separate issue and may not yet be implemented;
+the contract above is what any such implementation must satisfy.)
+
 ### The Streaming Algebra
 
 The streaming algebra is the set of operations that construct, compose,
@@ -612,10 +733,10 @@ remaining elements unevaluated in the token buffer.
 Round-trip: `$($$(1,2,3))` returns `(1,2,3)`.
 
 The streaming algebra is still being formalized. The stream literal
-syntax (ivtools-3.0) completes the source end of the algebra; bugs
-found during implementation will clarify the composition laws,
-particularly around nil propagation through composed operations and
-zip semantics between lazy and materialized sources.
+syntax (ivtools-3.0) completes the source end of the algebra; ongoing
+work continues to clarify the composition laws, particularly around nil
+propagation through composed operations and zip semantics between lazy
+and materialized sources.
 
 ### Scalar overdrive
 
@@ -691,44 +812,43 @@ In short: streams overdrive *into* non-post-eval commands through their
 arguments, and *around* post-eval commands through external combination
 or return values -- never *through* a post-eval command's own arguments.
 
-### Stream as an extra loop around for/while (currently broken)
+### Stream-scalar broadcast via replay
 
-External overdrive of a post-eval command by a stream argument should
-let the stream act as an outer loop wrapped around whatever the command
-does -- including a `for` or `while` loop used as that command's body.
-`each` is post-eval (`each[0|0|1]*`); given a stream first-argument and a
-body expression, each iteration of the outer stream should run the body
-to completion:
+When a non-post-eval binary operator (`+`, `*`, `,`, `**`, etc.) finds
+that exactly one of its two operands `is_stream()` and the other is a
+plain scalar, the runtime constructs a per-element stream from the
+scalar operand and hands two streams to the operator's existing
+stream-zip path -- the same path that already handles `(10**4)*(1..4)`
+correctly, producing `10,20,30,40`.
 
-```
-each((i=0..3);for(j=0 j<4 j++ print("i,j %d,%d\n" i j)))
-```
-
-EXPECTED: 16 lines, the cross product of `i=0..3` and `j=0..3` -- the
-outer stream `(i=0..3)` overdrives the entire `for(j=0 j<4 j++ ...)`
-loop, running it to completion four times.
-
-ACTUAL: 4 lines, `j` always shows the loop-exit value `4`:
+The scalar operand's *first* value is whatever was already computed by
+normal evaluation (no extra cost -- "the first draw is done"). For each
+subsequent element, the scalar operand's postfix token-slice is replayed
+via the same mechanism stream literals already use for lazy per-element
+evaluation (`StreamLiteralNextFunc`'s `comterpserv()->run(tokbuf+offset,
+cnt)`, proven by `(rand rand rand)` giving three distinct values).
 
 ```
-i,j 0,4
-i,j 1,4
-i,j 2,4
-i,j 3,4
+s=10**4*rand()
+list(s)     // four independently-drawn random values, each *10
 ```
 
-`each` correctly iterates `i` over `0..3` (4 lines, one per outer
-iteration), but `print(...)` appears to execute only once per outer
-iteration, after `for`'s loop has already exited with `j=4` -- as if
-`print(...)` is not being captured as part of `for`'s body argument.
-Needs investigation in `ctrlfunc.c` (`for`'s argument/body capture),
-likely related to the multi-statement `func` body issues seen earlier
-in `matrixmult.comt`.
+The operator (`*`) never sees anything but two streams -- it is
+unchanged, oblivious, and identical to the `(10**4)*(1..4)` case.
 
-This is the cross-product primitive from the stream algebra design
-discussion: once fixed, `for`/`while` overdriven by an external stream
-is the cross product, complementing zip (`,` overdriven by streams) as
-the other half of nd composition.
+**The stream is what makes the sibling operand post-eval.** `for` and
+`while` are post-eval commands that replay their body argument's
+token-slice once per iteration -- the loop construct itself decides to
+replay. Here, the *same replay mechanism* applies to the scalar operand,
+but the *trigger* is different: not the construct's own post-eval-ness,
+but the presence of a stream sibling. A stream operand effectively
+extends post-eval-style replay to whatever it's combined with -- the
+operator stays oblivious and non-post-eval throughout; only the sibling
+operand's evaluation pattern changes, from "once" to "replayed per
+element," exactly as a loop body goes from "once" to "replayed per
+iteration." Same mechanism (token-slice replay via the static postfix
+buffer -- see *Why the Pipeline Is So Clean: Fischer-LeBlanc and argoff*
+in APPENDIX-C), different trigger.
 
 ### Design Provenance and Prior Art
 
@@ -808,6 +928,47 @@ list(ss)               // {2,4,6,8,10} -- consumed
 next(ss)               // nil -- exhausted
 ss=(1..5)*2            // reassign to replay
 ```
+
+### Stream copy forks at the current position
+
+`$$s` (equivalently `stream(s)`) copies a stream **at its current state of
+consumption** — not from the beginning. The copy is an independent
+continuation from wherever `s` has been consumed to, and the two streams
+thereafter advance without affecting each other.
+
+```
+s=(10 20 30)
+next(s)                // 10  -- s is now at {20,30}
+t=$$s                  // t forks here: t is {20,30}, NOT {10,20,30}
+next(s)                // 20  -- s advances
+next(t)                // 20  -- t advances independently
+next(s)                // 30
+next(t)                // 30
+next(s)                // nil -- s exhausted; t was unaffected by s
+```
+
+This is the property cross-products rely on: copy the inner stream at the
+point the outer loop has reached, drain the copy, leave the original at
+its position for the next outer step.
+
+Mechanically, a stream's unconsumed remainder *is* its state — consumption
+diminishes the stream's internal directory in place, so "copy at current
+position" is simply a deep copy of whatever remains. The copy duplicates
+that remaining directory but **shares the underlying token buffer by
+reference** (it is immutable and reference-counted), so forking is cheap
+and never duplicates the elements' code — only the small record of which
+elements are left. A fresh full copy is therefore just a copy taken before
+any `next()`:
+
+```
+s=(10 20 30)
+t=$$s                  // copy before consuming -- t is a full {10,20,30}
+```
+
+This is the consume-once contract (above) made forkable: single-pass means
+each stream is consumed once and is gone as it flows by; copy-at-position
+means you may fork the *unconsumed* part into an independent stream at any
+point, and each fork is then itself single-pass.
 
 ### List construction and growth with `,`
 
@@ -993,11 +1154,6 @@ Use `==` for symbol equality — it works reliably for all symbol values:
 `foo==`bar             // false
 symbol(symid(`foo))==`foo  // true
 ```
-
-The `:sym` keyword on comparison operators (`eq`, `lt`, `gt`, etc.) is
-intended for symbol comparison but has a known bug: `eq(:sym)` returns
-false for symbols returned by `symbol()` even when `==` returns true.
-Use `==` instead until this is resolved.
 
 Lexicographic symbol ordering:
 

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -49,5 +49,13 @@ if(run("./stream-literal.comt")
   :then print("pass: stream-literal\n")
   :else print("FAIL: stream-literal\n");ok=false)
 
+if(run("./stream-info.comt")
+  :then print("pass: stream-info\n")
+  :else print("FAIL: stream-info\n");ok=false)
+
+if(run("./matrixmult.comt")
+  :then print("pass: matrixmult\n")
+  :else print("FAIL: matrixmult\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/comterp_/tests/stream-info.comt
+++ b/src/comterp_/tests/stream-info.comt
@@ -1,0 +1,188 @@
+// stream-info.comt version 2
+print("stream-info.comt version 2\n")
+
+// src/comterp_/tests/stream-info.comt -- tests for info() command and the
+// diminishing (consume-by-removal) stream-literal directory.
+//
+// coverage:
+//   tests 1-3:  info() command exists and returns sensible structure
+//   tests 4-6:  info(:raw) returns the raw internal directory list
+//   tests 7-9:  diminishing directory -- next() shrinks the directory,
+//               observable through info(:raw)
+//   test 10:    $$ forks a stream at its current position; forks drain
+//               independently (deep-copied directory)
+//
+// REAL directory layout (current base, post reverse-accumulation build):
+//   [0]      FuncObj(tokbuf, ntoks)
+//   [1]      nremaining  (decremented / consumed on each next())
+//   [2..]    element entries: positional = (offset,count) pair = 2 slots;
+//            keyword = KeywordType marker [+ (offset,count) if it has a value]
+//   so (10 20 30) -> 2 header slots + 3*2 element slots = size 8.
+//
+// Build/observe sequence:
+//   STAGE 0 (no info command):  every info() test fails -- unknown command.
+//   STAGE 1 (info patch in):    all tests pass.
+//
+// Note: the diminishing directory (next() removes consumed entries and
+// decrements nremaining) is ALREADY present in the base -- the current
+// StreamLiteralNextFunc::execute consumes destructively.  So tests 7-9
+// (which assert the directory shrinks) pass as soon as info() exists to
+// observe it; there is no separate "add diminishing" stage.  A later
+// optimization replaces the destructive Remove()+renavigation with a
+// cheaper cursor, but that does not change these assertions -- they test
+// THAT it diminishes, not how efficiently.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/stream-info.comt")
+
+errmsg(:clear)
+run("./testlib.comt")
+ok=true
+
+// --- test 1: info() on a stream literal returns an AttributeList ---
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s1=(10 20 30)
+i1=info(s1)
+ok1=(class(i1)==`AttributeList)
+ok=ok&&ok1
+print("1 class(info((10 20 30)))==`AttributeList (expect true): %v\n" ok1)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: info() reports the backing next-func name ---
+// func prints as streamliteralnext (backtick dropped on print -- known
+// bquote serialization bug; compared as symbol so equality still holds).
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s2=(10 20 30)
+i2=info(s2)
+ok2=(i2.func==`streamliteralnext)
+ok=ok&&ok2
+print("2 info((10 20 30)).func==`streamliteralnext (expect true): %v\n" ok2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: info() reports nelem==3 for a 3-element literal ---
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s3=(10 20 30)
+i3=info(s3)
+ok3=(i3.nelem==3)
+ok=ok&&ok3
+print("3 info((10 20 30)).nelem==3 (expect true): %v\n" ok3)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: info(:raw) returns the raw internal directory as a list ---
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s4=(10 20 30)
+r4=info(s4 :raw)
+ok4=(type(r4)==`ListType)
+ok=ok&&ok4
+print("4 type(info((10 20 30) :raw))==`ListType (expect true): %v\n" ok4)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: raw directory size == 8 for (10 20 30) ---
+// 2 header slots ([0]FuncObj [1]nremaining) + 3 positionals * 2 slots = 8.
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s5=(10 20 30)
+r5=info(s5 :raw)
+ok5=(size(r5)==8)
+ok=ok&&ok5
+print("5 size(info((10 20 30) :raw))==8 (expect true): %v\n" ok5)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: raw [1] is nremaining, starts at element count (3) ---
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s6=(10 20 30)
+r6=info(s6 :raw)
+ok6=(at(r6 1)==3)
+ok=ok&&ok6
+print("6 info((10 20 30) :raw)[1]==3 (nremaining starts at 3) (expect true): %v\n" ok6)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: next() decrements nremaining (directory diminishes) ---
+// before: fails (info unknown)
+// after: passes -- base already consumes destructively, so nremaining drops
+//         to 2 after one next()
+errmsg(:clear)
+s7=(10 20 30)
+r7a=next(s7)
+i7=info(s7 :raw)
+ok7=(r7a==10)&&(at(i7 1)==2)
+ok=ok&&ok7
+print("7 next() then nremaining==2 (expect 10 and true): %v %v\n" r7a ok7)
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: raw directory size shrinks by 2 per positional consumed ---
+// after one next(), the consumed (offset,count) pair is gone: size 8 -> 6.
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s8=(10 20 30)
+next(s8)
+r8=info(s8 :raw)
+ok8=(size(r8)==6)
+ok=ok&&ok8
+print("8 size after one next()==6 (8 minus consumed off,cnt pair) (expect true): %v\n" ok8)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: drain to exhaustion -- directory empties, next() yields nil ---
+// after 3 next()s: nremaining 0, only the 2 header slots remain (size 2),
+// and a further next() yields nil.
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s9=(10 20 30)
+next(s9)
+next(s9)
+next(s9)
+r9=info(s9 :raw)
+ok9a=(size(r9)==2)
+r9last=next(s9)
+ok9b=(r9last==nil)
+ok9=ok9a&&ok9b
+ok=ok&&ok9
+print("9 drained: size==2 and next()==nil (expect true true): %v %v\n" ok9a ok9b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: $$ forks at the CURRENT position; forks drain independently ---
+// Pull one element from s (now at {20,30}), then t=$$s.  t must fork the
+// REMAINDER {20,30}, not restart at {10,20,30}.  Each fork then advances on
+// its own diminishing directory without disturbing the other.
+//
+// Observable via info(:raw): right after the fork, s and t have equal raw
+// sizes (same remaining directory, independently owned -- deep copy confirmed:
+// AttributeValueList copy ctor does Append(new AttributeValue(...)) per entry).
+// After draining t, s is unchanged and still yields its own 20,30.
+// before: fails (info unknown)   after: passes
+errmsg(:clear)
+s10=(10 20 30)
+r10a=next(s10)                       // 10 -- s10 now at {20,30}
+t10=$$s10                            // fork at current position
+
+// both have the same remaining directory size (2 elements left -> size 6)
+sz_s=size(info(s10 :raw))
+sz_t=size(info(t10 :raw))
+ok10a=(r10a==10)&&(sz_s==6)&&(sz_t==6)
+
+// drain t fully; t yields the REMAINDER 20,30 (proves fork-at-position, not restart)
+t10a=next(t10)
+t10b=next(t10)
+t10c=next(t10)
+ok10b=(t10a==20)&&(t10b==30)&&(t10c==nil)
+
+// s is undisturbed by t's consumption: still at {20,30}, its own directory intact
+sz_s_after=size(info(s10 :raw))
+ok10c=(sz_s_after==6)
+s10a=next(s10)
+s10b=next(s10)
+ok10d=(s10a==20)&&(s10b==30)
+
+ok10=ok10a&&ok10b&&ok10c&&ok10d
+ok=ok&&ok10
+print("10 $$ fork at position: t yields remainder, s undisturbed (expect 10 / 20 30 nil / 20 30): %v / %v %v %v / %v %v\n" r10a t10a t10b t10c s10a s10b)
+prev_ok=check_fail(:ok ok)
+
+
+print("stream-info: %v\n" ok)
+ok


### PR DESCRIPTION
## Add info() stream introspection command, stream-info.comt suite, and postfix/stream design docs

Adds the `info()` command for inspecting a stream's internal directory, a
`stream-info.comt` regression suite wired into `run_all.comt`, and design
documentation for postfix indexing and the stream model.

## info() command
info(streamobj)        // AttributeList describing a literal stream's directory:

//   func, ntoks, nremaining, elemN_off/elemN_cnt..., nelem

// non-literal streams report (:mode :func)

info(streamobj :raw)   // the raw internal directory list, layout-agnostic

`:raw` returns the directory list verbatim and is the probe the regression tests
assert against; the field-aware form gives the named-field human view. `InfoFunc`
is `post_eval`, so the `:raw` keyword is fetched via `stack_key_post_eval` before
`reset_stack()` clears the post-eval region. All `AttributeList` values are stack
`ComValue`s added by reference (the list copies them), so there is no heap
ownership to track. Matches the current directory layout:
`[0]=FuncObj(tokbuf,ntoks)`, `[1]=nremaining`, `[2..]=(offset,count)` per
positional element.

Files: `comterp.c` (registration), `strmfunc.h` (decl), `strmfunc.c` (impl).
No existing behavior changes.

## Tests

`stream-info.comt` (10 tests), wired into `run_all.comt`:
- info() existence, class, func name, nelem (1–3)
- info(:raw) directory shape — list type, size 8 for `(10 20 30)`, nremaining
  at `[1]` (4–6)
- diminishing directory under next() — nremaining drops, raw size 8→6→2,
  exhaustion yields nil (7–9)
- `$$` forks at the current position — after one next(), the fork takes the
  remainder and drains independently of the original (10)

`run_all.comt` also gains a `matrixmult.comt` entry.

## Documentation

- `POSTFIX-INDEXING.md` (new) — ground truth on postfix buffer layout (reversed,
  two-pass walk), the two arity-count families (token vs funcstate) and the
  `nargs`/`nargsfixed` distinction, the linear `skip_*` traversal, the
  accessor-side O(n²) and its single-descent fix, and the stream-literal
  representation: reverse-built directory (traversal paid once), cheap
  head-removal consumption, and copy-forks-at-current-position.
- `LANGUAGE.md` — the stream contract (monotonic, nil-terminated, forkable),
  copy-forks-at-current-position semantics, and a Background section on how the
  stream model was built up in layers.
- `HACKING.md` — notes that `func` is a command returning a FuncObj (not a
  declaration) and that lists grow with `,` not `list()`.

## Confirms behavior, does not change it

The diminishing directory (consume-by-removal) and the deep-copy `$$` fork are
already present in the base; this PR adds the `info()` command to observe them
and the tests to regression them. The consumption design is settled:
reverse-built directory, head-removal to exhaustion, re-navigation from the head
(O(few), and deliberately never holding an iterator across the lazy boundary).

## Verification
comterp run src/comterp_/tests/stream-info.comt    # -> stream-info: true (all 10)

comterp run src/comterp_/tests/run_all.comt        # full suite