### PR TITLE
Run the full drawmo distributed suite green in CI (it was never X11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,17 @@ jobs:
         if: always()
         timeout-minutes: 6
         run: |
+          set -o pipefail
           cd src/drawserv_/tests
-          # drawmo exits 0 on full pass, 1 on any failure -- that IS the signal
-          xvfb-run -a ./drawmo < /dev/null
+          # drawmo exits 0 on full pass, 1 on any failure (the comterp_listen
+          # wrapper now propagates that status).  Belt-and-suspenders: also grep
+          # the log for ': FAIL' like the comdraw suite, so a regression anywhere
+          # in the xvfb-run -> wrapper -> comterp exit-code chain can't fake green.
+          xvfb-run -a ./drawmo < /dev/null 2>&1 | tee drawmo.log
+          rc=${PIPESTATUS[0]}
+          if [ "$rc" -ne 0 ] || grep -q ': FAIL' drawmo.log; then
+            echo "drawmo suite FAILED (rc=$rc)"; exit 1
+          fi
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,16 +167,9 @@ jobs:
         if: always()
         timeout-minutes: 6
         run: |
-          set +e
           cd src/drawserv_/tests
-          xvfb-run -a ./drawmo --tests updown < /dev/null & dm=$!
-          sleep 40
-          echo "=== live processes ==="; ps -eo pid,args | grep -iE 'drawserv|comterp|sleep|pgrep' | grep -v grep
-          echo "=== drawserv alive? ==="; pgrep -af 'drawserv -comdraw' || echo "(drawserv gone)"
-          pid=$(pgrep -f 'comterp listen 10002' | head -1)
-          echo "=== drawmo interp pid=$pid wchan=$(cat /proc/$pid/wchan 2>/dev/null) ==="
-          [ -n "$pid" ] && sudo gdb -p "$pid" -batch -ex 'set pagination off' -ex 'bt' 2>&1 | grep -aE '^#|in [A-Za-z_]' | head -25
-          sudo pkill -9 -f drawserv; sudo pkill -9 -f 'comterp listen'; kill -9 "$dm" 2>/dev/null; sudo pkill -9 Xvfb 2>/dev/null; true
+          # drawmo exits 0 on full pass, 1 on any failure -- that IS the signal
+          xvfb-run -a ./drawmo < /dev/null
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,18 +175,18 @@ jobs:
           xvfb-run -a ./drawmo --tests updown < /dev/null & dm=$!
           sleep 45
           echo "=== live processes ==="
-          ps -eo pid,comm,args | grep -iE 'drawserv|comterp' | grep -v grep
-          for pat in 'drawserv -comdraw' 'comterp_listen'; do
-            pid=$(pgrep -f "$pat" | head -1)
-            echo "=== wchan + backtrace: [$pat] pid=$pid ==="
-            if [ -n "$pid" ]; then
-              echo "wchan: $(cat /proc/$pid/wchan 2>/dev/null)"
-              sudo gdb -p "$pid" -batch -ex 'set pagination off' -ex 'thread apply all bt' 2>&1 \
-                | grep -aE '^#|^Thread|signal|in [a-zA-Z]' | head -45
-            fi
-          done
-          sudo pkill -9 -f 'drawserv -comdraw'; kill -9 "$dm" 2>/dev/null; sudo pkill -9 Xvfb 2>/dev/null
-          true
+          ps -eo pid,args | grep -iE 'drawserv|comterp' | grep -v grep
+          echo "=== drawserv still alive? ==="; pgrep -af 'drawserv -comdraw' || echo "(drawserv gone -- it exited)"
+          # the drawmo interpreter is `comterp listen 10002 ./drawmo` (space), NOT
+          # the `comterp_listen` (underscore) bash wrapper.
+          pid=$(pgrep -f 'comterp listen 10002' | head -1)
+          echo "=== drawmo interpreter pid=$pid wchan=$(cat /proc/$pid/wchan 2>/dev/null) ==="
+          if [ -n "$pid" ]; then
+            sudo gdb -p "$pid" -batch -ex 'set pagination off' -ex 'thread apply all bt' 2>&1 \
+              | grep -aE '^#|^Thread|signal|in [A-Za-z]' | head -50
+          fi
+          sudo pkill -9 -f drawserv; kill -9 "$dm" 2>/dev/null; sudo pkill -9 Xvfb 2>/dev/null
+          sudo pkill -9 -f 'comterp listen'; true
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,9 @@ jobs:
 
       # Wire-protocol test: ivtools' defining idea is that the command language IS
       # the wire protocol, so this exercises a `comterp server` over a real
-      # loopback TCP socket -- no X, no drawserv, fully deterministic, so it blocks
-      # CI. (This is the network half of what drawmo covers; drawmo's GUI/X
-      # coupling is what keeps the full drawmo suite out of hosted CI -- see below.)
+      # loopback TCP socket -- no X, no drawserv, fully deterministic. A fast,
+      # focused check of the protocol on its own, ahead of the heavier full drawmo
+      # distributed suite below.
       - name: Test - comterp networking (wire protocol over TCP)
         timeout-minutes: 2
         run: sh src/comterp_/tests/remote_loopback.sh
@@ -153,20 +153,23 @@ jobs:
           xvfb-run -a drawserv -stdin_off -runexpr 'print("DRAWSERV-ALIVE\n");exit' 2>&1 | tee ds.log
           grep -q 'DRAWSERV-ALIVE' ds.log || { echo "drawserv failed to start"; exit 1; }
 
-      # The full drawmo distributed suite (src/drawserv_/tests/drawmo) is NOT run
-      # here. It's an integration test: drawmo shells out a child drawserv that
-      # must call back over a loopback TCP socket within 60s per test. On a hosted
-      # runner that callback never completes -- the child starts fine (it maps a
-      # window and prints its banner, under either Xvfb or a real dummy-driver
-      # Xorg), but its remote("localhost" <port> ...) never reaches drawmo's
-      # listener, almost certainly an IPv4/IPv6 `localhost` mismatch on the runner
-      # (child connects to ::1 while the ACE listener is bound IPv4-only). So every
-      # test just burns its 60s timeout -- ~11 min of red for no signal.
-      #
-      # drawmo passes in full on a real environment -- verified locally on XQuartz
-      # (all 11 tests). Run it there, or on a self-hosted runner with real X and
-      # working loopback, gated e.g. `if: runner.environment == 'self-hosted'`.
-      # See src/drawserv_/tests/TESTING.md.
+      # Full drawmo distributed suite -- now runs headless under xvfb and BLOCKS.
+      # It was thought to need real X, but the real blocker was networking, not the
+      # GUI: drawmo dialed "localhost", which on this runner resolves to IPv6 ::1
+      # first, while the comterp/drawserv acceptors bind IPv4 only -- so every
+      # callback hit ECONNREFUSED and the child appeared to "never call back."
+      # drawmo now uses 127.0.0.1 literals (no resolver in the path), so the child
+      # drawserv it spawns under xvfb maps its window and calls back over IPv4
+      # loopback exactly as it does on a real display. (The deeper fix -- accept
+      # IPv6 on the listener side -- is ACE-build-dependent and rides with the
+      # in-tree ACE-lite, issue #147.)
+      - name: Test - drawserv drawmo full suite
+        if: always()
+        timeout-minutes: 6
+        run: |
+          cd src/drawserv_/tests
+          # drawmo exits 0 on full pass, 1 on any failure -- that IS the signal
+          xvfb-run -a ./drawmo < /dev/null
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,26 +167,9 @@ jobs:
         if: always()
         timeout-minutes: 6
         run: |
-          set +e   # keep going past non-zero rc so the probe runs
           cd src/drawserv_/tests
-          # DIAG: launch updown in the background, let it reach the teardown hang,
-          # then backtrace drawserv AND drawmo *live* (killing via timeout takes
-          # the stuck drawserv with it, so we must catch it mid-hang).
-          xvfb-run -a ./drawmo --tests updown < /dev/null & dm=$!
-          sleep 45
-          echo "=== live processes ==="
-          ps -eo pid,args | grep -iE 'drawserv|comterp' | grep -v grep
-          echo "=== drawserv still alive? ==="; pgrep -af 'drawserv -comdraw' || echo "(drawserv gone -- it exited)"
-          # the drawmo interpreter is `comterp listen 10002 ./drawmo` (space), NOT
-          # the `comterp_listen` (underscore) bash wrapper.
-          pid=$(pgrep -f 'comterp listen 10002' | head -1)
-          echo "=== drawmo interpreter pid=$pid wchan=$(cat /proc/$pid/wchan 2>/dev/null) ==="
-          if [ -n "$pid" ]; then
-            sudo gdb -p "$pid" -batch -ex 'set pagination off' -ex 'thread apply all bt' 2>&1 \
-              | grep -aE '^#|^Thread|signal|in [A-Za-z]' | head -50
-          fi
-          sudo pkill -9 -f drawserv; kill -9 "$dm" 2>/dev/null; sudo pkill -9 Xvfb 2>/dev/null
-          sudo pkill -9 -f 'comterp listen'; true
+          # drawmo exits 0 on full pass, 1 on any failure -- that IS the signal
+          xvfb-run -a ./drawmo < /dev/null
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,17 @@ jobs:
         timeout-minutes: 6
         run: |
           cd src/drawserv_/tests
-          # drawmo exits 0 on full pass, 1 on any failure -- that IS the signal
-          xvfb-run -a ./drawmo < /dev/null
+          # DIAG: cap updown, then gdb the drawserv that wouldn't die on `exit`.
+          timeout 100 xvfb-run -a ./drawmo --tests updown < /dev/null; echo "drawmo rc=$?"
+          echo "=== surviving drawserv ==="; pgrep -af drawserv || echo "(none)"
+          pid=$(pgrep -f 'drawserv -comdraw' | head -1)
+          if [ -n "$pid" ]; then
+            echo "=== /proc/$pid/wchan ==="; cat /proc/$pid/wchan; echo
+            echo "=== open fds ==="; sudo ls -l /proc/$pid/fd 2>&1 | head -30
+            echo "=== backtrace (all threads) ==="
+            sudo gdb -p "$pid" -batch -ex 'thread apply all bt' 2>&1 | grep -aE '^#|Thread|^Program|signal' | head -60 || true
+            sudo kill -9 "$pid" 2>/dev/null || true
+          fi
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
         if: always()
         timeout-minutes: 6
         run: |
+          set +e   # don't let `timeout` (rc 124) abort the step before the probe runs
           cd src/drawserv_/tests
           # DIAG: cap updown, then gdb the drawserv that wouldn't die on `exit`.
           timeout 100 xvfb-run -a ./drawmo --tests updown < /dev/null; echo "drawmo rc=$?"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,16 @@ jobs:
         if: always()
         timeout-minutes: 6
         run: |
+          set +e
           cd src/drawserv_/tests
-          # drawmo exits 0 on full pass, 1 on any failure -- that IS the signal
-          xvfb-run -a ./drawmo < /dev/null
+          xvfb-run -a ./drawmo --tests updown < /dev/null & dm=$!
+          sleep 40
+          echo "=== live processes ==="; ps -eo pid,args | grep -iE 'drawserv|comterp|sleep|pgrep' | grep -v grep
+          echo "=== drawserv alive? ==="; pgrep -af 'drawserv -comdraw' || echo "(drawserv gone)"
+          pid=$(pgrep -f 'comterp listen 10002' | head -1)
+          echo "=== drawmo interp pid=$pid wchan=$(cat /proc/$pid/wchan 2>/dev/null) ==="
+          [ -n "$pid" ] && sudo gdb -p "$pid" -batch -ex 'set pagination off' -ex 'bt' 2>&1 | grep -aE '^#|in [A-Za-z_]' | head -25
+          sudo pkill -9 -f drawserv; sudo pkill -9 -f 'comterp listen'; kill -9 "$dm" 2>/dev/null; sudo pkill -9 Xvfb 2>/dev/null; true
 
       - name: Upload build log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,19 +167,26 @@ jobs:
         if: always()
         timeout-minutes: 6
         run: |
-          set +e   # don't let `timeout` (rc 124) abort the step before the probe runs
+          set +e   # keep going past non-zero rc so the probe runs
           cd src/drawserv_/tests
-          # DIAG: cap updown, then gdb the drawserv that wouldn't die on `exit`.
-          timeout 100 xvfb-run -a ./drawmo --tests updown < /dev/null; echo "drawmo rc=$?"
-          echo "=== surviving drawserv ==="; pgrep -af drawserv || echo "(none)"
-          pid=$(pgrep -f 'drawserv -comdraw' | head -1)
-          if [ -n "$pid" ]; then
-            echo "=== /proc/$pid/wchan ==="; cat /proc/$pid/wchan; echo
-            echo "=== open fds ==="; sudo ls -l /proc/$pid/fd 2>&1 | head -30
-            echo "=== backtrace (all threads) ==="
-            sudo gdb -p "$pid" -batch -ex 'thread apply all bt' 2>&1 | grep -aE '^#|Thread|^Program|signal' | head -60 || true
-            sudo kill -9 "$pid" 2>/dev/null || true
-          fi
+          # DIAG: launch updown in the background, let it reach the teardown hang,
+          # then backtrace drawserv AND drawmo *live* (killing via timeout takes
+          # the stuck drawserv with it, so we must catch it mid-hang).
+          xvfb-run -a ./drawmo --tests updown < /dev/null & dm=$!
+          sleep 45
+          echo "=== live processes ==="
+          ps -eo pid,comm,args | grep -iE 'drawserv|comterp' | grep -v grep
+          for pat in 'drawserv -comdraw' 'comterp_listen'; do
+            pid=$(pgrep -f "$pat" | head -1)
+            echo "=== wchan + backtrace: [$pat] pid=$pid ==="
+            if [ -n "$pid" ]; then
+              echo "wchan: $(cat /proc/$pid/wchan 2>/dev/null)"
+              sudo gdb -p "$pid" -batch -ex 'set pagination off' -ex 'thread apply all bt' 2>&1 \
+                | grep -aE '^#|^Thread|signal|in [a-zA-Z]' | head -45
+            fi
+          done
+          sudo pkill -9 -f 'drawserv -comdraw'; kill -9 "$dm" 2>/dev/null; sudo pkill -9 Xvfb 2>/dev/null
+          true
 
       - name: Upload build log
         if: always()

--- a/src/Attribute/paramlist.c
+++ b/src/Attribute/paramlist.c
@@ -961,8 +961,23 @@ char ParamList::octal(const char* p) {
     return c;
 }
 
-// filter escapes embedded special characters
-
+// filter escapes a raw byte string so it can be embedded inside a double-quoted
+// ComTerp string literal and survive being re-parsed by the scanner.  It is the
+// escaping behind ComValue string output (operator<< StringType -> output_text
+// -> filter), so any value serialized through ComValue is safe to write to a
+// file or send over a comterp connection; text that is hand-assembled into a
+// command (snprintf/ostream) without passing through here is NOT escaped.
+//
+// Each non-ASCII or control byte becomes an octal escape "\NNN" (so a raw
+// newline -- which also delimits commands on a socket -- can't break the frame
+// or the parse), and a literal backslash or double-quote is backslash-escaped
+// (so a '"' can't prematurely close the string).  The ComTerp scanner reverses
+// all of these when it reads the string back.
+//
+// Caveat: it builds into a fixed-size static buffer and clamps rather than
+// grows, so an input whose escaped form exceeds BUFSIZE is silently truncated
+// (see issue #183 for the growable-buffer rewrite).
+//
 const char* ParamList::filter (const char* string, int len) {
     TextBuffer text(textbuf, 0, BUFSIZE);
     int dot;

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1205,9 +1205,12 @@ void ComTerp::exit(int status) {
      atexit handlers / C++ static destructors over a still-live interpreter (the
      same use-after-free class fixed elsewhere in this layer).  But _exit() also
      skips the stdio flush, so a final print() before exit could be lost from a
-     block-buffered stdout (e.g. when piped).  Flush every output stream first so
-     the buffered output reaches the pipe regardless of buffering mode. */
-  fflush(NULL);
+     block-buffered stdout (e.g. when piped) -- flush it (and stderr) first.
+     NOT fflush(NULL): a server interpreter holds FILE* streams wrapping live
+     client sockets, and flushing one whose peer has stalled blocks the exit
+     forever (drawserv hung exactly this way during drawmo's teardown). */
+  fflush(stdout);
+  fflush(stderr);
   _exit( status );
 }
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1206,9 +1206,9 @@ void ComTerp::exit(int status) {
      same use-after-free class fixed elsewhere in this layer).  But _exit() also
      skips the stdio flush, so a final print() before exit could be lost from a
      block-buffered stdout (e.g. when piped) -- flush it (and stderr) first.
-     NOT fflush(NULL): a server interpreter holds FILE* streams wrapping live
-     client sockets, and flushing one whose peer has stalled blocks the exit
-     forever (drawserv hung exactly this way during drawmo's teardown). */
+     Deliberately NOT fflush(NULL): a server interpreter can hold FILE* streams
+     wrapping live client sockets, and flushing one whose peer has stalled could
+     block the exit -- stdout/stderr are all a final print() needs. */
   fflush(stdout);
   fflush(stderr);
   _exit( status );

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -33,9 +33,7 @@
 #include <DrawServ/drawserv.h>
 #include <DrawServ/drawserv-handler.h>
 #include <DrawServ/sid.h>
-#include <Attribute/paramlist.h>
 #include <Unidraw/globals.h>
-#include <string.h>
 #include <fstream.h>
 #include <unistd.h>
 #include <iostream>
@@ -119,19 +117,20 @@ int DrawLink::open(uuid_t linkid) {
     void* ptr = nil;
     ((DrawServ*)unidraw)->sessionidtable()->find(ptr, uuid_key(sid));
     SessionId* sessionid = (SessionId*)ptr;
-    sbuf << ParamList::filter(buffer, strlen(buffer)) << "\"";
+    sbuf << buffer << "\"";
     sbuf << " :port " << ((DrawServ*)unidraw)->comdraw_port();
     sbuf << " :state " << _state+1;
     sbuf << " :sid " << "\"" << sid_str << "\"";
     sbuf << " :linkid " << "\"" << linkid_str << "\"";
     if (sessionid) {
       sbuf << " :pid " << sessionid->pid();
-      // username() is NULL on a runner with no login/USER; ostream << (char*)NULL
-      // sets badbit and silently truncates the rest of the command (closing quote,
-      // ')', newline all dropped -> an unframed, unparseable command).  NUL-safe,
-      // and escaped through the same filter ComValue string output uses.
+      // On a host with no login/USER the username is a NULL pointer, and
+      // ostream operator<<(const char*) on NULL sets the stream's badbit -- the
+      // closing quote, the ')', and the newline then silently vanish, leaving a
+      // truncated, unframed command the receiver can't parse, which stalls the
+      // two-way handshake.  Emit "" for a NULL username so the stream stays good.
       const char* uname = sessionid->username();
-      sbuf << " :user \"" << ParamList::filter(uname ? uname : "", uname ? strlen(uname) : 0) << "\"";
+      sbuf << " :user \"" << (uname ? uname : "") << "\"";
     }
     sbuf << ")";
     log_outgoing_command(sbuf.str().c_str());

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -128,6 +128,10 @@ int DrawLink::open(uuid_t linkid) {
     sbuf << ")";
     log_outgoing_command(sbuf.str().c_str());
     sbuf << "\n";
+    { std::string d=sbuf.str(); fprintf(stderr,"LINKUPCMD[");      /* DIAG */
+      for(size_t k=0;k<d.size();k++){unsigned char c=d[k];
+        if(c>=32&&c<127)fputc(c,stderr); else fprintf(stderr,"\\%03o",c);}
+      fprintf(stderr,"]\n"); fflush(stderr); }
     out << sbuf.str().c_str();
     out.flush();
     _ok = true;

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -33,7 +33,9 @@
 #include <DrawServ/drawserv.h>
 #include <DrawServ/drawserv-handler.h>
 #include <DrawServ/sid.h>
+#include <Attribute/paramlist.h>
 #include <Unidraw/globals.h>
+#include <string.h>
 #include <fstream.h>
 #include <unistd.h>
 #include <iostream>
@@ -105,7 +107,8 @@ int DrawLink::open(uuid_t linkid) {
     sbuf << "drawlink(\"";
     char buffer[HOST_NAME_MAX];
     gethostname(buffer, HOST_NAME_MAX);
-    
+    buffer[HOST_NAME_MAX-1] = '\0';  // gethostname needn't NUL-terminate on truncation
+
     uuid_t& sid = ((DrawServ*)unidraw)->sessionid();
     uuid_string_t sid_str;
     uuid_unparse(sid, sid_str);
@@ -116,22 +119,23 @@ int DrawLink::open(uuid_t linkid) {
     void* ptr = nil;
     ((DrawServ*)unidraw)->sessionidtable()->find(ptr, uuid_key(sid));
     SessionId* sessionid = (SessionId*)ptr;
-    sbuf << buffer << "\"";
+    sbuf << ParamList::filter(buffer, strlen(buffer)) << "\"";
     sbuf << " :port " << ((DrawServ*)unidraw)->comdraw_port();
     sbuf << " :state " << _state+1;
     sbuf << " :sid " << "\"" << sid_str << "\"";
     sbuf << " :linkid " << "\"" << linkid_str << "\"";
     if (sessionid) {
       sbuf << " :pid " << sessionid->pid();
-      sbuf << " :user \"" << sessionid->username() << "\"";
+      // username() is NULL on a runner with no login/USER; ostream << (char*)NULL
+      // sets badbit and silently truncates the rest of the command (closing quote,
+      // ')', newline all dropped -> an unframed, unparseable command).  NUL-safe,
+      // and escaped through the same filter ComValue string output uses.
+      const char* uname = sessionid->username();
+      sbuf << " :user \"" << ParamList::filter(uname ? uname : "", uname ? strlen(uname) : 0) << "\"";
     }
     sbuf << ")";
     log_outgoing_command(sbuf.str().c_str());
     sbuf << "\n";
-    { std::string d=sbuf.str(); fprintf(stderr,"LINKUPCMD[");      /* DIAG */
-      for(size_t k=0;k<d.size();k++){unsigned char c=d[k];
-        if(c>=32&&c<127)fputc(c,stderr); else fprintf(stderr,"\\%03o",c);}
-      fprintf(stderr,"]\n"); fflush(stderr); }
     out << sbuf.str().c_str();
     out.flush();
     _ok = true;

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -416,6 +416,13 @@ void DrawServ::SendCmdString(DrawLink* link, const char* cmdstring) {
   if (link) {
     int fd = link->handle();
     if (fd>=0) {
+      /* DIAG: dump outgoing command bytes, non-printables shown as \NNN */
+      { fprintf(stderr, "SENDCMD fd=%d [", fd);
+        for (const char* p=cmdstring; *p; p++) {
+          unsigned char c=(unsigned char)*p;
+          if (c>=32 && c<127) fputc(c, stderr); else fprintf(stderr, "\\%03o", c);
+        }
+        fprintf(stderr, "]\n"); fflush(stderr); }
       link->log_outgoing_command(cmdstring);
       FILE* fp=fdopen(dup(fd), "w");
       fputs(cmdstring, fp);

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -65,7 +65,6 @@
 #include <Attribute/attribute.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attrvalue.h>
-#include <Attribute/paramlist.h>
 
 #include <fstream.h>
 #include <sstream>
@@ -98,23 +97,6 @@ extern uint32_t uuid_key(const uuid_t u)
     memcpy(&v, u, sizeof(v));
     return ntohl(v);
 }
-
-#ifdef HAVE_ACE
-// Escape a (possibly NULL) string field for a command going onto a link, via
-// ParamList::filter (the same escaping ComValue string output uses).  filter()
-// octal-escapes control/8-bit bytes and backslash-escapes \ and ", so a field
-// can't smuggle a raw newline (the frame delimiter) or an unbalanced quote into
-// the command -- the receiving comterp parses it back as a clean string.  These
-// link commands are hand-assembled with snprintf("%s") and otherwise bypass that
-// escaping.  filter() returns a shared static buffer, so copy each field out
-// before the next filter() call (don't call it twice in one snprintf).
-static const char* ds_filter(char* out, int outsz, const char* s) {
-    const char* f = ParamList::filter(s ? s : "", s ? strlen(s) : 0);
-    strncpy(out, f, outsz - 1);
-    out[outsz - 1] = '\0';
-    return out;
-}
-#endif /* HAVE_ACE */
 
 /*****************************************************************************/
 
@@ -437,11 +419,9 @@ void DrawServ::sessionid_register(DrawLink* link) {
 	char buf[BUFSIZ];
 	uuid_string_t sid_str;
 	uuid_unparse(sessionid->sid(), sid_str);
-	char e_user[BUFSIZ], e_host[BUFSIZ];  // escape so a stray byte can't break the parse
-	ds_filter(e_user, sizeof(e_user), sessionid->username());
-	ds_filter(e_host, sizeof(e_host), sessionid->hostname());
-	snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c",
-		 sid_str, sessionid->pid(), e_user, e_host, sessionid->hostid(), '\0');
+	snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", 
+		 sid_str, sessionid->pid(), sessionid->username(),
+		 sessionid->hostname(), sessionid->hostid(), '\0');
 	SendCmdString(link, buf);
       }
     }
@@ -480,10 +460,7 @@ void DrawServ::sessionid_register_propagate
     char buf[BUFSIZ];
     DrawLink* otherlink = _linklist->GetDrawLink(it);
     if (otherlink != link) {
-      char e_user[BUFSIZ], e_host[BUFSIZ];
-      ds_filter(e_user, sizeof(e_user), username);
-      ds_filter(e_host, sizeof(e_host), hostname);
-      snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", sid_str, pid, e_user, e_host, hostid, '\0');
+      snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", sid_str, pid, username, hostname, hostid, '\0');
       SendCmdString(otherlink, buf);
     }
     _linklist->Next(it);

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -416,13 +416,6 @@ void DrawServ::SendCmdString(DrawLink* link, const char* cmdstring) {
   if (link) {
     int fd = link->handle();
     if (fd>=0) {
-      /* DIAG: dump outgoing command bytes, non-printables shown as \NNN */
-      { fprintf(stderr, "SENDCMD fd=%d [", fd);
-        for (const char* p=cmdstring; *p; p++) {
-          unsigned char c=(unsigned char)*p;
-          if (c>=32 && c<127) fputc(c, stderr); else fprintf(stderr, "\\%03o", c);
-        }
-        fprintf(stderr, "]\n"); fflush(stderr); }
       link->log_outgoing_command(cmdstring);
       FILE* fp=fdopen(dup(fd), "w");
       fputs(cmdstring, fp);

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -65,6 +65,7 @@
 #include <Attribute/attribute.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attrvalue.h>
+#include <Attribute/paramlist.h>
 
 #include <fstream.h>
 #include <sstream>
@@ -97,6 +98,23 @@ extern uint32_t uuid_key(const uuid_t u)
     memcpy(&v, u, sizeof(v));
     return ntohl(v);
 }
+
+#ifdef HAVE_ACE
+// Escape a (possibly NULL) string field for a command going onto a link, via
+// ParamList::filter (the same escaping ComValue string output uses).  filter()
+// octal-escapes control/8-bit bytes and backslash-escapes \ and ", so a field
+// can't smuggle a raw newline (the frame delimiter) or an unbalanced quote into
+// the command -- the receiving comterp parses it back as a clean string.  These
+// link commands are hand-assembled with snprintf("%s") and otherwise bypass that
+// escaping.  filter() returns a shared static buffer, so copy each field out
+// before the next filter() call (don't call it twice in one snprintf).
+static const char* ds_filter(char* out, int outsz, const char* s) {
+    const char* f = ParamList::filter(s ? s : "", s ? strlen(s) : 0);
+    strncpy(out, f, outsz - 1);
+    out[outsz - 1] = '\0';
+    return out;
+}
+#endif /* HAVE_ACE */
 
 /*****************************************************************************/
 
@@ -419,9 +437,11 @@ void DrawServ::sessionid_register(DrawLink* link) {
 	char buf[BUFSIZ];
 	uuid_string_t sid_str;
 	uuid_unparse(sessionid->sid(), sid_str);
-	snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", 
-		 sid_str, sessionid->pid(), sessionid->username(),
-		 sessionid->hostname(), sessionid->hostid(), '\0');
+	char e_user[BUFSIZ], e_host[BUFSIZ];  // escape so a stray byte can't break the parse
+	ds_filter(e_user, sizeof(e_user), sessionid->username());
+	ds_filter(e_host, sizeof(e_host), sessionid->hostname());
+	snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c",
+		 sid_str, sessionid->pid(), e_user, e_host, sessionid->hostid(), '\0');
 	SendCmdString(link, buf);
       }
     }
@@ -460,7 +480,10 @@ void DrawServ::sessionid_register_propagate
     char buf[BUFSIZ];
     DrawLink* otherlink = _linklist->GetDrawLink(it);
     if (otherlink != link) {
-      snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", sid_str, pid, username, hostname, hostid, '\0');
+      char e_user[BUFSIZ], e_host[BUFSIZ];
+      ds_filter(e_user, sizeof(e_user), username);
+      ds_filter(e_host, sizeof(e_host), hostname);
+      snprintf(buf, BUFSIZ, "sid(\"%s\" :pid %d :user \"%s\" :host \"%s\" :hostid 0x%08x)%c", sid_str, pid, e_user, e_host, hostid, '\0');
       SendCmdString(otherlink, buf);
     }
     _linklist->Next(it);

--- a/src/drawserv_/tests/TESTING.md
+++ b/src/drawserv_/tests/TESTING.md
@@ -38,25 +38,22 @@ them down. Each test function manages its own process lifecycle.
 `drawmo` exits 0 on full pass, 1 on any failure. All test progress and
 failure messages go to stderr; the exit code is the CI signal.
 
-### Not run in GitHub Actions CI
+### Runs in GitHub Actions CI (headless, under xvfb)
 
-The hosted CI (`.github/workflows/ci.yml`) does **not** run this suite. drawmo
-shells out a child `drawserv` that must call back over a loopback TCP socket
-within 60s per test; on a GitHub-hosted runner the child starts fine (maps a
-window, prints its banner, under Xvfb or a real dummy-driver Xorg) but its
-`remote("localhost" <port> ...)` never reaches drawmo's listener -- almost
-certainly an IPv4/IPv6 `localhost` mismatch (the child connects to `::1` while
-the ACE listener is bound IPv4-only), so every test just burns its 60s timeout.
+The hosted CI (`.github/workflows/ci.yml`) runs the full suite under xvfb and
+blocks on it. This was thought to need a real X server, but the blocker turned
+out to be networking, not the GUI: drawmo dialed `"localhost"`, which on the
+runner resolves to IPv6 `::1` first, while the comterp/drawserv acceptors bind
+IPv4 only (`ACE_INET_Addr(port)` → `INADDR_ANY`). Every callback hit
+`ECONNREFUSED`, so the child `drawserv` looked like it "never called back" when in
+fact it had started fine. The harness now uses `127.0.0.1` literals (no resolver
+in the path), so the child maps its window under xvfb and calls back over IPv4
+loopback exactly as on a real display.
 
-What *is* CI-hostile here is the GUI/X coupling, not the networking: the
-wire protocol itself is exercised headless and blocking by
-`src/comterp_/tests/remote_loopback.sh` (a `comterp server` answering an
-expression sent over a loopback TCP socket). CI gates that plus the deterministic
-single-process pieces -- the comterp suite, the comdraw graphical-scripting
-suite, and a `drawserv` startup smoke. The full drawmo suite, which adds the
-GUI-coupled distributed path on top, runs on a real environment -- a dev box with
-real X (verified on XQuartz: all tests pass) or a self-hosted runner, gated e.g.
-`if: runner.environment == 'self-hosted'`.
+The deeper fix -- have the listener accept IPv6 too (dual-stack), so `"localhost"`
+works regardless of resolver order -- is ACE-build-dependent (`ACE_HAS_IPV6`) and
+is left to the in-tree ACE-lite work (issue #147). Until then, distributed
+ivtools across IPv6-preferring hosts should use IPv4 literals.
 
 ## Port Convention
 

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -37,7 +37,7 @@ have_nc=shell("which nc > /dev/null 2>&1")==0;
 port_probe=if(have_lsof :then
   "lsof -i :%d > /dev/null 2>&1"
 :else if(have_nc :then
-  "nc -z localhost %d > /dev/null 2>&1"
+  "nc -z 127.0.0.1 %d > /dev/null 2>&1"
 :else
   "false"));
 
@@ -68,7 +68,7 @@ updown_test=func(
   ds_import=ds_port-1;
   global(drawserv_up)=false;
   print("updown: launching drawserv on port %d\n" ds_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up)=true\\\")\" &" ds_port ds_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up)=true\\\")\" &" ds_port ds_import callback_port :str);
   print("updown: cmdstr=[%s]\n" cmdstr :err);
   shell(cmdstr);
   print("updown: waiting for drawserv callback on port %d\n" callback_port :err);
@@ -88,7 +88,7 @@ updown_test=func(
     return(false));
     
   print("updown: drawserv callback received after %d polls\n" cnt :err);
-  sock=socket("localhost" ds_port);
+  sock=socket("127.0.0.1" ds_port);
   if(type(sock)==`UnknownType :then
     print("updown: FAIL could not connect to drawserv on port %d\n" ds_port :err);
     kill_port(:kill_port_num ds_port);
@@ -121,7 +121,7 @@ updown1_test=func(
   ds_import=ds_port-1;
   global(drawserv_up1)=false;
   print("updown1: launching drawserv on port %d\n" ds_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up1)=true\\\")\" &" ds_port ds_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up1)=true\\\")\" &" ds_port ds_import callback_port :str);
   print("updown1: cmdstr=[%s]\n" cmdstr :err);
   shell(cmdstr);
   print("updown1: waiting for drawserv callback on port %d\n" callback_port :err);
@@ -141,7 +141,7 @@ updown1_test=func(
     return(false));
 
   print("updown1: drawserv callback received after %d polls\n" cnt :err);
-  sock=socket("localhost" ds_port);
+  sock=socket("127.0.0.1" ds_port);
   if(type(sock)==`UnknownType :then
     print("updown1: FAIL could not connect to drawserv on port %d\n" ds_port :err);
     kill_port(:kill_port_num ds_port);
@@ -186,7 +186,7 @@ updown2_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_up2a)=false;
   print("updown2: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up2a)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up2a)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   print("updown2: cmdstr=[%s]\n" cmdstr :err);
   shell(cmdstr);
   print("updown2: waiting for ds1 callback on port %d\n" callback_port :err);
@@ -205,7 +205,7 @@ updown2_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_up2b)=false;
   print("updown2: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up2b)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up2b)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   print("updown2: cmdstr=[%s]\n" cmdstr :err);
   shell(cmdstr);
   print("updown2: waiting for ds2 callback on port %d\n" callback_port :err);
@@ -215,7 +215,7 @@ updown2_test=func(
   if(!global(drawserv_up2b) :then
     print("updown2: FAIL timeout waiting for ds2 callback\n" :err);
     /* ds1 is up; shut it down so its port is freed */
-    s1=socket("localhost" ds1_port);
+    s1=socket("127.0.0.1" ds1_port);
     if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);
@@ -224,12 +224,12 @@ updown2_test=func(
   print("updown2: ds2 callback received after %d polls\n" cnt :err);
 
   /* --- connect to both --- */
-  sock1=socket("localhost" ds1_port);
+  sock1=socket("127.0.0.1" ds1_port);
   if(type(sock1)==`UnknownType :then
     print("updown2: FAIL could not connect to ds1 on port %d\n" ds1_port :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);
     return(false));
-  sock2=socket("localhost" ds2_port);
+  sock2=socket("127.0.0.1" ds2_port);
   if(type(sock2)==`UnknownType :then
     print("updown2: FAIL could not connect to ds2 on port %d\n" ds2_port :err);
     remote(sock1 "exit" :nowait);close(sock1);
@@ -238,7 +238,7 @@ updown2_test=func(
 
   /* --- establish the link ds1 -> ds2 --- */
   print("updown2: linking ds1(%d) -> ds2(%d)\n" ds1_port ds2_port :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
 
   /* drawlink blocks until the two-way handshake completes (its own spin-loop),
      so the link is established by the time the command returns -- no settle. */
@@ -304,7 +304,7 @@ updown3A_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_up3a1)=false;
   print("updown3A: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up3a1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up3a1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up3a1) && cnt<timeout
@@ -320,14 +320,14 @@ updown3A_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_up3a2)=false;
   print("updown3A: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up3a2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up3a2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up3a2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown3A: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up3a2) :then
     print("updown3A: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -338,15 +338,15 @@ updown3A_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_up3a3)=false;
   print("updown3A: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up3a3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up3a3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up3a3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown3A: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up3a3) :then
     print("updown3A: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -354,9 +354,9 @@ updown3A_test=func(
   print("updown3A: ds3 up on %d\n" ds3_port :err);
 
   /* --- connect to all three --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
     print("updown3A: FAIL could not connect to all three drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
@@ -364,8 +364,8 @@ updown3A_test=func(
 
   /* --- build the chain: ds1->ds2 (on ds1), then ds2->ds3 (on ds2) --- */
   print("updown3A: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock2 print("drawlink(\"localhost\" %d)" ds3_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
 
   /* --- create a graphic on ds1; PasteCmd propagates it along the chain --- */
   remote(sock1 "ellipse(100,100,40,40)");
@@ -424,7 +424,7 @@ updown3B_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_up3b1)=false;
   print("updown3B: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up3b1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up3b1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up3b1) && cnt<timeout
@@ -440,14 +440,14 @@ updown3B_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_up3b2)=false;
   print("updown3B: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up3b2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up3b2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up3b2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown3B: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up3b2) :then
     print("updown3B: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -458,15 +458,15 @@ updown3B_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_up3b3)=false;
   print("updown3B: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up3b3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up3b3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up3b3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown3B: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up3b3) :then
     print("updown3B: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -474,9 +474,9 @@ updown3B_test=func(
   print("updown3B: ds3 up on %d\n" ds3_port :err);
 
   /* --- connect to all three --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
     print("updown3B: FAIL could not connect to all three drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
@@ -484,8 +484,8 @@ updown3B_test=func(
 
   /* --- build the tree: both links from ds1 (hub) --- */
   print("updown3B: tree ds1(%d) -> ds2(%d), ds3(%d)\n" ds1_port ds2_port ds3_port :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds3_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
 
   /* --- create a graphic on ds1; PasteCmd fans it out to both branches --- */
   remote(sock1 "ellipse(100,100,40,40)");
@@ -543,7 +543,7 @@ updown4A_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_up4a1)=false;
   print("updown4A: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4a1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4a1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4a1) && cnt<timeout
@@ -559,14 +559,14 @@ updown4A_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_up4a2)=false;
   print("updown4A: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4a2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4a2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4a2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4A: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4a2) :then
     print("updown4A: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -577,15 +577,15 @@ updown4A_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_up4a3)=false;
   print("updown4A: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4a3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4a3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4a3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4A: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4a3) :then
     print("updown4A: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -597,16 +597,16 @@ updown4A_test=func(
   ds4_import=ds4_port-1;
   global(drawserv_up4a4)=false;
   print("updown4A: launching ds4 on port %d\n" ds4_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4a4)=true\\\")\" &" ds4_port ds4_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4a4)=true\\\")\" &" ds4_port ds4_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4a4) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4A: still waiting for ds4 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4a4) :then
     print("updown4A: FAIL timeout waiting for ds4 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    s3=socket("localhost" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
@@ -615,10 +615,10 @@ updown4A_test=func(
   print("updown4A: ds4 up on %d\n" ds4_port :err);
 
   /* --- connect to all four --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
-  sock4=socket("localhost" ds4_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
+  sock4=socket("127.0.0.1" ds4_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType || type(sock4)==`UnknownType :then
     print("updown4A: FAIL could not connect to all four drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds4_port);
@@ -626,9 +626,9 @@ updown4A_test=func(
 
   /* --- build topology --- */
   print("updown4A: wiring topology\n" :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock2 print("drawlink(\"localhost\" %d)" ds3_port :str));
-  remote(sock3 print("drawlink(\"localhost\" %d)" ds4_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
+  remote(sock3 print("drawlink(\"127.0.0.1\" %d)" ds4_port :str));
 
   /* --- create a graphic on ds1; PasteCmd propagates it --- */
   remote(sock1 "ellipse(100,100,40,40)");
@@ -699,7 +699,7 @@ updown4B_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_up4b1)=false;
   print("updown4B: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4b1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4b1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4b1) && cnt<timeout
@@ -715,14 +715,14 @@ updown4B_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_up4b2)=false;
   print("updown4B: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4b2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4b2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4b2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4B: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4b2) :then
     print("updown4B: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -733,15 +733,15 @@ updown4B_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_up4b3)=false;
   print("updown4B: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4b3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4b3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4b3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4B: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4b3) :then
     print("updown4B: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -753,16 +753,16 @@ updown4B_test=func(
   ds4_import=ds4_port-1;
   global(drawserv_up4b4)=false;
   print("updown4B: launching ds4 on port %d\n" ds4_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4b4)=true\\\")\" &" ds4_port ds4_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4b4)=true\\\")\" &" ds4_port ds4_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4b4) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4B: still waiting for ds4 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4b4) :then
     print("updown4B: FAIL timeout waiting for ds4 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    s3=socket("localhost" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
@@ -771,10 +771,10 @@ updown4B_test=func(
   print("updown4B: ds4 up on %d\n" ds4_port :err);
 
   /* --- connect to all four --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
-  sock4=socket("localhost" ds4_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
+  sock4=socket("127.0.0.1" ds4_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType || type(sock4)==`UnknownType :then
     print("updown4B: FAIL could not connect to all four drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds4_port);
@@ -782,9 +782,9 @@ updown4B_test=func(
 
   /* --- build topology --- */
   print("updown4B: wiring topology\n" :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds3_port :str));
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds4_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds4_port :str));
 
   /* --- create a graphic on ds1; PasteCmd propagates it --- */
   remote(sock1 "ellipse(100,100,40,40)");
@@ -855,7 +855,7 @@ updown4C_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_up4c1)=false;
   print("updown4C: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4c1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4c1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4c1) && cnt<timeout
@@ -871,14 +871,14 @@ updown4C_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_up4c2)=false;
   print("updown4C: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4c2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4c2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4c2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4C: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4c2) :then
     print("updown4C: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -889,15 +889,15 @@ updown4C_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_up4c3)=false;
   print("updown4C: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4c3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4c3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4c3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4C: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4c3) :then
     print("updown4C: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -909,16 +909,16 @@ updown4C_test=func(
   ds4_import=ds4_port-1;
   global(drawserv_up4c4)=false;
   print("updown4C: launching ds4 on port %d\n" ds4_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_up4c4)=true\\\")\" &" ds4_port ds4_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_up4c4)=true\\\")\" &" ds4_port ds4_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_up4c4) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("updown4C: still waiting for ds4 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_up4c4) :then
     print("updown4C: FAIL timeout waiting for ds4 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    s3=socket("localhost" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
@@ -927,10 +927,10 @@ updown4C_test=func(
   print("updown4C: ds4 up on %d\n" ds4_port :err);
 
   /* --- connect to all four --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
-  sock4=socket("localhost" ds4_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
+  sock4=socket("127.0.0.1" ds4_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType || type(sock4)==`UnknownType :then
     print("updown4C: FAIL could not connect to all four drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds4_port);
@@ -938,9 +938,9 @@ updown4C_test=func(
 
   /* --- build topology --- */
   print("updown4C: wiring topology\n" :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock2 print("drawlink(\"localhost\" %d)" ds3_port :str));
-  remote(sock2 print("drawlink(\"localhost\" %d)" ds4_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
+  remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds4_port :str));
 
   /* --- create a graphic on ds1; PasteCmd propagates it --- */
   remote(sock1 "ellipse(100,100,40,40)");
@@ -1036,7 +1036,7 @@ gsbrushA_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_upgba1)=false;
   print("gsbrushA: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgba1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgba1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgba1) && cnt<timeout
@@ -1052,14 +1052,14 @@ gsbrushA_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_upgba2)=false;
   print("gsbrushA: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgba2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgba2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgba2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushA: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upgba2) :then
     print("gsbrushA: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -1070,15 +1070,15 @@ gsbrushA_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_upgba3)=false;
   print("gsbrushA: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgba3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgba3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgba3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushA: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upgba3) :then
     print("gsbrushA: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -1086,9 +1086,9 @@ gsbrushA_test=func(
   print("gsbrushA: ds3 up on %d\n" ds3_port :err);
 
   /* --- connect to all three --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
     print("gsbrushA: FAIL could not connect to all three drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
@@ -1096,8 +1096,8 @@ gsbrushA_test=func(
 
   /* --- build the chain: ds1->ds2 (on ds1), then ds2->ds3 (on ds2) --- */
   print("gsbrushA: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock2 print("drawlink(\"localhost\" %d)" ds3_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
 
   /* --- create a rect on ds1 with a distinctive dashed brush (linepat 65520,
      width 2).  far nodes default to a solid brush, so a match downstream proves
@@ -1158,7 +1158,7 @@ gsbrushB_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_upgbb1)=false;
   print("gsbrushB: launching ds1 on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgbb1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgbb1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgbb1) && cnt<timeout
@@ -1174,14 +1174,14 @@ gsbrushB_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_upgbb2)=false;
   print("gsbrushB: launching ds2 on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgbb2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgbb2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgbb2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushB: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upgbb2) :then
     print("gsbrushB: FAIL timeout waiting for ds2 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
@@ -1192,15 +1192,15 @@ gsbrushB_test=func(
   ds3_import=ds3_port-1;
   global(drawserv_upgbb3)=false;
   print("gsbrushB: launching ds3 on port %d\n" ds3_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgbb3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgbb3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgbb3) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsbrushB: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upgbb3) :then
     print("gsbrushB: FAIL timeout waiting for ds3 callback\n" :err);
-    s1=socket("localhost" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    s2=socket("localhost" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
@@ -1208,9 +1208,9 @@ gsbrushB_test=func(
   print("gsbrushB: ds3 up on %d\n" ds3_port :err);
 
   /* --- connect to all three --- */
-  sock1=socket("localhost" ds1_port);
-  sock2=socket("localhost" ds2_port);
-  sock3=socket("localhost" ds3_port);
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
     print("gsbrushB: FAIL could not connect to all three drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
@@ -1218,8 +1218,8 @@ gsbrushB_test=func(
 
   /* --- build the tree: both links from ds1 (hub) --- */
   print("gsbrushB: tree ds1(%d) -> ds2(%d), ds3(%d)\n" ds1_port ds2_port ds3_port :err);
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds2_port :str));
-  remote(sock1 print("drawlink(\"localhost\" %d)" ds3_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
 
   /* --- create a rect on ds1 with a distinctive dashed brush (linepat 65520,
      width 2); it fans out to both branches. --- */
@@ -1286,7 +1286,7 @@ gsexim_test=func(
   ds1_import=ds1_port-1;
   global(drawserv_upgsx1)=false;
   print("gsexim: launching ds1 (source) on port %d\n" ds1_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgsx1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgsx1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgsx1) && cnt<timeout
@@ -1302,14 +1302,14 @@ gsexim_test=func(
   ds2_import=ds2_port-1;
   global(drawserv_upgsx2)=false;
   print("gsexim: launching ds2 (dest) on port %d\n" ds2_port :err);
-  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"localhost\\\" %d \\\"global(drawserv_upgsx2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upgsx2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upgsx2) && cnt<timeout
     update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("gsexim: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upgsx2) :then
     print("gsexim: FAIL timeout waiting for ds2 callback\n" :err);
-    s1s=socket("localhost" ds1_port);
+    s1s=socket("127.0.0.1" ds1_port);
     if(type(s1s)!=`UnknownType :then remote(s1s "exit" :nowait);close(s1s));
     while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
@@ -1317,12 +1317,12 @@ gsexim_test=func(
   print("gsexim: ds2 callback received after %d polls\n" cnt :err);
 
   /* --- connect to both --- */
-  sock1=socket("localhost" ds1_port);
+  sock1=socket("127.0.0.1" ds1_port);
   if(type(sock1)==`UnknownType :then
     print("gsexim: FAIL could not connect to ds1 on port %d\n" ds1_port :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);
     return(false));
-  sock2=socket("localhost" ds2_port);
+  sock2=socket("127.0.0.1" ds2_port);
   if(type(sock2)==`UnknownType :then
     print("gsexim: FAIL could not connect to ds2 on port %d\n" ds2_port :err);
     remote(sock1 "exit" :nowait);close(sock1);

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -108,9 +108,13 @@ updown_test=func(
   /* wait for the drawserv PROCESS to be gone, matched by its unique
      -comdraw port on the command line.  the comdraw socket closes early,
      before the process releases X11; pgrep watches the actual process so
-     the next test can't launch into a still-held X11. */
+     the next test can't launch into a still-held X11.  pace the poll with a
+     shell sleep, NOT update(): by this point drawserv and its sockets are gone,
+     and on some ACE builds (Debian's libACE-7.1.2) handle_events() on an empty
+     reactor blocks instead of honoring its timeout -- it hangs.  We don't need
+     to pump the reactor just to wait on a PID.  (cf. ACE-lite, issue #147.) */
   while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
-    update(200000));
+    shell("sleep 0.2"));
   print("updown: drawserv shut down\n" :err);
   true)
 
@@ -164,7 +168,7 @@ updown1_test=func(
   close(sock);
   /* wait for the drawserv PROCESS to be gone (see updown_test) */
   while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
-    update(200000));
+    shell("sleep 0.2"));
   print("updown1: drawserv shut down\n" :err);
   ok)
 
@@ -217,7 +221,7 @@ updown2_test=func(
     /* ds1 is up; shut it down so its port is freed */
     s1=socket("127.0.0.1" ds1_port);
     if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);
     kill_port(:kill_port_num ds2_import);
     return(false));
@@ -263,12 +267,12 @@ updown2_test=func(
   remote(sock1 "exit" :nowait);
   close(sock1);
   while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0
-    update(200000));
+    shell("sleep 0.2"));
   print("updown2: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);
   close(sock2);
   while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0
-    update(200000));
+    shell("sleep 0.2"));
   print("updown2: ds2 shut down\n" :err);
   ok)
 
@@ -328,7 +332,7 @@ updown3A_test=func(
   if(!global(drawserv_up3a2) :then
     print("updown3A: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown3A: ds2 up on %d\n" ds2_port :err);
@@ -347,8 +351,8 @@ updown3A_test=func(
     print("updown3A: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown3A: ds3 up on %d\n" ds3_port :err);
@@ -385,9 +389,9 @@ updown3A_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     return(false));
   on2=grid_has_id(:gh_sock sock2 :gh_id id1);
   print("updown3A: graphic on ds2 (hop 1): %v\n" on2 :err);
@@ -400,13 +404,13 @@ updown3A_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("updown3A: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("updown3A: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("updown3A: ds3 shut down\n" :err);
   ok)
 
@@ -448,7 +452,7 @@ updown3B_test=func(
   if(!global(drawserv_up3b2) :then
     print("updown3B: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown3B: ds2 up on %d\n" ds2_port :err);
@@ -467,8 +471,8 @@ updown3B_test=func(
     print("updown3B: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown3B: ds3 up on %d\n" ds3_port :err);
@@ -505,9 +509,9 @@ updown3B_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     return(false));
   on2=grid_has_id(:gh_sock sock2 :gh_id id1);
   print("updown3B: graphic on ds2 (branch 1): %v\n" on2 :err);
@@ -520,13 +524,13 @@ updown3B_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("updown3B: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("updown3B: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("updown3B: ds3 shut down\n" :err);
   ok)
 
@@ -567,7 +571,7 @@ updown4A_test=func(
   if(!global(drawserv_up4a2) :then
     print("updown4A: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown4A: ds2 up on %d\n" ds2_port :err);
@@ -586,8 +590,8 @@ updown4A_test=func(
     print("updown4A: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown4A: ds3 up on %d\n" ds3_port :err);
@@ -607,9 +611,9 @@ updown4A_test=func(
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds4_port);kill_port(:kill_port_num ds4_import);
     return(false));
   print("updown4A: ds4 up on %d\n" ds4_port :err);
@@ -649,10 +653,10 @@ updown4A_test=func(
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
     remote(sock4 "exit" :nowait);close(sock4);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
     return(false));
 
   /* --- verify propagation to leaf nodes --- */
@@ -673,16 +677,16 @@ updown4A_test=func(
 
   /* --- tear all four down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("updown4A: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("updown4A: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("updown4A: ds3 shut down\n" :err);
   remote(sock4 "exit" :nowait);close(sock4);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
   print("updown4A: ds4 shut down\n" :err);
   ok)
 
@@ -723,7 +727,7 @@ updown4B_test=func(
   if(!global(drawserv_up4b2) :then
     print("updown4B: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown4B: ds2 up on %d\n" ds2_port :err);
@@ -742,8 +746,8 @@ updown4B_test=func(
     print("updown4B: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown4B: ds3 up on %d\n" ds3_port :err);
@@ -763,9 +767,9 @@ updown4B_test=func(
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds4_port);kill_port(:kill_port_num ds4_import);
     return(false));
   print("updown4B: ds4 up on %d\n" ds4_port :err);
@@ -805,10 +809,10 @@ updown4B_test=func(
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
     remote(sock4 "exit" :nowait);close(sock4);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
     return(false));
 
   /* --- verify propagation to leaf nodes --- */
@@ -829,16 +833,16 @@ updown4B_test=func(
 
   /* --- tear all four down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("updown4B: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("updown4B: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("updown4B: ds3 shut down\n" :err);
   remote(sock4 "exit" :nowait);close(sock4);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
   print("updown4B: ds4 shut down\n" :err);
   ok)
 
@@ -879,7 +883,7 @@ updown4C_test=func(
   if(!global(drawserv_up4c2) :then
     print("updown4C: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown4C: ds2 up on %d\n" ds2_port :err);
@@ -898,8 +902,8 @@ updown4C_test=func(
     print("updown4C: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown4C: ds3 up on %d\n" ds3_port :err);
@@ -919,9 +923,9 @@ updown4C_test=func(
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds4_port);kill_port(:kill_port_num ds4_import);
     return(false));
   print("updown4C: ds4 up on %d\n" ds4_port :err);
@@ -961,10 +965,10 @@ updown4C_test=func(
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
     remote(sock4 "exit" :nowait);close(sock4);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
     return(false));
 
   /* --- verify propagation: the hub ds2 (graphic routes through it) and
@@ -986,16 +990,16 @@ updown4C_test=func(
 
   /* --- tear all four down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("updown4C: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("updown4C: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("updown4C: ds3 shut down\n" :err);
   remote(sock4 "exit" :nowait);close(sock4);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
   print("updown4C: ds4 shut down\n" :err);
   ok)
 
@@ -1060,7 +1064,7 @@ gsbrushA_test=func(
   if(!global(drawserv_upgba2) :then
     print("gsbrushA: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("gsbrushA: ds2 up on %d\n" ds2_port :err);
@@ -1079,8 +1083,8 @@ gsbrushA_test=func(
     print("gsbrushA: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("gsbrushA: ds3 up on %d\n" ds3_port :err);
@@ -1115,9 +1119,9 @@ gsbrushA_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     return(false));
 
   /* --- verify arrival (by grid id) then the brush gs at each far node --- */
@@ -1134,13 +1138,13 @@ gsbrushA_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("gsbrushA: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("gsbrushA: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("gsbrushA: ds3 shut down\n" :err);
   ok)
 
@@ -1182,7 +1186,7 @@ gsbrushB_test=func(
   if(!global(drawserv_upgbb2) :then
     print("gsbrushB: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("gsbrushB: ds2 up on %d\n" ds2_port :err);
@@ -1201,8 +1205,8 @@ gsbrushB_test=func(
     print("gsbrushB: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("gsbrushB: ds3 up on %d\n" ds3_port :err);
@@ -1235,9 +1239,9 @@ gsbrushB_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
     return(false));
 
   /* --- verify arrival then the brush gs on BOTH branches --- */
@@ -1254,13 +1258,13 @@ gsbrushB_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
   print("gsbrushB: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
   print("gsbrushB: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 update(200000));
+  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
   print("gsbrushB: ds3 shut down\n" :err);
   ok)
 
@@ -1311,7 +1315,7 @@ gsexim_test=func(
     print("gsexim: FAIL timeout waiting for ds2 callback\n" :err);
     s1s=socket("127.0.0.1" ds1_port);
     if(type(s1s)!=`UnknownType :then remote(s1s "exit" :nowait);close(s1s));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("gsexim: ds2 callback received after %d polls\n" cnt :err);
@@ -1342,8 +1346,8 @@ gsexim_test=func(
   if(type(s1)!=`StringType :then
     print("gsexim: FAIL ds1 export(r :string :percomp) did not return a string (got %v)\n" s1 :err);
     remote(sock1 "exit" :nowait);close(sock1);remote(sock2 "exit" :nowait);close(sock2);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 update(200000));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 update(200000));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
     return(false));
 
   /* --- ds2 (dest): set the editor to gs B, then import s1 (naming the result r2
@@ -1369,11 +1373,11 @@ gsexim_test=func(
      are free for the next test --- */
   remote(sock1 "exit" :nowait);close(sock1);
   while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0
-    update(200000));
+    shell("sleep 0.2"));
   print("gsexim: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
   while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0
-    update(200000));
+    shell("sleep 0.2"));
   print("gsexim: ds2 shut down\n" :err);
   ok)
 

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -105,16 +105,21 @@ updown_test=func(
   print("updown: drawserv up and responding\n" :err);
   remote(sock "exit" :nowait);
   close(sock);
-  /* wait for the drawserv PROCESS to be gone, matched by its unique
-     -comdraw port on the command line.  the comdraw socket closes early,
-     before the process releases X11; pgrep watches the actual process so
-     the next test can't launch into a still-held X11.  pace the poll with a
-     shell sleep, NOT update(): by this point drawserv and its sockets are gone,
-     and on some ACE builds (Debian's libACE-7.1.2) handle_events() on an empty
-     reactor blocks instead of honoring its timeout -- it hangs.  We don't need
-     to pump the reactor just to wait on a PID.  (cf. ACE-lite, issue #147.) */
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
-    shell("sleep 0.2"));
+  /* wait for the drawserv PROCESS to be gone, matched by its unique -comdraw
+     port on the command line.  the comdraw socket closes early, before the
+     process releases X11; pgrep watches the actual process so the next test
+     can't launch into a still-held X11.  Two non-obvious points:
+       - The pattern is '[d]rawserv', not 'drawserv': pgrep -f matches against
+         the whole command line, and the shell that runs this very pgrep has
+         'drawserv -comdraw <port>' in ITS argv -- so a plain pattern matches the
+         poller's own shell and the loop never ends (Linux procps does this;
+         macOS BSD pgrep doesn't, which is why it only hung in CI).  The bracket
+         keeps the literal pattern text from matching itself while still matching
+         the real drawserv.
+       - Pace with usleep(), not update(): we're waiting on a PID, not servicing
+         the reactor, so there's no reason to pump handle_events() here. */
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
+    usleep(200000));
   print("updown: drawserv shut down\n" :err);
   true)
 
@@ -167,8 +172,8 @@ updown1_test=func(
   remote(sock "exit" :nowait);
   close(sock);
   /* wait for the drawserv PROCESS to be gone (see updown_test) */
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
-    shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
+    usleep(200000));
   print("updown1: drawserv shut down\n" :err);
   ok)
 
@@ -221,7 +226,7 @@ updown2_test=func(
     /* ds1 is up; shut it down so its port is freed */
     s1=socket("127.0.0.1" ds1_port);
     if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);
     kill_port(:kill_port_num ds2_import);
     return(false));
@@ -266,13 +271,13 @@ updown2_test=func(
      ports are free for the next test --- */
   remote(sock1 "exit" :nowait);
   close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0
-    shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0
+    usleep(200000));
   print("updown2: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);
   close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0
-    shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0
+    usleep(200000));
   print("updown2: ds2 shut down\n" :err);
   ok)
 
@@ -332,7 +337,7 @@ updown3A_test=func(
   if(!global(drawserv_up3a2) :then
     print("updown3A: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown3A: ds2 up on %d\n" ds2_port :err);
@@ -351,8 +356,8 @@ updown3A_test=func(
     print("updown3A: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown3A: ds3 up on %d\n" ds3_port :err);
@@ -389,9 +394,9 @@ updown3A_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     return(false));
   on2=grid_has_id(:gh_sock sock2 :gh_id id1);
   print("updown3A: graphic on ds2 (hop 1): %v\n" on2 :err);
@@ -404,13 +409,13 @@ updown3A_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("updown3A: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("updown3A: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("updown3A: ds3 shut down\n" :err);
   ok)
 
@@ -452,7 +457,7 @@ updown3B_test=func(
   if(!global(drawserv_up3b2) :then
     print("updown3B: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown3B: ds2 up on %d\n" ds2_port :err);
@@ -471,8 +476,8 @@ updown3B_test=func(
     print("updown3B: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown3B: ds3 up on %d\n" ds3_port :err);
@@ -509,9 +514,9 @@ updown3B_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     return(false));
   on2=grid_has_id(:gh_sock sock2 :gh_id id1);
   print("updown3B: graphic on ds2 (branch 1): %v\n" on2 :err);
@@ -524,13 +529,13 @@ updown3B_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("updown3B: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("updown3B: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("updown3B: ds3 shut down\n" :err);
   ok)
 
@@ -571,7 +576,7 @@ updown4A_test=func(
   if(!global(drawserv_up4a2) :then
     print("updown4A: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown4A: ds2 up on %d\n" ds2_port :err);
@@ -590,8 +595,8 @@ updown4A_test=func(
     print("updown4A: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown4A: ds3 up on %d\n" ds3_port :err);
@@ -611,9 +616,9 @@ updown4A_test=func(
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds4_port);kill_port(:kill_port_num ds4_import);
     return(false));
   print("updown4A: ds4 up on %d\n" ds4_port :err);
@@ -653,10 +658,10 @@ updown4A_test=func(
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
     remote(sock4 "exit" :nowait);close(sock4);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
     return(false));
 
   /* --- verify propagation to leaf nodes --- */
@@ -677,16 +682,16 @@ updown4A_test=func(
 
   /* --- tear all four down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("updown4A: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("updown4A: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("updown4A: ds3 shut down\n" :err);
   remote(sock4 "exit" :nowait);close(sock4);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
   print("updown4A: ds4 shut down\n" :err);
   ok)
 
@@ -727,7 +732,7 @@ updown4B_test=func(
   if(!global(drawserv_up4b2) :then
     print("updown4B: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown4B: ds2 up on %d\n" ds2_port :err);
@@ -746,8 +751,8 @@ updown4B_test=func(
     print("updown4B: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown4B: ds3 up on %d\n" ds3_port :err);
@@ -767,9 +772,9 @@ updown4B_test=func(
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds4_port);kill_port(:kill_port_num ds4_import);
     return(false));
   print("updown4B: ds4 up on %d\n" ds4_port :err);
@@ -809,10 +814,10 @@ updown4B_test=func(
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
     remote(sock4 "exit" :nowait);close(sock4);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
     return(false));
 
   /* --- verify propagation to leaf nodes --- */
@@ -833,16 +838,16 @@ updown4B_test=func(
 
   /* --- tear all four down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("updown4B: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("updown4B: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("updown4B: ds3 shut down\n" :err);
   remote(sock4 "exit" :nowait);close(sock4);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
   print("updown4B: ds4 shut down\n" :err);
   ok)
 
@@ -883,7 +888,7 @@ updown4C_test=func(
   if(!global(drawserv_up4c2) :then
     print("updown4C: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("updown4C: ds2 up on %d\n" ds2_port :err);
@@ -902,8 +907,8 @@ updown4C_test=func(
     print("updown4C: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("updown4C: ds3 up on %d\n" ds3_port :err);
@@ -923,9 +928,9 @@ updown4C_test=func(
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     s3=socket("127.0.0.1" ds3_port);if(type(s3)!=`UnknownType :then remote(s3 "exit" :nowait);close(s3));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds4_port);kill_port(:kill_port_num ds4_import);
     return(false));
   print("updown4C: ds4 up on %d\n" ds4_port :err);
@@ -965,10 +970,10 @@ updown4C_test=func(
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
     remote(sock4 "exit" :nowait);close(sock4);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
     return(false));
 
   /* --- verify propagation: the hub ds2 (graphic routes through it) and
@@ -990,16 +995,16 @@ updown4C_test=func(
 
   /* --- tear all four down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("updown4C: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("updown4C: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("updown4C: ds3 shut down\n" :err);
   remote(sock4 "exit" :nowait);close(sock4);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
   print("updown4C: ds4 shut down\n" :err);
   ok)
 
@@ -1064,7 +1069,7 @@ gsbrushA_test=func(
   if(!global(drawserv_upgba2) :then
     print("gsbrushA: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("gsbrushA: ds2 up on %d\n" ds2_port :err);
@@ -1083,8 +1088,8 @@ gsbrushA_test=func(
     print("gsbrushA: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("gsbrushA: ds3 up on %d\n" ds3_port :err);
@@ -1119,9 +1124,9 @@ gsbrushA_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     return(false));
 
   /* --- verify arrival (by grid id) then the brush gs at each far node --- */
@@ -1138,13 +1143,13 @@ gsbrushA_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("gsbrushA: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("gsbrushA: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("gsbrushA: ds3 shut down\n" :err);
   ok)
 
@@ -1186,7 +1191,7 @@ gsbrushB_test=func(
   if(!global(drawserv_upgbb2) :then
     print("gsbrushB: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("gsbrushB: ds2 up on %d\n" ds2_port :err);
@@ -1205,8 +1210,8 @@ gsbrushB_test=func(
     print("gsbrushB: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
   print("gsbrushB: ds3 up on %d\n" ds3_port :err);
@@ -1239,9 +1244,9 @@ gsbrushB_test=func(
     remote(sock1 "exit" :nowait);close(sock1);
     remote(sock2 "exit" :nowait);close(sock2);
     remote(sock3 "exit" :nowait);close(sock3);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
     return(false));
 
   /* --- verify arrival then the brush gs on BOTH branches --- */
@@ -1258,13 +1263,13 @@ gsbrushB_test=func(
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
   print("gsbrushB: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("gsbrushB: ds2 shut down\n" :err);
   remote(sock3 "exit" :nowait);close(sock3);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 usleep(200000));
   print("gsbrushB: ds3 shut down\n" :err);
   ok)
 
@@ -1315,7 +1320,7 @@ gsexim_test=func(
     print("gsexim: FAIL timeout waiting for ds2 callback\n" :err);
     s1s=socket("127.0.0.1" ds1_port);
     if(type(s1s)!=`UnknownType :then remote(s1s "exit" :nowait);close(s1s));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
   print("gsexim: ds2 callback received after %d polls\n" cnt :err);
@@ -1346,8 +1351,8 @@ gsexim_test=func(
   if(type(s1)!=`StringType :then
     print("gsexim: FAIL ds1 export(r :string :percomp) did not return a string (got %v)\n" s1 :err);
     remote(sock1 "exit" :nowait);close(sock1);remote(sock2 "exit" :nowait);close(sock2);
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 shell("sleep 0.2"));
-    while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 shell("sleep 0.2"));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     return(false));
 
   /* --- ds2 (dest): set the editor to gs B, then import s1 (naming the result r2
@@ -1372,12 +1377,12 @@ gsexim_test=func(
   /* --- tear both down, waiting for each process to clear so the canonical ports
      are free for the next test --- */
   remote(sock1 "exit" :nowait);close(sock1);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0
-    shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0
+    usleep(200000));
   print("gsexim: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
-  while(shell(print("pgrep -f 'drawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0
-    shell("sleep 0.2"));
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0
+    usleep(200000));
   print("gsexim: ds2 shut down\n" :err);
   ok)
 

--- a/src/scripts/comterp_listen.bash
+++ b/src/scripts/comterp_listen.bash
@@ -58,3 +58,8 @@ while true; do
         port=$((port + 10000))
     done
 done
+# Propagate the interpreter's exit status.  Without this the script returns the
+# exit code of the last command run (the `[ $status -ne 75 ]` test, i.e. 0), so a
+# script that exits non-zero -- e.g. drawmo signalling a test failure -- would
+# look successful to callers (CI, `./drawmo; echo $?`).
+exit $status


### PR DESCRIPTION
## What this does

Brings the full **drawmo** distributed test suite (all 11 cases) up green in hosted GitHub Actions CI, headless under xvfb. The suite had never actually run in CI — it hung, then was sidestepped — and the standing assumption was that it needed a real X server. It didn't.

## The turn: comdraw's green ruled out X11

The hunt was aimed at "drawmo needs a real X display" until one observation reframed everything: the **comdraw** graphical-scripting suite was *already passing* under headless xvfb. comdraw is the same Unidraw/X11 GUI stack as drawserv — if it maps windows and runs scripts fine under xvfb, then X11 cannot be what's stopping drawmo. That ruled X out and pointed the search at the actual, ordinary bugs in the distributed path. Every one turned out to be a non-GUI defect.

## The chain (each bug masked the next)

1. **IPv6 `localhost`.** drawmo dialed `"localhost"`, which resolves to `::1` first on the runner, while the comterp/drawserv acceptors bind IPv4 only — every cross-process connect hit `ECONNREFUSED`. Switched the harness to `127.0.0.1` literals.

2. **`pgrep` self-match + reactor death-wait.** The "wait for drawserv to exit" loop ran `pgrep -f 'drawserv -comdraw <port>'`, which on Linux procps matches the very shell running pgrep (its argv contains the pattern), so it never saw the process leave and spun forever (macOS BSD pgrep doesn't — which is why it only hung in CI). Fixed with the `[d]rawserv` bracket trick. Also swapped the loop's `update()` — which pumps the ACE reactor and, on Debian's libACE, blocks on an empty reactor instead of honoring its timeout — for `usleep()`; there's no reason to pump a reactor while waiting on a PID.

3. **The wrapper swallowed the exit code (a fake green).** drawmo's own `exit(if(ok) 0 else 1)` was correct, but the `comterp_listen` shebang wrapper captured the status into `$status` and never `exit $status`, so it returned the last command's `0`. A failing suite looked successful to CI. Fixed with `exit $status`, and the CI gate now fails on a `: FAIL` line as well as the exit code (belt-and-suspenders, like the comdraw step).

4. **The real handshake corruption: an unhandled nil.** `getlogin()` returns `NULL` when there's no login session (CI runners have none), so `DrawLink::open` serialized a `NULL` username with `ostream operator<<(const char*)` — which sets the stream's badbit and silently drops the closing quote, the `)`, and the framing newline. The two-way link command went out truncated and unparseable, the receiver never acked, the handshake timed out — and that failed *every* link/grid test at once. Fixed with a null-guard (`uname ? uname : ""`), plus a defensive NUL-terminate of the `gethostname` buffer.

## On the diagnosis

A long detour theorized the malformation was an unescaped byte, fixable by routing fields through `ParamList::filter`. That was speculation, and wrong: dumping the literal wire bytes showed the command simply truncated at `:user "` — a nil, not an escaping failure. (The filter route only "worked" in a trial push because of a null-guard that happened to sit inside its argument.) So the fix is the plain null-guard; the escaping concern is real but separate and untriggered — left as a standalone note on `ParamList::filter`, with issue #183 tracking its fixed-buffer truncation.

## Result

All 11 drawmo cases green in hosted CI under xvfb — no real X server, no self-hosted runner. The "needs real X" ceiling was an illusion stacked out of four ordinary bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
