### PR TITLE
Fix assignval use-after-free in pop_stack attribute path 

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -981,7 +981,8 @@ ComValue ComTerp::pop_stack(boolean lookupsym) {
     if (lookupsym && topval.is_symbol()) {
       return lookup_symval(topval);
     } else if (lookupsym && topval.is_attribute()) {
-      topval.assignval(*((Attribute*)topval.obj_val())->Value());
+      ComValue attrval = *((Attribute*)topval.obj_val())->Value();
+      topval.assignval(attrval);
       return topval;
     }else 
       return topval;


### PR DESCRIPTION
# Fix assignval aliasing twin in pop_stack
:
Companion to the assignval use-after-free fix already on master. That
patch hardened lookup_symval; the identical aliasing survived in
pop_stack -- the path symbol/attribute pops actually traverse. Same
mechanism, same temp-copy fix.

Follow-up (not in this PR): stream-argcnt test 1 guards the lookup_symval
path only; the pop_stack path wants its own probe.