### PR TITLE
drawmo gsbrush tests + the two bugs they surfaced (map-race segfault, chain gs relay)

### DIFF
--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -360,7 +360,7 @@ void GraphicIdFunc::execute() {
   ComValue denyv(stack_key(deny_sym));
   static int table_sym = symbol_add("table");
   ComValue tablev(stack_key(table_sym));
- 
+
   ComValue idv(stack_arg(0));
   ComValue selectorv(stack_arg(1));
 
@@ -414,9 +414,14 @@ void GraphicIdFunc::execute() {
     }
     
   } else if (idv.is_known() && selectorv.is_unknown()) {
-    /* single uuid arg -- lookup and return compview */
+    /* single id arg -- look up and return the compview.  accept either a full
+       uuid or its 8-char index: inside a linkup the distributed traffic carries
+       only the 8-char, and the gridtable is keyed on it (uuid_key = first 4
+       bytes).  uuid_parse can't parse the 8-char prefix, so for an 8-char id
+       parse it straight to the key. */
     void* ptr = nil;
-    uint32_t key = uuid_key(id);
+    const char* idstr = idv.is_string() ? idv.string_ptr() : nil;
+    uint32_t key = (idstr && strlen(idstr)==8) ? (uint32_t)strtoul(idstr, nil, 16) : uuid_key(id);
     ((DrawServ*)unidraw)->gridtable()->find(ptr, key);
     if (ptr) {
         GraphicId* grid = (GraphicId*)ptr;

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -326,6 +326,10 @@ void DrawServ::ExecuteCmd(Command* cmd) {
       {
 	const char* script = ((LinkBrushCmd*)cmd)->dist_script();
 	if (script && *script) sbuf << script;
+	/* exclude the link back toward the change's owner so a relayed brush
+	   flows onward along a chain instead of echoing to its origin (on the
+	   originating node the owner is self -> linkget()==nil -> send to all). */
+	uuid_copy(sid, ((LinkBrushCmd*)cmd)->dist_owner_sid());
 	cmd->Execute();
 	break;
       }
@@ -334,6 +338,7 @@ void DrawServ::ExecuteCmd(Command* cmd) {
       {
 	const char* script = ((LinkColorCmd*)cmd)->dist_script();
 	if (script && *script) sbuf << script;
+	uuid_copy(sid, ((LinkColorCmd*)cmd)->dist_owner_sid());
 	cmd->Execute();
 	break;
       }

--- a/src/DrawServ/linkcmd.c
+++ b/src/DrawServ/linkcmd.c
@@ -86,6 +86,13 @@ const char* LinkBrushCmd::dist_script() {
             if (!any) {
                 sbuf << "s=select();select(grid(";
                 any = true;
+                /* INTERIM LIMITATION: the owner key+sid are captured from the
+                   FIRST matching comp only, so the whole dance relays under one
+                   owner's :unlock/:lock key and ExecuteCmd excludes one back-
+                   link.  Correct today, when a selection's comps share an owner;
+                   a mixed-ownership selection would mis-stamp the rest.  Revisit
+                   when per-owner signatures land (issue #163) -- the dance would
+                   then have to group comps by owner and emit one bracket each. */
                 if (grid->selected() == LinkSelection::LocallySelected) {
                     owner_key = drawserv->sessionidkey();
                     uuid_copy(_dist_owner_sid, drawserv->sessionid());
@@ -198,6 +205,13 @@ const char* LinkColorCmd::dist_script() {
             if (!any) {
                 sbuf << "s=select();select(grid(";
                 any = true;
+                /* INTERIM LIMITATION: the owner key+sid are captured from the
+                   FIRST matching comp only, so the whole dance relays under one
+                   owner's :unlock/:lock key and ExecuteCmd excludes one back-
+                   link.  Correct today, when a selection's comps share an owner;
+                   a mixed-ownership selection would mis-stamp the rest.  Revisit
+                   when per-owner signatures land (issue #163) -- the dance would
+                   then have to group comps by owner and emit one bracket each. */
                 if (grid->selected() == LinkSelection::LocallySelected) {
                     owner_key = drawserv->sessionidkey();
                     uuid_copy(_dist_owner_sid, drawserv->sessionid());

--- a/src/DrawServ/linkcmd.c
+++ b/src/DrawServ/linkcmd.c
@@ -44,6 +44,7 @@ LinkBrushCmd::LinkBrushCmd(Editor* ed, PSBrush* br) : BrushCmd(ed, br) {}
 
 const char* LinkBrushCmd::dist_script() {
     _dist_script_buf = "";
+    uuid_clear(_dist_owner_sid);
 
     PSBrush* brush = GetBrush();
     if (!brush) return _dist_script_buf.c_str();
@@ -60,19 +61,38 @@ const char* LinkBrushCmd::dist_script() {
 
     std::ostringstream sbuf;
     boolean any = false;
+    uint32_t owner_key = 0;
     Iterator it;
 
-    /* collect all LocallySelected comps */
+    /* Collect the comps whose brush change to propagate.  Originating: comps we
+       own (LocallySelected).  Relaying along a chain: comps a remote owner has
+       temporarily unlocked through us (grid->unlocked()) via the incoming
+       select(:unlock) -- forward those onward so a chain ds1->ds2->ds3 carries
+       the change past the first hop.  Stamp the OWNER's key, not ours, so the
+       forwarded :unlock/:lock bracket stays valid at the next hop; today that
+       key is derivable (selectorkey), but once it becomes a per-owner signature
+       (issue #163, the atomic select(:body :sign) follow-on) only the owner
+       could mint it, so the relay must forward, never re-derive.  Record the
+       owner sid so
+       ExecuteCmd can exclude the link back toward the origin. */
     for (sel->First(it); !sel->Done(it); sel->Next(it)) {
         OverlayView* view = (OverlayView*)sel->GetView(it);
         OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
         void* ptr = nil;
         if (comp) drawserv->compidtable()->find(ptr, comp);
         GraphicId* grid = (GraphicId*)ptr;
-        if (grid && grid->selected() == LinkSelection::LocallySelected) {
-	     if (!any) {
+        if (grid && (grid->selected() == LinkSelection::LocallySelected ||
+                     grid->unlocked())) {
+            if (!any) {
                 sbuf << "s=select();select(grid(";
                 any = true;
+                if (grid->selected() == LinkSelection::LocallySelected) {
+                    owner_key = drawserv->sessionidkey();
+                    uuid_copy(_dist_owner_sid, drawserv->sessionid());
+                } else {
+                    owner_key = grid->selectorkey();
+                    uuid_copy(_dist_owner_sid, grid->selector());
+                }
             } else {
                 sbuf << ",grid(";
             }
@@ -82,7 +102,7 @@ const char* LinkBrushCmd::dist_script() {
 
     if (any) {
         char keystr[9];
-        snprintf(keystr, sizeof(keystr), "%08X", drawserv->sessionidkey());
+        snprintf(keystr, sizeof(keystr), "%08X", owner_key);
 	sbuf << " :unlock \"" << keystr << "\")";
         if (brush->None())
             sbuf << ";brush(:none);select(s :lock \"" << keystr << "\")";
@@ -147,6 +167,7 @@ LinkColorCmd::LinkColorCmd(Editor* ed, PSColor* fg, PSColor* bg, int fgnum, int 
 
 const char* LinkColorCmd::dist_script() {
     _dist_script_buf = "";
+    uuid_clear(_dist_owner_sid);
 
     Editor* ed = GetEditor();
     if (!ed) return _dist_script_buf.c_str();
@@ -160,18 +181,30 @@ const char* LinkColorCmd::dist_script() {
 
     std::ostringstream sbuf;
     boolean any = false;
+    uint32_t owner_key = 0;
     Iterator it;
 
+    /* same originate-or-relay collection as LinkBrushCmd::dist_script(): own
+       (LocallySelected) comps when originating, plus remote-owner comps we hold
+       unlocked when relaying onward, stamped with the owner's key. */
     for (sel->First(it); !sel->Done(it); sel->Next(it)) {
         OverlayView* view = (OverlayView*)sel->GetView(it);
         OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
         void* ptr = nil;
         if (comp) drawserv->compidtable()->find(ptr, comp);
         GraphicId* grid = (GraphicId*)ptr;
-        if (grid && grid->selected() == LinkSelection::LocallySelected) {
+        if (grid && (grid->selected() == LinkSelection::LocallySelected ||
+                     grid->unlocked())) {
             if (!any) {
                 sbuf << "s=select();select(grid(";
                 any = true;
+                if (grid->selected() == LinkSelection::LocallySelected) {
+                    owner_key = drawserv->sessionidkey();
+                    uuid_copy(_dist_owner_sid, drawserv->sessionid());
+                } else {
+                    owner_key = grid->selectorkey();
+                    uuid_copy(_dist_owner_sid, grid->selector());
+                }
             } else {
                 sbuf << ",grid(";
             }
@@ -181,7 +214,7 @@ const char* LinkColorCmd::dist_script() {
 
     if (any) {
         char keystr[9];
-        snprintf(keystr, sizeof(keystr), "%08X", drawserv->sessionidkey());
+        snprintf(keystr, sizeof(keystr), "%08X", owner_key);
         sbuf << " :unlock \"" << keystr << "\")";
         /* serialize by RGB intensities so both the menu path and the
            colors("#RRGGBB") path distribute identically, exactly, and

--- a/src/DrawServ/linkcmd.h
+++ b/src/DrawServ/linkcmd.h
@@ -31,14 +31,24 @@
 #include <Unidraw/Commands/brushcmd.h>
 #include <Unidraw/Commands/colorcmd.h>
 #include <string>
+#include <uuid/uuid.h>
 
 //: mixin for Commands that generate distributed scripts in DrawServ
 // Mix into any Command subclass to provide dist_script() for use
 // by DrawServ::ExecuteCmd when distributing commands to remote drawservs.
 class DrawServCmd {
 public:
+    DrawServCmd() { uuid_clear(_dist_owner_sid); }
     virtual const char* dist_script() = 0;
     // return ComTerp script to distribute, or empty string if none.
+
+    const uuid_t& dist_owner_sid() { return _dist_owner_sid; }
+    // session id of the owner the most recent dist_script() was generated for
+    // (cleared if none).  DrawServ::ExecuteCmd excludes the link toward this
+    // session so a relayed change flows onward along a chain without looping
+    // back to its origin.
+protected:
+    uuid_t _dist_owner_sid;
 };
 
 //: BrushCmd with distributed script generation for DrawServ

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -93,9 +93,14 @@ void stack_trace_handler(int sig) {
 }
 
 int main(int argc, char *argv[]) {
- 
+
     signal(SIGSEGV, stack_trace_handler);
-    
+    /* ignore SIGPIPE: a peer that closed its socket should make a write return
+       EPIPE (which remote()/the socket path handles) instead of terminating the
+       interpreter.  matters for `comterp listen` driving multiple drawservs --
+       e.g. drawmo's gsbrushB, where a far node's connection can drop mid-run. */
+    signal(SIGPIPE, SIG_IGN);
+
     boolean server_flag = argc>1 && strcmp(argv[1], "server") == 0;
     boolean logger_flag = argc>1 && strcmp(argv[1], "logger") == 0;
     boolean remote_flag = argc>1 && strcmp(argv[1], "remote") == 0;

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -415,13 +415,21 @@ int main (int argc, char** argv) {
 	unidraw->Open(ed);
 
 #ifdef HAVE_ACE
-	/*  Start up one on stdin */
-	DrawServHandler* stdin_handler = new DrawServHandler();
-	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
+	/*  Start up one on stdin, unless -stdin_off (mirror comdraw).  Registering
+	    a live fd-0 handler under -stdin_off means a closed/EOF stdin -- as when
+	    drawmo launches us detached -- fires DrawServHandler::handle_input, which
+	    pops the "unexpected EOF" dialog and, if it fires while the seed update()
+	    below is pumping the event loop, re-enters comterp on the shared eval
+	    stack and corrupts it (SIGSEGV).  honor what -stdin_off documents. */
+	const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
+	DrawServHandler* stdin_handler = nil;
+	if (!stdin_off_str || strcmp(stdin_off_str, "false")==0) {
+	    stdin_handler = new DrawServHandler();
+	    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							  ACE_Event_Handler::READ_MASK)==-1)
-          cerr << "drawserv: unable to open stdin with ACE\n";
-	
-	ed->stdio_setup(stdin_handler);
+	      cerr << "drawserv: unable to open stdin with ACE\n";
+	    ed->stdio_setup(stdin_handler);
+	}
 	fprintf(stderr, "ivtools-%s drawserv: type help here for command info\n", VersionString);
 	ed->stdio_prompt(stdin_handler);
 
@@ -432,6 +440,18 @@ int main (int argc, char** argv) {
 	/* execute -runfile or -runexpr after editor is fully initialized */
 	ComTerpServ* terp = ed->GetComTerp();
 	if (terp) {
+	    /* Seed update: the mandatory first update() that wins the X11
+	       map/realize race (see comdraw/main.c).  It pumps the event loop so the
+	       window maps and the viewer's canvas is bound before any GUI command
+	       can run.  For a drawserv this guards more than the -runfile/-runexpr
+	       path: a freshly-launched node can receive a relayed GUI command over a
+	       drawlink (e.g. the select()/brush() fan-out in drawmo's gsbrushB tree)
+	       as the very first event it processes inside Run(), before its window's
+	       Configure/Expose has bound the canvas -- OverlaySelection::Update()
+	       then repairs damage through a null canvas and segfaults.  Mapping the
+	       window here, before Run() owns the loop, closes that window. */
+	    terp->run("update(1000000)\n");
+
 	    const char* runfile = catalog->GetAttribute("runfile");
 	    if (runfile && *runfile) {
 	        if (terp->runfile(runfile) < 0)

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,7 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim] --port [portnum] --help
+# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,9 +10,9 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim]\n");
+    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim|gsbrushA|gsbrushB]\n");
     print("\t\t\ttests to run (comma-separated), returns -1 on error\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
@@ -1000,6 +1000,270 @@ updown4C_test=func(
   ok)
 
 
+/* brush_on_node -- read the propagated graphic's serialized gs on a far node by
+   grid id and confirm its brush contains the expected ":brush p,w".  the far
+   node's editor defaults to a different brush, so a match proves the brush
+   graphic-state rode along with the graphic, not the far editor's state.
+
+   grid(uuid) resolves the comp by id and hands it to export -- a read-only path,
+   so unlike export(at(select(:all))) there is no distributive select() to collide
+   with the distribution locks; polling is safe even mid-distribution.  the brush
+   is a separate command from the create, so it can lag the grid-id arrival. */
+brush_on_node=func(
+  found=false;
+  poll_usec=2000000;
+  timeout=20*1000000/poll_usec;
+  cnt=0;
+  expr=print("export(grid(%c%s%c) :string :percomp)" 34 bn_id 34 :str);
+  while(!found && cnt<timeout
+    e=remote(bn_sock expr);
+    if(type(e)==`StringType && index(e bn_brush)!=nil :then found=true);
+    if(!found :then update(poll_usec);cnt++));
+  found)
+
+/* gsbrushA test -- graphic-state BRUSH propagation, CHAIN topology ds1->ds2->ds3.
+   create a rect carrying a distinctive brush on ds1; verify the graphic AND its
+   brush propagate two hops to ds3.  parallels updown3A (chain) but checks the
+   brush gs at the far nodes, not just grid-id arrival.  ports 20002/30002/40002. */
+gsbrushA_test=func(
+
+  poll_usec=2000000;
+  timeout=60*1000000/poll_usec;
+  progress_interval=10*1000000/poll_usec;
+
+  /* --- launch ds1 (20002) --- */
+  ds1_port=find_open_port(:base_port 20002);
+  ds1_import=ds1_port-1;
+  global(drawserv_upgba1)=false;
+  print("gsbrushA: launching ds1 on port %d\n" ds1_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgba1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upgba1) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushA: still waiting for ds1 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upgba1) :then
+    print("gsbrushA: FAIL timeout waiting for ds1 callback\n" :err);
+    kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds1_import);
+    return(false));
+  print("gsbrushA: ds1 up on %d\n" ds1_port :err);
+
+  /* --- launch ds2 (30002) --- */
+  ds2_port=find_open_port(:base_port 30002);
+  ds2_import=ds2_port-1;
+  global(drawserv_upgba2)=false;
+  print("gsbrushA: launching ds2 on port %d\n" ds2_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgba2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upgba2) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushA: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upgba2) :then
+    print("gsbrushA: FAIL timeout waiting for ds2 callback\n" :err);
+    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
+    return(false));
+  print("gsbrushA: ds2 up on %d\n" ds2_port :err);
+
+  /* --- launch ds3 (40002) --- */
+  ds3_port=find_open_port(:base_port 40002);
+  ds3_import=ds3_port-1;
+  global(drawserv_upgba3)=false;
+  print("gsbrushA: launching ds3 on port %d\n" ds3_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgba3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upgba3) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushA: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upgba3) :then
+    print("gsbrushA: FAIL timeout waiting for ds3 callback\n" :err);
+    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
+    return(false));
+  print("gsbrushA: ds3 up on %d\n" ds3_port :err);
+
+  /* --- connect to all three --- */
+  sock1=socket("localhost" ds1_port);
+  sock2=socket("localhost" ds2_port);
+  sock3=socket("localhost" ds3_port);
+  if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
+    print("gsbrushA: FAIL could not connect to all three drawservs\n" :err);
+    kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
+    return(false));
+
+  /* --- build the chain: ds1->ds2 (on ds1), then ds2->ds3 (on ds2) --- */
+  print("gsbrushA: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
+  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
+  remote(sock2 print("drawlink(\"localhost\" %d)" ds3_port :str));
+
+  /* --- create a rect on ds1 with a distinctive dashed brush (linepat 65520,
+     width 2).  far nodes default to a solid brush, so a match downstream proves
+     the BRUSH graphic-state propagated with the graphic. --- */
+  brushstr=":brush 65520,2";
+  remote(sock1 "r=rect(20,20,80,80)");
+  remote(sock1 "brush(65520,2)");
+  /* one reasoned settle (see updown3A): command distribution is fire-and-forget;
+     give the create+brush a head start before polling the far nodes. */
+  update(2000000);
+  id1=remote(sock1 "at(grid(:table)).grid");
+  print("gsbrushA: created rect+brush on ds1, grid id=%v\n" id1 :err);
+  if(type(id1)!=`StringType :then
+    print("gsbrushA: FAIL could not read grid id from ds1 (got %v)\n" id1 :err);
+    remote(sock1 "exit" :nowait);close(sock1);
+    remote(sock2 "exit" :nowait);close(sock2);
+    remote(sock3 "exit" :nowait);close(sock3);
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    return(false));
+
+  /* --- verify arrival (by grid id) then the brush gs at each far node --- */
+  on2=grid_has_id(:gh_sock sock2 :gh_id id1);
+  b2=on2 && brush_on_node(:bn_sock sock2 :bn_id id1 :bn_brush brushstr);
+  print("gsbrushA: ds2 (hop 1) has graphic=%v with brush=%v\n" on2 b2 :err);
+  on3=grid_has_id(:gh_sock sock3 :gh_id id1);
+  b3=on3 && brush_on_node(:bn_sock sock3 :bn_id id1 :bn_brush brushstr);
+  print("gsbrushA: ds3 (hop 2) has graphic=%v with brush=%v\n" on3 b3 :err);
+  ok=b2 && b3;
+  if(!b2 :then print("gsbrushA: FAIL brush did not reach ds2 intact\n" :err));
+  if(!b3 :then print("gsbrushA: FAIL brush did not propagate to ds3 intact\n" :err));
+  if(ok :then print("gsbrushA: brush propagated two hops along the chain\n" :err));
+
+  /* --- tear all three down --- */
+  remote(sock1 "exit" :nowait);close(sock1);
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  print("gsbrushA: ds1 shut down\n" :err);
+  remote(sock2 "exit" :nowait);close(sock2);
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  print("gsbrushA: ds2 shut down\n" :err);
+  remote(sock3 "exit" :nowait);close(sock3);
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  print("gsbrushA: ds3 shut down\n" :err);
+  ok)
+
+/* gsbrushB test -- graphic-state BRUSH propagation, TREE topology: ds1 -> ds2 and
+   ds1 -> ds3 (ds1 hub).  create a rect carrying a distinctive brush on ds1; verify
+   the graphic AND its brush fan out to BOTH branches.  parallels updown3B. */
+gsbrushB_test=func(
+
+  poll_usec=2000000;
+  timeout=60*1000000/poll_usec;
+  progress_interval=10*1000000/poll_usec;
+
+  /* --- launch ds1 (20002) --- */
+  ds1_port=find_open_port(:base_port 20002);
+  ds1_import=ds1_port-1;
+  global(drawserv_upgbb1)=false;
+  print("gsbrushB: launching ds1 on port %d\n" ds1_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgbb1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upgbb1) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushB: still waiting for ds1 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upgbb1) :then
+    print("gsbrushB: FAIL timeout waiting for ds1 callback\n" :err);
+    kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds1_import);
+    return(false));
+  print("gsbrushB: ds1 up on %d\n" ds1_port :err);
+
+  /* --- launch ds2 (30002) --- */
+  ds2_port=find_open_port(:base_port 30002);
+  ds2_import=ds2_port-1;
+  global(drawserv_upgbb2)=false;
+  print("gsbrushB: launching ds2 on port %d\n" ds2_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgbb2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upgbb2) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushB: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upgbb2) :then
+    print("gsbrushB: FAIL timeout waiting for ds2 callback\n" :err);
+    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
+    return(false));
+  print("gsbrushB: ds2 up on %d\n" ds2_port :err);
+
+  /* --- launch ds3 (40002) --- */
+  ds3_port=find_open_port(:base_port 40002);
+  ds3_import=ds3_port-1;
+  global(drawserv_upgbb3)=false;
+  print("gsbrushB: launching ds3 on port %d\n" ds3_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgbb3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upgbb3) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushB: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upgbb3) :then
+    print("gsbrushB: FAIL timeout waiting for ds3 callback\n" :err);
+    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
+    return(false));
+  print("gsbrushB: ds3 up on %d\n" ds3_port :err);
+
+  /* --- connect to all three --- */
+  sock1=socket("localhost" ds1_port);
+  sock2=socket("localhost" ds2_port);
+  sock3=socket("localhost" ds3_port);
+  if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
+    print("gsbrushB: FAIL could not connect to all three drawservs\n" :err);
+    kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
+    return(false));
+
+  /* --- build the tree: both links from ds1 (hub) --- */
+  print("gsbrushB: tree ds1(%d) -> ds2(%d), ds3(%d)\n" ds1_port ds2_port ds3_port :err);
+  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
+  remote(sock1 print("drawlink(\"localhost\" %d)" ds3_port :str));
+
+  /* --- create a rect on ds1 with a distinctive dashed brush (linepat 65520,
+     width 2); it fans out to both branches. --- */
+  brushstr=":brush 65520,2";
+  remote(sock1 "r=rect(20,20,80,80)");
+  remote(sock1 "brush(65520,2)");
+  /* one reasoned settle (see updown3B): fire-and-forget distribution. */
+  update(2000000);
+  id1=remote(sock1 "at(grid(:table)).grid");
+  print("gsbrushB: created rect+brush on ds1, grid id=%v\n" id1 :err);
+  if(type(id1)!=`StringType :then
+    print("gsbrushB: FAIL could not read grid id from ds1 (got %v)\n" id1 :err);
+    remote(sock1 "exit" :nowait);close(sock1);
+    remote(sock2 "exit" :nowait);close(sock2);
+    remote(sock3 "exit" :nowait);close(sock3);
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    return(false));
+
+  /* --- verify arrival then the brush gs on BOTH branches --- */
+  on2=grid_has_id(:gh_sock sock2 :gh_id id1);
+  b2=on2 && brush_on_node(:bn_sock sock2 :bn_id id1 :bn_brush brushstr);
+  print("gsbrushB: ds2 (branch 1) has graphic=%v with brush=%v\n" on2 b2 :err);
+  on3=grid_has_id(:gh_sock sock3 :gh_id id1);
+  b3=on3 && brush_on_node(:bn_sock sock3 :bn_id id1 :bn_brush brushstr);
+  print("gsbrushB: ds3 (branch 2) has graphic=%v with brush=%v\n" on3 b3 :err);
+  ok=b2 && b3;
+  if(!b2 :then print("gsbrushB: FAIL brush did not reach ds2 intact\n" :err));
+  if(!b3 :then print("gsbrushB: FAIL brush did not reach ds3 intact\n" :err));
+  if(ok :then print("gsbrushB: brush fanned out to both branches\n" :err));
+
+  /* --- tear all three down --- */
+  remote(sock1 "exit" :nowait);close(sock1);
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  print("gsbrushB: ds1 shut down\n" :err);
+  remote(sock2 "exit" :nowait);close(sock2);
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  print("gsbrushB: ds2 shut down\n" :err);
+  remote(sock3 "exit" :nowait);close(sock3);
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  print("gsbrushB: ds3 shut down\n" :err);
+  ok)
+
 /* gsexim test -- graphic-state export/import round-trip ACROSS two drawservs.
    THE THESIS: the string that export(:string :percomp) produces IS the command
    that recreates the graphic -- the script is the picture.  ds1 builds a rect
@@ -1174,6 +1438,20 @@ if(tests_flag :then
         print("gsexim: pass\n" :err)
       :else
         print("gsexim: FAIL\n" :err);
+        ok=false));
+    if(t==`gsbrushA || t==`all :then
+      print("running gsbrushA test\n" :err);
+      if(gsbrushA_test(:dummy 0) :then
+        print("gsbrushA: pass\n" :err)
+      :else
+        print("gsbrushA: FAIL\n" :err);
+        ok=false));
+    if(t==`gsbrushB || t==`all :then
+      print("running gsbrushB test\n" :err);
+      if(gsbrushB_test(:dummy 0) :then
+        print("gsbrushB: pass\n" :err)
+      :else
+        print("gsbrushB: FAIL\n" :err);
         ok=false));
     if(t==`updown4C || t==`all :then
       print("running updown4C test\n" :err);


### PR DESCRIPTION
Adds the `gsbrushA`/`gsbrushB` drawmo tests for distributed graphic-state
propagation and fixes the two real bugs they surfaced. Verified end-to-end
against installed binaries: gsbrushA, gsbrushB, and the `updown*` regressions
all pass.

## What the tests do

`gsbrushA` (chain `ds1->ds2->ds3`) and `gsbrushB` (tree `ds1->ds2`, `ds1->ds3`)
create a rect with a distinctive dashed brush on `ds1` and verify the brush
graphic-state reaches the far nodes intact, reading each node's serialized state
via `export(grid(id) :string :percomp)`. Three drawservs each, to exercise a
chain and a tree.

## Bug 1 — X11 map-race segfault on a relayed GUI command (`93ec7430`)

A freshly-launched drawserv could process a GUI command relayed over a drawlink
(the `select()`/`brush()` fan-out) as its *first* event inside `Run()`, before
its window mapped and `Viewer::Resize()` bound the viewer canvas —
`OverlaySelection::Update()` then repaired damage through a null canvas
(`OverlayDamage::DrawAreas`) and segfaulted. A timing race; full speed lost it,
lldb hid it.

Fix (mirrors `comdraw/main.c`), two coupled parts:
- **Seed `update()`** before the runfile/runexpr so the window maps and the
  canvas binds before any command runs — removes the whole "operating before
  mapped" window rather than guarding one deref site.
- **Honor `-stdin_off`**: drawserv registered the fd-0 stdin handler
  unconditionally; under a detached/EOF stdin that handler fires during the
  seed's pump, re-enters comterp on the shared eval stack and corrupts it (a
  second SIGSEGV), and is also what popped the "unexpected EOF" dialog. Honoring
  the flag makes the seed safe and ends the dialog.

## Bug 2 — distributed gs change relays only one hop in a chain (`23c9f773`)

A brush/color change propagated `ds1->ds2` but `ds2` never forwarded it to
`ds3`, so `ds3` kept the create-time state. `dist_script()` only emitted the
forward dance for `LocallySelected` comps stamped with the *local* key; on a
relay node the comp is held *unlocked* on the owner's behalf, so it matched
nothing.

Fix (mirrors how create already chains):
- `dist_script()` also forwards comps held unlocked (`grid->unlocked()`),
  stamped with the **owner's** key (`selectorkey()`) so the forwarded
  `:unlock`/`:lock` bracket stays valid downstream; records the owner sid.
- `DrawServ::ExecuteCmd` sets the distribution sid to that owner sid, so the
  existing `linkget(sid)` exclusion drops the link back toward the origin — the
  change flows onward and never echoes back. On the originating node the owner
  is self → `linkget()==nil` → send-to-all (unchanged).

Today the tag is the derivable `selectorkey()`; once it becomes a per-owner
signature the relay must forward it rather than re-mint it. The atomic
`select(:body :sign)` design (#163) is the structural home for that and for
making the unlock/lock bracket indivisible — filed as a follow-on, not built
here.

## Supporting fixes (`a3e754d3`)
- `grid()` with an 8-char index resolves (distributed traffic carries only the
  8-char uuid prefix the gridtable is keyed on).
- comterp ignores `SIGPIPE` so a peer dropping mid-run returns `EPIPE` instead
  of killing the interpreter driving the drawservs.

## Test results
- gsbrushA — pass (brush two hops along the chain)
- gsbrushB — pass (tree fan-out, ds3 intact, no crash)
- updown, updown2, updown3A, updown3B, updown4A, updown4C — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)