### PR TITLE
Fix assignval use-after-free in Attribute dot-path; document info()

### DIFF
--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -185,7 +185,7 @@ public:
     int type_symid() const;
     // return symbol id corresponding to type
     const char* type_name() { return symbol_pntr(type_symid()); }
-    // type name of object.
+    // type name of value.
 
     void assignval (const AttributeValue&);
     // copy contents of AttributeValue

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1018,9 +1018,8 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	  return ComValue::nullval();
 
     } else if (comval.is_object(Attribute::class_symid())) {
-
-      comval.assignval(*((Attribute*)comval.obj_val())->Value());
-
+      ComValue attrval = *((Attribute*)comval.obj_val())->Value(); 
+      comval.assignval(attrval);
     }       
     return comval;
 }

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -53,6 +53,10 @@ if(run("./stream-info.comt")
   :then print("pass: stream-info\n")
   :else print("FAIL: stream-info\n");ok=false)
 
+if(run("./stream-argcnt.comt")
+  :then print("pass: stream-argcnt.comt\n")
+  :else print("FAIL: stream-argcnt.comt\n");ok=false)
+
 if(run("./matrixmult.comt")
   :then print("pass: matrixmult\n")
   :else print("FAIL: matrixmult\n");ok=false)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -54,8 +54,8 @@ if(run("./stream-info.comt")
   :else print("FAIL: stream-info\n");ok=false)
 
 if(run("./stream-argcnt.comt")
-  :then print("pass: stream-argcnt.comt\n")
-  :else print("FAIL: stream-argcnt.comt\n");ok=false)
+  :then print("pass: stream-argcnt\n")
+  :else print("FAIL: stream-argcnt\n");ok=false)
 
 if(run("./matrixmult.comt")
   :then print("pass: matrixmult\n")

--- a/src/comterp_/tests/stream-argcnt.comt
+++ b/src/comterp_/tests/stream-argcnt.comt
@@ -1,0 +1,112 @@
+// stream-argcnt.comt version 1
+print("stream-argcnt.comt version 1\n")
+
+// src/comterp_/tests/stream-argcnt.comt -- verify that the directory argcnt of
+// each stream-literal element is the postfix token count of that element's value
+// expression, identically for keyword values and positionals.
+//
+// argcnt rules (value-expression postfix token count):
+//   single value   :key 3           -> 1
+//   comma pair      :key x,y         -> 3   (x y ,  -- comma is a binary op)
+//   arithmetic      :key 1+2+3+5     -> 7   (1 2 + 3 + 5 +  -- 4 operands, 3 ops)
+//   bare keyword    :standalonekey   -> 0   (no value span stored)
+// and a positional value uses the SAME counting:
+//   positional      1+2+3+5          -> 7
+//
+// Tests 1-3 check keyword value argcnt (1, 3, 7).  Test 4 checks a bare keyword
+// in a non-deciding position (well-formed: lone marker, counted as an element).
+// Test 5 probes a bare keyword AS the deciding second element -- a KNOWN
+// construction bug that builds a malformed directory; it is print-only until
+// fixed.  Tests 6-7 check that a positional value span equals the equivalent
+// keyword value span.
+//
+// A stream literal needs positional content to BE a stream (a lone (:key val)
+// is an attrlist literal), so each keyword case carries a leading positional 0;
+// the keyword is then element 1 and is reported as key1_cnt.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/stream-argcnt.comt")
+
+errmsg(:clear)
+run("./testlib.comt")
+ok=true
+
+// --- test 1: single-token keyword value -- argcnt 1 ---
+errmsg(:clear)
+s1=(0 :key 3)
+ok1=(info(s1).key1_cnt==1)
+ok=ok&&ok1
+print("1 (0 :key 3) key1_cnt==1 (expect true): %v\n" ok1)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: comma-pair keyword value -- argcnt 3 (x y ,) ---
+errmsg(:clear)
+s2=(0 :key x,y)
+ok2=(info(s2).key1_cnt==3)
+ok=ok&&ok2
+print("2 (0 :key x,y) key1_cnt==3 (expect true): %v\n" ok2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: arithmetic keyword value -- argcnt 7 (1 2 + 3 + 5 +) ---
+errmsg(:clear)
+s3=(0 :key 1+2+3+5)
+ok3=(info(s3).key1_cnt==7)
+ok=ok&&ok3
+print("3 (0 :key 1+2+3+5) key1_cnt==7 (expect true): %v\n" ok3)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: bare keyword -- inspect how it is represented ---
+// (0 :standalonekey): a leading positional plus a bare keyword.  A bare keyword
+// stores no (offset,count) pair.  This dumps the raw directory so the actual
+// element count and bare-keyword representation are visible rather than assumed.
+// --- test 4: bare keyword in a NON-deciding position -- well-formed ---
+// (0 1 :standalonekey): two positionals then a bare keyword.  A bare keyword
+// stores a lone marker (one slot, no offset/count pair), and is counted as an
+// element.  Directory: {FuncObj,3, 0,1, 1,1, :standalonekey} -> nelem 3.
+errmsg(:clear)
+s4=(0 1 :standalonekey)
+ok4=(info(s4).nelem==3)
+ok=ok&&ok4
+print("4 (0 1 :standalonekey) nelem==3 (expect true): %v\n" ok4)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: bare keyword AS the deciding second element -- KNOWN BUG, probe ---
+// (0 :standalonekey): the keyword is the element that decides stream-ness.  This
+// currently builds a MALFORMED directory ({0,} -- no FuncObj header, no marker)
+// and info().nelem returns nil.  Contrast with test 4, where the same bare
+// keyword in a non-deciding slot is well-formed.  See issue:
+//   stream literal with a bare keyword as the deciding (second) element builds a
+//   malformed directory.
+// Left as a PRINT-ONLY probe (no assertion) until that construction bug is fixed;
+// once fixed, this should match test 4's shape and become a hard assertion.
+// Style note: the durable fix on the authoring side is to never put a keyword in
+// a deciding position -- keep to positionals-then-keywords even in stream literals.
+errmsg(:clear)
+s5=(0 :standalonekey)
+print("5 (0 :standalonekey) [known bug] nelem: %v   raw: %v\n" info(s5).nelem info(s5 :raw))
+
+// --- test 6: positional value uses the SAME span counting -- argcnt 7 ---
+// 1+2+3+5 as a positional element has the same postfix count as a keyword value.
+// Note: (1+2+3+5) alone is just grouped arithmetic (evaluates to 11), NOT a
+// stream -- a stream literal needs a sequence, so a second element is added to
+// make it one; the arithmetic is element 0.
+errmsg(:clear)
+s6=(1+2+3+5 0)
+ok6=(info(s6).elem0_cnt==7)
+ok=ok&&ok6
+print("6 (1+2+3+5 0) elem0_cnt==7 (expect true): %v\n" ok6)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: keyword value span and equivalent positional span agree ---
+// the whole point: a value expression has one postfix length, regardless of
+// whether it arrives as a keyword's value or as a standalone positional element.
+errmsg(:clear)
+s7k=(0 :key 1+2+3+5)
+s7p=(1+2+3+5 0)
+ok7=(info(s7k).key1_cnt==info(s7p).elem0_cnt)
+ok=ok&&ok7
+print("7 keyword value span == positional span (expect true): %v\n" ok7)
+prev_ok=check_fail(:ok ok)
+
+print("stream-argcnt: %v\n" ok)
+ok

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -227,6 +227,8 @@ both until exit.
 
  comp=filter(comps classid) -- filter stream of comps for matching classid
 
+ attrlst|lst=info(strm :raw) -- return internal list of a stream
+
 .SH CONTROL COMMANDS (using post evaluation):
 
  val=cond(testexpr trueexpr falseexpr) -- evaluate testexpr, and if true, evaluate and return trueexpr, otherwise evaluate and return falseexpr


### PR DESCRIPTION
## What

Fixes a use-after-free in `ComTerp::lookup_symval()` on the Attribute
dot-path, plus documentation and a regression test for the `info()`
command.

## The bug (primary)

Resolving an `Attribute`-typed `ComValue` did this:

```cpp
comval.assignval(*((Attribute*)comval.obj_val())->Value());
```

The source of the assignment (`->Value()`) lives *inside* the Attribute
held by `comval` — the very object `assignval` is about to overwrite.
`assignval` clears its target before copying, so the source is freed
under the read. Classic aliased assignment: source must not alias
destination.

It was latent for years because the old toolchain's assignment ordering
and allocator reuse happened to copy the bytes before they were
clobbered. A newer toolchain stopped masking it; the symptom was a
corrupted `ComValue` carrying an **impossible** `KeywordType` where an
`Attribute` should have been — a wrong type tag is the fingerprint of
overwritten memory, not of wrong logic.

Fix: copy to a temporary first, then assign from the independent copy.

```cpp
ComValue attrval = *((Attribute*)comval.obj_val())->Value();
comval.assignval(attrval);
```

The precondition (source must not alias destination) is unwritten on
`assignval`'s signature; this is the one call site in the tree that
violated it. It becomes reliably fatal once these payloads are
reference-counted, so fixing it now also de-risks the planned
ObjectType-Resource work.

## Regression coverage

`stream-argcnt.comt` test 1 evaluates `info((0 :key 3)).key1_cnt`, which
exercises the Attribute dot-path that crashed. It passes only with the
fix in place.

## Also included

- **stream-argcnt.comt** (new) — verifies that a stream-literal element's
  directory `argcnt` is the postfix token count of its value expression,
  the same for keyword values and positionals: `:key 3` → 1, `:key x,y`
  → 3, `:key 1+2+3+5` → 7, bare keyword → 0. Tests 1–4, 6, 7 assert;
  test 5 is a print-only probe documenting a separate known bug
  (malformed directory when a bare keyword is the deciding second
  element — see issue).
- **comterp.1** — documents `info(strm :raw)`.
- **attrvalue.h** — corrects a stale comment.

## Verification
comterp run src/comterp_/tests/stream-argcnt.comt   # all asserts pass

comterp run src/comterp_/tests/run_all.comt         # full suite

Before the fix, the Attribute dot-path corrupts/crashes under the current
toolchain; after, it resolves correctly.