### PR TITLE
Fix scalar overdrive when a stream operand is a variable (var*var / var*lit)

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -308,7 +308,22 @@ void ComTerp::eval_expr_internals(int pedepth) {
       }
 
       for(int i=0; i<sv.narg()+sv.nkey(); i++) {
-	ComValue topval(pop_stack(i==streamid));
+	/* Resolve EVERY stream-valued arg, not just the first one found
+	   (streamid).  A stream held in a variable arrives here as a symbol;
+	   left unresolved (the old pop_stack(i==streamid)) it is not is_stream()
+	   in the AVL, so the per-element zip treats it as a whole non-stream
+	   argument -- which is why stream-var*stream-var (and var*literal)
+	   returned only the left operand's elements.  Resolving it makes it a
+	   stream value that zips per-element like a stream literal.  Scalar args
+	   stay unresolved (symbols) for per-element re-evaluation (broadcast). */
+	boolean argstream;
+	if (!stack_top().is_symbol() && !stack_top().is_attribute())
+	  argstream = stack_top().is_stream();
+	else {
+	  AttributeValue* tv = lookup_symval(&stack_top());
+	  argstream = tv ? tv->is_stream() : false;
+	}
+	ComValue topval(pop_stack(argstream));
 	avl->Prepend(new AttributeValue(topval));
       }
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -283,20 +283,18 @@ void ComTerp::eval_expr_internals(int pedepth) {
     /* create another StreamType ComValue to hold all its */
     /* arguments, along with a pointer to the func. */
     boolean has_streams = false;
-    int streamid = -1;
     if (!((ComFunc*)sv.obj_val())->post_eval())
       for(int i=0; i<sv.narg()+sv.nkey(); i++) {
 	if (!stack_top(-i).is_symbol() && !stack_top(-i).is_attribute())
 	  has_streams = stack_top(-i).is_stream();
 	else {
-	  AttributeValue* testval = 
+	  AttributeValue* testval =
 	    lookup_symval(&stack_top(-i));
 	  has_streams = testval ? testval->is_stream() : false;
 	}
-	if (has_streams) {
-	  streamid = i;
-	  break;
-	}
+	if (has_streams)
+	  break;   // any stream arg triggers the overdrive; the pack loop
+		   // below re-detects stream-ness per arg (no streamid needed)
       }
     if (has_streams) {
       AttributeValueList* avl = new AttributeValueList();
@@ -308,9 +306,9 @@ void ComTerp::eval_expr_internals(int pedepth) {
       }
 
       for(int i=0; i<sv.narg()+sv.nkey(); i++) {
-	/* Resolve EVERY stream-valued arg, not just the first one found
-	   (streamid).  A stream held in a variable arrives here as a symbol;
-	   left unresolved (the old pop_stack(i==streamid)) it is not is_stream()
+	/* Resolve EVERY stream-valued arg, not just the first one found.
+	   A stream held in a variable arrives here as a symbol; left unresolved
+	   (as the old pop_stack(i==streamid) did for all but the first) it is not is_stream()
 	   in the AVL, so the per-element zip treats it as a whole non-stream
 	   argument -- which is why stream-var*stream-var (and var*literal)
 	   returned only the left operand's elements.  Resolving it makes it a

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -318,6 +318,21 @@ print("38a next(s1);next(s1); s2=$$s1; next(s2) pos preserved (expect 3): %v\n" 
 print("38b next(s1) original also at 3 (expect 3): %v\n" v2)
 prev_ok=check_fail(:ok ok)
 
+// --- test 39: scalar overdrive with a stream held in a VARIABLE.
+//     Bug: var*var and var*lit returned only the left operand's elements
+//     (the left stream-variable was left unresolved in the overdrive pack, so
+//     the per-element zip did not stream it).  A stream in a variable must
+//     overdrive exactly like a stream literal on the left. ---
+a1=(1 2 3)
+b1=(4 5 6)
+r1=list(a1*b1)
+ok=ok&&(r1==(4,10,18))
+c1=(4 5 6)
+r2=list(c1*(1 2 3))
+ok=ok&&(r2==(4,10,18))
+print("39 var*var and var*lit overdrive (expect {4,10,18} both): %v %v\n" r1 r2)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 


### PR DESCRIPTION
## Bug
Scalar overdrive (`*`, `+`, …) vectorizes a binary op when one operand is a stream. But when a stream is held in a **variable** and isn't the first-found stream operand, it wasn't streamed — the op returned only the *other* operand's elements:

```
(1 2 3) * c       → {1,4,9}     ✓   (literal on the left works)
d * (1 2 3)       → {4,5,6}     ✗   (var on the left — returns d's elements, ignores the right)
a * b             → {1,2,3}     ✗   (var * var — returns a's elements, ignores b)
```

This blocked anything that multiplies two stream *variables* — e.g. a dot product `total(row*col)`, and hence matrix multiply.

## Root cause
`ComTerp::eval_expr_internals` packs a non-post-eval op's args into a `STREAM_EXTERNAL` stream for per-element evaluation. The per-element zip (`NextFunc::execute_impl`) streams any AVL arg that `is_stream()` and passes the rest whole. But the pack resolved **only the first stream found** (`pop_stack(i==streamid)`) and left every other arg unresolved. A stream held in a variable arrives as a *symbol*; unresolved, it isn't `is_stream()` in the AVL, so the zip passed it **whole** instead of per-element. A literal stream on the left worked only because a literal is already a stream *value*, not a symbol.

## Fix
During the pack, resolve **every** stream-valued arg (so a stream in a variable becomes a stream value that zips per-element, exactly like a stream literal); scalar args stay unresolved for per-element broadcast. One localized change in `eval_expr_internals`.

## Test
`stream.comt` **test 39** covers `var*var` and `var*lit` (both → `{4,10,18}`); the full stream suite still passes (`stream: true`). Scalar broadcast (`(1..5)*2` → `{2,4,6,8,10}`) and all existing stream ops unaffected.

Pre-existing bug, independent of any feature work; split out on its own so it can land separately.