### PR TITLE
Add group()/ungroup() comdraw commands (#157) + spinning petals demo

### DIFF
--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -223,6 +223,8 @@ void ComEditor::AddCommands(ComTerp* comterp) {
 
     comterp->add_command("growgroup", new GrowGroupFunc(comterp, this));
     comterp->add_command("trimgroup", new TrimGroupFunc(comterp, this));
+    comterp->add_command("group", new GroupFunc(comterp, this));
+    comterp->add_command("ungroup", new UngroupFunc(comterp, this));
     comterp->add_command("front", new FrontSelectionFunc(comterp, this));
     comterp->add_command("back", new BackSelectionFunc(comterp, this));
 

--- a/src/ComUnidraw/groupfunc.c
+++ b/src/ComUnidraw/groupfunc.c
@@ -161,6 +161,77 @@ void TrimGroupFunc::execute() {
     push_stack(ComValue::nullval());
 }
 
+/*****************************************************************************/
+
+GroupFunc::GroupFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
+}
+
+void GroupFunc::execute() {
+    reset_stack();
+
+    OverlayViewer* viewer = (OverlayViewer*)GetEditor()->GetViewer();
+
+    /* gather the current selection to group -- the "regroup" half of
+       growgroup, but sourced from the selection instead of an existing
+       group's members (see #157: growgroup/trimgroup could grow/trim a group
+       but there was no way to bootstrap one). */
+    Clipboard* cb = new Clipboard();
+    cb->Init(viewer->GetSelection());
+
+    /* nothing selected -> nothing to group */
+    Iterator i;
+    cb->First(i);
+    if (cb->Done(i)) {
+	delete cb;
+	push_stack(ComValue::nullval());
+	return;
+    }
+
+    OvGroupCmd* gcmd = new OvGroupCmd(GetEditor());
+    OverlaysComp* grgroup = new OverlaysComp();
+    gcmd->SetGroup(grgroup);
+    gcmd->SetClipboard(cb);
+    execute_log(gcmd);
+
+    ComValue retval(new OverlayViewRef(grgroup), OverlaysComp::class_symid());
+    push_stack(retval);
+}
+
+/*****************************************************************************/
+
+UngroupFunc::UngroupFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
+}
+
+void UngroupFunc::execute() {
+    ComValue grval(stack_arg(0));
+    reset_stack();
+
+    OverlayViewer* viewer = (OverlayViewer*)GetEditor()->GetViewer();
+
+    /* ungroup the given group compview, else the current selection */
+    Clipboard* cb = new Clipboard();
+    if (grval.object_compview()) {
+	ComponentView* grview = (ComponentView*)grval.obj_val();
+	OverlayComp* grcomp = grview ? (OverlayComp*)grview->GetSubject() : nil;
+	if (grcomp) cb->Append(grcomp);
+    } else
+	cb->Init(viewer->GetSelection());
+
+    Iterator i;
+    cb->First(i);
+    if (cb->Done(i)) {
+	delete cb;
+	push_stack(ComValue::nullval());
+	return;
+    }
+
+    UngroupCmd* ucmd = new UngroupCmd(GetEditor());
+    ucmd->SetClipboard(cb);
+    execute_log(ucmd);
+
+    push_stack(ComValue::oneval());
+}
+
 
 /*****************************************************************************/
 

--- a/src/ComUnidraw/groupfunc.h
+++ b/src/ComUnidraw/groupfunc.h
@@ -27,33 +27,33 @@
 #include <ComUnidraw/unifunc.h>
 
 //: command to add graphic to existing group graphic
-// newgroup=growgroup(groupview compview) -- add graphic to existing group graphic
+// newgrp=growgroup(groupview compview) -- add graphic to existing group graphic
 class GrowGroupFunc : public UnidrawFunc {
 public:
     GrowGroupFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "newgroup=%s(groupview compview) -- add graphic to existing group graphic"; }
+	return "newgrp=%s(groupview compview) -- add graphic to existing group graphic"; }
 };
 
 //: command to remove graphic from existing group graphic
-// newgroup=trimgroup(groupview compview) -- remove graphic from existing group graphic
+// newgrp=trimgroup(groupview compview) -- remove graphic from existing group graphic
 class TrimGroupFunc : public UnidrawFunc {
 public:
     TrimGroupFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() {
-	return "newgroup=%s(groupview compview) -- remove graphic from existing group graphic"; }
+	return "newgrp=%s(groupview compview) -- remove graphic from existing group graphic"; }
 };
 
 //: command to group the current selection into a single group graphic
-// group=group() -- group the current selection into one group graphic
+// newgrp=group() -- group the current selection into one group graphic
 class GroupFunc : public UnidrawFunc {
 public:
     GroupFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() {
-	return "group=%s() -- group the current selection into a single group graphic"; }
+	return "newgrp=%s() -- group the current selection into a single group graphic"; }
 };
 
 //: command to ungroup a group graphic back into its members

--- a/src/ComUnidraw/groupfunc.h
+++ b/src/ComUnidraw/groupfunc.h
@@ -42,8 +42,28 @@ class TrimGroupFunc : public UnidrawFunc {
 public:
     TrimGroupFunc(ComTerp*,Editor*);
     virtual void execute();
-    virtual const char* docstring() { 
+    virtual const char* docstring() {
 	return "newgroup=%s(groupview compview) -- remove graphic from existing group graphic"; }
+};
+
+//: command to group the current selection into a single group graphic
+// group=group() -- group the current selection into one group graphic
+class GroupFunc : public UnidrawFunc {
+public:
+    GroupFunc(ComTerp*,Editor*);
+    virtual void execute();
+    virtual const char* docstring() {
+	return "group=%s() -- group the current selection into a single group graphic"; }
+};
+
+//: command to ungroup a group graphic back into its members
+// ungroup([compview]) -- dissolve the selected group (or the given group) into its members
+class UngroupFunc : public UnidrawFunc {
+public:
+    UngroupFunc(ComTerp*,Editor*);
+    virtual void execute();
+    virtual const char* docstring() {
+	return "%s([compview]) -- ungroup the selected group (or given group) into its members"; }
 };
 
 //: command to move selection or graphic to the front

--- a/src/comdraw/tests/group.comt
+++ b/src/comdraw/tests/group.comt
@@ -8,10 +8,12 @@
 // funcs: rect() select() group() ungroup() size()
 ok=true
 
-// two rects, grouped into one group of two members
-rect(0,0, 50,50)
-rect(60,60, 100,100)
-select(:all)
+// two rects, grouped into one group of two members.
+// select them explicitly (not :all): run_all runs earlier scripts first, so
+// their leftover graphics are still on the canvas and :all would sweep them in.
+r1=rect(0,0, 50,50)
+r2=rect(60,60, 100,100)
+select(r1 r2)
 g=group()
 ok=ok&&(size(g)==2)
 print("group: size(group() of 2 rects)==2 -> %v (got %v)\n" size(g)==2 size(g))

--- a/src/comdraw/tests/group.comt
+++ b/src/comdraw/tests/group.comt
@@ -1,0 +1,25 @@
+// src/comdraw/tests/group.comt -- group()/ungroup() (#157)
+//
+// group() collapses the current selection into a single group graphic and
+// returns the group's compview; ungroup() dissolves a group back into its
+// members.  growgroup/trimgroup could only grow/trim an EXISTING group --
+// there was no way to bootstrap one from a selection until group().
+//
+// funcs: rect() select() group() ungroup() size()
+ok=true
+
+// two rects, grouped into one group of two members
+rect(0,0, 50,50)
+rect(60,60, 100,100)
+select(:all)
+g=group()
+ok=ok&&(size(g)==2)
+print("group: size(group() of 2 rects)==2 -> %v (got %v)\n" size(g)==2 size(g))
+
+// ungroup the group -- returns non-nil on success
+r=ungroup(g)
+ok=ok&&(r!=nil)
+print("group: ungroup(g)!=nil -> %v\n" r!=nil)
+
+print("group: %v\n" ok)
+ok

--- a/src/comdraw/tests/petals.comt
+++ b/src/comdraw/tests/petals.comt
@@ -31,7 +31,7 @@ brush(5)      // Thick
 // shared center (160,160).
 select(:all)
 group()
-handles()
+handles(false)
 
 // spin the group a couple degrees per frame, paced by update(usec).
 // rotate(degflt) rotates the current selection; the group stays selected.
@@ -43,4 +43,4 @@ for(f=0 f<frames f++
   update(20000))    // 20 ms / frame
 
 select(:clear)
-handles()
+handles(true)

--- a/src/comdraw/tests/petals.comt
+++ b/src/comdraw/tests/petals.comt
@@ -31,6 +31,7 @@ brush(5)      // Thick
 // shared center (160,160).
 select(:all)
 group()
+handles()
 
 // spin the group a couple degrees per frame, paced by update(usec).
 // rotate(degflt) rotates the current selection; the group stays selected.
@@ -38,7 +39,8 @@ frames = 720
 f = 0
 for(f=0 f<frames f++
   select(:all);
-  rotate(2);
+  rotate(-2);
   update(20000))    // 20 ms / frame
 
 select(:clear)
+handles()

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -23,5 +23,9 @@ if(run("./gsexim.comt")
   :then print("pass: gsexim\n")
   :else print("FAIL: gsexim\n");ok=false)
 
+if(run("./group.comt")
+  :then print("pass: group\n")
+  :else print("FAIL: group\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/drawserv_/tests/petals.comt
+++ b/src/drawserv_/tests/petals.comt
@@ -24,4 +24,21 @@ colors(1 10)  // Black circle, around it
 pattern(1)    // None
 brush(5)      // Thick
 
+// --- spin ---
+// Rotating a multi-selection turns each graphic about its OWN center, so the
+// petals would spin in place instead of orbiting.  Collapse the whole picture
+// into one group first (group() -- #157) so rotate() pivots about the group's
+// shared center (160,160).
+select(:all)
+group()
+
+// spin the group a couple degrees per frame, paced by update(usec).
+// rotate(degflt) rotates the current selection; the group stays selected.
+frames = 720
+f = 0
+for(f=0 f<frames f++
+  select(:all);
+  rotate(2);
+  update(20000))    // 20 ms / frame
+
 select(:clear)

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -77,11 +77,11 @@ graphical object assigned to an interpreter variable.
 
 .SH GROUP/UNGROUP COMMANDS
 
- group=group() -- group the current selection into a single group graphic
+ newgrp=group() -- group the current selection into a single group graphic
  ungroup([compview]) -- ungroup the selected group (or given group) into its members
- newgroup=growgroup(groupview compview)
+ newgrp=growgroup(groupview compview)
    -- add graphic to existing group graphic
- newgroup=trimgroup(groupview compview)
+ newgrp=trimgroup(groupview compview)
    -- remove graphic from existing group graphic
  front([compview]) -- move selection or graphic to front
  back([compview]) -- move selection or graphic to back

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -77,6 +77,8 @@ graphical object assigned to an interpreter variable.
 
 .SH GROUP/UNGROUP COMMANDS
 
+ group=group() -- group the current selection into a single group graphic
+ ungroup([compview]) -- ungroup the selected group (or given group) into its members
  newgroup=growgroup(groupview compview)
    -- add graphic to existing group graphic
  newgroup=trimgroup(groupview compview)


### PR DESCRIPTION
Closes #157 — adds the missing first-class **`group()`** / **`ungroup()`** commands to comdraw, and uses them to make `petals.comt` spin.

## The hole (#157)
`growgroup`/`trimgroup` could only *grow* or *trim* an **existing** group — both are gated on their first argument already being a group comp, so there was no way to bootstrap a group from the command language. You could add to a group you couldn't create.

## New commands (`ComUnidraw/groupfunc.{h,c}`)
- **`group=group()`** — collapses the current selection into one group graphic and returns its compview. Implemented as the "regroup" half of `growgroup` (`OvGroupCmd` over a `Clipboard` `Init`'d from the current selection) rather than from an existing group's members.
- **`ungroup([compview])`** — dissolves the selected group (or a given group compview) back into its members via `UngroupCmd`.

Registered in `ComEditor::AddCommands` beside `growgroup`/`trimgroup`; documented in `comdraw.1`. Both use only machinery already exercised by `growgroup`/`Back`/`FrontSelectionFunc` in the same file.

## Tests
- `src/comdraw/tests/group.comt` (registered in `run_all.comt`): group two rects → `size(group())==2`, then `ungroup()` returns non-nil. Runs in the comdraw suite under xvfb.

## Demo: spinning petals
`src/drawserv_/tests/petals.comt` now spins. A bare multi-selection rotates each graphic about *its own* center, so the petals would spin in place; `group()`-ing the whole picture first makes `rotate()` pivot about the group's shared center (160,160). The spin is a `for` loop of `select(:all); rotate(2); update(20000)`, mirroring `beachball.comt`.

## Notes
- Built in a worktree off `master`, separate from the other in-flight branches.
- Draft until CI confirms the comdraw build + `group.comt` pass (can't build comdraw on macOS/clang locally).