### PR TITLE
comterp: silence spurious argoff-anchor warnings when remote() de-serializes a list reply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,19 @@ jobs:
             grep 'substituting fixed font' drawmo.log
             exit 1
           fi
+          # "The command language is the wire protocol": remote() de-serializes a
+          # reply by re-entering the interpreter, and a returned LIST literal (the
+          # (:table) introspection commands -- drawlink/sid -- return lists) used to
+          # trip the argoff-anchor range guard in stack_key_post_eval, printing
+          # "offtop out of range ... argoff anchor missing or corrupt" once per
+          # keyword probe.  Benign in updown1 (its empty table still read as size 0,
+          # a false green) but noise that would mask a genuine anchor corruption.
+          # Fixed in comfunc.c (nkeys()==0 short-circuit); fail if it ever returns.
+          if grep -qE 'offtop out of range|argoff anchor' drawmo.log; then
+            echo "drawmo suite FAILED: comterp argoff/anchor warning during remote() de-serialization"
+            grep -nE 'offtop out of range|argoff anchor' drawmo.log | head
+            exit 1
+          fi
 
       - name: Upload build log
         if: always()

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -245,6 +245,20 @@ ComValue** ComFunc::stack_arg_post_eval_nargsfixed(boolean symbol, ComValue& dfl
 
 ComValue ComFunc::stack_key_post_eval
 (int id, boolean symbol, ComValue& dflt, boolean use_dflt_for_no_key) {
+  /* No keyword tokens for this command -> the sought keyword is definitively
+     absent, and an absent keyword is a normal, silent result in comterp -- not
+     an error.  Return the not-found default WITHOUT reading the operand stack.
+     This also disarms the offtop guard below for the benign case it kept
+     tripping on: when remote() re-enters the interpreter to de-serialize a
+     returned list literal, the argoff anchor on the shared operand stack still
+     belongs to the outer in-flight command (the whole reply evaluates inside
+     it), so the anchor read here is bogus -- but with nkeys()==0 there is
+     nothing to find anyway, so skip the read and stay quiet.  The guard's
+     warning is preserved only for nkeys()>0, where a bad anchor is a genuine
+     anomaly and not just proof that a keyword is missing. */
+  if (nkeys() == 0)
+    return use_dflt_for_no_key ? dflt : ComValue::nullval();
+
   ComValue argoff(comterp()->stack_top());
   int offtop = argoff.int_val()-comterp()->_pfnum;
   /* guard the anchor-recovered offtop: a bad/missing argoff anchor (e.g. left by
@@ -302,6 +316,13 @@ ComValue& ComFunc::stack_arg_post(int n, boolean symbol, ComValue& dflt) {
 
 ComValue& ComFunc::stack_key_post
 (int id, boolean symbol, ComValue& dflt, boolean use_dflt_for_no_key) {
+  /* nkeys()==0 -> keyword definitively absent; return the not-found default
+     without touching the operand stack (an absent keyword is silent by design,
+     and the offtop guard below would otherwise warn on the benign re-entrant
+     de-serialization case).  See the fuller note in stack_key_post_eval. */
+  if (nkeys() == 0)
+    return use_dflt_for_no_key ? dflt : ComValue::nullval();
+
   ComValue argoff(comterp()->stack_top());
   int offtop = argoff.int_val()-comterp()->_pfnum;
   /* same anchor-recovered-offtop guard as stack_key_post_eval; see note there. */


### PR DESCRIPTION
## Symptom
`drawmo --tests updown1` passes green but prints three copies of:
```
comterp: stack_key_post_eval: offtop out of range (offtop=-1 nkeys=0 argoff=0 _pfnum=1) -- argoff anchor missing or corrupt; upstream command likely failed to push its bookmark
```
Not an ACE / ACE-lite issue — reproduced and traced with lldb entirely on the **local comterp (drawmo) side**.

## Root cause
"The command language is the wire protocol," so `remote(sock "drawlink(:table)")` de-serializes the reply by **re-entering the interpreter** to evaluate it (`RemoteFunc::execute` → `ComTerpServ::run(reply, nested=true)`). The lldb backtrace:
```
AssignFunc::execute                 table = remote(...)
 └ stack_arg_post_eval               evaluate RHS lazily
    └ RemoteFunc::execute            ctrlfunc.c:262
       └ ComTerpServ::run("{}")      de-serialize the reply
          └ ListFunc::execute        {} is a list literal
             └ stack_key_post_eval   probe :strmlst/:attr/:size -> GUARD
```
The de-serialize runs **inside** the still-in-flight outer assignment, on the same interpreter, sharing its operand stack (correctly — that stack is how the reply value is returned). But `stack_key_post_eval` reads the top of that shared stack as its argoff anchor, and here the top still belongs to the outer `AssignFunc` (argoff=0). Offset math → −1 → range guard → warning.

## Why it's benign but wrong to warn
`ListFunc` for the reply has `nkeys()==0` — there are **no keyword tokens**, so the keyword it's probing for is *definitively absent*. An absent keyword is a normal, silent result in comterp (unknown keywords are ignored by design). The value is still reconstructed correctly (updown1's empty `{}` reads as size 0 — which is why the test was green). The only defect is the noise.

## Fix
Short-circuit `stack_key_post_eval` and its twin `stack_key_post` on `nkeys()==0`: return the not-found default without reading the operand stack. The benign case goes silent; the range guard's warning survives only for `nkeys()>0`, where a corrupt anchor is a genuine anomaly rather than proof a keyword is missing.

## Regression guard
The full drawmo CI step now greps `drawmo.log` for `offtop out of range` / `argoff anchor` and fails if either appears — so this can't silently regress, and this PR's own CI run (which includes updown2's **non-empty** drawlink table) demonstrates the fix covers list replies of any size.

## Notes
- Independent of the ACE-lite PRs; branch off `master`.
- Touches `.github/workflows/ci.yml` (drawmo step), which also overlaps #188/#189 — whichever merges last needs a trivial re-merge; no logic conflict.