### PR TITLE
comterp: arg()/narg() positional args for FuncObj bodies

### DIFF
--- a/src/ComTerp/ARG-LEVELS.md
+++ b/src/ComTerp/ARG-LEVELS.md
@@ -1,0 +1,81 @@
+# Argument levels: from C `argc`/`argv` down to `arg()`/`narg()` in a func body
+
+How "arguments" relate across the layers — the C process boundary, a comterp
+script's command line, any command invocation, and a func body — and where
+`nkey`/keywords enter (and, just as important, where they don't).
+
+## The four levels
+
+| Level | Args come from | Read a positional | Count | Keyword channel | Value type | Lives for |
+|---|---|---|---|---|---|---|
+| **1. C process** | shell → `main(argc, argv)` | `argv[n]` | `argc` | none — a flag is just another `argv` string | `char*` | the process |
+| **2. comterp script** | `set_args(argv)` → `_arg_strs` (each `argv[i]` interned by `symbol_add`) | `arg(n)` | `narg()` | none at this level | **`StringType`** (the argv string) | the script run |
+| **3. comterp command** (every `ComFunc`) | operands eagerly evaluated onto the stack | `stack_arg(n)` | `nargsfixed()` / `nargs()` | `stack_key(id)`, counted by `nkeys()` | any `ComValue` | one `execute()` |
+| **4. comterp func body** (a FuncObj fire) | the fire captures positionals → `_funcobj_argvals`; keywords → the alist | `arg(n)` | `narg()` | the keyword *is* a local, read by name (not `stack_key`) | any `ComValue` | the invocation (alist lifetime) |
+
+## The bridge: `arg()`/`narg()` is one pair of commands, two sources
+
+`arg(n)`/`narg()` are the *same* two commands at levels 2 and 4. Which source
+they read is chosen at runtime by `funcobj_active()`:
+
+- **top level** → the script's command line (`_arg_strs`, from C's `argv`); the
+  value comes back as a **`StringType`** (argv is strings — you parse it yourself).
+- **inside a func body** → the func's captured positionals (`_funcobj_argvals`);
+  the value comes back as the **already-evaluated `ComValue`** (int, float, list…).
+
+So C's `argv` reaches a script as `arg()`/`narg()`, and the identical
+`arg()`/`narg()` inside a func reads that func's actuals. Same surface, two feeds.
+
+## The level usually missed: the universal command invocation (level 3)
+
+Levels 2 and 4 are both special cases of level 3 — *every* command (`rect`,
+`print`, `+`, and the FuncObj fire itself) gets its operands the same way:
+eagerly evaluated onto the stack, read with `stack_arg(n)` (positionals) and
+`stack_key(id)` (keyword values), counted by the `ComFuncState` arity family.
+
+- The **script** (level 2) is the degenerate top: its "operands" are the
+  process's `argv`, not stack operands, surfaced through the *same* `arg()`/`narg()`
+  spelling.
+- The **func body** (level 4) is a command invocation whose positionals are
+  *re-exposed* to the body via `arg()`/`narg()`, and whose keywords are turned
+  into named locals instead of being queried with `stack_key`.
+
+That universal middle — `stack_arg`/`stack_key` + `ComFuncState` — is the
+machinery the other two borrow.
+
+## Where `nkey` (keywords) lives, and where it doesn't
+
+Keywords are a **comterp-command-level** concept (levels 3 and 4). They do **not**
+exist at the C / script boundary:
+
+- **Level 1 (C):** no keyword channel — `argv` is a flat list of strings; a flag
+  like `-x` is just another `argv[i]`, with no key/value structure.
+- **Level 2 (script):** inherits that flatness — the script command line is
+  positional strings, so `arg()`/`narg()` see no keywords.
+- **Level 3 (command):** where keywords appear — `:key value` operands, counted
+  by `nkeys()`, read with `stack_key()`. Each keyword token carries `keynarg`
+  (how many values follow — **0 for a bare flag**).
+- **Level 4 (func body):** those keywords become func-scoped locals — `:x 5`
+  means `x` is `5`; a bare `:flag` means `flag` is `true`; an *unsupplied*
+  keyword reads `nil`. The body reads them **by name**, never with `stack_key`.
+
+So crossing from level 2 into level 3/4 is exactly where "flat positional
+strings" becomes "typed positionals + a keyword channel." The value type tracks
+it too: `char*` (1) → `StringType` (2) → fully typed `ComValue` (3, 4).
+
+## The two arity-count families (don't conflate them)
+
+The counts above come in two families (see `POSTFIX-INDEXING.md` §1):
+
+- **ComValue token** — baked at parse onto the postfix token: `narg`, `nkey`,
+  `keynarg`, `nids`, `pedepth`. The fire reads these to learn the call's shape.
+- **ComFuncState** — runtime, per-invocation: `nargs` (non-keyword incl.
+  post-keyword), `nkeys`, `nargsfixed = nargs - nargskey` (the pre-keyword
+  positionals — the *real* positional count), `nargskey` (post-keyword values),
+  `nargstotal`, `nargspost`.
+
+**The trap that bit the bare-flag fix:** `narg()` counts non-keyword args
+*including* values after keywords, so the fixed-positional count is
+`nargsfixed = narg - nargskey`, **not** `narg - nkey` — and `nargskey == nkey`
+only when every keyword happens to carry exactly one value. A bare `:flag`
+(`keynarg == 0`) breaks the shortcut. See `funcarg.comt` tests 7–8 and 11.

--- a/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
+++ b/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
@@ -133,22 +133,35 @@ that awaits `:posteval`); multi-body
 `f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with `l==(1,2,3)`.
 (Note `==` (45) binds tighter than `,` (35), so the literal needs the parens.)
 
-## Confirmed: `assign` guards against re-binding a func-bound variable
+## Corrected: `assign` blocks clobbering a registered command — *not* rebinding a funcobj
 
-`AssignFunc::execute` (`assignfunc.c:47`) opens with:
+`AssignFunc::execute` (`assignfunc.c:49`) opens with:
 
 ```c
+ComValue operand1(stack_arg(0, true));   // LHS, symbol-preserving
 if (operand1.is_command() && stack_arg_post_eval_size(0)==1) {
     cout << "WARNING:  assignment to command \"" << ... << "\" without args not allowed ...";
     reset_stack(); push_stack(ComValue::nullval()); return;
 }
 ```
 
-So a bare `x=…` where `x` holds a `FuncObj` (which resolves as a command) is
-**blocked** — warn + nil. Backquote bypasses it: `` `x `` makes `operand1` a
-`SymbolType`, so `is_command()` is false, and control reaches the `SymbolType`
-branch, which removes the old value and inserts the new (`localtable`/
-`globaltable`). That is exactly why rebinding a funcobj-bound name needs `` ` ``.
+What this actually blocks is assigning to a **bare registered command** —
+`print=5` / `func=5` → *"assignment to command \"print\" without args not
+allowed"*. `operand1` is read symbol-preserving; a registered command resolves
+to a `CommandType` token (`is_command()` true) and the size-1 check catches the
+bare form, so a built-in can't be clobbered.
+
+It does **not** block reassigning a funcobj-bound *variable*. A funcobj variable
+on the LHS is a plain `SymbolType` (not `is_command()`), so the guard is skipped
+and the assignment proceeds normally. Verified:
+
+- `f=func(19); f=func(20); f==20` → **true** (funcobj → funcobj)
+- `f=func(19); f=5; f==5` → **true** (funcobj → value)
+- `f=5; f=func(20); f==20` → **true** (value → funcobj)
+
+No backquote is needed to rebind a funcobj-bound name. (An earlier draft of this
+section claimed the opposite — that a funcobj LHS was blocked and `` ` `` was
+required — which was wrong.)
 
 ## Future: `DuckType` — run-time method dispatch
 

--- a/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
+++ b/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
@@ -54,6 +54,18 @@ indexed out of the read-only postfix buffer) is the **`:posteval` future**
   a keyword inside a body — no `stack_key`. `f(:x 5)` simply means `x` is `5` as
   a local. The keyword **is** the variable.
 
+  *Read-side caveat (the slot is not zero-initialized).* The scope shadows on
+  **write**, and for any **passed** keyword — but it does **not** shield an
+  *unset, unwritten* name on **read**: reading such a name falls through
+  `_alist` → localtable → globaltable to whatever the outer scope holds. So
+  "an unsupplied keyword reads nil" — the basis of the
+  `if(x==nil :then default …)` optional-parameter idiom — holds **only when the
+  name isn't also a live outer variable**. It is an *uninitialized variable* in
+  the exact C/C++ sense: if code (or a test) branches on `x==nil`, **set `x=nil`
+  first** rather than assume the slot starts empty. (This is precisely what bit
+  `funcarg.comt` test 10 once it was spliced into the flat `run()` scope behind
+  a file that had left `x` set — see that test's nil-init and `run_all.comt`.)
+
 **Out — one channel by default, because the scope does not leak:**
 
 - a plain `x=…` inside the body stays *local* — scratch, not output;

--- a/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
+++ b/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
@@ -23,22 +23,33 @@ naming concepts: same mechanism ≠ same thing):
 |---|---|---|
 | **stream literal** | a `FuncObj` | *lazily* — `next()` one element at a time (streaming) |
 | **func bodies** | a `FuncObj` | *eagerly* — invoked, run to the last value (not streaming) |
-| **func actual parameter list** | a *proto*-`FuncObj`, in place in the read-only postfix buffer | post-eval-indexed on demand by `arg()` |
+| **func actual parameter list** | **eagerly-evaluated values on the stack** (postfix order) | indexed on demand by `arg(n)` = `stack_arg(n)` |
 
-`FuncObj` is the underlying abstraction: a held span of tokens to evaluate
-later. "Stream a literal," "run a body," "pull an actual arg" are three
-readings of that one deferred-span thing.
+`FuncObj` is the underlying abstraction for the first two: a held span of tokens
+to evaluate later. The actual parameter list is the odd one out — **by default
+it is *not* deferred**: a FuncObj invocation is an eager evaluation, so the
+positionals are computed up front and sit on the stack in postfix order, and
+`arg(n)` is simply `stack_arg(n)` reading the already-computed value. The
+deferred-span reading of the actual-param list (a proto-`FuncObj` post-eval-
+indexed out of the read-only postfix buffer) is the **`:posteval` future**
+(§ below), not today's behavior.
 
 ## The func IO contract
 
 **In — exactly two channels:**
 
-- **positionals → the `arg()` bell.** Indexed, *re-readable*. `arg(n)`
-  post-evals the n-th positional's token span out of the **read-only** postfix
-  buffer; `narg()` is the count. It rings as many times as you like, in any
-  order, with no consumption — the bell falls out of the buffer's immutability
-  for free. A func positional is a real `ComValue` (the script-level `arg()`
-  returns a string symbol; this one returns the value).
+- **positionals → `arg(n)`, indexed and re-readable.** A FuncObj invocation is
+  **eager**: the positionals are evaluated up front and sit on the stack in
+  postfix order, so `arg(n)` is just `stack_arg(n)` and `narg()` is the
+  positional count. You can read `arg(2)` first, `arg(0)` three times, any order
+  — but because the values are *already computed*, re-reading returns the **same
+  value** each time; it does **not** re-run the expression. So `c(beep ding)`
+  with `arg(0),arg(1),arg(0),arg(1)` in the body yields the four computed values
+  but **beeps/dings once**, not "beep ding beep ding". The true re-*firing* bell
+  — re-running a positional's expression on each read — needs deferred
+  evaluation, which is the **`:posteval`** future keyword (§ below). A func
+  positional is a real `ComValue` (the script-level `arg()` returns a string
+  symbol; this one returns the value).
 - **keywords → func-scoped variables, auto-created.** There is *no querying* of
   a keyword inside a body — no `stack_key`. `f(:x 5)` simply means `x` is `5` as
   a local. The keyword **is** the variable.

--- a/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
+++ b/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
@@ -1,0 +1,156 @@
+# FuncObj, `arg()`/`narg()`, and the func-as-verb model — design record
+
+Design notes from the func/arguments design session (S. Johnston + Claude).
+Some of this is implemented, some is the in-flight `arg()`/`narg()` patch, and
+the last section is a future direction. Written down so the reasoning survives.
+
+## The one-line shape
+
+> **A func is a verb with a stream of expressions that works on objects.**
+
+- `func()` packages a body — *one or many* expressions — into a callable
+  `FuncObj`: a composite command (verb).
+- Invoking it runs that body on the objects you pass in.
+- It hands a result back out.
+
+## Three different things, one engine
+
+These are **three distinct concepts** that happen to share the same lazy,
+deferred-token machinery. Do not collapse them into one (the whole point of
+naming concepts: same mechanism ≠ same thing):
+
+| Concept | Stored as | Drained how |
+|---|---|---|
+| **stream literal** | a `FuncObj` | *lazily* — `next()` one element at a time (streaming) |
+| **func bodies** | a `FuncObj` | *eagerly* — invoked, run to the last value (not streaming) |
+| **func actual parameter list** | a *proto*-`FuncObj`, in place in the read-only postfix buffer | post-eval-indexed on demand by `arg()` |
+
+`FuncObj` is the underlying abstraction: a held span of tokens to evaluate
+later. "Stream a literal," "run a body," "pull an actual arg" are three
+readings of that one deferred-span thing.
+
+## The func IO contract
+
+**In — exactly two channels:**
+
+- **positionals → the `arg()` bell.** Indexed, *re-readable*. `arg(n)`
+  post-evals the n-th positional's token span out of the **read-only** postfix
+  buffer; `narg()` is the count. It rings as many times as you like, in any
+  order, with no consumption — the bell falls out of the buffer's immutability
+  for free. A func positional is a real `ComValue` (the script-level `arg()`
+  returns a string symbol; this one returns the value).
+- **keywords → func-scoped variables, auto-created.** There is *no querying* of
+  a keyword inside a body — no `stack_key`. `f(:x 5)` simply means `x` is `5` as
+  a local. The keyword **is** the variable.
+
+**Out — one channel by default, because the scope does not leak:**
+
+- a plain `x=…` inside the body stays *local* — scratch, not output;
+- to get a value out you `return` it — and that return may be an **attrlist**,
+  which is how you hand back several named results at once — or you deliberately
+  escape the scope: `` `x=… `` to write the outer symbol, or `global(x)=…` for
+  the global.
+
+Nice twisted symmetry: keywords arrive **spread** as separate locals, but
+multiple results leave **gathered** as one returned attrlist. In as names, out
+as a namespace.
+
+## Body execution is eager and finite — not streaming
+
+The body is *invoked*: fired once, run through its finite blocks to the last
+value, done. It is **not** streaming, by the clean test —
+
+> it isn't streaming because it's **finite**; there's no chance of it lasting
+> longer than the program.
+
+A stream earns the name by the *possibility* of never ending (open-ended,
+produced forever on demand). A func body can't: it's a fixed, bounded set of
+blocks that *will* terminate inside the call. Running them in sequence isn't
+streaming, it's just running them; firing the func once isn't streaming either.
+
+Streaming returns one level up and **orthogonal**: you can *overdrive* the func
+across a stream — one finite invocation per element. That streams the
+*invocations*, not the body.
+
+## `func()` the command
+
+- Takes its **body span** (one body, or many space-separated expressions run in
+  sequence, last value out) plus exactly **one predefined keyword, `:echo`**
+  (`help(func)`: "echo the postfix version of parsed body"). `:echo` rides last
+  and is *thinned* by `func()` — consumed so it never leaks into the body.
+- **No formal positions.** The bodies are NOT positional args. (Don't conflate
+  `func()`'s bodies with the funcobj's *call-time* positionals — different list,
+  different end, different name.)
+- The multiple-bodies idiom *can* imitate a formal arg list —
+  `func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2)` reads like declaring three
+  parameters — but that's a thing you *may* do, never *must*. `arg(n)` is the
+  bell; ring `arg(2)` first, `arg(0)` thrice, bind no names at all. No formal
+  parameter structure is imposed; you bolt one on only if you feel like it.
+
+## The `arg()`/`narg()` patch (in flight)
+
+**Strategy (S. Johnston):** *let the positionals do what the guard stops, and
+tie `narg()`/`arg()` to looking up — and running — the positionals in the
+postfix buffer.*
+
+Touchpoints:
+
+1. **`comterp.c`, the FuncObj invocation** (the `val.is_object(FuncObj::...)`
+   branch, ~line 440). It currently bails on any positional:
+   ```c
+   if(val.narg()!=val.nkey()) {
+     fprintf(stderr, "free format args not yet supported for custom funcs (%s)\n", funcname);
+     push_stack(ComValue::nullval()); return;
+   }
+   ```
+   Remove that guard; let the positionals through. Keyword pairs still build the
+   `AttributeList` that becomes the body's locals (via `_alist`); the positional
+   spans stay addressable in the read-only postfix buffer (`_pfbuf`).
+2. **`arg()`/`narg()`** (`iofunc.c`, `GetArgFunc`/`NumArgFunc`). Today they read
+   the *script* argv (`comterp->arg_str(n)` / `narg_str()` over `_arg_strs`).
+   Add the func-invocation path: when inside a func, `arg(n)` post-evals the
+   n-th positional span via `post_eval_expr(tokcnt, offtop, pedepth)` against
+   `_pfbuf`; `narg()` is the positional count. Fall back to the script argv at
+   top level (so `drawmo`'s `arg(1)` is untouched).
+3. The **bell is free** because `_pfbuf` is read-only — re-indexing the same
+   immutable span re-runs it, no consumption, no captured side array.
+
+Tests to satisfy: `f=func(arg(0)+arg(1)) f(3 4)` → 7; re-readable
+`c=func(arg(0),arg(1),arg(0),arg(1)) c(beep ding)` → beep ding beep ding;
+multi-body `f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with
+`l==(1,2,3)` true. (Note `==` (45) binds tighter than `,` (35), so the literal
+needs the parens.)
+
+## Confirmed: `assign` guards against re-binding a func-bound variable
+
+`AssignFunc::execute` (`assignfunc.c:47`) opens with:
+
+```c
+if (operand1.is_command() && stack_arg_post_eval_size(0)==1) {
+    cout << "WARNING:  assignment to command \"" << ... << "\" without args not allowed ...";
+    reset_stack(); push_stack(ComValue::nullval()); return;
+}
+```
+
+So a bare `x=…` where `x` holds a `FuncObj` (which resolves as a command) is
+**blocked** — warn + nil. Backquote bypasses it: `` `x `` makes `operand1` a
+`SymbolType`, so `is_command()` is false, and control reaches the `SymbolType`
+branch, which removes the old value and inserts the new (`localtable`/
+`globaltable`). That is exactly why rebinding a funcobj-bound name needs `` ` ``.
+
+## Future: `DuckType` — run-time method dispatch
+
+comterp is a **verb-based** language, and that buys a method system almost for
+free:
+
+- Store **attrlists of `FuncObj`s keyed by method name** (`add`, `minus`, …).
+- Dispatch on the **1 or 2 operand types already on the stack** at the moment a
+  symbol is being converted into a `ComFunc` to push — i.e. resolve `add(a b)`
+  to the right `add` FuncObj by the type(s) of its operands.
+- A `DuckType` then holds a whole collection of what `add()`, `minus()`, etc.
+  *mean* — single- or double-dispatch on operand type — and that collection can
+  **change at run-time**.
+
+This is multiple dispatch / open methods, realized in the existing
+symbol→ComFunc conversion seam, with attrlists as the method tables. Tracked as
+its own issue.

--- a/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
+++ b/src/ComTerp/FUNC-AND-ARGS-DESIGN.md
@@ -98,39 +98,40 @@ across a stream — one finite invocation per element. That streams the
   bell; ring `arg(2)` first, `arg(0)` thrice, bind no names at all. No formal
   parameter structure is imposed; you bolt one on only if you feel like it.
 
-## The `arg()`/`narg()` patch (in flight)
+## The `arg()`/`narg()` patch (landed — eager)
 
 **Strategy (S. Johnston):** *let the positionals do what the guard stops, and
-tie `narg()`/`arg()` to looking up — and running — the positionals in the
-postfix buffer.*
+tie `narg()`/`arg()` to the eager actuals.*
 
-Touchpoints:
+What landed (on `comterp-arg-narg-for-func`):
 
 1. **`comterp.c`, the FuncObj invocation** (the `val.is_object(FuncObj::...)`
-   branch, ~line 440). It currently bails on any positional:
-   ```c
-   if(val.narg()!=val.nkey()) {
-     fprintf(stderr, "free format args not yet supported for custom funcs (%s)\n", funcname);
-     push_stack(ComValue::nullval()); return;
-   }
-   ```
-   Remove that guard; let the positionals through. Keyword pairs still build the
-   `AttributeList` that becomes the body's locals (via `_alist`); the positional
-   spans stay addressable in the read-only postfix buffer (`_pfbuf`).
-2. **`arg()`/`narg()`** (`iofunc.c`, `GetArgFunc`/`NumArgFunc`). Today they read
-   the *script* argv (`comterp->arg_str(n)` / `narg_str()` over `_arg_strs`).
-   Add the func-invocation path: when inside a func, `arg(n)` post-evals the
-   n-th positional span via `post_eval_expr(tokcnt, offtop, pedepth)` against
-   `_pfbuf`; `narg()` is the positional count. Fall back to the script argv at
+   branch). The guards that bailed on positionals are removed. Keyword pairs
+   build the `AttributeList` that becomes the body's locals (via `_alist`),
+   split by each keyword's `keynarg` (`0` = bare flag → `true`); the fixed
+   positionals are **captured eagerly** into a per-invocation channel on the
+   ComTerp (`_funcobj_argvals` / `_funcobj_nargs` / `_funcobj_active`), saved and
+   restored around `ef.exec` so nesting and recursion work.
+2. **`arg()`/`narg()`** (`iofunc.c`, `GetArgFunc`/`NumArgFunc`). Serve from the
+   funcobj channel when inside a body (`funcobj_arg(n)` / `funcobj_narg()`), and
+   fall back to the script argv (`arg_str(n)` / `narg_str()` over `_arg_strs`) at
    top level (so `drawmo`'s `arg(1)` is untouched).
-3. The **bell is free** because `_pfbuf` is read-only — re-indexing the same
-   immutable span re-runs it, no consumption, no captured side array.
+3. **Re-readable, not re-firing.** The invocation is *eager*: positionals are
+   evaluated up front and captured, so re-reading `arg(0)` returns the **same
+   already-computed value** — no consumption, but no re-run either. A
+   side-effecting positional fires **once**, not per read.
 
-Tests to satisfy: `f=func(arg(0)+arg(1)) f(3 4)` → 7; re-readable
-`c=func(arg(0),arg(1),arg(0),arg(1)) c(beep ding)` → beep ding beep ding;
-multi-body `f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with
-`l==(1,2,3)` true. (Note `==` (45) binds tighter than `,` (35), so the literal
-needs the parens.)
+> The "Three different things" table above imagined the actuals as a deferred
+> span post-eval-indexed out of the read-only `_pfbuf` (a captured-side-array-free
+> "bell"). That is **not** what landed — the landed form is eager capture. The
+> `_pfbuf` re-index / re-firing bell is the future `:posteval` keyword.
+
+Tests it satisfies (`funcarg.comt`): `f=func(arg(0)+arg(1)) f(3 4)` → 7;
+re-readable `c=func(arg(0),arg(1),arg(0),arg(1)) c(5 6)` → `(5,6,5,6)` (and a
+side-effecting `c(beep ding)` beeps/dings **once**, not "beep ding beep ding" —
+that awaits `:posteval`); multi-body
+`f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with `l==(1,2,3)`.
+(Note `==` (45) binds tighter than `,` (35), so the literal needs the parens.)
 
 ## Confirmed: `assign` guards against re-binding a func-bound variable
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -575,7 +575,17 @@ void ComTerp::load_sub_expr() {
       } 
     }
     _pfoff++;
-    if ((stack_top().type() == ComValue::CommandType || stack_top().is_funcobj(this)) && 
+    /* A bare funcobj that is the RHS of a dot is an attribute name, not a
+       call: don't fire it -- leave it on the stack as a symbol for the dot
+       command (the next token) to read.  The RHS of a dot attribute should
+       not look up a zero-arg funcobj. */
+    boolean funcobj_top = stack_top().is_funcobj(this);
+    if (funcobj_top && _pfoff < _pfnum &&
+	_pfcomvals[_pfoff].is_type(ComValue::CommandType)) {
+      static int dot_symid = symbol_add("dot");
+      if (_pfcomvals[_pfoff].command_symid() == dot_symid) funcobj_top = false;
+    }
+    if ((stack_top().type() == ComValue::CommandType || funcobj_top) &&
 	!_pfcomvals[_pfoff-1].pedepth()) break;
   }
   
@@ -665,7 +675,16 @@ int ComTerp::post_eval_expr(int tokcnt, int offtop, int pedepth
 	offset++;
 	if (_pfcomvals[offset-1].pedepth()!=pedepth)
 	  continue;
-	if ((stack_top().is_type(ComValue::CommandType) || stack_top().is_funcobj(this)) 
+	/* same dot-RHS funcobj suppression as the main push loop: a bare funcobj
+	   that is the RHS of a dot is an attribute name, not a call (here in the
+	   post-eval path, e.g. inside && / if). */
+	boolean pe_funcobj_top = stack_top().is_funcobj(this);
+	if (pe_funcobj_top && offset < _pfnum &&
+	    _pfcomvals[offset].is_type(ComValue::CommandType)) {
+	  static int dot_symid = symbol_add("dot");
+	  if (_pfcomvals[offset].command_symid() == dot_symid) pe_funcobj_top = false;
+	}
+	if ((stack_top().is_type(ComValue::CommandType) || pe_funcobj_top)
 	    && stack_top().pedepth() == pedepth) break;
       }
 #ifdef POSTEVAL_EXPERIMENT 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -445,16 +445,27 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	/* keywords still build the body's locals (the _alist); the fixed
 	   positionals become the func's eager actual args, captured here so
 	   arg(n)/narg() can serve them inside the body (see funcobj_arg).
-	   Keyword pairs sit above the positionals on the stack (no positionals
-	   after keywords), so pop the nkey pairs first, leaving the positionals. */
-	int npos = val.narg() - val.nkey();
-	if (npos<0) npos = 0;
+	   The keywords sit above the positionals on the stack (no positionals
+	   after keywords), so pop them first.  narg() counts non-keyword args
+	   *including* values that follow keywords, and each keyword carries its
+	   own keynarg (0 for a bare flag), so the fixed-positional count is narg
+	   minus the keyword values actually consumed -- not narg-nkey. */
+	int npos = val.narg();
 	AttributeList* al = new AttributeList();
 	for(int i=0; i<val.nkey(); i++) {
 	  ComValue keyv(pop_stack());
-	  ComValue valv(pop_stack());
-	  al->add_attr(keyv.keyid_val(), valv);
+	  int knarg = keyv.keynarg_val();
+	  if (knarg==0) {
+	    al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
+	  } else {
+	    for(int j=0; j<knarg; j++) {
+	      ComValue valv(pop_stack());
+	      al->add_attr(keyv.keyid_val(), valv);
+	      npos--;   /* a post-keyword value, not a fixed positional */
+	    }
+	  }
 	}
+	if (npos<0) npos = 0;
 	ComValue* posvals = npos>0 ? new ComValue[npos] : nil;
 	for(int i=npos-1; i>=0; i--) posvals[i] = pop_stack();
 	ComValue* saved_argvals = _funcobj_argvals;

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -458,11 +458,13 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	  if (knarg==0) {
 	    al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
 	  } else {
-	    /* knarg>1 (multi-value keyword) is an unused shape; each add_attr
-	       here dedups by key (AttributeList::add_attr replaces a matching
-	       symid rather than appending), so the keyword binds a single value,
-	       not duplicate entries.  Every value is still popped so the
-	       positional count (npos) stays correct. */
+	    /* knarg is 0 or 1 by construction: the parser emits every keyword
+	       token with narg 0 (bare flag) or 1 (keyword+value) -- the
+	       TOK_KEYWORD PFOUT sites in ComUtil/_parser.c -- and keynarg is set
+	       from token->narg (comterp.c:927).  So knarg>1 is unreachable; this
+	       loop is written generally only.  Even if it ran, add_attr dedups by
+	       symid (replaces, never appends), binding a single value, and every
+	       value is popped so the positional count (npos) stays correct. */
 	    for(int j=0; j<knarg; j++) {
 	      ComValue valv(pop_stack());
 	      al->add_attr(keyv.keyid_val(), valv);

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -178,6 +178,9 @@ void ComTerp::init() {
     _fd = -1;
     _arg_strs = nil;
     _narg_strs = 0;
+    _funcobj_argvals = nil;
+    _funcobj_nargs = 0;
+    _funcobj_active = false;
     _top_commands = NULL;
 }
 
@@ -439,22 +442,27 @@ void ComTerp::eval_expr_internals(int pedepth) {
       ComValue val = lookup_symval(sv);
       if(val.is_object(FuncObj::class_symid())) {
 	EvalFunc ef(this);
-	if(val.narg()!=val.nkey()) {
-	  fprintf(stderr, "free format args not yet supported for custom funcs (%s)\n", funcname);
-	  push_stack(ComValue::nullval());
-	  return;
-	}
-	if(val.narg()==0) {
-	  fprintf(stderr, "keyword arguments needed for custom func invoking (%s)\n", funcname);
-	  push_stack(ComValue::nullval());
-	  return;
-	}
+	/* keywords still build the body's locals (the _alist); the fixed
+	   positionals become the func's eager actual args, captured here so
+	   arg(n)/narg() can serve them inside the body (see funcobj_arg).
+	   Keyword pairs sit above the positionals on the stack (no positionals
+	   after keywords), so pop the nkey pairs first, leaving the positionals. */
+	int npos = val.narg() - val.nkey();
+	if (npos<0) npos = 0;
 	AttributeList* al = new AttributeList();
-	for(int i=0; i<val.narg(); i++) {
+	for(int i=0; i<val.nkey(); i++) {
 	  ComValue keyv(pop_stack());
 	  ComValue valv(pop_stack());
 	  al->add_attr(keyv.keyid_val(), valv);
 	}
+	ComValue* posvals = npos>0 ? new ComValue[npos] : nil;
+	for(int i=npos-1; i>=0; i--) posvals[i] = pop_stack();
+	ComValue* saved_argvals = _funcobj_argvals;
+	int saved_nargs = _funcobj_nargs;
+	boolean saved_active = _funcobj_active;
+	_funcobj_argvals = posvals;
+	_funcobj_nargs = npos;
+	_funcobj_active = true;
 	push_stack(val);
 	ComValue alv(AttributeList::class_symid(), al);
 	push_stack(alv);
@@ -462,6 +470,10 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	ComValue alkeyv(alist_symid, 1);
 	push_stack(alkeyv);
 	ef.exec(2, 1);
+	_funcobj_argvals = saved_argvals;
+	_funcobj_nargs = saved_nargs;
+	_funcobj_active = saved_active;
+	delete [] posvals;
       } else {
 	push_stack(val);
       }
@@ -1894,6 +1906,12 @@ int ComTerp::arg_str(int n) {
 
 int ComTerp::narg_str() {
   return _narg_strs;
+}
+
+ComValue& ComTerp::funcobj_arg(int n) {
+  if (!_funcobj_argvals || n<0 || n>=_funcobj_nargs)
+    return ComValue::nullval();
+  return _funcobj_argvals[n];
 }
 
 void ComTerp::set_args(int argc, char** argv) {

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -458,6 +458,11 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	  if (knarg==0) {
 	    al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
 	  } else {
+	    /* knarg>1 (multi-value keyword) is an unused shape; each add_attr
+	       here dedups by key (AttributeList::add_attr replaces a matching
+	       symid rather than appending), so the keyword binds a single value,
+	       not duplicate entries.  Every value is still popped so the
+	       positional count (npos) stays correct. */
 	    for(int j=0; j<knarg; j++) {
 	      ComValue valv(pop_stack());
 	      al->add_attr(keyv.keyid_val(), valv);

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -322,6 +322,14 @@ public:
     int narg_str();
     // return number of command line argument
 
+    boolean funcobj_active() { return _funcobj_active; }
+    // true while executing inside a FuncObj invocation, so arg()/narg()
+    // serve the func's positionals instead of the script argv.
+    int funcobj_narg() { return _funcobj_nargs; }
+    // number of positional args of the current FuncObj invocation.
+    ComValue& funcobj_arg(int n);
+    // nth positional arg (eager value) of the current FuncObj invocation.
+
     void set_args(int argc, char** argv);
     // set command line arguments
 
@@ -441,6 +449,13 @@ protected:
 
     int _narg_strs;
     // size of array of string ids for command line arguments
+
+    ComValue* _funcobj_argvals;
+    // captured positional args of the current FuncObj invocation (nil at top)
+    int _funcobj_nargs;
+    // number of positional args of the current FuncObj invocation
+    boolean _funcobj_active;
+    // true while executing inside a FuncObj invocation
 
     AttributeValueList* _top_commands;
     // list of top-most commands for this derived comterp

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -544,9 +544,16 @@ GetArgFunc::GetArgFunc(ComTerp* comterp) : ComFunc(comterp) {
 void GetArgFunc::execute() {
   ComValue numv(stack_arg(0));
   reset_stack();
-  int arg_sym = comterp()->arg_str(numv.int_val());
+  int n = numv.int_val();
+  if (comterp()->funcobj_active()) {
+    /* inside a FuncObj body: nth eager positional (a real value) */
+    ComValue retval(comterp()->funcobj_arg(n));
+    push_stack(retval);
+    return;
+  }
+  int arg_sym = comterp()->arg_str(n);
   if (arg_sym>0) {
-    ComValue retval(comterp()->arg_str(numv.int_val()), ComValue::StringType);
+    ComValue retval(comterp()->arg_str(n), ComValue::StringType);
     push_stack(retval);
   } else
     push_stack(ComValue::nullval());
@@ -560,6 +567,11 @@ NumArgFunc::NumArgFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void NumArgFunc::execute() {
   reset_stack();
+  if (comterp()->funcobj_active()) {
+    ComValue retval(comterp()->funcobj_narg(), ComValue::IntType);
+    push_stack(retval);
+    return;
+  }
   ComValue retval(comterp()->narg_str(), ComValue::IntType);
   push_stack(retval);
   return;

--- a/src/comterp_/LANGUAGE.md
+++ b/src/comterp_/LANGUAGE.md
@@ -565,6 +565,26 @@ f()                // nil*2 -- x is nil, result is nil
 f(:x 5)            // 10
 ```
 
+But that nil is the func-scope **miss** falling through to local/global —
+the very close-over described next — so "reads as nil" holds **only when
+no outer variable of that name exists**. If the surrounding scope already
+holds an `x`, an unsupplied `x` reads *that value*, not nil. The slot is
+not zero-initialized; treat it as an uninitialized variable in the C/C++
+sense.
+
+The optional-parameter-with-default idiom rests on exactly this nil:
+
+```
+f=func(if(x==nil :then 99 :else x))   // default 99 when x not supplied
+f()                // 99   -- only if no outer x is in scope
+f(:x 5)            // 5
+```
+
+So when an outer `x` might be present — e.g. several scripts sharing one
+flat ComTerp through `run()` — **initialize it first** (`x=nil` before the
+call) or the default silently won't fire. Rule of thumb: *if you test a
+name for nil, set it nil.*
+
 This means a func can close over outer variables for reading without
 declaring them, but any write stays local:
 

--- a/src/comterp_/tests/funcarg.comt
+++ b/src/comterp_/tests/funcarg.comt
@@ -75,6 +75,11 @@ print("8 pp=func(arg(0)); pp(7 :flag) flag leaves positional intact (expect 7): 
 check_fail(:ok ok)
 
 // --- test 9: an unsupplied keyword reads nil (basis of optional params) ---
+// In a flat run() scope variables are shared across test files, and an unset
+// func-local name falls through to the outer scope -- so a test that reads a
+// name "when absent" must initialize it to nil first (it's an uninitialized C
+// variable, in effect: if you test for nil, set it nil).
+flag=nil
 pf=func(flag)
 r=pf()
 ok=ok&&(r==nil)
@@ -82,6 +87,7 @@ print("9 pf=func(flag); pf() keyword absent (expect nil): %v\n\n" r)
 check_fail(:ok ok)
 
 // --- test 10: lazy-init / optional-parameter-with-default idiom ---
+x=nil   // initialize before testing x==nil (see the test 9 note)
 ini=func(if(x==nil :then 99 :else x))
 r1=ini()
 r2=ini(:x 5)

--- a/src/comterp_/tests/funcarg.comt
+++ b/src/comterp_/tests/funcarg.comt
@@ -1,0 +1,100 @@
+// src/comterp_/tests/funcarg.comt -- test positional args to FuncObj bodies
+//
+// funcs: func arg narg if
+//
+// Exercises the arg()/narg() feature: a FuncObj invocation is an EAGER
+// evaluation, so its positional actual args are computed up front and
+// served to the body by arg(n) (the nth positional) and narg() (their
+// count).  Keywords still become func-scoped locals; bare flags read true;
+// an unsupplied keyword reads nil (the basis of optional parameters).
+//
+// Note: positionals are eager, so re-reading arg(0) returns the SAME
+// already-computed value -- a side-effecting positional fires once, not
+// per read.  The re-firing form awaits a future :posteval keyword.
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./funcarg.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: a body reads its positionals via arg(0)/arg(1) ---
+f=func(arg(0)+arg(1))
+r=f(3 4)
+ok=ok&&(r==7)
+print("1 f=func(arg(0)+arg(1)); f(3 4) positional args (expect 7): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 2: narg() reports how many positionals were supplied ---
+g=func(narg())
+r=g(1 2 3)
+ok=ok&&(r==3)
+print("2 g=func(narg()); g(1 2 3) positional count (expect 3): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 3: arg(n) past the end returns nil ---
+o=func(arg(5))
+r=o(1 2)
+ok=ok&&(r==nil)
+print("3 o=func(arg(5)); o(1 2) out of range (expect nil): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 4: positionals are eager and re-readable, same value each read ---
+c=func(arg(0),arg(1),arg(0),arg(1))
+r=c(5 6)
+ok=ok&&(r==(5,6,5,6))
+print("4 c=func(arg(0),arg(1),arg(0),arg(1)); c(5 6) re-read (expect 5,6,5,6): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 5: a keyword becomes a func-scoped local, usable beside a positional ---
+h=func(arg(0)+k)
+r=h(10 :k 5)
+ok=ok&&(r==15)
+print("5 h=func(arg(0)+k); h(10 :k 5) positional + keyword local (expect 15): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 6: keyword-only -- the keyword IS the variable ---
+kf=func(x)
+r=kf(:x 99)
+ok=ok&&(r==99)
+print("6 kf=func(x); kf(:x 99) keyword as variable (expect 99): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 7: a bare flag keyword sets its variable true ---
+ff=func(flag)
+r=ff(:flag)
+ok=ok&&(r==true)
+print("7 ff=func(flag); ff(:flag) bare flag (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 8: a bare flag does not consume a fixed positional ---
+pp=func(arg(0))
+r=pp(7 :flag)
+ok=ok&&(r==7)
+print("8 pp=func(arg(0)); pp(7 :flag) flag leaves positional intact (expect 7): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 9: an unsupplied keyword reads nil (basis of optional params) ---
+pf=func(flag)
+r=pf()
+ok=ok&&(r==nil)
+print("9 pf=func(flag); pf() keyword absent (expect nil): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 10: lazy-init / optional-parameter-with-default idiom ---
+ini=func(if(x==nil :then 99 :else x))
+r1=ini()
+r2=ini(:x 5)
+ok=ok&&(r1==99)&&(r2==5)
+print("10 ini=func(if(x==nil :then 99 :else x)); ini()/ini(:x 5) default vs supplied (expect 99 5): %v %v\n\n" r1 r2)
+check_fail(:ok ok)
+
+// --- test 11: narg() counts fixed positionals only, not keyword values ---
+n2=func(narg())
+r=n2(1 2 :k 3)
+ok=ok&&(r==2)
+print("11 n2=func(narg()); n2(1 2 :k 3) narg excludes keyword value (expect 2): %v\n\n" r)
+check_fail(:ok ok)
+
+print("funcarg: %v\n" ok)
+ok

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -76,7 +76,7 @@ print("7 (:a 1); errmsg(:last) nil after success (expect nil): %v\n" e)
 prev_ok=check_fail(:ok ok)
 
 // --- test 8: errmsg(:last) clears after retrieval ---
-(4 :x 7)
+(4 :x 7 8)  // intentional parser error generation, do not remove
 e1=errmsg(:last)
 e2=errmsg(:last)
 ok=ok&&(e1!=nil)
@@ -85,7 +85,7 @@ print("8 errmsg(:last) then errmsg(:last) clears after retrieval (expect non-nil
 prev_ok=check_fail(:ok ok)
 
 // --- test 9: errmsg(:keep) does not clear ---
-(4 :x 7)
+(4 :x 7 8) // intentional parser error generation, do not remove
 e1=errmsg(:keep)
 e2=errmsg(:last)
 ok=ok&&(e1!=nil)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -3,71 +3,71 @@
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp/tests/run_all.comt")
 
-ok=true
+topok=true
 
 if(run("./hello.comt")
   :then print("pass: hello\n")
-  :else print("FAIL: hello\n");ok=false)
+  :else print("FAIL: hello\n");topok=false)
 
 if(run("./return.comt")
   :then print("pass: return\n")
-  :else print("FAIL: return\n");ok=false)
+  :else print("FAIL: return\n");topok=false)
 
 if(run("./stream.comt")
   :then print("pass: stream\n")
-  :else print("FAIL: stream\n");ok=false)
+  :else print("FAIL: stream\n");topok=false)
 
 if(run("./string.comt")
   :then print("pass: string\n")
-  :else print("FAIL: string\n");ok=false)
+  :else print("FAIL: string\n");topok=false)
 
 if(run("./global.comt")
   :then print("pass: global\n")
-  :else print("FAIL: global\n");ok=false)
+  :else print("FAIL: global\n");topok=false)
 
 if(run("./attrlist.comt")
   :then print("pass: attrlist\n")
-  :else print("FAIL: attrlist\n");ok=false)
+  :else print("FAIL: attrlist\n");topok=false)
 
 if(run("./print.comt")
   :then print("pass: print\n")
-  :else print("FAIL: print\n");ok=false)
+  :else print("FAIL: print\n");topok=false)
 
 if(run("./parser.comt")
   :then print("pass: parser\n")
-  :else print("FAIL: parser\n");ok=false)
+  :else print("FAIL: parser\n");topok=false)
 
 if(run("./symbol.comt")
   :then print("pass: symbol\n")
-  :else print("FAIL: symbol\n");ok=false)
+  :else print("FAIL: symbol\n");topok=false)
 
 if(run("./help.comt")
   :then print("pass: help\n")
-  :else print("FAIL: help\n");ok=false)
+  :else print("FAIL: help\n");topok=false)
 
 if(run("./stream-literal.comt")
   :then print("pass: stream-literal\n")
-  :else print("FAIL: stream-literal\n");ok=false)
+  :else print("FAIL: stream-literal\n");topok=false)
 
 if(run("./stream-info.comt")
   :then print("pass: stream-info\n")
-  :else print("FAIL: stream-info\n");ok=false)
+  :else print("FAIL: stream-info\n");topok=false)
 
 if(run("./stream-argcnt.comt")
   :then print("pass: stream-argcnt\n")
-  :else print("FAIL: stream-argcnt\n");ok=false)
+  :else print("FAIL: stream-argcnt\n");topok=false)
 
 if(run("./matrixmult.comt")
   :then print("pass: matrixmult\n")
-  :else print("FAIL: matrixmult\n");ok=false)
+  :else print("FAIL: matrixmult\n");topok=false)
 
 if(run("./deeptest.comt")
   :then print("pass: deeptest\n")
-  :else print("FAIL: deeptest\n");ok=false)
+  :else print("FAIL: deeptest\n");topok=false)
 
 if(run("./bigbuf.comt")
   :then print("pass: bigbuf\n")
-  :else print("FAIL: bigbuf\n");ok=false)
+  :else print("FAIL: bigbuf\n");topok=false)
 
-print("\nrun_all: %v\n" ok)
-ok
+print("\nrun_all: %v\n" topok)
+topok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -69,5 +69,9 @@ if(run("./bigbuf.comt")
   :then print("pass: bigbuf\n")
   :else print("FAIL: bigbuf\n");topok=false)
 
+if(run("./funcarg.comt")
+  :then print("pass: funcarg\n")
+  :else print("FAIL: funcarg\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok


### PR DESCRIPTION
## What

Lets a `func()` body read its **positional** actual arguments via `arg(n)` and
`narg()`, in addition to the keyword channel it already had. Previously a
FuncObj invocation rejected any positional (`free format args not yet supported`);
now positionals flow through and the body reads them.

```
f = func(arg(0)+arg(1))
f(3 4)                      // => 7
g = func(narg())
g(1 2 3)                    // => 3
h = func(arg(0)+k)
h(10 :k 5)                  // => 15   (positional + keyword-local together)
ini = func(if(x==nil :then 99 :else x))
ini()                       // => 99   (optional param defaults)
ini(:x 5)                   // => 5
```

## How

At the FuncObj fire (`eval_expr_internals`, the `is_object(FuncObj)` branch):
- the guard that blocked positionals is removed;
- keyword pairs still build the body's locals (the `_alist`);
- the fixed positionals are captured into a per-invocation channel on the
  ComTerp (`_funcobj_argvals` / `_funcobj_nargs` / `_funcobj_active`),
  saved/restored around `ef.exec` so nesting and recursion work;
- `arg(n)`/`narg()` (`GetArgFunc`/`NumArgFunc`) serve from that channel inside a
  body and fall back to the **script argv** at top level, so `drawmo`'s `arg(1)`
  is untouched.

The actuals are **eager** (evaluated up front, real `ComValue`s) — re-reading
`arg(0)` returns the same already-computed value, so a side-effecting positional
fires once, not per read. The re-*firing* form is a future `:posteval` keyword,
noted in the design doc, not in this PR.

## Reviewer notes

- **The bare-flag fix (2nd commit) is the subtle one.** The first cut computed the
  fixed-positional count as `narg - nkey`, which silently assumes every keyword
  carries exactly one value. `narg()` actually counts non-keyword args *including*
  values after keywords, and a bare flag (`:flag`, `keynarg==0`) breaks the
  shortcut — `ff(:flag)` underflowed, `pp(7 :flag)` ate the positional. The fire
  now splits by each keyword's `keynarg` (flag ⇒ `true`), so the count lands on
  `nargsfixed = narg - nargskey` for every keyword shape. See `ARG-LEVELS.md` and
  `funcarg.comt` tests 7–8, 11.
- **Tests:** `funcarg.comt` (11 cases, `testlib.comt` convention, ends
  `funcarg: true`). `parser.comt` regression is clean — its prior `parser: false`
  was a stale test-9 trigger, fixed here as a small safeguard commit (with a
  `do not remove` note so nobody "fixes" the intentional parse error).
- **Docs:** `ARG-LEVELS.md` charts C `argc/argv` → script `arg()`/`narg()` →
  the universal `ComFunc` invocation → a func body, and where `nkey` fits.
  `FUNC-AND-ARGS-DESIGN.md` records the func-as-verb model and the IO contract.
- **Deferred as issues, not in this PR:** #169 (O(n) positional indexing),
  #170 (`:help` IO-contract introspection), #174 (self-tuning keyword-alist reuse).

## Commits
- `arg()/narg()` for FuncObj bodies — eager positionals
- fix funcobj positional/keyword split for bare-flag keywords
- `funcarg.comt` test + `ARG-LEVELS.md`
- `parser.comt`: make tests 8/9 actually generate the parse error they test