### PR TITLE
Fix predictable-tempfile bug at the mkstemp sites (security + -Wunused-result, 3.0)

### DIFF
--- a/src/ComUnidraw/plotfunc.c
+++ b/src/ComUnidraw/plotfunc.c
@@ -98,6 +98,7 @@ void BarPlotFunc::execute() {
     close(psfd);                              // plotmtv writes it by name
     snprintf(cmd, sizeof(cmd), "plotmtv -noxplot -color -o %s %s", pstmp, tmpfilename);
     FILE* plotp = popen(cmd, "w");
+    if (plotp == nil) { unlink(pstmp); unlink(tmpfilename); reset_stack(); return; }
     fprintf(plotp, "n\n");
     pclose(plotp);
 

--- a/src/ComUnidraw/plotfunc.c
+++ b/src/ComUnidraw/plotfunc.c
@@ -121,6 +121,7 @@ void BarPlotFunc::execute() {
     imp->pathname(idtmp);
     imp->Execute();
 
+    unlink(idtmp);      // now that 6-X mkstemp actually creates it, clean it up too
     unlink(pstmp);
     unlink(tmpfilename);
   }

--- a/src/ComUnidraw/plotfunc.c
+++ b/src/ComUnidraw/plotfunc.c
@@ -47,8 +47,10 @@ void BarPlotFunc::execute() {
 
   if (Component::use_unidraw()) {
     boolean ok;
-    char tmpfilename[] = "/tmp/plivXXXX";
-    mkstemp(tmpfilename);
+    char tmpfilename[] = "/tmp/plivXXXXXX";   // 6 X's: mkstemp needs exactly six
+    int tmpfd = mkstemp(tmpfilename);         // and creates a unique O_EXCL file
+    if (tmpfd < 0) { reset_stack(); return; }
+    close(tmpfd);                             // reopened by name via ofstream below
     ofstream out(tmpfilename);
 
     ComValue title(stack_key(title_symid));
@@ -90,18 +92,22 @@ void BarPlotFunc::execute() {
     out.close();
 
     char cmd[256];
-    char pstmp[] = "/tmp/psivXXXX";
-    mkstemp(pstmp);
+    char pstmp[] = "/tmp/psivXXXXXX";
+    int psfd = mkstemp(pstmp);
+    if (psfd < 0) { unlink(tmpfilename); reset_stack(); return; }
+    close(psfd);                              // plotmtv writes it by name
     snprintf(cmd, sizeof(cmd), "plotmtv -noxplot -color -o %s %s", pstmp, tmpfilename);
     FILE* plotp = popen(cmd, "w");
     fprintf(plotp, "n\n");
     pclose(plotp);
 
-    char idtmp[] = "/tmp/idivXXXX";
-    mkstemp(idtmp);
+    char idtmp[] = "/tmp/idivXXXXXX";
+    int idfd = mkstemp(idtmp);
+    if (idfd < 0) { unlink(pstmp); unlink(tmpfilename); reset_stack(); return; }
+    close(idfd);                              // pstoedit writes it by name
     snprintf(cmd, sizeof(cmd), "pstoedit -f idraw < %s > %s", pstmp, idtmp);
-fprintf(stderr, "%s\n", cmd);
-    system(cmd);
+    if (system(cmd) != 0)
+      fprintf(stderr, "plot: pstoedit conversion failed: %s\n", cmd);
 
     ComEditor* ed = nil;
     if (newview_flag.is_true()) {

--- a/src/GraphUnidraw/graphexport.c
+++ b/src/GraphUnidraw/graphexport.c
@@ -63,6 +63,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fstream.h>
+#include <unistd.h>    // mkstemp, close
 
 /*****************************************************************************/
 
@@ -199,12 +200,17 @@ boolean GraphExportCmd::Export (const char* pathname) {
     if (ovpsv != nil) {
       
       filebuf fbuf;
-      char tmpfilename[] = "/tmp/grivXXXX";
-      
+      char tmpfilename[] = "/tmp/grivXXXXXX";  // 6 X's for mkstemp
+
       if (chooser_->to_printer()) {
-	mkstemp(tmpfilename);
-	false_top->SetPathName(tmpfilename);
-	ok = fbuf.open(tmpfilename, output) != 0;
+	int fd = mkstemp(tmpfilename);
+	if (fd < 0)
+	  ok = false;
+	else {
+	  close(fd);                             // reopened by name below
+	  false_top->SetPathName(tmpfilename);
+	  ok = fbuf.open(tmpfilename, output) != 0;
+	}
       } else {
 	ok = fbuf.open(pathname, output) != 0;
       }

--- a/src/OverlayUnidraw/ovexport.c
+++ b/src/OverlayUnidraw/ovexport.c
@@ -61,6 +61,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fstream.h>
+#include <unistd.h>    // mkstemp, close
 
 /*****************************************************************************/
 
@@ -209,10 +210,15 @@ boolean OvExportCmd::Export (const char* pathname) {
       char* tmpfilename;
       
       if (chooser_->to_printer()) {
-	char tmpfilename[] = "/tmp/exinXXXX";
-        mkstemp(tmpfilename);
-	false_top->SetPathName(tmpfilename);
-	ok = fbuf.open(tmpfilename, output) != 0;
+	char tmpfilename[] = "/tmp/exinXXXXXX";  // 6 X's for mkstemp
+        int fd = mkstemp(tmpfilename);
+	if (fd < 0)
+	  ok = false;
+	else {
+	  close(fd);                             // reopened by name below
+	  false_top->SetPathName(tmpfilename);
+	  ok = fbuf.open(tmpfilename, output) != 0;
+	}
       } else {
 	ok = fbuf.open(pathname, output) != 0;
       }

--- a/src/OverlayUnidraw/ovexport.c
+++ b/src/OverlayUnidraw/ovexport.c
@@ -207,10 +207,14 @@ boolean OvExportCmd::Export (const char* pathname) {
     if (ovpsv != nil) {
       
       filebuf fbuf;
-      char* tmpfilename;
-      
+      // One outer array (6 X's for mkstemp), also referenced by the print
+      // command below.  Previously this was an uninitialized `char*` shadowed
+      // by an inner array in the to_printer() branch, so the print command read
+      // the uninitialized outer pointer -- latent while mkstemp always failed,
+      // now live.  Single scope like ovprint.c/graphexport.c.
+      char tmpfilename[] = "/tmp/exinXXXXXX";
+
       if (chooser_->to_printer()) {
-	char tmpfilename[] = "/tmp/exinXXXXXX";  // 6 X's for mkstemp
         int fd = mkstemp(tmpfilename);
 	if (fd < 0)
 	  ok = false;

--- a/src/OverlayUnidraw/ovprint.c
+++ b/src/OverlayUnidraw/ovprint.c
@@ -59,6 +59,7 @@
 #include <stream.h>
 #include <string.h>
 #include <fstream.h>
+#include <unistd.h>    // mkstemp, close
 
 /*****************************************************************************/
 
@@ -121,11 +122,16 @@ void OvPrintCmd::Execute () {
 	    if (ok) { 
 
 		filebuf fbuf;
-		char tmpfilename[] = "/tmp/privXXXX";
-		
+		char tmpfilename[] = "/tmp/privXXXXXX";  // 6 X's for mkstemp
+
 		if (chooser_->to_printer()) {
-		    mkstemp(tmpfilename);
-		    ok = fbuf.open(tmpfilename, output) != 0;
+		    int fd = mkstemp(tmpfilename);
+		    if (fd < 0)
+			ok = false;
+		    else {
+			close(fd);                   // reopened by name below
+			ok = fbuf.open(tmpfilename, output) != 0;
+		    }
 		} else {
 		    ok = fbuf.open(ns.string(), output) != 0;
 		}

--- a/src/Unidraw/catalog.c
+++ b/src/Unidraw/catalog.c
@@ -677,7 +677,8 @@ void* Catalog::CopyObject (void* obj, ClassId base_id) {
     static int stackLvl;
 
     if (strcmp(_tmpfile, "/tmp/XXXXXX")==0 || ++stackLvl > 1) {
-      mkstemp(_tmpfile);
+      int fd = mkstemp(_tmpfile);
+      if (fd >= 0) close(fd);   // reopened by name via obuf; -1 -> obuf.open fails
     }
     boolean ok = obuf.open(_tmpfile, output) != 0;
 


### PR DESCRIPTION
Surfaced while doing the `-Wunused-result` cleanup (#192): the ignored `mkstemp` return was hiding a real bug.

## The bug
`mkstemp` requires a template ending in **exactly six** `X`s. **Five of six** sites used only four (`/tmp/plivXXXX`, `psivXXXX`, `idivXXXX`, `privXXXX`, `exinXXXX`, `grivXXXX`). On glibc a short template makes `mkstemp` fail with `EINVAL`, create nothing, return −1 (ignored) — and the code then opens the **literal** name (`/tmp/plivXXXX`, …). So plot / print / export all wrote to a **predictable `/tmp` filename**: a classic race / symlink-attack surface, with `mkstemp` doing nothing at all.

## The fix (per site)
- Template → **6 `X`s**, so `mkstemp` actually creates a unique `O_EXCL` file (unpredictable name).
- **Capture the fd** and blend failure into the enclosing error path:
  - `plotfunc.c` (3 temps, `void`): bail early and `unlink` the temps already created.
  - `ovprint.c` / `ovexport.c` / `graphexport.c`: set the existing `ok = false`.
  - `catalog.c`: falls through to its existing `"couldn't copy object (/tmp unwritable?)"` message.
- **`close()` the fd** — each file is reopened by name (`ofstream` / `filebuf::open` / external-command output), so the descriptor was otherwise leaked.

`catalog.c` already had a correct `/tmp/XXXXXX` — it only needed the return checked and the fd closed.

## Also in scope
- `plotfunc.c`'s `pstoedit` `system()` return is now checked (warns on failure); a stray debug `fprintf` was dropped.
- `ovprint`/`ovexport`/`graphexport` gain `#include <unistd.h>` for `close()`.

## Notes
- All five files syntax-checked locally; clears their 6 `-Wunused-result` warnings (the last remaining after #192).
- A **7th** 4-`X` site — `ovhull.c`'s `qhinXXXX` — is left to **#192**, which already owns that file (its return is consumed via `int status = mkstemp`, so it's not a `-Wunused-result`, but the template + the inverted `if(!status)` check are broken; flagged there).
- The `close()`-then-reopen-by-name window is inherent to the `ofstream`/command-output design and out of scope; the **predictable-name** bug is what this fixes.
- Branch off `master` (post-#191-merge); independent of #188/#190/#192.