### PR TITLE
comvalue: fix CharType sign-extension in serialization; drawserv: guard NULL getlogin()

### DIFF
--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -209,7 +209,7 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    
 	case ComValue::CharType:
 	  if (brief)
-            out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (int)svp->char_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
+            out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (int)(unsigned char)svp->char_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
 	  else
 	    out << "char( " << svp->char_ref() << ":" << (int)svp->char_ref() << " )";
 	  break;	    

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -730,6 +730,7 @@ boolean DrawServ::selftest(const char* host, unsigned int portnum)
     else {
       char hostbuf[HOST_NAME_MAX];
       gethostname(hostbuf, HOST_NAME_MAX);
+      hostbuf[HOST_NAME_MAX-1] = '\0';  // gethostname needn't NUL-terminate on truncation
       if (strcmp(host, hostbuf)==0)
 	return 1;
     }

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -122,7 +122,9 @@ void DrawServ::Init() {
   create_unique_sessionid();
   char hostbuf[HOST_NAME_MAX];
   gethostname(hostbuf, HOST_NAME_MAX);
-  char* username = getlogin();
+  hostbuf[HOST_NAME_MAX-1] = '\0';  // gethostname needn't NUL-terminate on truncation
+  const char* username = getlogin();
+  if (!username) username = "";  // getlogin() is NULL with no login session (e.g. a CI runner)
   int pid = getpid();
   int hostid = gethostid();
   SessionId* sid = new SessionId(_sessionid, pid, username, hostbuf, hostid);

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -1,0 +1,29 @@
+// src/comterp_/tests/char.comt -- char-value serialization (backquote-octal)
+//
+// A char value's brief output is `\NNN` (backtick, backslash, the byte as a
+// 3-digit octal, backtick).  Regression: a high-bit (signed) char was widened to
+// int with sign extension and serialized as `\37777777640` instead of `\240`, so
+// the byte value was corrupted.  ASCII chars (no high bit) were unaffected, so
+// 'A'/'\x7f' below pass either way and isolate the bug to the >=0x80 cases.
+//
+// (The `\NNN` form is asserted directly via print(:str) rather than round-tripped
+// through eval -- eval of that form currently returns nil, a separate matter.)
+//
+// funcs: char-constant ('x', '\xNN')  print(:str)  ==
+
+ok=true
+
+ok=ok&&(print('A' :str)=="`\\101`")
+print("1 print('A' :str)==`\\101` (expect true): %v\n" print('A' :str)=="`\\101`")
+
+ok=ok&&(print('\x7f' :str)=="`\\177`")
+print("2 print('\\x7f' :str)==`\\177` (expect true): %v\n" print('\x7f' :str)=="`\\177`")
+
+ok=ok&&(print('\xa0' :str)=="`\\240`")
+print("3 print('\\xa0' :str)==`\\240` (expect true): %v\n" print('\xa0' :str)=="`\\240`")
+
+ok=ok&&(print('\xff' :str)=="`\\377`")
+print("4 print('\\xff' :str)==`\\377` (expect true): %v\n" print('\xff' :str)=="`\\377`")
+
+print("char: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -41,6 +41,10 @@ if(run("./symbol.comt")
   :then print("pass: symbol\n")
   :else print("FAIL: symbol\n");topok=false)
 
+if(run("./char.comt")
+  :then print("pass: char\n")
+  :else print("FAIL: char\n");topok=false)
+
 if(run("./help.comt")
   :then print("pass: help\n")
   :else print("FAIL: help\n");topok=false)


### PR DESCRIPTION
Two small, independent fixes surfaced while getting drawmo green; bundled.

## CharType serialization sign-extension (comvalue.c)
`ComValue`'s brief char output is `\`\NNN\`` (the byte as 3-digit octal). `(int)svp->char_ref()` widened a **signed** `char` ≥ 0x80 to a negative int, so e.g. `'\xa0'` serialized as `\`\37777777640\`` (the 32-bit two's-complement) instead of `\`\240\``. Fixed by casting through `(unsigned char)` first — exactly what the `UCharType` branch right below already does. Found live by Scott (`c='\xa0'`).

**Test-first:** `char.comt` asserts the serialized text via `print(:str)`. `'A'`/`'\x7f'` have no high bit and pass either way; `'\xa0'`/`'\xff'` fail before the fix, pass after. Registered in `run_all.comt`. (Confirmed failing on the unfixed build, passing on the fixed one.)

## NULL getlogin() guard (drawserv.c)
`getlogin()` returns NULL on a host with no login session (CI runners), so `DrawServ::Init` built the local `SessionId` with a null username — the *source* of the nil that #182 guarded downstream at `DrawLink::open`. Guarded here (`username = ""`) plus a defensive NUL-terminate of the `gethostname` buffer. Not separately unit-tested (getlogin's NULL isn't forceable in a portable test); the drawmo suite already exercises this condition on the login-less runner.

Draft until CI confirms the comterp suite (incl. char) and drawmo are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)