### PR TITLE
ACE-lite (#147): bundled in-tree ACE subset — sockets, reactor, acceptor (phases 1–3) + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Test - ACE-lite standalone units
         run: |
           set -e
-          for t in sock_loopback reactor_loop acceptor_spawn; do
+          for t in sock_loopback reactor_loop acceptor_spawn log_fmt; do
             echo "=== ACE-lite: $t ==="
             g++ -std=c++14 -Wall -I src -I src/include \
               src/ACE-lite/reactor.c src/ACE-lite/event_handler.c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
             uuid-dev libace-dev \
             xvfb lsof groff gdb netcat-openbsd
 
+      # ACE-lite (issue #147) standalone unit tests: self-contained g++ builds of
+      # the in-tree ACE subset (value/socket types, the select reactor, and the
+      # acceptor/svc_handler accept-and-spawn + EOF lifecycle), independent of the
+      # imake tree build and of libACE. A fast gate that runs before the heavy
+      # build; each test program exits nonzero on failure, so `set -e` fails here.
+      - name: Test - ACE-lite standalone units
+        run: |
+          set -e
+          for t in sock_loopback reactor_loop acceptor_spawn; do
+            echo "=== ACE-lite: $t ==="
+            g++ -std=c++14 -Wall -I src -I src/include \
+              src/ACE-lite/reactor.c src/ACE-lite/event_handler.c \
+              src/ACE-lite/sock.c src/ACE-lite/log_msg.c \
+              "src/ACE-lite/tests/$t.cc" -o "$RUNNER_TEMP/acelite_$t"
+            "$RUNNER_TEMP/acelite_$t"
+          done
+
       - name: Generate ./configure
         run: autoreconf -i
 

--- a/src/ACE-lite/NOTICE
+++ b/src/ACE-lite/NOTICE
@@ -1,0 +1,45 @@
+ACE-lite -- attribution and relationship to ACE
+================================================
+
+ACE-lite (in src/ACE-lite/ and src/include/ACE-lite/, ivtools issue #147) is an
+independent, clean-room reimplementation of a small subset of the *interface* of
+ACE (the ADAPTIVE Communication Environment): the Reactor / Socket / Acceptor /
+Service-Handler classes that ivtools actually uses. It is written from scratch
+for ivtools and contains no ACE source code -- it is layered over the existing
+InterViews Dispatcher select loop and POSIX sockets.
+
+It deliberately declares the same public names and signatures ACE uses (the
+ACE_* classes and methods) for one reason only: so ivtools' existing consumer
+source compiles unchanged against either backend. ivtools selects ACE-lite by
+default and the real ACE when built with --with-ace=<path> (which sets
+-DEXTERN_ACE so the consumer headers include <ace/...> instead of <ACE-lite/...>).
+
+
+Acknowledgment of ACE
+---------------------
+
+ACE is the work of Douglas C. Schmidt and his research group at Washington
+University, the University of California Irvine, and Vanderbilt University,
+Copyright (c) 1993-2018. ACE is open-source software; its full copyright and
+licensing terms are at:
+
+    https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html
+
+We gratefully acknowledge that body of work, whose published interface ACE-lite
+reimplements.
+
+
+What ACE-lite is NOT
+--------------------
+
+  * ACE-lite is NOT ACE, and is NOT derived from ACE source code.
+  * ACE-lite is NOT affiliated with, sponsored by, or endorsed by Douglas C.
+    Schmidt, the DOC group, or Washington University / UC Irvine / Vanderbilt
+    University. Those names are used here only to credit the authors of ACE, not
+    to endorse or promote ACE-lite.
+  * "ACE", "TAO", etc. are the marks of the DOC group; ACE-lite does not claim
+    them. The name "ACE-lite" and the ACE_* identifiers denote source-level
+    compatibility with the ACE interface, nothing more.
+
+We make no claim of authorship over ACE and intend nothing here to impede ACE's
+free distribution.

--- a/src/ACE-lite/event_handler.c
+++ b/src/ACE-lite/event_handler.c
@@ -26,3 +26,5 @@ int ACE_Event_Handler::handle_exception(ACE_HANDLE) { return -1; }
 int ACE_Event_Handler::handle_timeout(const ACE_Time_Value&, const void*) { return -1; }
 
 int ACE_Event_Handler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) { return 0; }
+
+int ACE_Event_Handler::handle_signal(int, void*, void*) { return 0; }

--- a/src/ACE-lite/event_handler.c
+++ b/src/ACE-lite/event_handler.c
@@ -1,0 +1,28 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/event_handler.c
+ * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
+ * group -- see src/ACE-lite/NOTICE.)
+ *
+ * ACE_Event_Handler default method bodies.  As in ACE, the demultiplexing
+ * hooks default to -1 (remove me) so an un-overridden handler retires rather
+ * than spins; ivtools' real handlers (ACE_IO_Handler, ACE_Svc_Handler
+ * subclasses, the acceptor) override the ones they use.
+ */
+
+#include <ACE-lite/Event_Handler.h>
+
+ACE_Event_Handler::~ACE_Event_Handler() {}
+
+ACE_HANDLE ACE_Event_Handler::get_handle() const { return ACE_INVALID_HANDLE; }
+
+void ACE_Event_Handler::set_handle(ACE_HANDLE) {}
+
+int ACE_Event_Handler::handle_input(ACE_HANDLE) { return -1; }
+
+int ACE_Event_Handler::handle_output(ACE_HANDLE) { return -1; }
+
+int ACE_Event_Handler::handle_exception(ACE_HANDLE) { return -1; }
+
+int ACE_Event_Handler::handle_timeout(const ACE_Time_Value&, const void*) { return -1; }
+
+int ACE_Event_Handler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) { return 0; }

--- a/src/ACE-lite/log_msg.c
+++ b/src/ACE-lite/log_msg.c
@@ -48,13 +48,16 @@ void ace_lite_log(int /*severity*/, const char* format, ...) {
         spec[si] = '\0';
 
         // Length modifier sits in the 1-2 chars just before the conversion.
+        // 't' is deliberately NOT treated as a length modifier here: ACE uses %t
+        // for the thread id (it's in the stop-set and has its own case below), so
+        // it can never reach this point as C's ptrdiff length prefix.  I.e. C's
+        // %td/%ti aren't supported -- ivtools uses ACE's %t, not that modifier.
         char m1 = (si >= 3) ? spec[si - 2] : 0;
         char m0 = (si >= 4) ? spec[si - 3] : 0;
         bool is_ll = (m1 == 'l' && m0 == 'l');
         bool is_l  = (m1 == 'l' && !is_ll);
         bool is_z  = (m1 == 'z');
         bool is_j  = (m1 == 'j');
-        bool is_t  = (m1 == 't');
         bool is_L  = (m1 == 'L');
         bool is_unsigned = (conv == 'u' || conv == 'x' || conv == 'X' || conv == 'o');
 
@@ -91,8 +94,6 @@ void ace_lite_log(int /*severity*/, const char* format, ...) {
                 fprintf(stderr, spec, va_arg(ap, size_t));
             } else if (is_j) {
                 fprintf(stderr, spec, va_arg(ap, intmax_t));
-            } else if (is_t) {
-                fprintf(stderr, spec, va_arg(ap, ptrdiff_t));
             } else {                  // default argument promotions: int width
                 if (is_unsigned) fprintf(stderr, spec, va_arg(ap, unsigned int));
                 else             fprintf(stderr, spec, va_arg(ap, int));

--- a/src/ACE-lite/log_msg.c
+++ b/src/ACE-lite/log_msg.c
@@ -1,0 +1,73 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/log_msg.c
+ * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
+ * group -- see src/ACE-lite/NOTICE.)
+ *
+ * ace_lite_log -- the stderr logger behind ACE_DEBUG/ACE_ERROR.  ivtools'
+ * format strings use a few ACE-specific directives that printf does not
+ * understand (and would mis-handle), so we walk the format and translate:
+ *   %P -> process id     %t -> thread id (0; single-threaded)
+ *   %p -> "<arg>: strerror(errno)" (ACE's perror form; arg is a const char*)
+ * Standard %s %d %u %x %c %% (and %ld etc.) pass through to printf one piece at
+ * a time, so they stay type-safe with the va_list.
+ */
+
+#include <ACE-lite/Log_Msg.h>
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+void ace_lite_log(int /*severity*/, const char* format, ...) {
+    if (format == 0) return;
+    va_list ap;
+    va_start(ap, format);
+
+    for (const char* p = format; *p; ++p) {
+        if (*p != '%') {
+            fputc(*p, stderr);
+            continue;
+        }
+        // Collect a full conversion spec "%[flags/width/length]<conv>".
+        char spec[32];
+        int si = 0;
+        spec[si++] = *p++;            // the '%'
+        while (*p && !strchr("PtpsdiuxXcfgeo%", *p) && si < (int)sizeof(spec) - 2) {
+            spec[si++] = *p++;
+        }
+        if (*p == '\0') { spec[si] = '\0'; fputs(spec, stderr); break; }
+        char conv = *p;
+        spec[si++] = conv;
+        spec[si] = '\0';
+
+        switch (conv) {
+        case 'P':
+            fprintf(stderr, "%ld", (long)getpid());
+            break;
+        case 't':
+            fputc('0', stderr);       // thread id; ACE-lite is single-threaded
+            break;
+        case 'p': {                   // ACE perror form: "<arg>: <errno msg>"
+            const char* msg = va_arg(ap, const char*);
+            fprintf(stderr, "%s: %s", msg ? msg : "", strerror(errno));
+            break;
+        }
+        case '%':
+            fputc('%', stderr);
+            break;
+        case 's':
+            fprintf(stderr, spec, va_arg(ap, const char*));
+            break;
+        case 'f': case 'g': case 'e':
+            fprintf(stderr, spec, va_arg(ap, double));
+            break;
+        default:                      // d i u x X c o -> int-width
+            fprintf(stderr, spec, va_arg(ap, int));
+            break;
+        }
+    }
+
+    va_end(ap);
+}

--- a/src/ACE-lite/log_msg.c
+++ b/src/ACE-lite/log_msg.c
@@ -8,14 +8,19 @@
  * understand (and would mis-handle), so we walk the format and translate:
  *   %P -> process id     %t -> thread id (0; single-threaded)
  *   %p -> "<arg>: strerror(errno)" (ACE's perror form; arg is a const char*)
- * Standard %s %d %u %x %c %% (and %ld etc.) pass through to printf one piece at
- * a time, so they stay type-safe with the va_list.
+ * Standard conversions (%s %d %u %x %c %f %% and their l/ll/z/j/t length
+ * modifiers) pass through to printf one piece at a time -- and CRUCIALLY each
+ * is read with the va_arg type matching its length modifier.  Reading a %ld/%lu
+ * arg as a plain int would, on LP64, consume 4 bytes where the caller pushed 8
+ * and desync the va_list for every following argument.
  */
 
 #include <ACE-lite/Log_Msg.h>
 
 #include <errno.h>
 #include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -30,17 +35,28 @@ void ace_lite_log(int /*severity*/, const char* format, ...) {
             fputc(*p, stderr);
             continue;
         }
-        // Collect a full conversion spec "%[flags/width/length]<conv>".
+        // Collect a full conversion spec "%[flags/width/.prec/length]<conv>".
         char spec[32];
         int si = 0;
         spec[si++] = *p++;            // the '%'
-        while (*p && !strchr("PtpsdiuxXcfgeo%", *p) && si < (int)sizeof(spec) - 2) {
+        while (*p && !strchr("PtpsdiuxXcfgeEgGo%", *p) && si < (int)sizeof(spec) - 2) {
             spec[si++] = *p++;
         }
         if (*p == '\0') { spec[si] = '\0'; fputs(spec, stderr); break; }
         char conv = *p;
         spec[si++] = conv;
         spec[si] = '\0';
+
+        // Length modifier sits in the 1-2 chars just before the conversion.
+        char m1 = (si >= 3) ? spec[si - 2] : 0;
+        char m0 = (si >= 4) ? spec[si - 3] : 0;
+        bool is_ll = (m1 == 'l' && m0 == 'l');
+        bool is_l  = (m1 == 'l' && !is_ll);
+        bool is_z  = (m1 == 'z');
+        bool is_j  = (m1 == 'j');
+        bool is_t  = (m1 == 't');
+        bool is_L  = (m1 == 'L');
+        bool is_unsigned = (conv == 'u' || conv == 'x' || conv == 'X' || conv == 'o');
 
         switch (conv) {
         case 'P':
@@ -60,11 +76,27 @@ void ace_lite_log(int /*severity*/, const char* format, ...) {
         case 's':
             fprintf(stderr, spec, va_arg(ap, const char*));
             break;
-        case 'f': case 'g': case 'e':
-            fprintf(stderr, spec, va_arg(ap, double));
+        case 'f': case 'g': case 'e': case 'E': case 'G':
+            if (is_L) fprintf(stderr, spec, va_arg(ap, long double));
+            else      fprintf(stderr, spec, va_arg(ap, double));
             break;
-        default:                      // d i u x X c o -> int-width
-            fprintf(stderr, spec, va_arg(ap, int));
+        default:                      // d i u x X c o  -- match the length modifier
+            if (is_ll) {
+                if (is_unsigned) fprintf(stderr, spec, va_arg(ap, unsigned long long));
+                else             fprintf(stderr, spec, va_arg(ap, long long));
+            } else if (is_l) {
+                if (is_unsigned) fprintf(stderr, spec, va_arg(ap, unsigned long));
+                else             fprintf(stderr, spec, va_arg(ap, long));
+            } else if (is_z) {
+                fprintf(stderr, spec, va_arg(ap, size_t));
+            } else if (is_j) {
+                fprintf(stderr, spec, va_arg(ap, intmax_t));
+            } else if (is_t) {
+                fprintf(stderr, spec, va_arg(ap, ptrdiff_t));
+            } else {                  // default argument promotions: int width
+                if (is_unsigned) fprintf(stderr, spec, va_arg(ap, unsigned int));
+                else             fprintf(stderr, spec, va_arg(ap, int));
+            }
             break;
         }
     }

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -175,25 +175,34 @@ int ACE_Reactor::expire_timers() {
         for (size_t i = 0; i < timers_.size(); i++) {
             if (timers_[i].id == due[k]) { idx = (int)i; break; }
         }
-        if (idx < 0) continue;  // already cancelled by an earlier callback
+        if (idx < 0) continue;  // already cancelled/fired by an earlier callback
         ACE_Event_Handler* eh = timers_[idx].eh;
         const void* arg = timers_[idx].arg;
         ACE_Time_Value interval = timers_[idx].interval;
         int id = timers_[idx].id;
+        bool oneshot = (interval.sec() == 0 && interval.usec() == 0);
+
+        // Retire/reschedule BEFORE firing.  handle_timeout can re-enter
+        // handle_events() (e.g. via update()), and the nested expire_timers()
+        // would otherwise still see this timer as due and fire it again --
+        // unbounded recursion.  A one-shot is removed; an interval timer is
+        // pushed to its next expiry (so the reentrant pass sees it in the
+        // future).
+        if (oneshot) {
+            timers_.erase(timers_.begin() + idx);
+        } else {
+            timers_[idx].expire = now + interval;
+        }
 
         int rc = eh->handle_timeout(now, arg);
         fired++;
 
-        // Re-find: handle_timeout may have cancelled/rescheduled.
-        idx = -1;
-        for (size_t i = 0; i < timers_.size(); i++) {
-            if (timers_[i].id == id) { idx = (int)i; break; }
-        }
-        if (idx < 0) continue;
-        if (rc < 0 || (interval.sec() == 0 && interval.usec() == 0)) {
-            timers_.erase(timers_.begin() + idx);
-        } else {
-            timers_[idx].expire = now + interval;
+        // An interval timer whose handler asked to stop (rc < 0) is cancelled
+        // now (re-find: the callback may already have removed it).
+        if (!oneshot && rc < 0) {
+            for (size_t i = 0; i < timers_.size(); i++) {
+                if (timers_[i].id == id) { timers_.erase(timers_.begin() + i); break; }
+            }
         }
     }
     return fired;
@@ -248,7 +257,13 @@ int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
         timeval nowtv;
         gettimeofday(&nowtv, 0);
         ACE_Time_Value wait = timer_at - ACE_Time_Value(nowtv);
-        if (wait.sec() < 0) wait.set(0, 0);
+        // Clamp any non-positive wait to zero.  A timer that's already due (or
+        // fired a few usec late) gives wait <= 0, often as (sec=0, usec<0) -- a
+        // negative tv_usec makes select() fail with EINVAL, which would drop the
+        // overdue timer.  `<= zero` catches the (0, usec<0) case that a plain
+        // `sec() < 0` test misses; a 0 timeout makes select() return at once so
+        // expire_timers() runs.
+        if (wait <= ACE_Time_Value::zero) wait.set(0, 0);
         tvbuf = (timeval)wait;
         tvp = &tvbuf;
     }

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -213,7 +213,18 @@ int ACE_Reactor::expire_timers() {
 int ACE_Reactor::handle_events() { return handle_events((ACE_Time_Value*)0); }
 
 int ACE_Reactor::handle_events(ACE_Time_Value& max_wait_time) {
-    return handle_events(&max_wait_time);
+    // The reference form decrements the caller's budget by the time actually
+    // spent, as real ACE does, so a loop like `while (tv > zero)
+    // handle_events(tv)` terminates instead of spinning.
+    timeval before;
+    gettimeofday(&before, 0);
+    int n = handle_events(&max_wait_time);
+    timeval after;
+    gettimeofday(&after, 0);
+    ACE_Time_Value elapsed = ACE_Time_Value(after) - ACE_Time_Value(before);
+    if (elapsed >= max_wait_time) max_wait_time = ACE_Time_Value::zero;
+    else max_wait_time -= elapsed;
+    return n;
 }
 
 int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -20,6 +20,7 @@
 #include <sys/select.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include <set>
 #include <vector>
 
 ACE_Reactor::ACE_Reactor() : next_timer_id_(1) {}
@@ -226,7 +227,11 @@ int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
     }
 
     int dispatched = 0;
-    std::vector<ACE_HANDLE> to_retire;
+    // Once a handler returns -1 in any of read/write/except, it is retiring:
+    // exclude it from the remaining masks this same cycle (ACE removes a
+    // handler on the first -1; calling its other hooks afterward -- on an
+    // object about to be torn down -- is wrong), and retire each fd once.
+    std::set<ACE_HANDLE> retiring;
 
     if (nready > 0) {
         // Snapshot ready fds, then dispatch re-verifying registration each
@@ -243,30 +248,34 @@ int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
             if (FD_ISSET(it->first, &eset)) efds.push_back(it->first);
 
         for (size_t i = 0; i < rfds.size(); i++) {
+            if (retiring.count(rfds[i])) continue;
             std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.find(rfds[i]);
             if (it == read_.end()) continue;  // removed mid-dispatch
             int rc = it->second->handle_input(rfds[i]);
             dispatched++;
-            if (rc < 0) to_retire.push_back(rfds[i]);
+            if (rc < 0) retiring.insert(rfds[i]);
         }
         for (size_t i = 0; i < wfds.size(); i++) {
+            if (retiring.count(wfds[i])) continue;  // already retiring from read
             std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = write_.find(wfds[i]);
             if (it == write_.end()) continue;
             int rc = it->second->handle_output(wfds[i]);
             dispatched++;
-            if (rc < 0) to_retire.push_back(wfds[i]);
+            if (rc < 0) retiring.insert(wfds[i]);
         }
         for (size_t i = 0; i < efds.size(); i++) {
+            if (retiring.count(efds[i])) continue;
             std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = except_.find(efds[i]);
             if (it == except_.end()) continue;
             int rc = it->second->handle_exception(efds[i]);
             dispatched++;
-            if (rc < 0) to_retire.push_back(efds[i]);
+            if (rc < 0) retiring.insert(efds[i]);
         }
     }
 
-    for (size_t i = 0; i < to_retire.size(); i++) {
-        retire(to_retire[i], ACE_Event_Handler::RWE_MASK);
+    for (std::set<ACE_HANDLE>::iterator it = retiring.begin();
+         it != retiring.end(); ++it) {
+        retire(*it, ACE_Event_Handler::RWE_MASK);
     }
 
     dispatched += expire_timers();

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -213,19 +213,28 @@ int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
     FD_ZERO(&wset);
     FD_ZERO(&eset);
 
+    // FD_SET/FD_ISSET on a descriptor >= FD_SETSIZE indexes past the fixed-size
+    // fd_set -- undefined behavior (stack corruption).  Guard every use: a fd
+    // that large is skipped rather than corrupting memory.  ivtools' workloads
+    // keep fd numbers well under FD_SETSIZE; lifting the limit entirely means
+    // moving this select() loop to poll() (no FD_SETSIZE bound), noted as future
+    // work in issue #147.
     int maxfd = -1;
     for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.begin();
          it != read_.end(); ++it) {
+        if (it->first < 0 || it->first >= FD_SETSIZE) continue;
         FD_SET(it->first, &rset);
         if (it->first > maxfd) maxfd = it->first;
     }
     for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = write_.begin();
          it != write_.end(); ++it) {
+        if (it->first < 0 || it->first >= FD_SETSIZE) continue;
         FD_SET(it->first, &wset);
         if (it->first > maxfd) maxfd = it->first;
     }
     for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = except_.begin();
          it != except_.end(); ++it) {
+        if (it->first < 0 || it->first >= FD_SETSIZE) continue;
         FD_SET(it->first, &eset);
         if (it->first > maxfd) maxfd = it->first;
     }
@@ -272,13 +281,16 @@ int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
         std::vector<ACE_HANDLE> rfds, wfds, efds;
         for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.begin();
              it != read_.end(); ++it)
-            if (FD_ISSET(it->first, &rset)) rfds.push_back(it->first);
+            if (it->first >= 0 && it->first < FD_SETSIZE && FD_ISSET(it->first, &rset))
+                rfds.push_back(it->first);
         for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = write_.begin();
              it != write_.end(); ++it)
-            if (FD_ISSET(it->first, &wset)) wfds.push_back(it->first);
+            if (it->first >= 0 && it->first < FD_SETSIZE && FD_ISSET(it->first, &wset))
+                wfds.push_back(it->first);
         for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = except_.begin();
              it != except_.end(); ++it)
-            if (FD_ISSET(it->first, &eset)) efds.push_back(it->first);
+            if (it->first >= 0 && it->first < FD_SETSIZE && FD_ISSET(it->first, &eset))
+                efds.push_back(it->first);
 
         for (size_t i = 0; i < rfds.size(); i++) {
             if (retiring.count(rfds[i])) continue;

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -67,7 +67,7 @@ int ACE_Reactor::register_handler(ACE_Event_Handler* eh,
 
 int ACE_Reactor::register_handler(ACE_HANDLE handle, ACE_Event_Handler* eh,
                                   ACE_Reactor_Mask mask) {
-    if (handle == ACE_INVALID_HANDLE) return -1;
+    if (handle == ACE_INVALID_HANDLE || eh == 0) return -1;  // never bind a null
     bind(handle, eh, mask);
     return 0;
 }

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -1,0 +1,274 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/reactor.c
+ * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
+ * group -- see src/ACE-lite/NOTICE.)
+ *
+ * ACE_Reactor -- a self-contained select() demultiplexer that drops into the
+ * same slot as libACE's reactor (AceDispatcher forwards into it; socket
+ * handlers register with it).
+ *
+ * handle_events() is written to survive reentrancy: a handler can call
+ * update() -> handle_events() recursively, and a callback (or that nested
+ * call) can remove handlers out from under an in-progress dispatch.  So we
+ * snapshot the ready set, re-verify each handler is still registered before
+ * invoking it, and defer removals -- mirroring the null-checked tables the base
+ * InterViews Dispatcher uses for the same reason.
+ */
+
+#include <ACE-lite/Reactor.h>
+
+#include <sys/select.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <vector>
+
+ACE_Reactor::ACE_Reactor() : next_timer_id_(1) {}
+
+ACE_Reactor::~ACE_Reactor() {}
+
+/* ----------------------------------------------------------- registration */
+
+void ACE_Reactor::bind(ACE_HANDLE h, ACE_Event_Handler* eh,
+                       ACE_Reactor_Mask mask) {
+    if (mask & ACE_Event_Handler::READ_MASK)   read_[h] = eh;
+    if (mask & ACE_Event_Handler::WRITE_MASK)  write_[h] = eh;
+    if (mask & ACE_Event_Handler::EXCEPT_MASK) except_[h] = eh;
+    if (eh) eh->reactor(this);
+}
+
+int ACE_Reactor::register_handler(ACE_Event_Handler* eh,
+                                  ACE_Reactor_Mask mask) {
+    if (eh == 0) return -1;
+    ACE_HANDLE h = eh->get_handle();
+    if (h == ACE_INVALID_HANDLE) return -1;
+    bind(h, eh, mask);
+    return 0;
+}
+
+int ACE_Reactor::register_handler(ACE_HANDLE handle, ACE_Event_Handler* eh,
+                                  ACE_Reactor_Mask mask) {
+    if (handle == ACE_INVALID_HANDLE) return -1;
+    bind(handle, eh, mask);
+    return 0;
+}
+
+int ACE_Reactor::remove_handler(ACE_HANDLE handle, ACE_Reactor_Mask mask) {
+    if (mask & ACE_Event_Handler::READ_MASK)   read_.erase(handle);
+    if (mask & ACE_Event_Handler::WRITE_MASK)  write_.erase(handle);
+    if (mask & ACE_Event_Handler::EXCEPT_MASK) except_.erase(handle);
+    return 0;
+}
+
+// Retire a handle on the -1/EOF path: drop every mask and notify the handler
+// so it can close its socket (ACE_Svc_Handler::handle_close does this).
+void ACE_Reactor::retire(ACE_HANDLE h, ACE_Reactor_Mask mask) {
+    std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.find(h);
+    ACE_Event_Handler* eh = (it != read_.end()) ? it->second : 0;
+    if (!eh) { it = write_.find(h);  if (it != write_.end())  eh = it->second; }
+    if (!eh) { it = except_.find(h); if (it != except_.end()) eh = it->second; }
+    remove_handler(h, ACE_Event_Handler::RWE_MASK);
+    if (eh && !(mask & ACE_Event_Handler::DONT_CALL)) {
+        eh->handle_close(h, mask);
+    }
+}
+
+/* ---------------------------------------------------------------- timers */
+
+int ACE_Reactor::schedule_timer(ACE_Event_Handler* eh, const void* arg,
+                                const ACE_Time_Value& delay,
+                                const ACE_Time_Value& interval) {
+    if (eh == 0) return -1;
+    timeval now;
+    gettimeofday(&now, 0);
+    Timer t;
+    t.id = next_timer_id_++;
+    t.eh = eh;
+    t.arg = arg;
+    t.expire = ACE_Time_Value(now) + delay;
+    t.interval = interval;
+    eh->reactor(this);
+    timers_.push_back(t);
+    return t.id;
+}
+
+int ACE_Reactor::cancel_timer(int timer_id, const void** arg) {
+    for (std::vector<Timer>::iterator it = timers_.begin();
+         it != timers_.end(); ++it) {
+        if (it->id == timer_id) {
+            if (arg) *arg = it->arg;
+            timers_.erase(it);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int ACE_Reactor::cancel_timer(ACE_Event_Handler* eh) {
+    int n = 0;
+    for (std::vector<Timer>::iterator it = timers_.begin();
+         it != timers_.end(); ) {
+        if (it->eh == eh) { it = timers_.erase(it); n++; }
+        else ++it;
+    }
+    return n;
+}
+
+bool ACE_Reactor::earliest_timer(ACE_Time_Value& tv) const {
+    if (timers_.empty()) return false;
+    tv = timers_[0].expire;
+    for (size_t i = 1; i < timers_.size(); i++) {
+        if (timers_[i].expire < tv) tv = timers_[i].expire;
+    }
+    return true;
+}
+
+// Fire every timer whose expiry has passed.  Snapshot first: a callback may
+// schedule/cancel timers (directly or via a reentrant handle_events).
+int ACE_Reactor::expire_timers() {
+    timeval nowtv;
+    gettimeofday(&nowtv, 0);
+    ACE_Time_Value now(nowtv);
+
+    std::vector<int> due;
+    for (size_t i = 0; i < timers_.size(); i++) {
+        if (!(timers_[i].expire > now)) due.push_back(timers_[i].id);
+    }
+
+    int fired = 0;
+    for (size_t k = 0; k < due.size(); k++) {
+        // Re-find by id each time: the vector may have been mutated.
+        int idx = -1;
+        for (size_t i = 0; i < timers_.size(); i++) {
+            if (timers_[i].id == due[k]) { idx = (int)i; break; }
+        }
+        if (idx < 0) continue;  // already cancelled by an earlier callback
+        ACE_Event_Handler* eh = timers_[idx].eh;
+        const void* arg = timers_[idx].arg;
+        ACE_Time_Value interval = timers_[idx].interval;
+        int id = timers_[idx].id;
+
+        int rc = eh->handle_timeout(now, arg);
+        fired++;
+
+        // Re-find: handle_timeout may have cancelled/rescheduled.
+        idx = -1;
+        for (size_t i = 0; i < timers_.size(); i++) {
+            if (timers_[i].id == id) { idx = (int)i; break; }
+        }
+        if (idx < 0) continue;
+        if (rc < 0 || (interval.sec() == 0 && interval.usec() == 0)) {
+            timers_.erase(timers_.begin() + idx);
+        } else {
+            timers_[idx].expire = now + interval;
+        }
+    }
+    return fired;
+}
+
+/* ------------------------------------------------------------ event loop */
+
+int ACE_Reactor::handle_events() { return handle_events((ACE_Time_Value*)0); }
+
+int ACE_Reactor::handle_events(ACE_Time_Value& max_wait_time) {
+    return handle_events(&max_wait_time);
+}
+
+int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
+    fd_set rset, wset, eset;
+    FD_ZERO(&rset);
+    FD_ZERO(&wset);
+    FD_ZERO(&eset);
+
+    int maxfd = -1;
+    for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.begin();
+         it != read_.end(); ++it) {
+        FD_SET(it->first, &rset);
+        if (it->first > maxfd) maxfd = it->first;
+    }
+    for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = write_.begin();
+         it != write_.end(); ++it) {
+        FD_SET(it->first, &wset);
+        if (it->first > maxfd) maxfd = it->first;
+    }
+    for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = except_.begin();
+         it != except_.end(); ++it) {
+        FD_SET(it->first, &eset);
+        if (it->first > maxfd) maxfd = it->first;
+    }
+
+    // Bound the wait by the soonest timer and the caller's cap (smaller wins).
+    timeval tvbuf;
+    timeval* tvp = 0;
+    ACE_Time_Value timer_at, now_tv;
+    bool have_timer = earliest_timer(timer_at);
+    if (have_timer) {
+        timeval nowtv;
+        gettimeofday(&nowtv, 0);
+        ACE_Time_Value wait = timer_at - ACE_Time_Value(nowtv);
+        if (wait.sec() < 0) wait.set(0, 0);
+        tvbuf = (timeval)wait;
+        tvp = &tvbuf;
+    }
+    if (max_wait_time) {
+        timeval cap = (timeval) * max_wait_time;
+        if (tvp == 0 || cap.tv_sec < tvbuf.tv_sec ||
+            (cap.tv_sec == tvbuf.tv_sec && cap.tv_usec < tvbuf.tv_usec)) {
+            tvbuf = cap;
+            tvp = &tvbuf;
+        }
+    }
+
+    int nready = (maxfd >= 0 || tvp)
+        ? ::select(maxfd + 1, &rset, &wset, &eset, tvp)
+        : 0;
+    if (nready < 0) {
+        return -1;  // EINTR etc.; caller loops again
+    }
+
+    int dispatched = 0;
+    std::vector<ACE_HANDLE> to_retire;
+
+    if (nready > 0) {
+        // Snapshot ready fds, then dispatch re-verifying registration each
+        // time (a callback may have removed handlers, incl. via reentrancy).
+        std::vector<ACE_HANDLE> rfds, wfds, efds;
+        for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.begin();
+             it != read_.end(); ++it)
+            if (FD_ISSET(it->first, &rset)) rfds.push_back(it->first);
+        for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = write_.begin();
+             it != write_.end(); ++it)
+            if (FD_ISSET(it->first, &wset)) wfds.push_back(it->first);
+        for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = except_.begin();
+             it != except_.end(); ++it)
+            if (FD_ISSET(it->first, &eset)) efds.push_back(it->first);
+
+        for (size_t i = 0; i < rfds.size(); i++) {
+            std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.find(rfds[i]);
+            if (it == read_.end()) continue;  // removed mid-dispatch
+            int rc = it->second->handle_input(rfds[i]);
+            dispatched++;
+            if (rc < 0) to_retire.push_back(rfds[i]);
+        }
+        for (size_t i = 0; i < wfds.size(); i++) {
+            std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = write_.find(wfds[i]);
+            if (it == write_.end()) continue;
+            int rc = it->second->handle_output(wfds[i]);
+            dispatched++;
+            if (rc < 0) to_retire.push_back(wfds[i]);
+        }
+        for (size_t i = 0; i < efds.size(); i++) {
+            std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = except_.find(efds[i]);
+            if (it == except_.end()) continue;
+            int rc = it->second->handle_exception(efds[i]);
+            dispatched++;
+            if (rc < 0) to_retire.push_back(efds[i]);
+        }
+    }
+
+    for (size_t i = 0; i < to_retire.size(); i++) {
+        retire(to_retire[i], ACE_Event_Handler::RWE_MASK);
+    }
+
+    dispatched += expire_timers();
+    return dispatched;
+}

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -17,11 +17,30 @@
 
 #include <ACE-lite/Reactor.h>
 
+#include <signal.h>
 #include <sys/select.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <set>
 #include <vector>
+
+#ifndef NSIG
+#define NSIG 64
+#endif
+
+// ACE_Time_Value::zero -- the shared 0 duration declared in Time_Value.h.
+const ACE_Time_Value ACE_Time_Value::zero;
+
+// Signal handlers are process-global, so the signum->handler table and the
+// trampoline are file-static.  handle_signal must be async-signal-safe (the
+// only registered use, ACE_Test_and_Set, just sets a sig_atomic_t flag).
+static ACE_Event_Handler* acelite_sig_handlers[NSIG];
+
+extern "C" void acelite_sig_trampoline(int signo) {
+    if (signo >= 0 && signo < NSIG && acelite_sig_handlers[signo]) {
+        acelite_sig_handlers[signo]->handle_signal(signo);
+    }
+}
 
 ACE_Reactor::ACE_Reactor() : next_timer_id_(1) {}
 
@@ -58,6 +77,20 @@ int ACE_Reactor::remove_handler(ACE_HANDLE handle, ACE_Reactor_Mask mask) {
     if (mask & ACE_Event_Handler::WRITE_MASK)  write_.erase(handle);
     if (mask & ACE_Event_Handler::EXCEPT_MASK) except_.erase(handle);
     return 0;
+}
+
+int ACE_Reactor::remove_handler(ACE_Event_Handler* eh, ACE_Reactor_Mask mask) {
+    if (eh == 0) return -1;
+    return remove_handler(eh->get_handle(), mask);
+}
+
+int ACE_Reactor::register_handler(int signum, ACE_Event_Handler* new_sh) {
+    if (signum < 0 || signum >= NSIG || new_sh == 0) {
+        return -1;
+    }
+    new_sh->reactor(this);
+    acelite_sig_handlers[signum] = new_sh;
+    return ::signal(signum, acelite_sig_trampoline) == SIG_ERR ? -1 : 0;
 }
 
 // Retire a handle on the -1/EOF path: drop every mask and notify the handler

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -101,6 +101,13 @@ void ACE_Reactor::retire(ACE_HANDLE h, ACE_Reactor_Mask mask) {
     if (!eh) { it = write_.find(h);  if (it != write_.end())  eh = it->second; }
     if (!eh) { it = except_.find(h); if (it != except_.end()) eh = it->second; }
     remove_handler(h, ACE_Event_Handler::RWE_MASK);
+    // Cancel any timers this handler still has scheduled BEFORE handle_close --
+    // handle_close can delete the handler (ACE_Svc_Handler::handle_close ->
+    // destroy -> delete this), and expire_timers() runs AFTER the retire loop
+    // in handle_events(), so a surviving timer would fire handle_timeout() on
+    // freed memory.  A handler registered for both I/O and a timer is the case
+    // that trips this (e.g. ComterpHandler: READ plus a timeout script timer).
+    if (eh) cancel_timer(eh);
     if (eh && !(mask & ACE_Event_Handler::DONT_CALL)) {
         eh->handle_close(h, mask);
     }

--- a/src/ACE-lite/sock.c
+++ b/src/ACE-lite/sock.c
@@ -1,0 +1,190 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/sock.c
+ * Implementations of the ACE-lite address and socket classes
+ * (ACE_INET_Addr, ACE_SOCK_Stream, ACE_SOCK_Connector, ACE_SOCK_Acceptor).
+ * ACE_Time_Value is header-inline; the templates are header-only.
+ */
+
+#include <ACE-lite/INET_Addr.h>
+#include <ACE-lite/SOCK_Stream.h>
+#include <ACE-lite/SOCK_Connector.h>
+#include <ACE-lite/SOCK_Acceptor.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+/* ---------------------------------------------------------------- INET_Addr */
+
+ACE_INET_Addr::ACE_INET_Addr() {
+    memset(&inet_addr_, 0, sizeof(inet_addr_));
+    inet_addr_.sin_family = AF_INET;
+    host_name_[0] = '\0';
+}
+
+ACE_INET_Addr::ACE_INET_Addr(u_short port) {
+    memset(&inet_addr_, 0, sizeof(inet_addr_));
+    inet_addr_.sin_family = AF_INET;
+    inet_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
+    inet_addr_.sin_port = htons(port);
+    host_name_[0] = '\0';
+}
+
+ACE_INET_Addr::ACE_INET_Addr(u_short port, const char* host) {
+    set(port, host);
+}
+
+int ACE_INET_Addr::set(u_short port, const char* host) {
+    memset(&inet_addr_, 0, sizeof(inet_addr_));
+    inet_addr_.sin_family = AF_INET;
+    inet_addr_.sin_port = htons(port);
+    host_name_[0] = '\0';
+
+    if (host == 0 || *host == '\0') {
+        inet_addr_.sin_addr.s_addr = htonl(INADDR_ANY);
+        return 0;
+    }
+    // Try dotted-quad first (no resolver round-trip), then a name lookup.
+    in_addr_t numeric = inet_addr(host);
+    if (numeric != (in_addr_t)-1) {
+        inet_addr_.sin_addr.s_addr = numeric;
+        return 0;
+    }
+    struct hostent* he = gethostbyname(host);
+    if (he == 0 || he->h_addr_list[0] == 0) {
+        return -1;
+    }
+    memcpy(&inet_addr_.sin_addr, he->h_addr_list[0], he->h_length);
+    return 0;
+}
+
+const char* ACE_INET_Addr::get_host_name() const {
+    if (host_name_[0] != '\0') {
+        return host_name_;
+    }
+    struct hostent* he = gethostbyaddr((const char*)&inet_addr_.sin_addr,
+                                       sizeof(inet_addr_.sin_addr), AF_INET);
+    if (he != 0 && he->h_name != 0) {
+        strncpy(host_name_, he->h_name, sizeof(host_name_) - 1);
+        host_name_[sizeof(host_name_) - 1] = '\0';
+    } else {
+        const char* dotted = inet_ntoa(inet_addr_.sin_addr);
+        strncpy(host_name_, dotted ? dotted : "", sizeof(host_name_) - 1);
+        host_name_[sizeof(host_name_) - 1] = '\0';
+    }
+    return host_name_;
+}
+
+int ACE_INET_Addr::addr_to_string(char* buffer, size_t size) const {
+    const char* dotted = inet_ntoa(inet_addr_.sin_addr);
+    int n = snprintf(buffer, size, "%s:%u",
+                     dotted ? dotted : "", (unsigned)ntohs(inet_addr_.sin_port));
+    return (n < 0 || (size_t)n >= size) ? -1 : 0;
+}
+
+u_short ACE_INET_Addr::get_port_number() const {
+    return ntohs(inet_addr_.sin_port);
+}
+
+/* -------------------------------------------------------------- SOCK_Stream */
+
+ssize_t ACE_SOCK_Stream::recv(void* buf, size_t n) const {
+    return ::recv(handle_, buf, n, 0);
+}
+
+ssize_t ACE_SOCK_Stream::send(const void* buf, size_t n) const {
+    return ::send(handle_, buf, n, 0);
+}
+
+int ACE_SOCK_Stream::enable(int value) const {
+    int flags = fcntl(handle_, F_GETFL, 0);
+    if (flags == -1) {
+        return -1;
+    }
+    return fcntl(handle_, F_SETFL, flags | value);
+}
+
+int ACE_SOCK_Stream::get_remote_addr(ACE_INET_Addr& addr) const {
+    sockaddr_in sin;
+    socklen_t len = sizeof(sin);
+    if (getpeername(handle_, (sockaddr*)&sin, &len) == -1) {
+        return -1;
+    }
+    addr.set_addr(sin);
+    return 0;
+}
+
+int ACE_SOCK_Stream::close() {
+    if (handle_ == ACE_INVALID_HANDLE) {
+        return 0;
+    }
+    int rc = ::close(handle_);
+    handle_ = ACE_INVALID_HANDLE;
+    return rc;
+}
+
+/* ----------------------------------------------------------- SOCK_Connector */
+
+int ACE_SOCK_Connector::connect(ACE_SOCK_Stream& stream,
+                                const ACE_INET_Addr& remote_addr) {
+    ACE_HANDLE h = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (h == ACE_INVALID_HANDLE) {
+        return -1;
+    }
+    if (::connect(h, remote_addr.get_addr(), remote_addr.get_size()) == -1) {
+        ::close(h);
+        return -1;
+    }
+    stream.set_handle(h);
+    return 0;
+}
+
+/* ------------------------------------------------------------ SOCK_Acceptor */
+
+int ACE_SOCK_Acceptor::open(const ACE_INET_Addr& local_addr, int reuse_addr) {
+    ACE_HANDLE h = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (h == ACE_INVALID_HANDLE) {
+        return -1;
+    }
+    if (reuse_addr) {
+        int one = 1;
+        setsockopt(h, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    }
+    if (::bind(h, local_addr.get_addr(), local_addr.get_size()) == -1 ||
+        ::listen(h, SOMAXCONN) == -1) {
+        ::close(h);
+        return -1;
+    }
+    handle_ = h;
+    return 0;
+}
+
+int ACE_SOCK_Acceptor::accept(ACE_SOCK_Stream& new_stream,
+                              ACE_INET_Addr* remote_addr) const {
+    sockaddr_in sin;
+    socklen_t len = sizeof(sin);
+    ACE_HANDLE h = ::accept(handle_, (sockaddr*)&sin, &len);
+    if (h == ACE_INVALID_HANDLE) {
+        return -1;
+    }
+    new_stream.set_handle(h);
+    if (remote_addr != 0) {
+        remote_addr->set_addr(sin);
+    }
+    return 0;
+}
+
+int ACE_SOCK_Acceptor::close() {
+    if (handle_ == ACE_INVALID_HANDLE) {
+        return 0;
+    }
+    int rc = ::close(handle_);
+    handle_ = ACE_INVALID_HANDLE;
+    return rc;
+}

--- a/src/ACE-lite/sock.c
+++ b/src/ACE-lite/sock.c
@@ -1,5 +1,7 @@
 /*
  * ACE-lite (issue #147).  src/ACE-lite/sock.c
+ * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
+ * group -- see src/ACE-lite/NOTICE for attribution and the relationship.)
  * Implementations of the ACE-lite address and socket classes
  * (ACE_INET_Addr, ACE_SOCK_Stream, ACE_SOCK_Connector, ACE_SOCK_Acceptor).
  * ACE_Time_Value is header-inline; the templates are header-only.

--- a/src/ACE-lite/sock.c
+++ b/src/ACE-lite/sock.c
@@ -94,6 +94,29 @@ u_short ACE_INET_Addr::get_port_number() const {
     return ntohs(inet_addr_.sin_port);
 }
 
+/* ------------------------------------------------------------ SIGPIPE guard */
+
+// Writing to a socket whose peer has closed raises SIGPIPE, whose default
+// action terminates the process -- unacceptable for a long-running server that
+// a peer can disconnect at any time.  Two mechanisms, because no single one is
+// portable: Linux passes MSG_NOSIGNAL on the send() call; macOS/BSD lack that
+// flag and instead set SO_NOSIGPIPE once on the socket.  Apply both where each
+// exists so send() returns EPIPE instead of signalling on every platform.
+#ifdef MSG_NOSIGNAL
+static const int ace_lite_send_flags = MSG_NOSIGNAL;
+#else
+static const int ace_lite_send_flags = 0;
+#endif
+
+static void ace_lite_no_sigpipe(ACE_HANDLE h) {
+#ifdef SO_NOSIGPIPE
+    int one = 1;
+    setsockopt(h, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#else
+    (void)h;
+#endif
+}
+
 /* -------------------------------------------------------------- SOCK_Stream */
 
 ssize_t ACE_SOCK_Stream::recv(void* buf, size_t n) const {
@@ -101,7 +124,7 @@ ssize_t ACE_SOCK_Stream::recv(void* buf, size_t n) const {
 }
 
 ssize_t ACE_SOCK_Stream::send(const void* buf, size_t n) const {
-    return ::send(handle_, buf, n, 0);
+    return ::send(handle_, buf, n, ace_lite_send_flags);
 }
 
 int ACE_SOCK_Stream::enable(int value) const {
@@ -143,6 +166,7 @@ int ACE_SOCK_Connector::connect(ACE_SOCK_Stream& stream,
         ::close(h);
         return -1;
     }
+    ace_lite_no_sigpipe(h);
     stream.set_handle(h);
     return 0;
 }
@@ -175,6 +199,7 @@ int ACE_SOCK_Acceptor::accept(ACE_SOCK_Stream& new_stream,
     if (h == ACE_INVALID_HANDLE) {
         return -1;
     }
+    ace_lite_no_sigpipe(h);
     new_stream.set_handle(h);
     if (remote_addr != 0) {
         remote_addr->set_addr(sin);

--- a/src/ACE-lite/tests/acceptor_spawn.cc
+++ b/src/ACE-lite/tests/acceptor_spawn.cc
@@ -1,0 +1,102 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/tests/acceptor_spawn.cc
+ * Standalone Phase-3 unit test for ACE_Acceptor + ACE_Svc_Handler, exercising
+ * the accept-and-spawn path and the EOF retirement lifecycle
+ * (handle_input -1 => reactor retire => handle_close => close => destroy)
+ * exactly as ComterpAcceptor/ComterpHandler use it.
+ * Build:
+ *   g++ -I src/include src/ACE-lite/{reactor,event_handler,sock,log_msg}.c \
+ *       src/ACE-lite/tests/acceptor_spawn.cc
+ * Exit 0 = pass, 1 = fail.
+ */
+
+#include <ACE-lite/Acceptor.h>
+#include <ACE-lite/Svc_Handler.h>
+#include <ACE-lite/SOCK_Acceptor.h>
+#include <ACE-lite/SOCK_Connector.h>
+#include <ACE-lite/SOCK_Stream.h>
+#include <ACE-lite/Synch.h>
+#include <ACE-lite/Reactor.h>
+
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int failures = 0;
+static void check(int cond, const char* what) {
+    printf("%s: %s\n", cond ? "ok  " : "FAIL", what);
+    if (!cond) failures++;
+}
+
+// An echo handler that registers itself on open() and self-retires on EOF, like
+// a real socket service handler.  Uses the default close()/destroy() (which
+// deletes it), so live_count tracks construction vs destruction.
+class EchoHandler : public ACE_Svc_Handler<ACE_SOCK_Stream, ACE_NULL_SYNCH> {
+public:
+    static int live_count;
+    static int opened;
+    EchoHandler() { live_count++; }
+    virtual ~EchoHandler() { live_count--; }
+
+    virtual int open(void*) {
+        opened++;
+        if (this->reactor()->register_handler(this, ACE_Event_Handler::READ_MASK) == -1)
+            return -1;
+        return 0;
+    }
+    virtual int handle_input(ACE_HANDLE) {
+        char buf[64];
+        ssize_t n = peer().recv(buf, sizeof(buf));
+        if (n <= 0) return -1;     // EOF -> reactor retires us
+        peer().send(buf, n);       // echo
+        return 0;
+    }
+};
+int EchoHandler::live_count = 0;
+int EchoHandler::opened = 0;
+
+int main() {
+    ACE_Reactor reactor;
+    ACE_Acceptor<EchoHandler, ACE_SOCK_ACCEPTOR> acceptor;
+
+    check(acceptor.open(ACE_INET_Addr((u_short)0), &reactor) == 0,
+          "ACE_Acceptor::open(addr, reactor)");
+
+    // Discover the bound port.
+    sockaddr_in sin;
+    socklen_t len = sizeof(sin);
+    getsockname(acceptor.get_handle(), (sockaddr*)&sin, &len);
+    u_short port = ntohs(sin.sin_port);
+
+    // Connect a client; one reactor turn should accept + spawn a handler.
+    ACE_SOCK_Connector connector;
+    ACE_SOCK_Stream client;
+    check(connector.connect(client, ACE_INET_Addr(port, "127.0.0.1")) == 0,
+          "client connect to acceptor");
+    ACE_Time_Value w(1, 0);
+    reactor.handle_events(&w);
+    check(EchoHandler::opened == 1 && EchoHandler::live_count == 1,
+          "acceptor accept-and-spawned one handler (open called)");
+
+    // Round-trip through the spawned handler.
+    client.send("ping", 4);
+    ACE_Time_Value w2(1, 0);
+    reactor.handle_events(&w2);
+    char buf[64];
+    ssize_t n = client.recv(buf, sizeof(buf) - 1);
+    if (n < 0) n = 0;
+    buf[n] = '\0';
+    check(strcmp(buf, "ping") == 0, "spawned handler echoed the payload");
+
+    // Close client -> handler hits EOF -> -1 -> retire -> close -> destroy.
+    client.close();
+    ACE_Time_Value w3(1, 0);
+    reactor.handle_events(&w3);
+    check(EchoHandler::live_count == 0,
+          "EOF retired the handler through handle_close->close->destroy");
+
+    printf("\nacceptor_spawn: %s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/src/ACE-lite/tests/log_fmt.cc
+++ b/src/ACE-lite/tests/log_fmt.cc
@@ -1,0 +1,74 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/tests/log_fmt.cc
+ * Standalone regression test for ace_lite_log's format handling.  The point is
+ * the length modifiers: a %ld/%lu argument must be read as a long, not an int,
+ * or on LP64 the va_list desyncs and every following argument is garbled.  We
+ * capture stderr and check that a mixed "%ld %s %lu %u" line renders all four
+ * arguments correctly.
+ * Build:
+ *   g++ -I src/include src/ACE-lite/log_msg.c src/ACE-lite/tests/log_fmt.cc
+ * Exit 0 = pass, 1 = fail.
+ */
+
+#include <ACE-lite/Log_Msg.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int failures = 0;
+static void check(int cond, const char* what) {
+    printf("%s: %s\n", cond ? "ok  " : "FAIL", what);
+    if (!cond) failures++;
+}
+
+int main() {
+    char path[256];
+    snprintf(path, sizeof(path), "/tmp/acelite_logcap_%ld.txt", (long)getpid());
+
+    // Redirect stderr (fd 2) to a file, log, then restore.
+    fflush(stderr);
+    int saved = dup(fileno(stderr));
+    FILE* f = fopen(path, "w+");
+    dup2(fileno(f), fileno(stderr));
+
+    // Values chosen so a wrong va_arg width is unmistakable: the long exceeds
+    // 32 bits, so reading it as int would corrupt it and everything after.
+    long big = 1234567890123L;          // > 2^32
+    ace_lite_log(LM_DEBUG, "a=%ld b=%s c=%lu d=%u e=%d\n",
+                 big, "mid", (unsigned long)42UL, (unsigned)7, -5);
+    fflush(stderr);
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+
+    rewind(f);
+    char buf[512];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    buf[n] = '\0';
+    fclose(f);
+    remove(path);
+
+    check(strcmp(buf, "a=1234567890123 b=mid c=42 d=7 e=-5\n") == 0,
+          "%ld/%s/%lu/%u/%d render correctly (no va_list desync)");
+    if (failures) printf("  got: %s", buf);
+
+    // %% and a bare trailing %P/%t still work without consuming args.
+    fflush(stderr);
+    saved = dup(fileno(stderr));
+    f = fopen(path, "w+");
+    dup2(fileno(f), fileno(stderr));
+    ace_lite_log(LM_DEBUG, "100%% done\n");
+    fflush(stderr);
+    dup2(saved, fileno(stderr));
+    close(saved);
+    rewind(f);
+    n = fread(buf, 1, sizeof(buf) - 1, f);
+    buf[n] = '\0';
+    fclose(f);
+    remove(path);
+    check(strcmp(buf, "100% done\n") == 0, "%% escapes to a literal percent");
+
+    printf("\nlog_fmt: %s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -81,6 +81,26 @@ public:
     int outputs_;
 };
 
+// Registered for READ *and* a timer.  Returns -1 on input (asks to retire);
+// its timer must be cancelled by the retire so handle_timeout never fires on a
+// handler the reactor has torn down (would be use-after-free once deleted).
+class IoTimerHandler : public ACE_Event_Handler {
+public:
+    IoTimerHandler(ACE_HANDLE fd) : fd_(fd), fires_(0) {}
+    virtual ACE_HANDLE get_handle() const { return fd_; }
+    virtual int handle_input(ACE_HANDLE) {
+        char b[16];
+        ssize_t n = ::read(fd_, b, sizeof(b));
+        (void)n;
+        return -1;                // EOF/retire me
+    }
+    virtual int handle_timeout(const ACE_Time_Value&, const void*) {
+        fires_++; return 0;
+    }
+    ACE_HANDLE fd_;
+    int fires_;
+};
+
 int main() {
     ACE_Reactor reactor;
 
@@ -218,6 +238,28 @@ int main() {
     check(1, "dispatch after a rejected null registration doesn't crash");
     close(sv4[0]);
     close(sv4[1]);
+
+    // --- retiring a handler cancels its still-pending timer ---
+    // A handler registered for both READ and a timer returns -1 on input.  The
+    // retire (remove + handle_close, which for a real Svc_Handler deletes it)
+    // must cancel the timer first, else expire_timers() -- which runs after the
+    // retire loop in handle_events() -- would fire handle_timeout() on freed
+    // memory.  Here the handler is stack-allocated, so a stale fire is visible
+    // as fires_ > 0 rather than a crash.
+    int sv5[2];
+    socketpair(AF_UNIX, SOCK_STREAM, 0, sv5);
+    IoTimerHandler iot(sv5[0]);
+    reactor.register_handler(sv5[0], &iot, ACE_Event_Handler::READ_MASK);
+    reactor.schedule_timer(&iot, 0, ACE_Time_Value(0, 30000));  // due in 30ms
+    close(sv5[1]);                                              // EOF -> retire
+    ACE_Time_Value w_iot(1, 0);
+    reactor.handle_events(&w_iot);     // dispatch EOF: handle_input -1 -> retire
+    usleep(50000);                     // past the 30ms timer
+    ACE_Time_Value w_iot2(0, 1000);
+    reactor.handle_events(&w_iot2);    // timer would fire here if not cancelled
+    check(iot.fires_ == 0,
+          "retiring a handler cancels its pending timer (no fire after handle_close)");
+    close(sv5[0]);
 
     printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
     return failures == 0 ? 0 : 1;

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -205,6 +205,20 @@ int main() {
     check(budget < ACE_Time_Value(0, 20000),
           "handle_events(ACE_Time_Value&) decrements the remaining-time budget");
 
+    // --- 3-arg register_handler rejects a null handler (no null in the table,
+    //     so the next dispatch on that fd can't deref null) ---
+    int sv4[2];
+    socketpair(AF_UNIX, SOCK_STREAM, 0, sv4);
+    check(reactor.register_handler(sv4[0], (ACE_Event_Handler*)0,
+                                   ACE_Event_Handler::READ_MASK) == -1,
+          "register_handler(fd, null, mask) is rejected");
+    write(sv4[1], "x", 1);
+    ACE_Time_Value w_nn(0, 1000);
+    reactor.handle_events(&w_nn);   // must not crash: no null was bound
+    check(1, "dispatch after a rejected null registration doesn't crash");
+    close(sv4[0]);
+    close(sv4[1]);
+
     printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
     return failures == 0 ? 0 : 1;
 }

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -1,0 +1,127 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/tests/reactor_loop.cc
+ * Standalone Phase-2 unit test for ACE_Reactor / ACE_Event_Handler.  Exercises
+ * exactly the reactor API AceDispatcher and comhandler use:
+ *   register_handler(fd, eh, READ_MASK), remove_handler(fd, RWE_MASK),
+ *   schedule_timer(eh, NULL, delay), cancel_timer(id), handle_events(&tv).
+ * Plus the -1 => retire+handle_close contract and reentrant handle_events.
+ * Build:
+ *   g++ -I src/include src/ACE-lite/{reactor,event_handler,sock}.c \
+ *       src/ACE-lite/tests/reactor_loop.cc
+ * Exit 0 = pass, 1 = fail.
+ */
+
+#include <ACE-lite/Reactor.h>
+#include <ACE-lite/Event_Handler.h>
+#include <ACE-lite/Time_Value.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int failures = 0;
+static void check(int cond, const char* what) {
+    printf("%s: %s\n", cond ? "ok  " : "FAIL", what);
+    if (!cond) failures++;
+}
+
+// A read handler that drains its fd and counts callbacks.  Returns -1 (retire)
+// on EOF, like a real socket handler.
+class ReadHandler : public ACE_Event_Handler {
+public:
+    ReadHandler(ACE_HANDLE fd) : fd_(fd), inputs_(0), closed_(0), total_(0) {}
+    virtual ACE_HANDLE get_handle() const { return fd_; }
+    virtual int handle_input(ACE_HANDLE) {
+        char buf[64];
+        ssize_t n = ::read(fd_, buf, sizeof(buf));
+        inputs_++;
+        if (n <= 0) return -1;   // EOF -> reactor retires us
+        total_ += n;
+        return 0;
+    }
+    virtual int handle_close(ACE_HANDLE, ACE_Reactor_Mask) { closed_++; return 0; }
+    ACE_HANDLE fd_;
+    int inputs_, closed_, total_;
+};
+
+// A timer handler that counts expirations; optionally re-enters handle_events.
+class TimerHandler : public ACE_Event_Handler {
+public:
+    TimerHandler() : fires_(0), reenter_(0), reactor_for_reentry_(0) {}
+    virtual int handle_timeout(const ACE_Time_Value&, const void*) {
+        fires_++;
+        if (reenter_ && reactor_for_reentry_) {
+            ACE_Time_Value zero(0, 0);
+            reactor_for_reentry_->handle_events(&zero);  // reentrancy probe
+        }
+        return 0;
+    }
+    int fires_, reenter_;
+    ACE_Reactor* reactor_for_reentry_;
+};
+
+int main() {
+    ACE_Reactor reactor;
+
+    // --- a connected fd pair to drive read events ---
+    int sv[2];
+    check(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0, "socketpair");
+    ReadHandler rh(sv[0]);
+
+    // 3-arg register (the AceDispatcher form).
+    check(reactor.register_handler(sv[0], &rh, ACE_Event_Handler::READ_MASK) == 0,
+          "register_handler(fd, eh, READ_MASK)");
+
+    // No data yet -> a short wait dispatches nothing.
+    ACE_Time_Value shortw(0, 1000);
+    check(reactor.handle_events(&shortw) == 0, "handle_events times out with no input");
+
+    // Write -> one input dispatched, payload delivered.
+    write(sv[1], "hello", 5);
+    ACE_Time_Value w1(1, 0);
+    int n = reactor.handle_events(&w1);
+    check(n == 1 && rh.inputs_ == 1 && rh.total_ == 5, "handle_events dispatches handle_input");
+
+    // Close peer -> EOF -> handler returns -1 -> retired + handle_close called.
+    close(sv[1]);
+    ACE_Time_Value w2(1, 0);
+    reactor.handle_events(&w2);
+    check(rh.closed_ == 1, "EOF: handle_input -1 => retire + handle_close");
+    // Now removed: a further wait dispatches nothing more for this fd.
+    ACE_Time_Value w3(0, 1000);
+    int after = reactor.handle_events(&w3);
+    check(after == 0, "retired handler no longer dispatched");
+    close(sv[0]);
+
+    // --- one-shot timer ---
+    TimerHandler th;
+    int id = reactor.schedule_timer(&th, 0, ACE_Time_Value(0, 20000));
+    check(id > 0, "schedule_timer returns id");
+    ACE_Time_Value w4(1, 0);
+    reactor.handle_events(&w4);
+    check(th.fires_ == 1, "one-shot timer fires once");
+    ACE_Time_Value w5(0, 30000);
+    reactor.handle_events(&w5);
+    check(th.fires_ == 1, "one-shot timer does not refire");
+
+    // --- cancel_timer before it fires ---
+    TimerHandler th2;
+    int id2 = reactor.schedule_timer(&th2, 0, ACE_Time_Value(0, 50000));
+    check(reactor.cancel_timer(id2) == 1, "cancel_timer(id) cancels pending timer");
+    ACE_Time_Value w6(0, 80000);
+    reactor.handle_events(&w6);
+    check(th2.fires_ == 0, "cancelled timer never fires");
+
+    // --- reentrant handle_events from within a timer callback ---
+    TimerHandler th3;
+    th3.reenter_ = 1;
+    th3.reactor_for_reentry_ = &reactor;
+    reactor.schedule_timer(&th3, 0, ACE_Time_Value(0, 10000));
+    ACE_Time_Value w7(1, 0);
+    reactor.handle_events(&w7);
+    check(th3.fires_ == 1, "reentrant handle_events inside a callback is safe");
+
+    printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -61,6 +61,23 @@ public:
     ACE_Reactor* reactor_for_reentry_;
 };
 
+// Registered for READ+WRITE; returns -1 on input (asks to retire).  Its
+// handle_output must NOT fire in the same cycle once it has retired.
+class RWHandler : public ACE_Event_Handler {
+public:
+    RWHandler(ACE_HANDLE fd) : fd_(fd), outputs_(0) {}
+    virtual ACE_HANDLE get_handle() const { return fd_; }
+    virtual int handle_input(ACE_HANDLE) {
+        char b[16];
+        ssize_t n = ::read(fd_, b, sizeof(b));
+        (void)n;
+        return -1;             // retire me
+    }
+    virtual int handle_output(ACE_HANDLE) { outputs_++; return 0; }
+    ACE_HANDLE fd_;
+    int outputs_;
+};
+
 int main() {
     ACE_Reactor reactor;
 
@@ -121,6 +138,24 @@ int main() {
     ACE_Time_Value w7(1, 0);
     reactor.handle_events(&w7);
     check(th3.fires_ == 1, "reentrant handle_events inside a callback is safe");
+
+    // --- a -1 from handle_input must exclude the fd from same-cycle output ---
+    int sv2[2];
+    socketpair(AF_UNIX, SOCK_STREAM, 0, sv2);
+    RWHandler rw(sv2[0]);
+    reactor.register_handler(sv2[0], &rw,
+                             ACE_Event_Handler::READ_MASK | ACE_Event_Handler::WRITE_MASK);
+    write(sv2[1], "x", 1);     // read-ready; the socket is also write-ready
+    ACE_Time_Value w8(1, 0);
+    reactor.handle_events(&w8);
+    check(rw.outputs_ == 0,
+          "handle_input -1 excludes the fd from handle_output in the same cycle");
+    // And it is fully retired: another turn produces no further output.
+    ACE_Time_Value w9(0, 1000);
+    reactor.handle_events(&w9);
+    check(rw.outputs_ == 0, "retired fd stays out of write dispatch");
+    close(sv2[0]);
+    close(sv2[1]);
 
     printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
     return failures == 0 ? 0 : 1;

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -197,6 +197,14 @@ int main() {
     reactor.handle_events(&w_ov);
     check(tov.fires_ == 1, "overdue timer fires (wait clamped, no select() EINVAL drop)");
 
+    // --- handle_events(ACE_Time_Value&) decrements the caller's budget ---
+    // (no fds/timers -> it waits the whole budget out, so the reference is
+    //  reduced toward zero; the pointer form leaves it untouched)
+    ACE_Time_Value budget(0, 20000);   // 20ms
+    reactor.handle_events(budget);
+    check(budget < ACE_Time_Value(0, 20000),
+          "handle_events(ACE_Time_Value&) decrements the remaining-time budget");
+
     printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
     return failures == 0 ? 0 : 1;
 }

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -14,7 +14,10 @@
 #include <ACE-lite/Reactor.h>
 #include <ACE-lite/Event_Handler.h>
 #include <ACE-lite/Time_Value.h>
+#include <ACE-lite/Test_and_Set.h>
+#include <ACE-lite/Synch.h>
 
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -156,6 +159,31 @@ int main() {
     check(rw.outputs_ == 0, "retired fd stays out of write dispatch");
     close(sv2[0]);
     close(sv2[1]);
+
+    // --- remove_handler(eh) by handler pointer (the drawlink form) ---
+    int sv3[2];
+    socketpair(AF_UNIX, SOCK_STREAM, 0, sv3);
+    ReadHandler rh2(sv3[0]);
+    reactor.register_handler(sv3[0], &rh2, ACE_Event_Handler::READ_MASK);
+    reactor.remove_handler(&rh2, ACE_Event_Handler::READ_MASK);  // by handler, not fd
+    write(sv3[1], "x", 1);
+    ACE_Time_Value w10(0, 1000);
+    reactor.handle_events(&w10);
+    check(rh2.inputs_ == 0, "remove_handler(eh) by pointer stops dispatch");
+    close(sv3[0]);
+    close(sv3[1]);
+
+    // --- ACE_Time_Value::zero ---
+    check(ACE_Time_Value::zero.sec() == 0 && ACE_Time_Value::zero.usec() == 0,
+          "ACE_Time_Value::zero is 0");
+
+    // --- signal handler: register an ACE_Test_and_Set, raise the signal,
+    //     verify handle_signal set the flag (the SIGINT quit pattern) ---
+    ACE_Test_and_Set<ACE_Null_Mutex, sig_atomic_t> quit;
+    check(quit.is_set() == 0, "Test_and_Set flag starts clear");
+    reactor.register_handler(SIGUSR1, &quit);
+    raise(SIGUSR1);
+    check(quit.is_set() == 1, "register_handler(signum) -> handle_signal sets the flag");
 
     printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
     return failures == 0 ? 0 : 1;

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -185,6 +185,18 @@ int main() {
     raise(SIGUSR1);
     check(quit.is_set() == 1, "register_handler(signum) -> handle_signal sets the flag");
 
+    // --- a timer already OVERDUE when handle_events runs must still fire ---
+    // Regression: an overdue timer yields wait = (sec=0, usec<0); a negative
+    // tv_usec makes select() return EINVAL, which dropped the timer before
+    // expire_timers() ran.  Schedule, then sleep well past the fire time so the
+    // wait is negative-but-within-a-second, then dispatch.
+    TimerHandler tov;
+    reactor.schedule_timer(&tov, 0, ACE_Time_Value(0, 5000));  // due in 5ms
+    usleep(30000);                                             // now ~25ms overdue
+    ACE_Time_Value w_ov(1, 0);
+    reactor.handle_events(&w_ov);
+    check(tov.fires_ == 1, "overdue timer fires (wait clamped, no select() EINVAL drop)");
+
     printf("\nreactor_loop: %s\n", failures == 0 ? "PASS" : "FAIL");
     return failures == 0 ? 0 : 1;
 }

--- a/src/ACE-lite/tests/sock_loopback.cc
+++ b/src/ACE-lite/tests/sock_loopback.cc
@@ -1,0 +1,91 @@
+/*
+ * ACE-lite (issue #147).  src/ACE-lite/tests/sock_loopback.cc
+ * Standalone Phase-1 unit test for the ACE-lite address/socket layer -- no
+ * reactor.  Binds a loopback acceptor on an OS-chosen port, connects to it,
+ * round-trips a message both directions, and checks get_remote_addr /
+ * addr_to_string / Time_Value arithmetic.  Build:
+ *   g++ -I src/include src/ACE-lite/sock.c src/ACE-lite/tests/sock_loopback.cc
+ * Exit 0 = pass, 1 = fail.
+ */
+
+#include <ACE-lite/INET_Addr.h>
+#include <ACE-lite/SOCK_Stream.h>
+#include <ACE-lite/SOCK_Connector.h>
+#include <ACE-lite/SOCK_Acceptor.h>
+#include <ACE-lite/Time_Value.h>
+
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+
+static int failures = 0;
+
+static void check(int cond, const char* what) {
+    printf("%s: %s\n", cond ? "ok  " : "FAIL", what);
+    if (!cond) failures++;
+}
+
+// Discover the port a wildcard-bound acceptor actually got.
+static u_short bound_port(ACE_HANDLE h) {
+    sockaddr_in sin;
+    socklen_t len = sizeof(sin);
+    if (getsockname(h, (sockaddr*)&sin, &len) == -1) return 0;
+    return ntohs(sin.sin_port);
+}
+
+int main() {
+    // --- Time_Value arithmetic (header-inline) ---
+    ACE_Time_Value a(2, 500000), b(1, 750000);
+    ACE_Time_Value d = a - b;
+    check(d.sec() == 0 && d.usec() == 750000, "ACE_Time_Value(2.5)-(1.75)==0.75");
+    check(a > b, "ACE_Time_Value(2.5) > (1.75)");
+    ACE_Time_Value carry(0, 1500000);
+    check(carry.sec() == 1 && carry.usec() == 500000, "ACE_Time_Value normalizes 1.5e6 usec");
+
+    // --- bring up a loopback acceptor on an OS-chosen port ---
+    ACE_SOCK_Acceptor acceptor;
+    check(acceptor.open(ACE_INET_Addr((u_short)0)) == 0, "ACE_SOCK_Acceptor::open(port 0)");
+    u_short port = bound_port(acceptor.get_handle());
+    check(port != 0, "acceptor bound a nonzero port");
+
+    // --- connect to it (kernel completes the handshake into the backlog) ---
+    ACE_SOCK_Connector connector;
+    ACE_SOCK_Stream client;
+    check(connector.connect(client, ACE_INET_Addr(port, "127.0.0.1")) == 0,
+          "ACE_SOCK_Connector::connect(127.0.0.1)");
+
+    ACE_SOCK_Stream server;
+    check(acceptor.accept(server) == 0, "ACE_SOCK_Acceptor::accept");
+
+    // --- client -> server ---
+    const char* msg = "hello ace-lite";
+    check(client.send(msg, strlen(msg)) == (ssize_t)strlen(msg), "client.send");
+    char buf[64];
+    ssize_t n = server.recv(buf, sizeof(buf) - 1);
+    if (n < 0) n = 0;
+    buf[n] = '\0';
+    check(n == (ssize_t)strlen(msg) && strcmp(buf, msg) == 0, "server.recv == sent");
+
+    // --- server -> client ---
+    const char* reply = "333";
+    check(server.send(reply, strlen(reply)) == (ssize_t)strlen(reply), "server.send");
+    n = client.recv(buf, sizeof(buf) - 1);
+    if (n < 0) n = 0;
+    buf[n] = '\0';
+    check(strcmp(buf, reply) == 0, "client.recv == reply");
+
+    // --- remote addr / addr_to_string ---
+    ACE_INET_Addr peer;
+    check(server.get_remote_addr(peer) == 0, "server.get_remote_addr");
+    char addrbuf[64];
+    check(peer.addr_to_string(addrbuf, sizeof(addrbuf)) == 0, "peer.addr_to_string");
+    check(strncmp(addrbuf, "127.0.0.1:", 10) == 0, "peer addr is 127.0.0.1:<port>");
+
+    client.close();
+    server.close();
+    acceptor.close();
+
+    printf("\nsock_loopback: %s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/src/include/ACE-lite/Acceptor.h
+++ b/src/include/ACE-lite/Acceptor.h
@@ -33,6 +33,7 @@ public:
             return -1;
         }
         if (r && r->register_handler(this, ACE_Event_Handler::READ_MASK) == -1) {
+            peer_acceptor_.close();   // don't leak the bound listen fd
             return -1;
         }
         return 0;

--- a/src/include/ACE-lite/Acceptor.h
+++ b/src/include/ACE-lite/Acceptor.h
@@ -23,9 +23,11 @@ public:
     ACE_Acceptor(ACE_Reactor* r = 0) : ACE_Event_Handler(r) {}
     virtual ~ACE_Acceptor() {}
 
-    // Open the listen socket on `local_addr' and register for READ on `r'.
+    // Open the listen socket on `local_addr' and register for READ on `r'
+    // (defaulting to the global reactor, as ACE does, so callers may omit it).
     // 0 on success, -1 on failure.
-    int open(const ACE_INET_Addr& local_addr, ACE_Reactor* r) {
+    int open(const ACE_INET_Addr& local_addr,
+             ACE_Reactor* r = ACE_Reactor::instance()) {
         this->reactor(r);
         if (peer_acceptor_.open(local_addr) == -1) {
             return -1;

--- a/src/include/ACE-lite/Acceptor.h
+++ b/src/include/ACE-lite/Acceptor.h
@@ -1,0 +1,59 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Acceptor.h
+ * ACE_Acceptor<HANDLER, PEER_ACCEPTOR> -- the accept-and-spawn template.  It is
+ * itself an ACE_Event_Handler registered on the listen fd; when the fd is
+ * readable it accept()s a connection, makes a HANDLER, hands it the new peer
+ * stream, and calls handler->open() -- the core thing the base Dispatcher could
+ * not do by itself.
+ *
+ * ivtools spells it: typedef ACE_Acceptor<ComterpHandler, ACE_SOCK_ACCEPTOR>
+ * ComterpAcceptor;  with open(addr, reactor) in main.c.
+ */
+
+#ifndef _acelite_Acceptor_h
+#define _acelite_Acceptor_h
+
+#include <ACE-lite/Event_Handler.h>
+#include <ACE-lite/Reactor.h>
+#include <ACE-lite/INET_Addr.h>
+
+template <class HANDLER, class PEER_ACCEPTOR>
+class ACE_Acceptor : public ACE_Event_Handler {
+public:
+    ACE_Acceptor(ACE_Reactor* r = 0) : ACE_Event_Handler(r) {}
+    virtual ~ACE_Acceptor() {}
+
+    // Open the listen socket on `local_addr' and register for READ on `r'.
+    // 0 on success, -1 on failure.
+    int open(const ACE_INET_Addr& local_addr, ACE_Reactor* r) {
+        this->reactor(r);
+        if (peer_acceptor_.open(local_addr) == -1) {
+            return -1;
+        }
+        if (r && r->register_handler(this, ACE_Event_Handler::READ_MASK) == -1) {
+            return -1;
+        }
+        return 0;
+    }
+
+    virtual ACE_HANDLE get_handle() const { return peer_acceptor_.get_handle(); }
+
+    // Listen fd is readable: accept and spawn a handler for the new connection.
+    virtual int handle_input(ACE_HANDLE) {
+        HANDLER* handler = new HANDLER;
+        if (peer_acceptor_.accept(handler->peer()) == -1) {
+            delete handler;
+            return 0;  // transient accept failure; keep listening
+        }
+        handler->reactor(this->reactor());
+        if (handler->open((void*)this) == -1) {
+            handler->close(0);
+        }
+        return 0;  // keep the acceptor registered
+    }
+
+protected:
+    PEER_ACCEPTOR peer_acceptor_;
+};
+
+#endif /* _acelite_Acceptor_h */

--- a/src/include/ACE-lite/Event_Handler.h
+++ b/src/include/ACE-lite/Event_Handler.h
@@ -48,6 +48,9 @@ public:
     // Called by the reactor when the handler is removed.
     virtual int handle_close(ACE_HANDLE fd = ACE_INVALID_HANDLE,
                              ACE_Reactor_Mask mask = ALL_EVENTS_MASK);
+    // Called from the signal trampoline when a registered signal fires
+    // (ivtools registers the SIGINT quit flag this way).  Keep it async-safe.
+    virtual int handle_signal(int signum, void* = 0, void* = 0);
 
     ACE_Reactor* reactor() const { return reactor_; }
     void reactor(ACE_Reactor* r) { reactor_ = r; }

--- a/src/include/ACE-lite/Event_Handler.h
+++ b/src/include/ACE-lite/Event_Handler.h
@@ -1,0 +1,61 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Event_Handler.h
+ * ACE_Event_Handler -- the base class registered with ACE_Reactor.  ivtools'
+ * ACE_IO_Handler (the InterViews IOHandler adapter) and, later, ACE_Svc_Handler
+ * derive from it.  Only the slice ivtools uses is declared.
+ */
+
+#ifndef _acelite_Event_Handler_h
+#define _acelite_Event_Handler_h
+
+#include <ACE-lite/OS.h>
+#include <ACE-lite/Time_Value.h>
+
+typedef unsigned long ACE_Reactor_Mask;
+
+class ACE_Reactor;
+
+class ACE_Event_Handler {
+public:
+    // Event masks (the bit values are private to ACE-lite; consumers use the
+    // names, e.g. ACE_Event_Handler::READ_MASK).
+    enum {
+        NULL_MASK   = 0,
+        READ_MASK   = (1 << 0),
+        WRITE_MASK  = (1 << 1),
+        EXCEPT_MASK = (1 << 2),
+        TIMER_MASK  = (1 << 3),
+        RWE_MASK    = READ_MASK | WRITE_MASK | EXCEPT_MASK,
+        ALL_EVENTS_MASK = RWE_MASK | TIMER_MASK,
+        DONT_CALL   = (1 << 4)
+    };
+
+    virtual ~ACE_Event_Handler();
+
+    // The fd this handler services; ACE_INVALID_HANDLE unless overridden
+    // (ACE_Svc_Handler / the acceptor return their socket).
+    virtual ACE_HANDLE get_handle() const;
+    virtual void set_handle(ACE_HANDLE);
+
+    // Demultiplexing hooks.  Return -1 to have the reactor remove (and close)
+    // this handler, 0 to keep it.
+    virtual int handle_input(ACE_HANDLE fd = ACE_INVALID_HANDLE);
+    virtual int handle_output(ACE_HANDLE fd = ACE_INVALID_HANDLE);
+    virtual int handle_exception(ACE_HANDLE fd = ACE_INVALID_HANDLE);
+    // Return -1 to cancel a (one-shot already-fired) timer's handler.
+    virtual int handle_timeout(const ACE_Time_Value& current_time,
+                               const void* act = 0);
+    // Called by the reactor when the handler is removed.
+    virtual int handle_close(ACE_HANDLE fd = ACE_INVALID_HANDLE,
+                             ACE_Reactor_Mask mask = ALL_EVENTS_MASK);
+
+    ACE_Reactor* reactor() const { return reactor_; }
+    void reactor(ACE_Reactor* r) { reactor_ = r; }
+
+protected:
+    ACE_Event_Handler(ACE_Reactor* r = 0) : reactor_(r) {}
+
+    ACE_Reactor* reactor_;
+};
+
+#endif /* _acelite_Event_Handler_h */

--- a/src/include/ACE-lite/INET_Addr.h
+++ b/src/include/ACE-lite/INET_Addr.h
@@ -1,0 +1,41 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/INET_Addr.h
+ * ACE_INET_Addr -- an IPv4 host/port address wrapping sockaddr_in, the subset
+ * of ACE's class the socket classes and consumer code use.
+ */
+
+#ifndef _acelite_INET_Addr_h
+#define _acelite_INET_Addr_h
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+class ACE_INET_Addr {
+public:
+    ACE_INET_Addr();
+    // Wildcard local address on `port' (INADDR_ANY), for binding a listener.
+    ACE_INET_Addr(u_short port);
+    // `port' on `host' (name or dotted-quad), for connecting.
+    ACE_INET_Addr(u_short port, const char* host);
+
+    int set(u_short port, const char* host);
+
+    // Reverse-resolved host name (falls back to dotted-quad on failure).
+    const char* get_host_name() const;
+    // "host:port" into `buffer'; returns 0 on success, -1 if truncated.
+    int addr_to_string(char* buffer, size_t size) const;
+
+    u_short get_port_number() const;
+
+    // Raw access for the socket classes (bind/connect/accept).
+    sockaddr* get_addr() const { return (sockaddr*)&inet_addr_; }
+    int get_size() const { return sizeof(inet_addr_); }
+    void set_addr(const sockaddr_in& sin) { inet_addr_ = sin; }
+
+private:
+    sockaddr_in inet_addr_;
+    mutable char host_name_[256];
+};
+
+#endif /* _acelite_INET_Addr_h */

--- a/src/include/ACE-lite/Log_Msg.h
+++ b/src/include/ACE-lite/Log_Msg.h
@@ -1,0 +1,32 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Log_Msg.h
+ * The ACE_DEBUG / ACE_ERROR / ACE_ERROR_RETURN / ACE_ASSERT logging macros the
+ * consumer code uses, routed to a small stderr logger that understands the few
+ * ACE format directives ivtools actually passes (%P pid, %t thread, %p errno).
+ *
+ * Usage matches ACE: ACE_DEBUG((LM_DEBUG, "fmt", args...)); the doubled parens
+ * make the (severity, fmt, ...) list a single macro argument.
+ */
+
+#ifndef _acelite_Log_Msg_h
+#define _acelite_Log_Msg_h
+
+#include <assert.h>
+
+// Severity tokens (values unused; only their presence as the first arg matters).
+enum {
+    LM_DEBUG   = 1,
+    LM_INFO    = 2,
+    LM_WARNING = 4,
+    LM_ERROR   = 8
+};
+
+// Formatted log to stderr; handles ACE's %P/%t/%p plus standard printf escapes.
+void ace_lite_log(int severity, const char* format, ...);
+
+#define ACE_DEBUG(X)            ::ace_lite_log X
+#define ACE_ERROR(X)            ::ace_lite_log X
+#define ACE_ERROR_RETURN(X, R)  do { ::ace_lite_log X; return R; } while (0)
+#define ACE_ASSERT(C)           assert(C)
+
+#endif /* _acelite_Log_Msg_h */

--- a/src/include/ACE-lite/OS.h
+++ b/src/include/ACE-lite/OS.h
@@ -8,8 +8,14 @@
 #ifndef _acelite_OS_h
 #define _acelite_OS_h
 
+// Like ace/OS.h, centralize the common OS/portability headers so consumer
+// source that leaned on ACE pulling these in transitively still compiles.
 #include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 // A handle is a POSIX file descriptor.
 typedef int ACE_HANDLE;
@@ -23,5 +29,21 @@ typedef int ACE_HANDLE;
 #ifndef ACE_NONBLOCK
 #define ACE_NONBLOCK O_NONBLOCK
 #endif
+
+// Default host/port the consumer code falls back to (matches ACE's values).
+#ifndef ACE_DEFAULT_SERVER_HOST
+#define ACE_DEFAULT_SERVER_HOST "localhost"
+#endif
+#ifndef ACE_DEFAULT_SERVER_PORT_STR
+#define ACE_DEFAULT_SERVER_PORT_STR "10002"
+#endif
+
+// The slice of ACE_OS ivtools calls (comhandler/aceimport: strncpy; main: atoi).
+namespace ACE_OS {
+    inline char* strncpy(char* dst, const char* src, size_t n) {
+        return ::strncpy(dst, src, n);
+    }
+    inline int atoi(const char* s) { return ::atoi(s); }
+}
 
 #endif /* _acelite_OS_h */

--- a/src/include/ACE-lite/OS.h
+++ b/src/include/ACE-lite/OS.h
@@ -1,0 +1,27 @@
+/*
+ * ACE-lite -- a small, name-compatible in-tree subset of ACE (issue #147).
+ * src/include/ACE-lite/OS.h -- base types and OS-handle definitions shared by
+ * the ACE-lite headers.  Declares the same ACE_* names the consumer code uses,
+ * so source compiles unchanged against either backend (selected by EXTERN_ACE).
+ */
+
+#ifndef _acelite_OS_h
+#define _acelite_OS_h
+
+#include <fcntl.h>
+#include <sys/types.h>
+
+// A handle is a POSIX file descriptor.
+typedef int ACE_HANDLE;
+
+// The invalid-handle sentinel (matches ACE).
+#ifndef ACE_INVALID_HANDLE
+#define ACE_INVALID_HANDLE (-1)
+#endif
+
+// Bit set passed to ACE_SOCK_Stream::enable(); only non-blocking is used.
+#ifndef ACE_NONBLOCK
+#define ACE_NONBLOCK O_NONBLOCK
+#endif
+
+#endif /* _acelite_OS_h */

--- a/src/include/ACE-lite/Reactor.h
+++ b/src/include/ACE-lite/Reactor.h
@@ -17,6 +17,7 @@
 #include <ACE-lite/OS.h>
 #include <ACE-lite/Event_Handler.h>
 #include <ACE-lite/Time_Value.h>
+#include <ACE-lite/Log_Msg.h>   // ACE_DEBUG/ACE_ERROR arrive transitively, as in ACE
 #include <map>
 #include <vector>
 

--- a/src/include/ACE-lite/Reactor.h
+++ b/src/include/ACE-lite/Reactor.h
@@ -1,0 +1,75 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Reactor.h
+ * ACE_Reactor -- a self-contained select()-based event demultiplexer, the
+ * drop-in for libACE's reactor.  It sits in the exact same slot: AceDispatcher
+ * forwards the InterViews Dispatcher's attach/dispatch into it, and socket
+ * handlers (ComterpHandler) register with it directly, so GUI and socket fds
+ * are serviced by one select loop -- as ivtools has always spliced them.
+ *
+ * Only the API ivtools calls is provided (see AceDispatcher and comhandler):
+ * register_handler / remove_handler / schedule_timer / cancel_timer /
+ * handle_events.
+ */
+
+#ifndef _acelite_Reactor_h
+#define _acelite_Reactor_h
+
+#include <ACE-lite/OS.h>
+#include <ACE-lite/Event_Handler.h>
+#include <ACE-lite/Time_Value.h>
+#include <map>
+#include <vector>
+
+class ACE_Reactor {
+public:
+    ACE_Reactor();
+    ~ACE_Reactor();
+
+    // Register `eh' for `mask' events.  The first form uses eh->get_handle().
+    int register_handler(ACE_Event_Handler* eh, ACE_Reactor_Mask mask);
+    int register_handler(ACE_HANDLE handle, ACE_Event_Handler* eh,
+                         ACE_Reactor_Mask mask);
+
+    // Stop dispatching `handle' for the events in `mask'.
+    int remove_handler(ACE_HANDLE handle, ACE_Reactor_Mask mask);
+
+    // Schedule `eh' to fire handle_timeout after `delay' (and every `interval'
+    // thereafter, if nonzero).  Returns a timer id (>=0), or -1 on failure.
+    int schedule_timer(ACE_Event_Handler* eh, const void* arg,
+                       const ACE_Time_Value& delay,
+                       const ACE_Time_Value& interval = ACE_Time_Value());
+    // Cancel by timer id, or every timer of a handler.  Returns # cancelled.
+    int cancel_timer(int timer_id, const void** arg = 0);
+    int cancel_timer(ACE_Event_Handler* eh);
+
+    // Wait once for and dispatch ready events / expired timers.  Blocks until
+    // something happens (or `max_wait_time', if given, elapses).  Returns the
+    // number of handlers dispatched, 0 on timeout, -1 on error.
+    int handle_events();
+    int handle_events(ACE_Time_Value* max_wait_time);
+    int handle_events(ACE_Time_Value& max_wait_time);
+
+private:
+    struct Timer {
+        int id;
+        ACE_Event_Handler* eh;
+        const void* arg;
+        ACE_Time_Value expire;    // absolute fire time
+        ACE_Time_Value interval;  // 0 => one-shot
+    };
+
+    void bind(ACE_HANDLE, ACE_Event_Handler*, ACE_Reactor_Mask);
+    // Remove from all masks and call handle_close (the -1/EOF retirement path).
+    void retire(ACE_HANDLE, ACE_Reactor_Mask mask);
+    // Soonest timer expiry into `tv'; returns false if no timers pending.
+    bool earliest_timer(ACE_Time_Value& tv) const;
+    int expire_timers();
+
+    std::map<ACE_HANDLE, ACE_Event_Handler*> read_;
+    std::map<ACE_HANDLE, ACE_Event_Handler*> write_;
+    std::map<ACE_HANDLE, ACE_Event_Handler*> except_;
+    std::vector<Timer> timers_;
+    int next_timer_id_;
+};
+
+#endif /* _acelite_Reactor_h */

--- a/src/include/ACE-lite/Reactor.h
+++ b/src/include/ACE-lite/Reactor.h
@@ -18,6 +18,8 @@
 #include <ACE-lite/Event_Handler.h>
 #include <ACE-lite/Time_Value.h>
 #include <ACE-lite/Log_Msg.h>   // ACE_DEBUG/ACE_ERROR arrive transitively, as in ACE
+#include <ACE-lite/Singleton.h>
+#include <ACE-lite/Synch.h>
 #include <map>
 #include <vector>
 
@@ -56,6 +58,12 @@ public:
     int handle_events(ACE_Time_Value* max_wait_time);
     int handle_events(ACE_Time_Value& max_wait_time);
 
+    // The global reactor singleton (ACE's ACE_Reactor::instance()).  Same object
+    // ivtools reaches via ComterpHandler::reactor_singleton(), so the default
+    // reactor used by ACE_Acceptor::open() and the one the event loop drives are
+    // one and the same.
+    static ACE_Reactor* instance();
+
 private:
     struct Timer {
         int id;
@@ -78,5 +86,14 @@ private:
     std::vector<Timer> timers_;
     int next_timer_id_;
 };
+
+// Defined inline (not in libACE-lite) so each consumer that needs the default
+// reactor -- e.g. ACE_Acceptor::open()'s default arg -- emits its own copy and
+// needs no exported symbol, exactly as ComterpHandler::reactor_singleton()'s
+// REACTOR::instance() does.  Both resolve to the one ACE_Singleton<ACE_Reactor>,
+// so the default reactor and the reactor the loop drives are the same object.
+inline ACE_Reactor* ACE_Reactor::instance() {
+    return ACE_Singleton<ACE_Reactor, ACE_Null_Mutex>::instance();
+}
 
 #endif /* _acelite_Reactor_h */

--- a/src/include/ACE-lite/Reactor.h
+++ b/src/include/ACE-lite/Reactor.h
@@ -31,8 +31,14 @@ public:
     int register_handler(ACE_HANDLE handle, ACE_Event_Handler* eh,
                          ACE_Reactor_Mask mask);
 
-    // Stop dispatching `handle' for the events in `mask'.
+    // Stop dispatching `handle' (or `eh' by its get_handle()) for `mask' events.
     int remove_handler(ACE_HANDLE handle, ACE_Reactor_Mask mask);
+    int remove_handler(ACE_Event_Handler* eh, ACE_Reactor_Mask mask);
+
+    // Install `new_sh' as the handler for signal `signum' (its handle_signal is
+    // invoked from the signal trampoline).  ivtools registers the SIGINT quit
+    // flag this way.  0 on success, -1 on failure.
+    int register_handler(int signum, ACE_Event_Handler* new_sh);
 
     // Schedule `eh' to fire handle_timeout after `delay' (and every `interval'
     // thereafter, if nonzero).  Returns a timer id (>=0), or -1 on failure.

--- a/src/include/ACE-lite/SOCK_Acceptor.h
+++ b/src/include/ACE-lite/SOCK_Acceptor.h
@@ -1,0 +1,40 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/SOCK_Acceptor.h
+ * ACE_SOCK_Acceptor -- the low-level passive socket: socket()/bind()/listen()
+ * and accept() of a new connection into an ACE_SOCK_Stream.  (The higher-level
+ * ACE_Acceptor<Handler> accept-and-spawn template is built on this later.)
+ */
+
+#ifndef _acelite_SOCK_Acceptor_h
+#define _acelite_SOCK_Acceptor_h
+
+#include <ACE-lite/OS.h>
+#include <ACE-lite/SOCK_Stream.h>
+#include <ACE-lite/INET_Addr.h>
+
+class ACE_SOCK_Acceptor {
+public:
+    ACE_SOCK_Acceptor() : handle_(ACE_INVALID_HANDLE) {}
+    ACE_SOCK_Acceptor(const ACE_INET_Addr& local_addr, int reuse_addr = 1)
+        : handle_(ACE_INVALID_HANDLE) { open(local_addr, reuse_addr); }
+
+    // socket()/bind()/listen() on `local_addr'; 0 on success, -1 on failure.
+    int open(const ACE_INET_Addr& local_addr, int reuse_addr = 1);
+
+    // accept() a pending connection into `new_stream'; fill `remote_addr' if
+    // non-null.  0 on success, -1 on failure.
+    int accept(ACE_SOCK_Stream& new_stream, ACE_INET_Addr* remote_addr = 0) const;
+
+    ACE_HANDLE get_handle() const { return handle_; }
+    int close();
+
+private:
+    ACE_HANDLE handle_;
+};
+
+// ACE spells the acceptor template argument this way.
+#ifndef ACE_SOCK_ACCEPTOR
+#define ACE_SOCK_ACCEPTOR ACE_SOCK_Acceptor
+#endif
+
+#endif /* _acelite_SOCK_Acceptor_h */

--- a/src/include/ACE-lite/SOCK_Connector.h
+++ b/src/include/ACE-lite/SOCK_Connector.h
@@ -1,0 +1,21 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/SOCK_Connector.h
+ * ACE_SOCK_Connector -- actively opens a TCP connection (socket()+connect())
+ * and hands the connected fd to an ACE_SOCK_Stream.
+ */
+
+#ifndef _acelite_SOCK_Connector_h
+#define _acelite_SOCK_Connector_h
+
+#include <ACE-lite/SOCK_Stream.h>
+#include <ACE-lite/INET_Addr.h>
+
+class ACE_SOCK_Connector {
+public:
+    ACE_SOCK_Connector() {}
+
+    // Connect `stream' to `remote_addr'; 0 on success, -1 on failure.
+    int connect(ACE_SOCK_Stream& stream, const ACE_INET_Addr& remote_addr);
+};
+
+#endif /* _acelite_SOCK_Connector_h */

--- a/src/include/ACE-lite/SOCK_Stream.h
+++ b/src/include/ACE-lite/SOCK_Stream.h
@@ -1,0 +1,42 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/SOCK_Stream.h
+ * ACE_SOCK_Stream -- a connected-TCP file-descriptor wrapper.  The consumer
+ * code mostly reads/writes the raw get_handle(), but recv/send/close/enable/
+ * get_remote_addr are provided to match ACE.
+ */
+
+#ifndef _acelite_SOCK_Stream_h
+#define _acelite_SOCK_Stream_h
+
+#include <ACE-lite/OS.h>
+#include <ACE-lite/INET_Addr.h>
+#include <stddef.h>
+
+class ACE_SOCK_Stream {
+public:
+    ACE_SOCK_Stream() : handle_(ACE_INVALID_HANDLE) {}
+    ACE_SOCK_Stream(ACE_HANDLE h) : handle_(h) {}
+
+    ACE_HANDLE get_handle() const { return handle_; }
+    void set_handle(ACE_HANDLE h) { handle_ = h; }
+
+    ssize_t recv(void* buf, size_t n) const;
+    ssize_t send(const void* buf, size_t n) const;
+
+    // Apply a flag to the fd (only ACE_NONBLOCK is used); 0 ok, -1 on error.
+    int enable(int value) const;
+
+    int get_remote_addr(ACE_INET_Addr& addr) const;
+
+    int close();
+
+private:
+    ACE_HANDLE handle_;
+};
+
+// ACE spells the peer-stream template argument this way.
+#ifndef ACE_SOCK_STREAM
+#define ACE_SOCK_STREAM ACE_SOCK_Stream
+#endif
+
+#endif /* _acelite_SOCK_Stream_h */

--- a/src/include/ACE-lite/Singleton.h
+++ b/src/include/ACE-lite/Singleton.h
@@ -1,0 +1,20 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Singleton.h
+ * ACE_Singleton<TYPE, LOCK> -- one shared instance of TYPE, reached via
+ * instance().  The LOCK parameter is accepted for signature compatibility and
+ * ignored (single-threaded build).
+ */
+
+#ifndef _acelite_Singleton_h
+#define _acelite_Singleton_h
+
+template <class TYPE, class ACE_LOCK>
+class ACE_Singleton {
+public:
+    static TYPE* instance() {
+        static TYPE instance_;
+        return &instance_;
+    }
+};
+
+#endif /* _acelite_Singleton_h */

--- a/src/include/ACE-lite/Svc_Handler.h
+++ b/src/include/ACE-lite/Svc_Handler.h
@@ -1,0 +1,62 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Svc_Handler.h
+ * ACE_Svc_Handler<PEER_STREAM, SYNCH> -- the per-connection handler base that
+ * ivtools' ComterpHandler and UnidrawImportHandler derive from.  It is an
+ * ACE_Event_Handler holding a connected peer stream; the reactor dispatches its
+ * handle_input, and on removal routes handle_close -> close() -> destroy()
+ * (the lifecycle ComterpHandler overrides).
+ */
+
+#ifndef _acelite_Svc_Handler_h
+#define _acelite_Svc_Handler_h
+
+#include <ACE-lite/Event_Handler.h>
+#include <ACE-lite/Reactor.h>
+#include <ACE-lite/Synch.h>
+#include <sys/types.h>
+
+template <class PEER_STREAM, class SYNCH_STRATEGY>
+class ACE_Svc_Handler : public ACE_Event_Handler {
+public:
+    // ACE's signature is (thread_manager, message_queue, reactor); ivtools only
+    // ever passes the reactor (or nothing).  The first two are accepted and
+    // ignored.  Serves as the default ctor too.
+    ACE_Svc_Handler(void* = 0, void* = 0, ACE_Reactor* r = 0)
+        : ACE_Event_Handler(r) {}
+    virtual ~ACE_Svc_Handler() {}
+
+    // The connected socket.
+    PEER_STREAM& peer() { return peer_; }
+
+    virtual ACE_HANDLE get_handle() const { return peer_.get_handle(); }
+    virtual void set_handle(ACE_HANDLE h) { peer_.set_handle(h); }
+
+    // Hooks subclasses override.
+    virtual int open(void* = 0) { return 0; }
+    virtual int close(u_long /*flags*/ = 0) { this->destroy(); return 0; }
+
+    // ACE_Svc_Handler::destroy: unregister and delete.  ComterpHandler overrides
+    // this with its own teardown (and deliberately does not delete itself), so
+    // for it this default is not used.
+    virtual void destroy() {
+        if (this->reactor()) {
+            this->reactor()->remove_handler(
+                this->get_handle(),
+                ACE_Event_Handler::RWE_MASK | ACE_Event_Handler::DONT_CALL);
+        }
+        delete this;
+    }
+
+    // The reactor calls this when retiring the handler (e.g. handle_input
+    // returned -1); route it to the close()/destroy() lifecycle.
+    virtual int handle_close(ACE_HANDLE = ACE_INVALID_HANDLE,
+                             ACE_Reactor_Mask mask =
+                                 ACE_Event_Handler::ALL_EVENTS_MASK) {
+        return this->close((u_long)mask);
+    }
+
+protected:
+    PEER_STREAM peer_;
+};
+
+#endif /* _acelite_Svc_Handler_h */

--- a/src/include/ACE-lite/Svc_Handler.h
+++ b/src/include/ACE-lite/Svc_Handler.h
@@ -44,6 +44,12 @@ public:
                 this->get_handle(),
                 ACE_Event_Handler::RWE_MASK | ACE_Event_Handler::DONT_CALL);
         }
+        // Close the connected socket fd: ACE_SOCK_Stream has no closing
+        // destructor, so without this the accepted fd leaks when the reactor
+        // retires a handler (handle_close -> close -> destroy -> delete this).
+        // After remove_handler so get_handle() above is still valid, and here
+        // (not in close()) so a direct destroy() is covered too.
+        peer_.close();
         delete this;
     }
 

--- a/src/include/ACE-lite/Synch.h
+++ b/src/include/ACE-lite/Synch.h
@@ -1,0 +1,27 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Synch.h
+ * ACE_Null_Mutex / ACE_NULL_SYNCH -- the no-op synchronization used as template
+ * parameters in ivtools' single-threaded reactor world.
+ */
+
+#ifndef _acelite_Synch_h
+#define _acelite_Synch_h
+
+// A mutex that does nothing (single-threaded build).
+class ACE_Null_Mutex {
+public:
+    ACE_Null_Mutex() {}
+    int acquire() { return 0; }
+    int release() { return 0; }
+    int tryacquire() { return 0; }
+    int remove() { return 0; }
+};
+
+// The null synchronization-strategy tag used by ACE_Svc_Handler<PEER, SYNCH>.
+class ACE_Null_Synch {};
+
+#ifndef ACE_NULL_SYNCH
+#define ACE_NULL_SYNCH ACE_Null_Synch
+#endif
+
+#endif /* _acelite_Synch_h */

--- a/src/include/ACE-lite/Test_and_Set.h
+++ b/src/include/ACE-lite/Test_and_Set.h
@@ -1,0 +1,23 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Test_and_Set.h
+ * ACE_Test_and_Set<LOCK, TYPE> -- holds a flag toggled by a signal and tested
+ * by the event loop.  ivtools uses it (via ACE_Singleton) as the SIGINT quit
+ * flag: COMTERP_QUIT_HANDLER::instance()->is_set().
+ */
+
+#ifndef _acelite_Test_and_Set_h
+#define _acelite_Test_and_Set_h
+
+template <class ACE_LOCK, class TYPE>
+class ACE_Test_and_Set {
+public:
+    ACE_Test_and_Set() : is_set_(0) {}
+
+    TYPE is_set() const { return is_set_; }
+    void is_set(TYPE value) { is_set_ = value; }
+
+private:
+    TYPE is_set_;
+};
+
+#endif /* _acelite_Test_and_Set_h */

--- a/src/include/ACE-lite/Test_and_Set.h
+++ b/src/include/ACE-lite/Test_and_Set.h
@@ -8,13 +8,20 @@
 #ifndef _acelite_Test_and_Set_h
 #define _acelite_Test_and_Set_h
 
+#include <ACE-lite/Event_Handler.h>
+
+// An event handler whose handle_signal sets a flag the event loop polls.
+// Registered for SIGINT via ACE_Reactor::register_handler(signum, handler),
+// so ^C makes COMTERP_QUIT_HANDLER::instance()->is_set() return true.
 template <class ACE_LOCK, class TYPE>
-class ACE_Test_and_Set {
+class ACE_Test_and_Set : public ACE_Event_Handler {
 public:
     ACE_Test_and_Set() : is_set_(0) {}
 
     TYPE is_set() const { return is_set_; }
     void is_set(TYPE value) { is_set_ = value; }
+
+    virtual int handle_signal(int, void* = 0, void* = 0) { is_set_ = 1; return 0; }
 
 private:
     TYPE is_set_;

--- a/src/include/ACE-lite/Time_Value.h
+++ b/src/include/ACE-lite/Time_Value.h
@@ -1,0 +1,101 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/Time_Value.h
+ * ACE_Time_Value -- a normalized (sec, usec) duration/instant, the subset of
+ * ACE's class the consumer code and AceDispatcher use.
+ */
+
+#ifndef _acelite_Time_Value_h
+#define _acelite_Time_Value_h
+
+#include <sys/time.h>
+
+#define ACE_ONE_SECOND_IN_USECS 1000000L
+
+class ACE_Time_Value {
+public:
+    ACE_Time_Value() { set(0, 0); }
+    ACE_Time_Value(long sec, long usec = 0) { set(sec, usec); }
+    ACE_Time_Value(const timeval& tv) { set(tv.tv_sec, tv.tv_usec); }
+
+    void set(long sec, long usec) {
+        tv_.tv_sec = sec;
+        tv_.tv_usec = usec;
+        normalize();
+    }
+
+    long sec() const { return tv_.tv_sec; }
+    void sec(long s) { tv_.tv_sec = s; }
+    long usec() const { return tv_.tv_usec; }
+    void usec(long us) { tv_.tv_usec = us; }
+
+    // Fill a timeval (e.g. for select()).
+    operator timeval() const { return tv_; }
+    const timeval* operator()() const { return &tv_; }
+
+    ACE_Time_Value& operator-=(const ACE_Time_Value& rhs) {
+        tv_.tv_sec -= rhs.tv_.tv_sec;
+        tv_.tv_usec -= rhs.tv_.tv_usec;
+        normalize();
+        return *this;
+    }
+    ACE_Time_Value& operator+=(const ACE_Time_Value& rhs) {
+        tv_.tv_sec += rhs.tv_.tv_sec;
+        tv_.tv_usec += rhs.tv_.tv_usec;
+        normalize();
+        return *this;
+    }
+
+private:
+    // Carry usec into the [0, 1e6) range, like ACE_Time_Value::normalize().
+    void normalize() {
+        if (tv_.tv_usec >= ACE_ONE_SECOND_IN_USECS) {
+            do {
+                tv_.tv_sec++;
+                tv_.tv_usec -= ACE_ONE_SECOND_IN_USECS;
+            } while (tv_.tv_usec >= ACE_ONE_SECOND_IN_USECS);
+        } else if (tv_.tv_usec <= -ACE_ONE_SECOND_IN_USECS) {
+            do {
+                tv_.tv_sec--;
+                tv_.tv_usec += ACE_ONE_SECOND_IN_USECS;
+            } while (tv_.tv_usec <= -ACE_ONE_SECOND_IN_USECS);
+        }
+        if (tv_.tv_sec >= 1 && tv_.tv_usec < 0) {
+            tv_.tv_sec--;
+            tv_.tv_usec += ACE_ONE_SECOND_IN_USECS;
+        } else if (tv_.tv_sec < 0 && tv_.tv_usec > 0) {
+            tv_.tv_sec++;
+            tv_.tv_usec -= ACE_ONE_SECOND_IN_USECS;
+        }
+    }
+
+    timeval tv_;
+
+    friend ACE_Time_Value operator-(const ACE_Time_Value&, const ACE_Time_Value&);
+    friend ACE_Time_Value operator+(const ACE_Time_Value&, const ACE_Time_Value&);
+    friend int operator>(const ACE_Time_Value&, const ACE_Time_Value&);
+    friend int operator<(const ACE_Time_Value&, const ACE_Time_Value&);
+    friend int operator==(const ACE_Time_Value&, const ACE_Time_Value&);
+};
+
+inline ACE_Time_Value operator-(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    ACE_Time_Value r(a);
+    r -= b;
+    return r;
+}
+inline ACE_Time_Value operator+(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    ACE_Time_Value r(a);
+    r += b;
+    return r;
+}
+inline int operator>(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    return a.tv_.tv_sec > b.tv_.tv_sec ||
+        (a.tv_.tv_sec == b.tv_.tv_sec && a.tv_.tv_usec > b.tv_.tv_usec);
+}
+inline int operator<(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    return b > a;
+}
+inline int operator==(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    return a.tv_.tv_sec == b.tv_.tv_sec && a.tv_.tv_usec == b.tv_.tv_usec;
+}
+
+#endif /* _acelite_Time_Value_h */

--- a/src/include/ACE-lite/Time_Value.h
+++ b/src/include/ACE-lite/Time_Value.h
@@ -101,5 +101,14 @@ inline int operator<(const ACE_Time_Value& a, const ACE_Time_Value& b) {
 inline int operator==(const ACE_Time_Value& a, const ACE_Time_Value& b) {
     return a.tv_.tv_sec == b.tv_.tv_sec && a.tv_.tv_usec == b.tv_.tv_usec;
 }
+inline int operator!=(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    return !(a == b);
+}
+inline int operator>=(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    return !(a < b);
+}
+inline int operator<=(const ACE_Time_Value& a, const ACE_Time_Value& b) {
+    return !(a > b);
+}
 
 #endif /* _acelite_Time_Value_h */

--- a/src/include/ACE-lite/Time_Value.h
+++ b/src/include/ACE-lite/Time_Value.h
@@ -17,6 +17,10 @@ public:
     ACE_Time_Value(long sec, long usec = 0) { set(sec, usec); }
     ACE_Time_Value(const timeval& tv) { set(tv.tv_sec, tv.tv_usec); }
 
+    // A shared zero duration (consumer code uses it as a poll timeout, e.g.
+    // ctrlfunc.c's UpdateFunc).  Defined in reactor.c.
+    static const ACE_Time_Value zero;
+
     void set(long sec, long usec) {
         tv_.tv_sec = sec;
         tv_.tv_usec = usec;

--- a/src/include/ACE-lite/config.h
+++ b/src/include/ACE-lite/config.h
@@ -1,0 +1,13 @@
+/*
+ * ACE-lite (issue #147).  src/include/ACE-lite/config.h
+ * Umbrella config header, the bundled stand-in for <ace/config.h>.  ACE's
+ * config.h carries platform feature macros; the ACE-lite subset needs none of
+ * them, so this only pulls in the shared base types.
+ */
+
+#ifndef _acelite_config_h
+#define _acelite_config_h
+
+#include <ACE-lite/OS.h>
+
+#endif /* _acelite_config_h */


### PR DESCRIPTION
## ACE-lite — a bundled, in-tree ACE subset (issue #147)

ivtools links libACE but uses only a small, bounded slice of it: the Reactor /
Socket / Acceptor / Service-Handler pattern behind `comterp listen`, `remote()`,
`socket()`, DrawServ's distributed channel, and the InterViews main loop. This
PR builds that slice **in-tree**, so ivtools can be networked with **no libACE
build/link dependency** — while keeping libACE available as an optional backend.

This PR lands the additive code (phases 1–3) plus a CI gate.
The build-system flip (phase 4) comes next, on this same branch — one PR for all
of ACE-lite. Marked ready only once phase 4 is green.

### Approach (mirrors the bundled-TIFF model)

ivtools already bundles libTIFF and lets `--with-tiff=<path>` override it with an
external libtiff (via `-DEXTERN_TIFF` + an include switch). ACE-lite mirrors that
exactly:

- In-tree headers live at **`src/include/ACE-lite/`**, declaring the **real
  `ACE_*` names** (`ACE_Reactor`, `ACE_SOCK_Stream`, `ACE_Svc_Handler`, …). Impl
  compiles into a new **`libACE-lite`** (`src/ACE-lite/`).
- Consumers select the backend the way `tiff.c` does:
  ```c
  #ifdef EXTERN_ACE
  #include <ace/Reactor.h>        // external libACE
  #else
  #include <ACE-lite/Reactor.h>   // bundled, default
  #endif
  ```
- **In-tree is the default**; `--with-ace=<path>` sets `-DEXTERN_ACE` and links
  real libACE. `HAVE_ACE` stays defined either way (networking is elemental, like
  TIFF is always available), so consumer source and the surviving conditionals
  don't care which backend is in play.

Because the names/signatures are identical, the consumer code
(`comhandler.{c,h}`, `ctrlfunc.c`, `socket.c`, `main.c`, the acceptors,
`AceDispatcher`) compiles **unchanged** against either backend — and libACE stays
relinkable in the future.

### What's done in this PR

| Phase | Scope | Status |
|------|-------|--------|
| 1 | Leaf value/socket/util types: `ACE_Time_Value`, `ACE_INET_Addr`, `ACE_SOCK_Stream`/`Connector`/`Acceptor`, `ACE_Null_Mutex`/`ACE_Singleton`/`ACE_Test_and_Set`/`ACE_NULL_SYNCH` | ✅ |
| 2 | `ACE_Reactor` (self-contained `select()` demux) + `ACE_Event_Handler` — drops into the same slot libACE's reactor did; `AceDispatcher` still forwards into it (GUI + socket fds on one loop, as always) | ✅ |
| 3 | `ACE_Acceptor` + `ACE_Svc_Handler` accept-and-spawn, plus the `ACE_DEBUG`/`ACE_ERROR` logging and `ACE_OS` slice the handlers need | ✅ |
| CI | "Test - ACE-lite standalone units" — fast g++ gate before the build | ✅ |
| 4 | Build toggle: flip configure default to in-tree, add the `#ifdef EXTERN_ACE` include switch to consumers, drop dead `HAVE_ACE` `#else` branches, validate `drawmo`/`comterp listen`/`remote()` end-to-end | ⏳ next |

**Proofs (not just new tests — the real drop-in):**
- The existing `AceDispatcher` / `ACE_IO_Handler` and the central
  `comhandler.c` (`ComterpHandler`/`ComterpAcceptor`) compile **unchanged**
  against ACE-lite.
- Three standalone tests (22 assertions, run in CI on g++):
  - `sock_loopback` — connect/accept/send/recv/close both directions,
    `get_remote_addr`/`addr_to_string`/`Time_Value` arithmetic.
  - `reactor_loop` — input dispatch, the `handle_input() == -1 ⇒ retire +
    handle_close` EOF contract, one-shot timer fire/cancel, and **reentrant
    `handle_events`** safety (a handler calling `update()` recursively).
  - `acceptor_spawn` — accept-and-spawn, echo, EOF retirement through the full
    `handle_close → close → destroy` lifecycle.

### Design notes worth a look in review

- **The reactor is a real, self-contained `select()` demuxer**, not a facade over
  the base `Dispatcher`. The splice (Dispatcher forwarding into the reactor) is
  deliberate and unchanged; unifying the two loops is a later optimization, not
  this work.
- **`handle_events` is reentrancy-safe**: it snapshots the ready set and
  re-verifies each handler is still registered before calling it, deferring
  removals — the same defensive pattern the base `Dispatcher` uses, and the same
  hazard class as the recent reactor-reentrancy UAF fix.
- **Licensing:** ACE-lite is a clean-room reimplementation of the ACE *interface*
  (no ACE source). `src/ACE-lite/NOTICE` credits Douglas C. Schmidt's DOC group
  per ACE's license, disclaims affiliation, and explains the `ACE_*` names exist
  only for source-level drop-in compatibility.

Closes #147 once phase 4 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
