### PR TITLE
Silence g++ format-security / format-zero-length / deprecated warnings (3.0 cleanup)

### DIFF
--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -359,5 +359,5 @@ void ComEditor::stdio_prompt(UnidrawComterpHandler* handler) {
   if (handler!=NULL) 
     (*handler->comterp()->outfunc()) (get_command_prompt(), nil);
   else
-    fprintf(stdout, get_command_prompt());
+    fprintf(stdout, "%s", get_command_prompt());
 }

--- a/src/ComUtil/comutil.h
+++ b/src/ComUtil/comutil.h
@@ -95,7 +95,7 @@ extern int _percent_ident;
 
 /* Error handling macros */
 #define COMERR_SET( status )\
-comerr_set( status, fprintf( err_fileio(), comerr_read( status )))
+comerr_set( status, fprintf( err_fileio(), "%s", comerr_read( status )))
 
 #define COMERR_SET1( status, val1 )\
 comerr_set( status, fprintf( err_fileio(), comerr_read( status ), val1 ))

--- a/src/IV-2_6/matcheditor.c
+++ b/src/IV-2_6/matcheditor.c
@@ -79,9 +79,22 @@ boolean MatchEditor::HandleChar (char c) {
         strncpy(buf, text->Text(), length);
         while (length > 0) {
             buf[length] = '\0';
+            /* `pattern' is an internally-built scanf MATCH template: every
+               conversion is suppressed (see Match() above -- it inserts `*'
+               before each `%', and appends "%*c"), so there are deliberately no
+               assigning arguments.  It is a legitimately dynamic format, not a
+               user-supplied one, so -Wformat-security's injection concern does
+               not apply; silence it locally rather than break the match. */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
             if (sscanf(buf, pattern) == EOF) {
                 break;
             }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             --length;
         }
         if (length != text->Length()) {

--- a/src/IVGlyph/namestate.c
+++ b/src/IVGlyph/namestate.c
@@ -48,7 +48,7 @@ NameView::NameView(NameState* s1) :MonoGlyph(), Observer()
     if (st1 && st1->name())
 	snprintf(str1, sizeof(str1),"%s", st1->name());
     else
-	snprintf(str1, sizeof(str1),"");
+	str1[0] = '\0';
     _label = new Patch(
 	lk.hbox(
 	    kit.label(str1),
@@ -72,7 +72,7 @@ void NameView::update(Observable* obs) {
     if (st1 && st1->name())
 	snprintf(str1, sizeof(str1),"%s", st1->name());
     else
-	snprintf(str1, sizeof(str1),"");
+	str1[0] = '\0';
     Glyph* text;
     if (_blink_state) {
       if (_blink_in)

--- a/src/OverlayUnidraw/ovimport.c
+++ b/src/OverlayUnidraw/ovimport.c
@@ -2058,7 +2058,7 @@ const char* OvImportCmd::Create_Tiled_File(
         return "error opening the output file";
     }
 
-    fprintf(outfile, pih->magic());
+    fprintf(outfile, "%s", pih->magic());
     // insert a comment to include the tile size
     fprintf(outfile,"# tile %d %d\n", twidth, theight);
     fprintf(outfile,"%d %d\n", width, height);

--- a/src/Unidraw/editor.c
+++ b/src/Unidraw/editor.c
@@ -41,6 +41,7 @@
 #include <InterViews/window.h>
 #include <IV-X11/xdisplay.h>
 #include <IV-X11/xevent.h>
+#include <X11/XKBlib.h>        /* XkbKeycodeToKeysym (replaces deprecated XKeycodeToKeysym) */
 #include <OS/list.h>
 #include <string.h>
 
@@ -124,8 +125,8 @@ void Editor::keystroke(const Event& e) {
 	buf[n] = '\0';
 	GetKeyMap()->Execute(buf);
     } else if (e.rep()->xevent_.type == KeyPress) {
-      KeySym ks = XKeycodeToKeysym(e.rep()->display_->rep()->display_,
-				   e.rep()->xevent_.xkey.keycode, 0);
+      KeySym ks = XkbKeycodeToKeysym(e.rep()->display_->rep()->display_,
+				     e.rep()->xevent_.xkey.keycode, 0, 0);
       if (ks) {
 	strncpy(buf, (const char*)&ks, 2);
 	n = 2;

--- a/src/Unidraw/editor.c
+++ b/src/Unidraw/editor.c
@@ -41,7 +41,13 @@
 #include <InterViews/window.h>
 #include <IV-X11/xdisplay.h>
 #include <IV-X11/xevent.h>
-#include <X11/XKBlib.h>        /* XkbKeycodeToKeysym (replaces deprecated XKeycodeToKeysym) */
+/* XkbKeycodeToKeysym (replaces deprecated XKeycodeToKeysym).  Bracket the XKB
+   header with Xdefs/Xundefs exactly as IV-X11/Xlib.h does for <X11/Xlib.h>, so
+   its Display parameter resolves to X11's XDisplay -- the type of the raw
+   handle we pass -- rather than InterViews' own Display class (ivDisplay). */
+#include <IV-X11/Xdefs.h>
+#include <X11/XKBlib.h>
+#include <IV-X11/Xundefs.h>
 #include <OS/list.h>
 #include <string.h>
 


### PR DESCRIPTION
First batch of the ivtools-3.0 g++ warning cleanup, from the Debian CI build's warning summary. Clears the three non-`unused-result` categories — **49 of ~111** warning lines — across 6 files.

## `-Wformat-security` (46)
- **`ComUtil/comutil.h` — the big one (43).** `COMERR_SET(status)` expanded to `fprintf(err_fileio(), comerr_read(status))` — a runtime `char*` used as the format with no args. Wrapped `"%s"`. Verified safe: the no-arg macro is only ever called with six status codes (`ERR_MEMORY`, `ERR_NO_OPTABLE`, `ERR_TXTUT_FNOTOPEN`/`DELIM`/`FOPEN`, `ERR_INCOMPLETE_EXPRESSION`), all mapping to **directive-free** messages, so output is byte-identical. The `%`-bearing messages in the table are only printed via `COMERR_SET1`/`COMERR_SET2`, which pass real args — left untouched.
- `OverlayUnidraw/ovimport.c`, `ComUnidraw/comeditor.c` — `fprintf(f, str)` → `fprintf(f, "%s", str)`.
- `IV-2_6/matcheditor.c` — `sscanf(buf, pattern)` is a *legitimately dynamic* scanf match template (all conversions suppressed, no assigning args), so `"%s"` would break it. Silenced locally with a documented `#pragma GCC diagnostic ignored "-Wformat-security"`.

## `-Wformat-zero-length` (2)
`IVGlyph/namestate.c` cleared a buffer with `snprintf(str, size, "")` → `str[0] = '\0'`.

## `-Wdeprecated-declarations` (1)
`Unidraw/editor.c` used core-Xlib `XKeycodeToKeysym` (flat keycode×index model, superseded by XKB's group/level model and marked deprecated in libX11). Migrated to `XkbKeycodeToKeysym(dpy, kc, 0, 0)` — the exact equivalent of the old `index 0` — via `<X11/XKBlib.h>` (part of libX11, no new link dependency).

## Verification
The CI **Warning summary (g++)** step is the check: these three categories should drop to ~0, leaving only `-Wunused-result` (62), which is the next batch. Draft until that summary confirms.

## Notes
- Independent 3.0 cleanup; branch off `master`. Does not touch `ci.yml` (unlike #188/#189/#190).
- `-Wunused-result` (fgets/fscanf/system/read return values, mostly in import.c/ovimport.c) is deliberately deferred to a focused follow-up.