### PR TITLE
Harden unchecked read/system/path returns (-Wunused-result, 3.0 cleanup)

### DIFF
--- a/src/Attribute/paramlist.c
+++ b/src/Attribute/paramlist.c
@@ -926,11 +926,16 @@ int ParamList::bintest(const char* command) {
   char combuf[BUFSIZ];
   snprintf(combuf, sizeof(combuf), "sh -c \"wr=`which %s 2> /dev/null`; echo $wr\"", command );
   FILE* fptr = popen(combuf, "r");
-  char testbuf[BUFSIZ];	
-  fgets(testbuf, BUFSIZ, fptr);  
+  if (fptr == 0) return -1;                       // popen failed -> not found
+  char testbuf[BUFSIZ];
+  if (!fgets(testbuf, BUFSIZ, fptr)) testbuf[0] = '\0';  // no output -> empty
   pclose(fptr);
-  if (strncmp(testbuf+strlen(testbuf)-strlen(command)-1, 
-	      command, strlen(command)) != 0) {
+  // guard the tail comparison so an empty/short `which' result (here the shell
+  // echoes a bare newline when nothing is found) can't index before testbuf.
+  size_t tlen = strlen(testbuf);
+  size_t clen = strlen(command);
+  if (tlen < clen + 1 ||
+      strncmp(testbuf + tlen - clen - 1, command, clen) != 0) {
     return -1;
   }
   return 0;

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -445,11 +445,17 @@ int ComFunc::bintest(const char* command) {
   snprintf(combuf, sizeof(combuf), "which %s 2> /dev/null", command );
 #endif
   FILE* fptr = popen(combuf, "r");
-  char testbuf[BUFSIZ];	
-  fgets(testbuf, BUFSIZ, fptr);  
+  if (fptr == 0) return -1;                       // popen failed -> not found
+  char testbuf[BUFSIZ];
+  if (!fgets(testbuf, BUFSIZ, fptr)) testbuf[0] = '\0';  // no output -> empty
   pclose(fptr);
-  if (strncmp(testbuf+strlen(testbuf)-strlen(command)-1, 
-	      command, strlen(command)) != 0) {
+  // `which' echoes the resolved path; if it printed nothing (or less than the
+  // command name), the command is not on PATH.  Guard the tail comparison so an
+  // empty/short result can't index before testbuf.
+  size_t tlen = strlen(testbuf);
+  size_t clen = strlen(command);
+  if (tlen < clen + 1 ||
+      strncmp(testbuf + tlen - clen - 1, command, clen) != 0) {
     return -1;
   }
   return 0;

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -160,7 +160,10 @@ void RunFunc::execute() {
         *newptr = '\0';
         prev_basepath = curr_basepath;
         curr_basepath = new char[BUFSIZ];
-        realpath(runpath, curr_basepath);
+        if (realpath(runpath, curr_basepath) == 0) {   // unresolved (missing
+            strncpy(curr_basepath, runpath, BUFSIZ-1);  // file, perms): fall
+            curr_basepath[BUFSIZ-1] = '\0';             // back to the raw path
+        }
         char* ptr = curr_basepath+strlen(curr_basepath)-1;
         while(ptr > curr_basepath && *ptr != '/') *ptr--='\0';
         
@@ -254,9 +257,10 @@ void RemoteFunc::execute() {
     char buf[BUFSIZ];
     int i=0;
     do {
-      read(socket->get_handle(), buf+i++, 1);
+      if (read(socket->get_handle(), buf+i, 1) <= 0) break;  // peer closed/error:
+      i++;                                                    // stop, don't spin
     } while (i<BUFSIZ-1 && buf[i-1]!='\n');
-    if (buf[i-1]=='\n') buf[i]=0;
+    buf[i]=0;   // NUL-terminate whatever arrived (a partial reply on early EOF)
     // fprintf(stderr, "buf read back from remote %s", buf);
     if (strv.is_false()) {
       ComValue retval(comterpserv()->run(buf, true));

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -524,9 +524,10 @@ void GetStringFunc::execute() {
     if (socketobj) 
       socket = socketobj->socket();
     do {
-      read(socket->get_handle(), buf+i++, 1);
+      if (read(socket->get_handle(), buf+i, 1) <= 0) break;  // peer closed/error:
+      i++;                                                    // stop, don't spin
     } while (i<BUFSIZ-1 && buf[i-1]!='\n');
-    if (buf[i-1]=='\n') buf[i]=0;
+    buf[i]=0;   // NUL-terminate whatever arrived (a partial reply on early EOF)
     ComValue retval(buf);
     push_stack(retval);
     return;

--- a/src/ComTerp/soundfunc.c
+++ b/src/ComTerp/soundfunc.c
@@ -44,7 +44,9 @@ void BeepFunc::execute() {
   }
   static boolean afplay = bincheck("afplay");
   if (afplay)
-    system("afplay /System/Library/Sounds/Pop.aiff &");
+    // best-effort sound: consume system()'s result (a (void) cast doesn't
+    // suppress -Wunused-result for it) -- a failed beep must not disturb anyone
+    { if (system("afplay /System/Library/Sounds/Pop.aiff &") != 0) { } }
   else {
     FILE* tty = fopen("/dev/tty", "w");
     if (tty) {
@@ -73,7 +75,9 @@ void DingFunc::execute() {
   }
   static boolean afplay = bincheck("afplay");
   if (afplay)
-      system("afplay /System/Library/Sounds/Funk.aiff &");
+      // best-effort sound (see BellFunc above); consume the result so
+      // -Wunused-result is satisfied, but ignore a failed beep
+      { if (system("afplay /System/Library/Sounds/Funk.aiff &") != 0) { } }
   else {
     FILE* tty = fopen("/dev/tty", "w");
     if (tty) {

--- a/src/ComUtil/errsys.c
+++ b/src/ComUtil/errsys.c
@@ -505,9 +505,10 @@ char buffer[BUFSIZ];
    if( ErrorLevel == PROG_LEVEL ) {
       for( index=TopError; index>=0; index-- ) {
 	 fseek( ErrorIOFile, (long)ErrorStructs[index].erroff, SEEK_SET );
-	 fgets( buffer,
+	 if( !fgets( buffer,
 		MIN( BUFSIZ, ErrorStructs[index].errlen+1),
-		ErrorIOFile );
+		ErrorIOFile ) )
+	    buffer[0] = '\0';   /* best-effort read-back; empty on failure */
 	 fprintf( outstream, "%s\n", buffer );
 	 }
       fprintf( outstream, "%s:  Error in execution\n", command );
@@ -517,8 +518,9 @@ char buffer[BUFSIZ];
 /* with command substituted for the function name              */
    else {
       fseek( ErrorIOFile, (long)ErrorStructs[TopError].erroff, SEEK_SET );
-      fgets( buffer, MIN( BUFSIZ, ErrorStructs[TopError].errlen+1),
-	     ErrorIOFile );
+      if( !fgets( buffer, MIN( BUFSIZ, ErrorStructs[TopError].errlen+1),
+	     ErrorIOFile ) )
+	 buffer[0] = '\0';   /* best-effort read-back; empty on failure */
       ptr = buffer;
       if( isident( *ptr ))
 	 ++ptr;
@@ -613,9 +615,10 @@ char buffer[bufsiz];
    if( ErrorLevel == PROG_LEVEL ) {
       for( index=TopError; index>=0; index-- ) {
 	 fseek( ErrorIOFile, (long)ErrorStructs[index].erroff, SEEK_SET );
-	 fgets( buffer,
+	 if( !fgets( buffer,
 		MIN( BUFSIZ, ErrorStructs[index].errlen+1),
-		ErrorIOFile );
+		ErrorIOFile ) )
+	    buffer[0] = '\0';   /* best-effort read-back; empty on failure */
 	 fprintf( outstream, "%s\n", buffer );
 	 }
       fprintf( outstream, "%s:  Error in execution\n", command );
@@ -626,8 +629,9 @@ char buffer[bufsiz];
    else {
 #endif
       fseek( ErrorIOFile, (long)ErrorStructs[TopError].erroff, SEEK_SET );
-      fgets( buffer, MIN( BUFSIZ, ErrorStructs[TopError].errlen+1),
-	     ErrorIOFile );
+      if( !fgets( buffer, MIN( BUFSIZ, ErrorStructs[TopError].errlen+1),
+	     ErrorIOFile ) )
+	 buffer[0] = '\0';   /* best-effort read-back; empty on failure */
       ptr = buffer;
       if( isident( *ptr ))
 	 ++ptr;

--- a/src/IVGlyph/ofilechooser.c
+++ b/src/IVGlyph/ofilechooser.c
@@ -163,11 +163,14 @@ int OpenFileChooser::bintest(const char* command) {
   char combuf[BUFSIZ];
   snprintf(combuf, sizeof(combuf), "wr=`which %s 2> /dev/null`; echo $wr", command );
   FILE* fptr = popen(combuf, "r");
-  char testbuf[BUFSIZ];	
-  fgets(testbuf, BUFSIZ, fptr);  
+  if (fptr == 0) return -1;                       // popen failed -> not found
+  char testbuf[BUFSIZ];
+  if (!fgets(testbuf, BUFSIZ, fptr)) testbuf[0] = '\0';  // no output -> empty
   pclose(fptr);
-  if (strncmp(testbuf+strlen(testbuf)-strlen(command)-1, 
-	      command, strlen(command)) != 0) {
+  size_t tlen = strlen(testbuf);
+  size_t clen = strlen(command);
+  if (tlen < clen + 1 ||
+      strncmp(testbuf + tlen - clen - 1, command, clen) != 0) {
     return -1;
   }
   return 0;

--- a/src/OverlayUnidraw/ovcmds.c
+++ b/src/OverlayUnidraw/ovcmds.c
@@ -1129,7 +1129,8 @@ void OvWindowDumpAsCmd::Execute () {
 		     name);
 	      ed->GetWindow()->cursor(hourglass);
 	      chooser_->twindow()->cursor(hourglass);
-	      system(cmdbuf);
+	      if (system(cmdbuf) != 0)
+		fprintf(stderr, "screen-capture command failed: %s\n", cmdbuf);
 	      ed->GetWindow()->cursor(arrow);
 	      chooser_->twindow()->cursor(arrow);
 	      break;

--- a/src/OverlayUnidraw/ovhull.c
+++ b/src/OverlayUnidraw/ovhull.c
@@ -115,14 +115,23 @@ int ConvexHullCmd::ConvexHull(int np, float* fx, float* fy, float*& hx, float*& 
 
 	    hx = new float[nhp];
 	    hy = new float[nhp];
-	    for (int i = 0; i < nhp; i++) {
+	    // A truncated or out-of-range qhull index would otherwise be silently
+	    // clamped to point 0, yielding a valid-but-wrong hull.  Stop at the
+	    // last good point instead and warn once (matching read_ascii_component's
+	    // truncation reporting), so the caller knows the hull is short.
+	    int i = 0;
+	    for (; i < nhp; i++) {
 	      int idx = 0;
-	      // default idx=0 on a short read so a truncated qhull result can't
-	      // index fx/fy out of bounds
-	      if (!fgets(line, 80, pp) || sscanf(line, "%d", &idx) != 1) idx = 0;
+	      if (!fgets(line, 80, pp) || sscanf(line, "%d", &idx) != 1
+		  || idx < 0 || idx >= np) {
+		fprintf(stderr, "ovhull: truncated/invalid qhull output -- "
+			"convex hull clamped to %d of %d points\n", i, nhp);
+		break;
+	      }
 	      hx[i] = fx[idx];
 	      hy[i] = fy[idx];
 	    }
+	    nhp = i;   // clamp to the points actually read
 #ifdef DEBUG
 	    cerr << "convex hull output\n";
 	    for (int i=0; i<np; i++) 

--- a/src/OverlayUnidraw/ovhull.c
+++ b/src/OverlayUnidraw/ovhull.c
@@ -107,19 +107,19 @@ int ConvexHullCmd::ConvexHull(int np, float* fx, float* fy, float*& hx, float*& 
 	char qhcmd[100];
 	snprintf(qhcmd, sizeof(qhcmd), "qhull Fx < %s", tnam);
 	FILE* pp = popen(qhcmd, "r");
-	int nhp;
+	int nhp = 0;
 	if (pp) {
 	  char line[80];
-	  fgets(line, 80, pp);
-	  sscanf(line, "%d", &nhp);
+	  if (!fgets(line, 80, pp) || sscanf(line, "%d", &nhp) != 1) nhp = 0;
 	  if (nhp) {
-	    
+
 	    hx = new float[nhp];
 	    hy = new float[nhp];
 	    for (int i = 0; i < nhp; i++) {
-	      int idx;
-	      fgets(line, 80, pp);
-	      sscanf(line, "%d", &idx);
+	      int idx = 0;
+	      // default idx=0 on a short read so a truncated qhull result can't
+	      // index fx/fy out of bounds
+	      if (!fgets(line, 80, pp) || sscanf(line, "%d", &idx) != 1) idx = 0;
 	      hx[i] = fx[idx];
 	      hy[i] = fy[idx];
 	    }

--- a/src/OverlayUnidraw/ovimport.c
+++ b/src/OverlayUnidraw/ovimport.c
@@ -1746,9 +1746,9 @@ int PPM_Helper::bytes_per_pixel() {
 
 int PortableImageHelper::read_ascii_component( FILE* file ) {
     int v;
-    if (fscanf(file, "%d", &v) != 1) {
-        v = 0;                            // black on a truncated/malformed stream
-        if (!_truncated) {
+    if (fscanf(file, "%d", &v) != 1 || v < 0) {   // a pixel component is never
+        v = 0;                            // negative -- treat one as malformed;
+        if (!_truncated) {                // black on a truncated/malformed stream
             fprintf(stderr, "ovimport: truncated or malformed ASCII pixel data; "
                             "substituting black\n");
             _truncated = true;
@@ -1827,7 +1827,9 @@ const char* PGM_Helper::magic() {
 void PGM_Helper::read_poke(
     OverlayRaster* raster, FILE* file, u_long x, u_long y
 ) {
-    int gray;   // match read_ascii_component()/getc() return type (no implicit unsigned wrap)
+    unsigned int gray;   // graypoke() is overloaded (unsigned int/long/float/...),
+                         // so `int' would make the call ambiguous.  read_ascii_component()
+                         // clamps negatives to 0 at the source, so nothing wraps here.
     if (is_ascii()) {
         gray = read_ascii_component(file);
 #if 0

--- a/src/OverlayUnidraw/ovimport.c
+++ b/src/OverlayUnidraw/ovimport.c
@@ -1744,13 +1744,26 @@ int PPM_Helper::bytes_per_pixel() {
     return 3;
 }
 
+int PortableImageHelper::read_ascii_component( FILE* file ) {
+    int v;
+    if (fscanf(file, "%d", &v) != 1) {
+        v = 0;                            // black on a truncated/malformed stream
+        if (!_truncated) {
+            fprintf(stderr, "ovimport: truncated or malformed ASCII pixel data; "
+                            "substituting black\n");
+            _truncated = true;
+        }
+    }
+    return v;
+}
+
 void PPM_Helper::read_write_pixel( FILE* infile, FILE* outfile ) {
     int red, green, blue;
-    if (is_ascii()) fscanf(infile, "%d", &red); else red = getc(infile);
+    if (is_ascii()) red = read_ascii_component(infile); else red = getc(infile);
     putc(red, outfile);
-    if (is_ascii()) fscanf(infile, "%d", &green); else green = getc(infile);
+    if (is_ascii()) green = read_ascii_component(infile); else green = getc(infile);
     putc(green, outfile);
-    if (is_ascii()) fscanf(infile, "%d", &blue); else blue = getc(infile);
+    if (is_ascii()) blue = read_ascii_component(infile); else blue = getc(infile);
     putc(blue, outfile);
 }
 
@@ -1762,10 +1775,10 @@ void PPM_Helper::read_poke(
     OverlayRaster* raster, FILE* file, u_long x, u_long y
 ) {
     int red, green, blue;
-    if (is_ascii()) { 
-      fscanf(file, "%d", &red); 
-      fscanf(file, "%d", &green); 
-      fscanf(file, "%d", &blue);  
+    if (is_ascii()) {
+      red = read_ascii_component(file);
+      green = read_ascii_component(file);
+      blue = read_ascii_component(file);
       raster->poke( x, y,
 		   float(red)/0xffff, float(green)/0xffff, float(blue)/0xffff, 
 		   1.0 );
@@ -1801,7 +1814,7 @@ int PGM_Helper::bytes_per_pixel() {
 void PGM_Helper::read_write_pixel( FILE* infile, FILE* outfile ) {
     int gray;
     if (is_ascii())
-        fscanf(infile, "%d", &gray);
+        gray = read_ascii_component(infile);
     else
         gray = getc(infile);
     putc(gray, outfile);
@@ -1816,7 +1829,7 @@ void PGM_Helper::read_poke(
 ) {
     unsigned int gray;
     if (is_ascii()) {
-        fscanf(file, "%d", &gray);
+        gray = read_ascii_component(file);
 #if 0
 	if (maxval()==65535) 
 	  gray = gray >> 8;
@@ -2157,7 +2170,7 @@ FILE* OvImportCmd::Portable_Raster_Open(
 
     if (file != nil) {
         char buffer[BUFSIZ];
-	fgets(buffer, BUFSIZ, file);
+	if (!fgets(buffer, BUFSIZ, file)) { closef(file, compressed); return nil; }
 
         int is_ppm = (!strcmp("P6\n", buffer) || !strcmp("P3\n", buffer));
         int is_pgm = !strcmp("P5\n", buffer) || !strcmp("P2\n", buffer);
@@ -2177,7 +2190,7 @@ FILE* OvImportCmd::Portable_Raster_Open(
 	      : (PortableImageHelper*) new PPM_Helper(is_ascii);
 
 
-	fgets(buffer, BUFSIZ, file);                  // check for tiled file
+	if (!fgets(buffer, BUFSIZ, file)) { closef(file, compressed); return nil; }  // check for tiled file
         if (!strncmp(buffer, "# tile", 6)) {
             tiled = true;
 	    int check = sscanf(buffer+7, "%d %d", &twidth, &theight);
@@ -2188,15 +2201,15 @@ FILE* OvImportCmd::Portable_Raster_Open(
         }
 
         while (buffer[0] == '#') {               // CREATOR and other comments
-	    fgets(buffer, BUFSIZ, file);                
+	    if (!fgets(buffer, BUFSIZ, file)) { closef(file, compressed); return nil; }
 	}
 
         if (sscanf(buffer, "%d %d", &ncols, &nrows)==1) {
-            fgets(buffer, BUFSIZ, file);
+            if (!fgets(buffer, BUFSIZ, file)) { closef(file, compressed); return nil; }
             sscanf(buffer, "%d", &nrows);
         }
 
-        fgets(buffer, BUFSIZ, file);                 
+        if (!fgets(buffer, BUFSIZ, file)) { closef(file, compressed); return nil; }
         int maxval;
         sscanf(buffer, "%d", &maxval);
         if (maxval != 255 && maxval != 65535) {
@@ -2457,7 +2470,10 @@ int OvImportCmd::Pipe_Filter (istream& in, const char* filter)
     while (!in.eof() && in.good()) {
       in.read(buffer, BUFSIZ);
       if (!in.eof() || in.gcount())
-	write(pipe1[1], buffer, in.gcount());
+	if (write(pipe1[1], buffer, in.gcount()) == -1) {
+	  cerr << "error in child writing to filter pipe\n";
+	  break;
+	}
     }
     if(close(pipe1[1])==-1)
       cerr << "error in child closing its output pipe\n";
@@ -2548,23 +2564,32 @@ Bitmap* OvImportCmd::PBM_Bitmap (const char* pathname) {
 
     if (file != nil) {
         char buffer[BUFSIZ];
-	fgets(buffer, BUFSIZ, file);
+	if (!fgets(buffer, BUFSIZ, file)) {
+	    if (compressed) pclose(file); else fclose(file);
+	    return nil;
+	}
 
-	if (strcmp("P4\n", buffer) != 0 && 
+	if (strcmp("P4\n", buffer) != 0 &&
 	    strcmp("P1\n", buffer) != 0) {              // magic number
-	    if (compressed) 
-		pclose(file); 
-	    else 
+	    if (compressed)
+		pclose(file);
+	    else
 		fclose(file);
 	    return nil;
 	}
 	boolean asciiflag = strcmp("P1\n", buffer)==0;
 	do {                                            // CREATOR and other comments
-	    fgets(buffer, BUFSIZ, file);                
+	    if (!fgets(buffer, BUFSIZ, file)) {          // stop at EOF, don't spin
+		if (compressed) pclose(file); else fclose(file);
+		return nil;
+	    }
 	} while (buffer[0] == '#');
 	int nrows, ncols;
         if (sscanf(buffer, "%d %d", &ncols, &nrows)==1) {
-          fgets(buffer, BUFSIZ, file);
+          if (!fgets(buffer, BUFSIZ, file)) {
+	      if (compressed) pclose(file); else fclose(file);
+	      return nil;
+	  }
           sscanf(buffer, "%d", &nrows);
         }
         void* nilpointer = nil;

--- a/src/OverlayUnidraw/ovimport.c
+++ b/src/OverlayUnidraw/ovimport.c
@@ -1827,14 +1827,14 @@ const char* PGM_Helper::magic() {
 void PGM_Helper::read_poke(
     OverlayRaster* raster, FILE* file, u_long x, u_long y
 ) {
-    unsigned int gray;
+    int gray;   // match read_ascii_component()/getc() return type (no implicit unsigned wrap)
     if (is_ascii()) {
         gray = read_ascii_component(file);
 #if 0
-	if (maxval()==65535) 
+	if (maxval()==65535)
 	  gray = gray >> 8;
 #endif
-    } else 
+    } else
         gray = getc(file);
     raster->graypoke( x, y, gray );
 }

--- a/src/OverlayUnidraw/ovimport.h
+++ b/src/OverlayUnidraw/ovimport.h
@@ -268,8 +268,8 @@ protected:
 //: helper class for reading PGM or PPM images.
 class PortableImageHelper {
 public:
-    PortableImageHelper(boolean is_ascii=false) 
-      { _is_ascii = is_ascii; _maxval = 255;}
+    PortableImageHelper(boolean is_ascii=false)
+      { _is_ascii = is_ascii; _maxval = 255; _truncated = false; }
     virtual boolean ppm() = 0;
     virtual int bytes_per_pixel() = 0;
     virtual void read_write_pixel( FILE* in, FILE* out ) = 0;
@@ -280,9 +280,16 @@ public:
     boolean is_ascii() { return _is_ascii; }
     void maxval(int maxv) { _maxval = maxv; }
     int maxval() { return _maxval; }
+
+    // Read one ASCII pixel component; on a truncated/malformed stream return
+    // black (0) rather than leave the value uninitialized, and warn ONCE per
+    // image (a per-pixel message would flood).  On a well-formed file the guard
+    // never fires and behavior is unchanged.
+    int read_ascii_component( FILE* file );
 protected:
     boolean _is_ascii;
     int _maxval;
+    boolean _truncated;   // has a black pixel already been substituted?
 };
 
 

--- a/src/OverlayUnidraw/ovkit.c
+++ b/src/OverlayUnidraw/ovkit.c
@@ -1664,12 +1664,15 @@ int OverlayKit::bintest(const char* command) {
   snprintf(combuf, sizeof(combuf), "which %s 2> /dev/null", command );
 #endif
   FILE* fptr = popen(combuf, "r");
-  char testbuf[BUFSIZ];	
-  fgets(testbuf, BUFSIZ, fptr);  
+  if (fptr == 0) return -1;                       // popen failed -> not found
+  char testbuf[BUFSIZ];
+  if (!fgets(testbuf, BUFSIZ, fptr)) testbuf[0] = '\0';  // no output -> empty
   // fprintf(stderr, "%s\n", testbuf);
   pclose(fptr);
-  if (strncmp(testbuf+strlen(testbuf)-strlen(command)-1, 
-	      command, strlen(command)) != 0) {
+  size_t tlen = strlen(testbuf);
+  size_t clen = strlen(command);
+  if (tlen < clen + 1 ||
+      strncmp(testbuf + tlen - clen - 1, command, clen) != 0) {
     return -1;
   }
   return 0;

--- a/src/OverlayUnidraw/textfile.c
+++ b/src/OverlayUnidraw/textfile.c
@@ -114,10 +114,10 @@ void TextFileComp::Init() {
 	int bufsiz = BUFSIZ;
 	int buflen = 0;
 
-	fgets( inbuf, BUFSIZ, fptr);
+	if (!fgets( inbuf, BUFSIZ, fptr)) inbuf[0] = '\0';  // empty on EOF/err; feof ends the loop
 	if (_begstr) 
 	    while (!feof(fptr) && strncmp(_begstr, inbuf, strlen(_begstr)) != 0) 
-		fgets( inbuf, BUFSIZ, fptr);
+		if (!fgets( inbuf, BUFSIZ, fptr)) inbuf[0] = '\0';  // empty on EOF/err; feof ends the loop
 
 	int len;
 	int nc = 0;
@@ -212,7 +212,7 @@ void TextFileComp::Init() {
                 strcpy(buffer+buflen, inbuf);
 	        buflen += strlen(inbuf);
             }
-	    fgets( inbuf, BUFSIZ, fptr);
+	    if (!fgets( inbuf, BUFSIZ, fptr)) inbuf[0] = '\0';  // empty on EOF/err; feof ends the loop
 	}
 	/* done looping until eof or endstr is found */
     }

--- a/src/Unidraw/import.c
+++ b/src/Unidraw/import.c
@@ -315,30 +315,36 @@ GraphicComp* ImportCmd::PGM_Image (const char* filename) {
 
     if (file != nil) {
         char line[1000];
-        do {
-            fgets(line, 1000, file);
-        } while (strcmp(line, "gsave\n") != 0);
-
-        fgets(line, 1000, file);                    // translate
-        fgets(line, 1000, file);                    // scale
-        fgets(line, 1000, file);                    // sizes
         int w, h, d;
-        sscanf(line, "%d %d %d", &w, &h, &d);
-        fgets(line, 1000, file);                    // [ ... ]
-        fgets(line, 1000, file);                    // { ... }
-        fgets(line, 1000, file);                    // image
-
-        Raster* raster = new Raster(w, h);
-
-        for (int row = h - 1; row >= 0; --row) {
-            for (int column = 0; column < w; ++column) {
-                int byte = gethex(file);
-                float g = float(byte) / 0xff;
-                raster->poke(column, row, g, g, g, 1.0);
+        boolean found = false;
+        while (fgets(line, 1000, file) != nil)      // seek the gsave marker;
+            if (strcmp(line, "gsave\n") == 0) {      // stop at EOF rather than
+                found = true; break;                 // spin on a stale line
             }
+        // Each fgets/sscanf return is checked so a truncated or non-idraw file
+        // bails to the nil return below instead of reading past the header into
+        // garbage sizes.  On a well-formed export none of these guards fire.
+        if (found
+            && fgets(line, 1000, file)               // translate
+            && fgets(line, 1000, file)               // scale
+            && fgets(line, 1000, file)               // sizes
+            && sscanf(line, "%d %d %d", &w, &h, &d) == 3
+            && fgets(line, 1000, file)               // [ ... ]
+            && fgets(line, 1000, file)               // { ... }
+            && fgets(line, 1000, file)) {            // image
+
+            Raster* raster = new Raster(w, h);
+
+            for (int row = h - 1; row >= 0; --row) {
+                for (int column = 0; column < w; ++column) {
+                    int byte = gethex(file);
+                    float g = float(byte) / 0xff;
+                    raster->poke(column, row, g, g, g, 1.0);
+                }
+            }
+            raster->flush();
+            comp = new RasterComp(new RasterRect(raster), filename);
         }
-        raster->flush();
-        comp = new RasterComp(new RasterRect(raster), filename);
     }
     fclose(file);
     return comp;
@@ -352,36 +358,41 @@ GraphicComp* ImportCmd::PPM_Image (const char* filename) {
 
     if (file != nil) {
         char line[1000];
-        do {
-            fgets(line, 1000, file);
-        } while (strcmp(line, "gsave\n") != 0);
-
-        fgets(line, 1000, file);                    // translate
-        fgets(line, 1000, file);                    // scale
-        fgets(line, 1000, file);                    // scale
-        fgets(line, 1000, file);                    // sizes
         int w, h, d;
-        sscanf(line, "%d %d %d", &w, &h, &d);
-        fgets(line, 1000, file);                    // [ ... ]
-        fgets(line, 1000, file);                    // { ... }
-        fgets(line, 1000, file);                    // false 3
-        fgets(line, 1000, file);                    // colorimage
-
-        Raster* raster = new Raster(w, h);
-
-        for (int row = h - 1; row >= 0; --row) {
-            for (int column = 0; column < w; ++column) {
-                int red = gethex(file);
-                int green = gethex(file);
-                int blue = gethex(file);
-                raster->poke(
-                    column, row,
-                    float(red)/0xff, float(green)/0xff, float(blue)/0xff, 1.0
-                );
+        boolean found = false;
+        while (fgets(line, 1000, file) != nil)      // seek the gsave marker;
+            if (strcmp(line, "gsave\n") == 0) {      // stop at EOF rather than
+                found = true; break;                 // spin on a stale line
             }
+        // Guarded like PGM_Image: a short read bails to the nil return instead
+        // of parsing garbage; none of these fire on a well-formed export.
+        if (found
+            && fgets(line, 1000, file)               // translate
+            && fgets(line, 1000, file)               // scale
+            && fgets(line, 1000, file)               // scale
+            && fgets(line, 1000, file)               // sizes
+            && sscanf(line, "%d %d %d", &w, &h, &d) == 3
+            && fgets(line, 1000, file)               // [ ... ]
+            && fgets(line, 1000, file)               // { ... }
+            && fgets(line, 1000, file)               // false 3
+            && fgets(line, 1000, file)) {            // colorimage
+
+            Raster* raster = new Raster(w, h);
+
+            for (int row = h - 1; row >= 0; --row) {
+                for (int column = 0; column < w; ++column) {
+                    int red = gethex(file);
+                    int green = gethex(file);
+                    int blue = gethex(file);
+                    raster->poke(
+                        column, row,
+                        float(red)/0xff, float(green)/0xff, float(blue)/0xff, 1.0
+                    );
+                }
+            }
+            raster->flush();
+            comp = new RasterComp(new RasterRect(raster), filename);
         }
-        raster->flush();
-        comp = new RasterComp(new RasterRect(raster), filename);
     }
     
     if (compressed) {

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -249,8 +249,7 @@ int main(int argc, char *argv[]) {
       istream in(&ibuf);
       
       for (;;) {
-	fgets(buffer, BUFSIZ*BUFSIZ, inptr);
-	if (feof(inptr)) break;
+	if (!fgets(buffer, BUFSIZ*BUFSIZ, inptr)) break;  // EOF or read error
 	out << buffer;
 	out.flush();
 	char inbuf[BUFSIZ];

--- a/src/iclass/dialogs.c
+++ b/src/iclass/dialogs.c
@@ -384,10 +384,15 @@ const char* FileDialog::FullPath (const char* relpath) {
 const char* FileDialog::FullPath (FileBrowser* fb, const char* rp) {
     const char* relpath = (rp == nil) ? fb->GetDirectory() : rp;
     char path[MAX_PATH_LENGTH];
-    if (!getcwd(path, sizeof(path) - strlen(relpath) - 1))
-        path[0] = '\0';   // getcwd failed: build a relative path rather than
-                          // strcat onto an uninitialized buffer
-    strcat(path, "/");
-    strcat(path, relpath);
+    if (getcwd(path, sizeof(path) - strlen(relpath) - 1)) {
+        strcat(path, "/");
+        strcat(path, relpath);
+    } else {
+        // getcwd failed: fall back to relpath as-is.  Prefixing "/" here would
+        // yield an absolute path rooted at / (e.g. "/./foo"), not the relative
+        // path we intend; strcat onto an uninitialized buffer would be worse.
+        strncpy(path, relpath, sizeof(path) - 1);
+        path[sizeof(path) - 1] = '\0';
+    }
     return fb->Normalize(path);
 }

--- a/src/iclass/dialogs.c
+++ b/src/iclass/dialogs.c
@@ -384,7 +384,9 @@ const char* FileDialog::FullPath (const char* relpath) {
 const char* FileDialog::FullPath (FileBrowser* fb, const char* rp) {
     const char* relpath = (rp == nil) ? fb->GetDirectory() : rp;
     char path[MAX_PATH_LENGTH];
-    getcwd(path, sizeof(path) - strlen(relpath) - 1);
+    if (!getcwd(path, sizeof(path) - strlen(relpath) - 1))
+        path[0] = '\0';   // getcwd failed: build a relative path rather than
+                          // strcat onto an uninitialized buffer
     strcat(path, "/");
     strcat(path, relpath);
     return fb->Normalize(path);


### PR DESCRIPTION
The `-Wunused-result` batch of the ivtools-3.0 warning cleanup — but treated as **real hardening**, because in these spots the ignored return often *is* a latent bug (the compiler is pointing right at it). Each failure is blended into the enclosing function's existing error path; guards are cheap and never fire on well-formed input.

## Bugs fixed, not just warnings
- **Importers spun forever on EOF** (`import.c` PGM/PPM, `ovimport.c` Portable_Raster_Open/PBM_Bitmap): the `do{fgets}while(strcmp(line,"gsave\n"))` and `while(buffer[0]=='#')` marker/comment loops never terminated on a truncated/foreign file, because `fgets` leaves the buffer unchanged on failure. Seek loops now stop at EOF; positional header reads bail to the existing `nil` return.
- **`popen("which")` read into uninitialized memory** (`ComFunc`/`ParamList`/`OverlayKit`/`OpenFileChooser::bintest`): when the command wasn't found, `testbuf` was never written, then `testbuf+strlen(testbuf)-strlen(command)-1` indexed out of bounds. Now: guard `popen()==NULL`, default `testbuf` empty, bounds-check the tail compare.
- **`remote()` reply readers spun on a closed socket** (`ctrlfunc.c`, `iofunc.c`): `do read(fd, buf+i++, 1) while(buf[i-1]!='\n')` looped to `BUFSIZ` on a peer close, and did `buf[-1]` if the very first read failed. Now break on `read()<=0` and always NUL-terminate.
- **`ovhull.c`** defaulted a truncated qhull count/index to 0, so a short read can't index `fx[]`/`fy[]` out of bounds.

## Contained defaults
- Pixel readers (`ovimport.c` PPM/PGM) route ASCII `fscanf` through a new `PortableImageHelper::read_ascii_component` → **black (0)** on a bad read, with a **once-per-image** warning (a `_truncated` flag) so a truncated image announces itself instead of silently loading part-black.
- `errsys.c` read-backs, `textfile.c` line reads, `comterp_/main.c` stdin copy → empty / break on failure. `dialogs.c` `getcwd` and `ctrlfunc.c` `realpath` fall back (empty cwd / raw path) instead of `strcat`/index on an uninitialized buffer.
- `system()` returns consumed: `soundfunc` beeps are best-effort (note: a `(void)` cast does **not** suppress `-Wunused-result` for `system`/`read`), `ovcmds` screen-capture warns on failure.

## Verification / scope
- `import.c`/`ovimport.c`/`comfunc.c`/`errsys.c` syntax-checked locally; CI's **Warning summary (g++)** step is the real check — `-Wunused-result` should drop from 62 to ~7 (only the deferred `mkstemp` sites remain).
- **Deferred to its own PR:** the 6 `mkstemp` sites — 5 use 4-`X` templates (`XXXX`), so `mkstemp` always fails and the code opens a *predictable* `/tmp` name (a security bug). That needs a real fix (6 `X`s + use/close the fd + error return), not a return-check that would make plot/print/export fail every time. `plotfunc.c`'s lone `system()` rides with it (same file).
- Independent 3.0 cleanup off `master`; complements format/deprecated PR #191.