### PR TITLE
Rename streamobj to streamtype

### DIFF
--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -185,7 +185,7 @@ public:
     int type_symid() const;
     // return symbol id corresponding to type
     const char* type_name() { return symbol_pntr(type_symid()); }
-    // type name of object.
+    // type name of value.
 
     void assignval (const AttributeValue&);
     // copy contents of AttributeValue

--- a/src/ComTerp/bquotefunc.c
+++ b/src/ComTerp/bquotefunc.c
@@ -34,17 +34,21 @@ BackQuoteFunc::BackQuoteFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void BackQuoteFunc::execute() {
-#if 0  // maybe, maybe not
-  ComValue topval(stack_arg(0, true));
-  if (topval.is_command())
-      topval.assignval(stack_arg_post_eval(0, true /* no symbol lookup */));
-  reset_stack();
-  topval.bquote(1);
-  push_stack(topval);
-#else
   ComValue retval(stack_arg(0, true));
   reset_stack();
+
+  /* `StreamObj is the obsolete name for `StreamType (the printed name of
+     a StreamType value, as returned by class()).  Warn once per session
+     so scripts still carrying the old back-quoted name are nudged forward
+     without flooding stderr from a loop.  To silence: comment this out. */
+  static int streamobj_symid = symbol_add("StreamObj");
+  static boolean streamobj_warned = false;
+  if (!streamobj_warned &&retval.type() == ComValue::SymbolType &&
+      retval.symbol_val() == streamobj_symid) {
+    fprintf(stderr, "warning: `StreamObj is obsolete; use `StreamType\n");
+    streamobj_warned = true;
+  }
+  
   retval.bquote(1);
   push_stack(retval);
-#endif  
 }

--- a/src/ComTerp/bquotefunc.c
+++ b/src/ComTerp/bquotefunc.c
@@ -43,7 +43,7 @@ void BackQuoteFunc::execute() {
      without flooding stderr from a loop.  To silence: comment this out. */
   static int streamobj_symid = symbol_add("StreamObj");
   static boolean streamobj_warned = false;
-  if (!streamobj_warned &&retval.type() == ComValue::SymbolType &&
+  if (!streamobj_warned && retval.type() == ComValue::SymbolType &&
       retval.symbol_val() == streamobj_symid) {
     fprintf(stderr, "warning: `StreamObj is obsolete; use `StreamType\n");
     streamobj_warned = true;

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -993,7 +993,9 @@ ComValue ComTerp::pop_stack(boolean lookupsym) {
 }
 
 ComValue& ComTerp::lookup_symval(ComValue& comval) {
-    if (comval.bquote()) return comval;
+    if (comval.bquote()) {
+        return comval;
+    }
 
     if (comval.type() == ComValue::SymbolType) {
         void* vptr = nil;

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1018,9 +1018,8 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	  return ComValue::nullval();
 
     } else if (comval.is_object(Attribute::class_symid())) {
-
-      comval.assignval(*((Attribute*)comval.obj_val())->Value());
-
+      ComValue attrval = *((Attribute*)comval.obj_val())->Value(); 
+      comval.assignval(attrval);
     }       
     return comval;
 }

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -331,7 +331,7 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    
 	case ComValue::StreamType:
 	  // out << "<stream:" << (svp->stream_mode()<0?"int":"ext") << "(" << symbol_pntr(((ComFunc*)svp->stream_func())->funcid()) << ")" << ">";
-	  out << "StreamObj";
+	  out << "StreamType";
 	  break;
 	    
 	case ComValue::CommandType:

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -1,5 +1,23 @@
 # ComTerp Language Guide
 
+ComTerp is the embedded scripting layer of the ivtools toolkit — the
+scriptable nervous system of its vector-graphics and distributed-drawing
+tools (comdraw, drawtool, DrawServ, and the drawmo orchestrator). It is
+not a language built to be admired as a language; it exists to let those
+tools be driven, automated, and coordinated across the wire. Everything
+below — the expression model, the streams, the value union — is in
+service of a tool above it that moves pixels and coordinates drawing.
+Read it as a tool's mind, not as a language for its own sake.
+
+In character it is, roughly, a Lisp for C: it keeps the interpreted,
+expression-all-the-way-down, read-eval-print quality that makes an
+interpreter pleasant to drive a tool with, but it is built in C and
+stays in close, transparent contact with the machine — a powerful
+orchestrator of sequences of instructions, not a self-describing model.
+The aim throughout is precise yet elegant interaction with the
+instruction set: enough of the interpreter's allure to be scriptable,
+none of the apparatus a tool's scripting layer does not need.
+
 ComTerp is a scripting language where the syntax is also the wire
 protocol. Every value — integer, string, list, attrlist, boolean —
 serializes back to valid ComTerp syntax that can be parsed and
@@ -123,6 +141,22 @@ element may be an int, a list, an attrlist, a FuncObj, or another stream.
 Without a uniform any-value type, "a stream of whatever" is not
 expressible, and `next()` could not return a value without the iteration
 machinery knowing its type.
+
+`StreamType` is the *last* first-class type added to this union. After it,
+the extension mechanism changed: rather than keep growing the closed set
+of built-in union types — each with its own slot and per-type handling —
+a single open-ended `ObjectType` was added as the one extension point.
+Its contract is "give me an object tagged by class symbol and I will
+reflect it back if I recognize it" (the `class_symid()` plus the
+`_as_needed` recognition in the printer and elsewhere). So the union
+being *full* is not an accident or a limit bumped into; it is a deliberate
+boundary. `StreamType` marks the end of one extension era (more union
+types) and the start of another (`ObjectType`, bounded reflection). This
+is why `ObjectType` is the sole remaining extension point, and why
+payloads carried through it must honor a uniform contract (see the
+Resource discussion in `HACKING.md`). The name `StreamType` — rather than
+the older printed name `StreamObj` — reflects that it is, correctly, the
+last of the union *types*.
 
 **Layer 4 — builtin primitives and user functions.** `func` is a command
 that returns a `FuncObj` you bind with `=` (there is no function
@@ -273,6 +307,14 @@ Unknown keywords are silently ignored, which enables layered keyword
 extension across the library hierarchy. See `ARCHITECTURE.md` for how
 this works internally.
 
+The same ordering applies inside a **stream literal**: positional values
+first, keywords after. A stream literal may end with keywords —
+`(a b :key v)` — but keywords belong after the positional content, never
+before or among it. Keep to positionals-then-keywords here as everywhere;
+a keyword in the position that decides a construct's kind (the second
+element, which is what tips grouping into a stream) is the one case the
+rule protects against, and following the rule keeps it out of reach.
+
 ## Operators
 
 Standard arithmetic, comparison, and logical operators work as expected.
@@ -366,6 +408,10 @@ The dot namespace rooted at a symbol is scoped with that symbol — see
 `foo             // the symbol foo, not its value
 type(val)==`IntType
 ```
+
+`StreamObj` was temporarily exported as the literal for a `StreamType`,
+and a warning will be printed if a script makes use of it as a symbol (by
+prefixing it with a back-quote). Use `` `StreamType `` instead.
 
 ## Control Flow
 
@@ -669,6 +715,27 @@ an attrlist literal, not a stream literal:
 (:key 99 :flag)   // attrlist -- first token is a keyword
 (0 :key 99)       // stream literal -- first token is a value
 ```
+
+**Element spans.** Each element of a stream literal is an expression of
+arbitrary depth, and its size is the number of postfix tokens that
+expression occupies — not a fixed stride. The same counting applies
+whether the element is a positional or a keyword's value:
+
+```
+(3 ...)              // element 3        -- 1 token
+(x,y ...)            // element x,y      -- 3 tokens (x y ,; comma is a binary op)
+(1+2+3+5 ...)        // element 1+2+3+5  -- 7 tokens (1 2 + 3 + 5 +)
+(0 :key 1+2+3+5)     // the keyword's value is the same 7-token span
+(0 :key 3)           // the keyword's value is 1 token
+(0 :standalonekey)   // a bare keyword has no value span (0 tokens)
+```
+
+A keyword value and the identical expression as a standalone positional
+have the same span — a value expression has one postfix length regardless
+of how it arrives. A bare keyword contributes no value span. (This is why
+keyword elements belong after positionals: see *Arguments: Fixed Before
+Keywords*. A bare keyword in the element that decides stream-ness — the
+second element — is the one shape to avoid.)
 
 **Consumption** — pulling values out:
 

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -53,6 +53,10 @@ if(run("./stream-info.comt")
   :then print("pass: stream-info\n")
   :else print("FAIL: stream-info\n");ok=false)
 
+if(run("./stream-argcnt.comt")
+  :then print("pass: stream-argcnt.comt\n")
+  :else print("FAIL: stream-argcnt.comt\n");ok=false)
+
 if(run("./matrixmult.comt")
   :then print("pass: matrixmult\n")
   :else print("FAIL: matrixmult\n");ok=false)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -54,8 +54,8 @@ if(run("./stream-info.comt")
   :else print("FAIL: stream-info\n");ok=false)
 
 if(run("./stream-argcnt.comt")
-  :then print("pass: stream-argcnt.comt\n")
-  :else print("FAIL: stream-argcnt.comt\n");ok=false)
+  :then print("pass: stream-argcnt\n")
+  :else print("FAIL: stream-argcnt\n");ok=false)
 
 if(run("./matrixmult.comt")
   :then print("pass: matrixmult\n")

--- a/src/comterp_/tests/stream-argcnt.comt
+++ b/src/comterp_/tests/stream-argcnt.comt
@@ -1,0 +1,112 @@
+// stream-argcnt.comt version 1
+print("stream-argcnt.comt version 1\n")
+
+// src/comterp_/tests/stream-argcnt.comt -- verify that the directory argcnt of
+// each stream-literal element is the postfix token count of that element's value
+// expression, identically for keyword values and positionals.
+//
+// argcnt rules (value-expression postfix token count):
+//   single value   :key 3           -> 1
+//   comma pair      :key x,y         -> 3   (x y ,  -- comma is a binary op)
+//   arithmetic      :key 1+2+3+5     -> 7   (1 2 + 3 + 5 +  -- 4 operands, 3 ops)
+//   bare keyword    :standalonekey   -> 0   (no value span stored)
+// and a positional value uses the SAME counting:
+//   positional      1+2+3+5          -> 7
+//
+// Tests 1-3 check keyword value argcnt (1, 3, 7).  Test 4 checks a bare keyword
+// in a non-deciding position (well-formed: lone marker, counted as an element).
+// Test 5 probes a bare keyword AS the deciding second element -- a KNOWN
+// construction bug that builds a malformed directory; it is print-only until
+// fixed.  Tests 6-7 check that a positional value span equals the equivalent
+// keyword value span.
+//
+// A stream literal needs positional content to BE a stream (a lone (:key val)
+// is an attrlist literal), so each keyword case carries a leading positional 0;
+// the keyword is then element 1 and is reported as key1_cnt.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/stream-argcnt.comt")
+
+errmsg(:clear)
+run("./testlib.comt")
+ok=true
+
+// --- test 1: single-token keyword value -- argcnt 1 ---
+errmsg(:clear)
+s1=(0 :key 3)
+ok1=(info(s1).key1_cnt==1)
+ok=ok&&ok1
+print("1 (0 :key 3) key1_cnt==1 (expect true): %v\n" ok1)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: comma-pair keyword value -- argcnt 3 (x y ,) ---
+errmsg(:clear)
+s2=(0 :key x,y)
+ok2=(info(s2).key1_cnt==3)
+ok=ok&&ok2
+print("2 (0 :key x,y) key1_cnt==3 (expect true): %v\n" ok2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: arithmetic keyword value -- argcnt 7 (1 2 + 3 + 5 +) ---
+errmsg(:clear)
+s3=(0 :key 1+2+3+5)
+ok3=(info(s3).key1_cnt==7)
+ok=ok&&ok3
+print("3 (0 :key 1+2+3+5) key1_cnt==7 (expect true): %v\n" ok3)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: bare keyword -- inspect how it is represented ---
+// (0 :standalonekey): a leading positional plus a bare keyword.  A bare keyword
+// stores no (offset,count) pair.  This dumps the raw directory so the actual
+// element count and bare-keyword representation are visible rather than assumed.
+// --- test 4: bare keyword in a NON-deciding position -- well-formed ---
+// (0 1 :standalonekey): two positionals then a bare keyword.  A bare keyword
+// stores a lone marker (one slot, no offset/count pair), and is counted as an
+// element.  Directory: {FuncObj,3, 0,1, 1,1, :standalonekey} -> nelem 3.
+errmsg(:clear)
+s4=(0 1 :standalonekey)
+ok4=(info(s4).nelem==3)
+ok=ok&&ok4
+print("4 (0 1 :standalonekey) nelem==3 (expect true): %v\n" ok4)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: bare keyword AS the deciding second element -- KNOWN BUG, probe ---
+// (0 :standalonekey): the keyword is the element that decides stream-ness.  This
+// currently builds a MALFORMED directory ({0,} -- no FuncObj header, no marker)
+// and info().nelem returns nil.  Contrast with test 4, where the same bare
+// keyword in a non-deciding slot is well-formed.  See issue:
+//   stream literal with a bare keyword as the deciding (second) element builds a
+//   malformed directory.
+// Left as a PRINT-ONLY probe (no assertion) until that construction bug is fixed;
+// once fixed, this should match test 4's shape and become a hard assertion.
+// Style note: the durable fix on the authoring side is to never put a keyword in
+// a deciding position -- keep to positionals-then-keywords even in stream literals.
+errmsg(:clear)
+s5=(0 :standalonekey)
+print("5 (0 :standalonekey) [known bug] nelem: %v   raw: %v\n" info(s5).nelem info(s5 :raw))
+
+// --- test 6: positional value uses the SAME span counting -- argcnt 7 ---
+// 1+2+3+5 as a positional element has the same postfix count as a keyword value.
+// Note: (1+2+3+5) alone is just grouped arithmetic (evaluates to 11), NOT a
+// stream -- a stream literal needs a sequence, so a second element is added to
+// make it one; the arithmetic is element 0.
+errmsg(:clear)
+s6=(1+2+3+5 0)
+ok6=(info(s6).elem0_cnt==7)
+ok=ok&&ok6
+print("6 (1+2+3+5 0) elem0_cnt==7 (expect true): %v\n" ok6)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: keyword value span and equivalent positional span agree ---
+// the whole point: a value expression has one postfix length, regardless of
+// whether it arrives as a keyword's value or as a standalone positional element.
+errmsg(:clear)
+s7k=(0 :key 1+2+3+5)
+s7p=(1+2+3+5 0)
+ok7=(info(s7k).key1_cnt==info(s7p).elem0_cnt)
+ok=ok&&ok7
+print("7 keyword value span == positional span (expect true): %v\n" ok7)
+prev_ok=check_fail(:ok ok)
+
+print("stream-argcnt: %v\n" ok)
+ok

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -227,6 +227,8 @@ both until exit.
 
  comp=filter(comps classid) -- filter stream of comps for matching classid
 
+ attrlst|lst=info(strm :raw) -- return internal list of a stream
+
 .SH CONTROL COMMANDS (using post evaluation):
 
  val=cond(testexpr trueexpr falseexpr) -- evaluate testexpr, and if true, evaluate and return trueexpr, otherwise evaluate and return falseexpr


### PR DESCRIPTION
# Renames `StreamObj 
#          to `StreamType

Renames the printed type name of a stream value from `StreamObj` to
`StreamType` (the value class() returns for a stream), and warns once if a
script back-quotes the obsolete `StreamObj symbol.

- comvalue.c: StreamType case in operator<< now prints "StreamType".
- bquotefunc.c: BackQuoteFunc::execute() warns once per session if it
  back-quotes the obsolete `StreamObj symbol; also drops a dead #if 0
  block. To silence the warning, comment it out.
- comterp.c: cosmetic braces on the lookup_symval bquote short-circuit.
- LANGUAGE.md: documents the deprecation in the Backquote section.

StreamType is the last first-class union type, from before ObjectType
became the sole extension mechanism; the rename makes the printed name
match its nature as a type. run_all.comt passes.