### PR TITLE
Add %% stream-replay operator (#140) + live operator-table editing

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1431,6 +1431,7 @@ void ComTerp::add_defaults() {
     add_command("stream", new StreamFunc(this));
     add_command("concat", new ConcatFunc(this));
     add_command("repeat", new RepeatFunc(this));
+    add_command("replay", new ReplayFunc(this));
     add_command("iterate", new IterateFunc(this));
     add_command("next", new NextFunc(this));
     add_command("info", new InfoFunc(this));

--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -289,7 +289,57 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
   static int table_symid = symbol_add("table");
   ComValue tableflag(stack_key(table_symid));
 
+  /* live operator-table editing (reprogram the parser at runtime): the change
+     takes effect for the NEXT parsed expression, like a func definition. */
+  static int insert_symid = symbol_add("insert");
+  ComValue insertflag(stack_key(insert_symid));
+  static int delete_symid = symbol_add("delete");
+  ComValue deleteflag(stack_key(delete_symid));
+  static int pri_symid = symbol_add("pri");
+  ComValue default_pri(80);
+  ComValue prival(stack_key(pri_symid, false, default_pri, true));
+  static int rtol_symid = symbol_add("rtol");
+  ComValue rtolflag(stack_key(rtol_symid));
+  static int prefix_symid = symbol_add("prefix");
+  ComValue prefixflag(stack_key(prefix_symid));
+  static int postfix_symid = symbol_add("postfix");
+  ComValue postfixflag(stack_key(postfix_symid));
+  ComValue opstrv(stack_arg(0));    // operator string (e.g. "%%")
+  ComValue commandv(stack_arg(1));  // command it maps to (e.g. "replay"), for :insert
+
   reset_stack();
+
+  /* optable("%%" "replay" :insert [:pri N] [:rtol] [:prefix|:postfix])
+     optable("%%" :delete [:prefix|:postfix])
+     -- returns 1 on success, 0 on failure.  Effective next expression. */
+  if (insertflag.is_true() || deleteflag.is_true()) {
+    if (!opstrv.is_string()) {
+      fprintf(stderr, "optable: :insert/:delete needs an operator string\n");
+      ComValue zero(0);
+      push_stack(zero);
+      return;
+    }
+    unsigned optype = prefixflag.is_true()  ? OPTYPE_UNARY_PREFIX
+                    : postfixflag.is_true() ? OPTYPE_UNARY_POSTFIX
+                    : OPTYPE_BINARY;
+    int rc;
+    if (deleteflag.is_true()) {
+      rc = opr_tbl_remove(opstrv.string_ptr(), optype);
+    } else {
+      if (!commandv.is_string()) {
+        fprintf(stderr, "optable: :insert needs a command name\n");
+        ComValue zero(0);
+        push_stack(zero);
+        return;
+      }
+      rc = opr_tbl_insert(opstrv.string_ptr(), commandv.string_ptr(),
+                          (unsigned)prival.int_val(),
+                          (BOOLEAN)rtolflag.is_true(), optype);
+    }
+    ComValue result(rc == 0 ? 1 : 0);
+    push_stack(result);
+    return;
+  }
 
   if (tableflag.is_true()) {
     // return list of attrlists, one per operator entry

--- a/src/ComTerp/helpfunc.h
+++ b/src/ComTerp/helpfunc.h
@@ -61,14 +61,20 @@ public:
     OptableFunc(ComTerp*);
     virtual void execute();
 
-    virtual const char* docstring() { 
-      return "%s(:bypri :byopr :bycom :table) -- print contents of operator table\n(or return as list of attrlists with :table)"; }
+    virtual const char* docstring() {
+      return "%s(:bypri :byopr :bycom :table | opstr [command] :insert|:delete [:pri n] [:rtol] [:prefix|:postfix]) -- print the operator table, or add/remove an operator live (effective next expression)"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":bypri     sort by priority",
 	":byopr     sort by operator name",
 	":bycom     sort by command name",
 	":table     return as list of attrlists (:opr :cmd :pri :rtol :type)",
+	":insert    add operator opstr->command to the table (opstr command required)",
+	":delete    remove operator opstr from the table (opstr required)",
+	":pri n     operator priority for :insert (default 80)",
+	":rtol      operator associates right-to-left (default left-to-right)",
+	":prefix    unary prefix operator (default binary)",
+	":postfix   unary postfix operator (default binary)",
 	nil
       };
       return keys;

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -451,6 +451,87 @@ void RepeatFunc::execute() {
 
 /*****************************************************************************/
 
+ReplayFunc::ReplayFunc(ComTerp* comterp) : StrmFunc(comterp) {
+}
+
+void ReplayFunc::execute() {
+    /* post_eval: take the WHOLE stream operand (like ConcatFunc), not a
+       per-element broadcast.  A %% N -- build the internal replay stream. */
+    ComValue operand1(stack_arg_post_eval(0));
+    ComValue operand2(stack_arg_post_eval(1));
+    reset_stack();
+
+    if (operand1.is_nil() || operand2.is_nil()) {
+      push_stack(ComValue::nullval());
+      return;
+    }
+    int n = operand2.int_val();
+
+    static ReplayNextFunc* rnfunc = nil;
+    if (!rnfunc) {
+      rnfunc = new ReplayNextFunc(comterp());
+      rnfunc->funcid(symbol_add("replaynext"));
+    }
+    AttributeValueList* avl = new AttributeValueList();
+    avl->Append(new AttributeValue(operand1));                    // [0] source stream (template, never consumed)
+    avl->Append(new AttributeValue(n, AttributeValue::IntType));  // [1] passes remaining
+    avl->Append(new AttributeValue(ComValue::nullval()));         // [2] current pass copy (a stream, or nil)
+    ComValue stream(rnfunc, avl);
+    stream.stream_mode(STREAM_INTERNAL); // driven by ReplayNextFunc
+    push_stack(stream);
+}
+
+/*****************************************************************************/
+
+ReplayNextFunc::ReplayNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
+}
+
+void ReplayNextFunc::execute() {
+    ComValue operand1(stack_arg(0));   // our internal replay stream
+
+    /* invoked by the next mechanism */
+    reset_stack();
+    AttributeValueList* avl = operand1.stream_list();
+    if (avl) {
+      Iterator i;
+      avl->First(i);
+      AttributeValue* srcval = avl->GetAttrVal(i);   // [0] source stream (template, never consumed)
+      avl->Next(i);
+      AttributeValue* cntval = avl->GetAttrVal(i);   // [1] passes remaining
+      avl->Next(i);
+      AttributeValue* curval = avl->GetAttrVal(i);   // [2] current pass copy (a stream, or nil)
+
+      for (;;) {
+	/* start of a pass: need a fresh $$-copy of the source */
+	if (!curval->is_stream()) {
+	  if (cntval->int_val() <= 0 || !srcval->is_stream()) {
+	    push_stack(ComValue::nullval());           // all passes done (or non-stream source)
+	    return;
+	  }
+	  /* $$ copy semantics: new AVL (independent cursor), same stream func,
+	     sharing the source's immutable elements -- the source is untouched */
+	  AttributeValueList* newavl = new AttributeValueList(srcval->stream_list());
+	  ComValue copyv(srcval->stream_func(), newavl);
+	  copyv.stream_mode(srcval->stream_mode());
+	  *curval = copyv;
+	  cntval->int_ref()--;
+	}
+	/* pull the next element from the current copy */
+	ComValue curcopy(*curval);
+	NextFunc::execute_impl(comterp(), curcopy, false);
+	if (comterp()->stack_top().is_unknown()) {
+	  comterp()->pop_stack();                      // this pass exhausted
+	  *curval = ComValue::nullval();               // force a fresh copy next time
+	  continue;                                    // ...and start the next pass
+	}
+	return;   // the value from execute_impl is already on the stack
+      }
+    } else
+      push_stack(ComValue::nullval());
+}
+
+/*****************************************************************************/
+
 IterateFunc::IterateFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
 

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -466,6 +466,10 @@ void ReplayFunc::execute() {
       return;
     }
     int n = operand2.int_val();
+    if (n <= 0) {           // no passes -> empty stream; don't allocate one (cf. RepeatFunc)
+      push_stack(ComValue::nullval());
+      return;
+    }
 
     static ReplayNextFunc* rnfunc = nil;
     if (!rnfunc) {

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -137,6 +137,36 @@ public:
 
 };
 
+//: %% (replay) operator.
+// The streaming counterpart to ** (repeat).  %% cycles a WHOLE stream through N
+// full passes: A%%3 -> A's elements, three times over.  It must be post_eval so
+// it receives the whole stream operand rather than being broadcast per-element
+// (a non-post-eval binary op with one stream operand is vectorized element-wise
+// -- that broadcast is exactly how ** repeats each element).  Like ConcatFunc,
+// setup builds a stream driven by a separate next-func (ReplayNextFunc).  Runs a
+// $$-copy of the source to exhaustion, then a fresh copy for the next pass, N
+// times -- each pass an independent cursor, the source itself never consumed.
+// Together with ** this yields cross-product streams: (A**3, B%%3).
+class ReplayFunc : public StrmFunc {
+public:
+    ReplayFunc(ComTerp*);
+
+    virtual void execute();
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "%% is the stream-replay operator (cycle a stream N times)"; }
+};
+
+//: hidden func used by next command for %% (replay) operator.
+class ReplayNextFunc : public StrmFunc {
+public:
+    ReplayNextFunc(ComTerp*);
+
+    virtual void execute();
+    virtual const char* docstring() {
+      return "hidden func used by next command for %% (stream replay) operator."; }
+};
+
 //: .. (iterate) operator.
 class IterateFunc : public StrmFunc {
 public:

--- a/src/ComUtil/comterp.arg
+++ b/src/ComUtil/comterp.arg
@@ -17,6 +17,7 @@ int scanner(void *infile,char *(*infunc)(),int (*eoffunc)(),int (*errfunc)(),
 int opr_tbl_create(unsigned maxop);
 int opr_tbl_insert(const char *opstr,const char *command,unsigned priority,BOOLEAN rtol,
 		   unsigned optype);
+int opr_tbl_remove(const char *opstr,unsigned optype);
 int opr_tbl_print(FILE *outfile,unsigned by);
 int opr_tbl_entries(char *opstr,int *op_ids,unsigned nop_ids,unsigned *nchars);
 int opr_tbl_operid(unsigned opnum);

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -507,6 +507,73 @@ static int gt_com(int a, int b) {
 
 /*!
 
+opr_tbl_remove   Remove a single operator entry from the operator table
+
+
+Summary:
+
+#include <ComUtil/comterp.h>
+*/
+
+int opr_tbl_remove(const char * opstr, unsigned optype)
+
+
+/*!
+Return Value:  0 if OK, -1 if not found or error
+
+
+Description:
+
+`opr_tbl_remove` removes the single operator entry matching `opstr` and `optype`
+-- the inverse of `opr_tbl_insert`.  Unlike `opr_tbl_delete`, which frees the
+whole table, every other operator is left in place.  Returns FUNCBAD if no such
+entry exists.  MaxPriority is left as-is (a harmless upper bound).
+!*/
+
+{
+unsigned table_off = 0;         /* Offset into operator table */
+
+/* Check if table exists */
+   if( OperatorTable == NULL ) {
+      COMERR_SET( ERR_NO_OPTABLE );
+      return FUNCBAD;
+      }
+
+/* Find the run of entries for opstr (table is sorted by operator string) */
+   while( table_off < NumOperators &&
+	  strcmp( OPSTR( table_off ), opstr ) < 0 )
+      table_off++;
+
+/* Scan that run for the requested optype */
+   while( table_off < NumOperators &&
+	  strcmp( OPSTR( table_off ), opstr ) == 0 ) {
+      if( OperatorTable[ table_off ].optype == optype ) {
+	 if( symbol_del( OperatorTable[ table_off ].operid ) ||
+	     symbol_del( OperatorTable[ table_off ].commid ))
+	    KAPUT( "Error in deleting symbols" );
+	 /* Slide the remaining entries down by one to close the gap */
+	 if( table_off < NumOperators - 1 )
+#ifndef DMM_OFF
+	    if( dmm_movrecs( (void **)&OperatorTable, (long)(table_off),
+			 (long)(table_off+1), (long)(NumOperators-table_off-1)))
+	       KAPUT( "Error in attempt to move operator table entries" );
+#else
+	    memmove((void*)(OperatorTable+table_off),
+		    (void*)(OperatorTable+table_off+1),
+		    (NumOperators-table_off-1)*sizeof( opr_tbl_entry ));
+#endif
+	 --NumOperators;
+	 return FUNCOK;
+	 }
+      table_off++;
+      }
+
+/* No matching entry */
+   return FUNCBAD;
+}
+
+/*!
+
 opr_tbl_print   Print contents of operator table
 
 
@@ -1042,8 +1109,13 @@ $          stream             125        Y      UNARY PREFIX
 !*/
 
 {
-  int table_size = sizeof( DefaultOperatorTable ) / 
+  int table_size = sizeof( DefaultOperatorTable ) /
     sizeof( struct _opr_tbl_default_entry );
+  /* Headroom beyond the built-in operators so new operators can be added at
+     runtime -- e.g. optable(:insert "%%" "replay" 80) defining an operator on
+     the fly -- without immediately maxing the table (ERR_OPRTBLMAXED).  The
+     table is created exactly full otherwise, leaving no room for a live insert. */
+  const int slack = 16;
   int index;
 
   if (OperatorTable && opr_tbl_is_default)
@@ -1061,8 +1133,8 @@ $          stream             125        Y      UNARY PREFIX
 
   OperatorTable = NULL;
 
-  /* Initalize table to the right size */
-  if( opr_tbl_create( table_size ) != 0 )
+  /* Initalize table to the right size (plus runtime-insert headroom) */
+  if( opr_tbl_create( table_size + slack ) != 0 )
      KAPUT( "Unable to create default operator table" );
 
   /* Fill it up */

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -1112,9 +1112,9 @@ $          stream             125        Y      UNARY PREFIX
 {
   int table_size = sizeof( DefaultOperatorTable ) /
     sizeof( struct _opr_tbl_default_entry );
-  /* Headroom beyond the built-in operators so new operators can be added at
-     runtime -- e.g. optable(:insert "%%" "replay" 80) defining an operator on
-     the fly -- without immediately maxing the table (ERR_OPRTBLMAXED).  The
+  /* Headroom beyond the built-in operators so a new operator can be added at
+     runtime -- e.g. optable("<+>" "mycmd" :insert :pri 50) defining an operator
+     on the fly -- without immediately maxing the table (ERR_OPRTBLMAXED).  The
      table is created exactly full otherwise, leaving no room for a live insert. */
   const int slack = 16;
   int index;

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -111,6 +111,7 @@ struct _opr_tbl_default_entry {
   {"$$",         "stream",             100,         TRUE,       OPTYPE_UNARY_PREFIX },
   {"..",         "iterate",            90,         FALSE,      OPTYPE_BINARY },
   {"**",         "repeat",             80,         FALSE,      OPTYPE_BINARY },
+  {"%%",         "replay",             79,         FALSE,      OPTYPE_BINARY },
   {",,",         "concat",             75,         FALSE,      OPTYPE_BINARY },
   {"%",          "mod",                70,         FALSE,      OPTYPE_BINARY },
   {"*",          "mpy",                70,         FALSE,      OPTYPE_BINARY },

--- a/src/comterp_/tests/replay.comt
+++ b/src/comterp_/tests/replay.comt
@@ -1,0 +1,57 @@
+// src/comterp_/tests/replay.comt -- the %% stream-replay operator (#140) and
+// the live optable(:insert/:delete) parser reprogramming that can remove and
+// re-add it.
+//
+// funcs: %% replay optable(:insert) optable(:delete) postfix errmsg
+// coverage: %% (cycle a whole stream N times), (A**3,B%%3) cross product,
+//           optable(:delete)/optable(:insert) round-trip
+//
+// %% is baked into the default operator table, so it works out of the box.
+// The round-trip deletes it (the parser then rejects %%), then re-inserts it --
+// demonstrating that optable() reprograms the parser live, effective on the
+// NEXT parsed expression (like a func definition).
+
+ok=true
+
+// --- test 1: %% cycles a WHOLE stream N times (baked-in operator) ---
+C=("a" "b" "c")
+r=list(C%%3)
+ok=ok&&(r==("a","b","c","a","b","c","a","b","c"))
+print("1 list(C%%3) cycles the stream 3x (expect 9 elements): %v\n" r)
+
+// --- test 2: cross product (A**3, B%%3) -- ** holds each element (outer),
+//     %% cycles the whole stream (inner); , zips them into pairs ---
+A=("a" "b" "c")
+B=("x" "y" "z")
+z=A**3,B%%3
+first=next(z)
+ok=ok&&(first==("a","x"))
+cnt=1
+v=next(z)
+while(v!=nil cnt=cnt+1;v=next(z))
+ok=ok&&(cnt==9)
+print("2 (A**3,B%%3) cross product first pair (expect {a,x}) and count (expect 9): %v %v\n" first cnt)
+
+// --- test 3: %% is present -- the parser compiles A%%3 to the replay command ---
+p=postfix(A%%3)
+ok=ok&&(index(p "replay")!=nil)
+print("3 postfix(A%%3) contains 'replay' (baked in): %v\n" p)
+
+// --- test 4: optable(:delete) removes %% -- the parser no longer knows it,
+//     so A%%3 is now a parse error (Unexpected operator %) ---
+optable("%%" :delete)
+errmsg(:clear)
+postfix(A%%3)
+e=errmsg()
+ok=ok&&(index(e "Unexpected")!=nil)
+print("4 after optable(\"%%\" :delete), A%%3 is a parse error (expect 'Unexpected'): %v\n" e)
+
+// --- test 5: optable(:insert) re-adds %% -- the parser knows it again ---
+optable("%%" "replay" :insert :pri 79)
+errmsg(:clear)
+p2=postfix(A%%3)
+ok=ok&&(index(p2 "replay")!=nil)
+print("5 after optable(:insert), postfix(A%%3) contains 'replay' again: %v\n" p2)
+
+print("replay: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -77,5 +77,9 @@ if(run("./funcarg.comt")
   :then print("pass: funcarg\n")
   :else print("FAIL: funcarg\n");topok=false)
 
+if(run("./replay.comt")
+  :then print("pass: replay\n")
+  :else print("FAIL: replay\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -109,8 +109,8 @@ both until exit.
     --         decr_after     110         R-to-L      unary-postfix
     $$         stream         100         R-to-L      unary-prefix
     **         repeat         90          L-to-R      binary
-    %%         replay         79          L-to-R      binary
     ..         iterate        80          L-to-R      binary
+    %%         replay         79          L-to-R      binary
     %          mod            70          L-to-R      binary
     *          mpy            70          L-to-R      binary
     /          div            70          L-to-R      binary

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -109,6 +109,7 @@ both until exit.
     --         decr_after     110         R-to-L      unary-postfix
     $$         stream         100         R-to-L      unary-prefix
     **         repeat         90          L-to-R      binary
+    %%         replay         79          L-to-R      binary
     ..         iterate        80          L-to-R      binary
     %          mod            70          L-to-R      binary
     *          mpy            70          L-to-R      binary

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -306,7 +306,11 @@ both until exit.
 
  help(cmdname [cmdname ...] :all :posteval) -- help for commands
 
- optable(:bypri :byopr :bycom) -- print contents of operator table
+ optable(:bypri :byopr :bycom :table) -- print contents of operator table (or return as list of attrlists with :table)
+
+ optable(opstr command :insert [:pri n] [:rtol] [:prefix|:postfix]) -- add an operator to the table at runtime, mapping operator string opstr to command (e.g. optable("%%" "replay" :insert :pri 80)); reprograms the parser for the NEXT expression
+
+ optable(opstr :delete [:prefix|:postfix]) -- remove an operator added with :insert
 
 .SH DEBUG COMMANDS
 


### PR DESCRIPTION
Adds `%%`, the streaming counterpart to `**` (repeat). Where `**` repeats each *element* of a stream, `%%` cycles a *whole* stream through N passes — `A%%3` → A's elements, three times over — so `(A**3, B%%3)` zips into a full cross product. Closes part of #140.

## `%%` behavior
- `ReplayFunc` is **post_eval** (like `ConcatFunc`), so it receives the whole stream operand instead of being broadcast per-element (that per-element broadcast is exactly how `**` repeats each element). It builds a stream driven by a new `ReplayNextFunc` that runs a `$$`-copy of the source to exhaustion, then a fresh copy per pass — the source is never consumed.
- **Baked into the default operator table** (`{"%%","replay",79,…}`) so it works out of the box, and documented in `comterp.1`. Priority 79 sits just under `**` (80) so `A**3%%2` groups as `(A**3)%%2` and both bind above the arithmetic they feed.

## Live operator-table editing (the reprogrammability angle)
The same PR gives `optable()` an **`:insert`/`:delete`** capability — `optable(opstr command :insert [:pri n] [:rtol] [:prefix|:postfix])` and `optable(opstr :delete)` — exposing `opr_tbl_insert` plus a new single-entry `opr_tbl_remove` (the old `opr_tbl_delete` only frees the whole table). And `opr_tbl_default()` now creates the table with **headroom** (it was exact-fit, so any runtime insert hit `ERR_OPRTBLMAXED`). Like a `func` definition, an `optable` edit takes effect on the **next** parsed expression.

## Test — `comterp_/tests/replay.comt` (registered in `run_all.comt`, suite green)
1. `%%` cycling: `list(C%%3)` → 9 elements.
2. cross product `(A**3, B%%3)` → first pair `{a,x}`, count 9.
3. **round-trip** demonstrating the live reprogramming, on `%%` itself: `postfix(A%%3)` compiles to `replay` (baked in) → `optable("%%" :delete)` → the parser now rejects `A%%3` (`Unexpected operator %`, caught via `errmsg`) → `optable(:insert)` re-adds it. So `%%` ships as a real operator *and* the test doubles as the live-reprogram demonstration.

## Notes
- Independent of #196 (the `var*var` overdrive fix) — that's only needed for the matrix-multiply demo, a follow-up.
- `IplFunc` (the IPL imaging-language mode switch) is the prior art for live table reprogramming; this is the incremental-insert counterpart.