### PR TITLE
Bare graphic-state commands return the literal that reproduces the current state

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1073,12 +1073,17 @@ BrushFunc::BrushFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 void BrushFunc::execute() {
     if (nargs()==0 && nkeys()==0) {
         /* brush() -- return the current editor brush as a linepat,width
-           literal (valid input to brush(linepat,width)); nil if none brush */
+           literal (valid input to brush(linepat,width)), or the keyword
+           :none for the none brush (valid input by paste or by value) */
         reset_stack();
         BrushVar* brVar = (BrushVar*) _ed->GetState("BrushVar");
         PSBrush* br = brVar ? brVar->GetBrush() : nil;
-        if (!br || br->None()) {
+        if (!br) {
             push_stack(ComValue::nullval());
+        } else if (br->None()) {
+            static int none_sym = symbol_add("none");
+            ComValue retval(none_sym, 0, ComValue::KeywordType);
+            push_stack(retval);
         } else {
             AttributeValueList* avl = new AttributeValueList();
             avl->Append(new ComValue(br->GetLinePattern()));
@@ -1096,8 +1101,10 @@ void BrushFunc::execute() {
 
     PSBrush* brush = nil;
 
-    if (nonev.is_true()) {
-        /* brush(:none) -- none brush */
+    if (nonev.is_true() || (bnum.is_key() && bnum.keyid_val()==none_sym)) {
+        /* brush(:none) -- none brush; also accepted positionally BY VALUE
+           (a variable holding the :none keyword returned by bare brush()),
+           so saved=brush(); ...; brush(saved) round-trips the none brush */
         brush = new PSBrush();
 
     } else if (bnum.is_array()) {

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1072,6 +1072,8 @@ BrushFunc::BrushFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
 void BrushFunc::execute() {
+    static int none_sym = symbol_add("none");
+
     if (nargs()==0 && nkeys()==0) {
         /* brush() -- return the current editor brush as a linepat,width
            literal (valid input to brush(linepat,width)), or the attrlist
@@ -1085,7 +1087,6 @@ void BrushFunc::execute() {
         if (!br) {
             push_stack(ComValue::nullval());
         } else if (br->None()) {
-            static int none_sym = symbol_add("none");
             AttributeList* al = new AttributeList();
             al->add_attr(none_sym, new AttributeValue(1, AttributeValue::BooleanType));
             ComValue retval(AttributeList::class_symid(), al);
@@ -1101,7 +1102,6 @@ void BrushFunc::execute() {
     }
 
     ComValue bnum(stack_arg(0));
-    static int none_sym = symbol_add("none");
     ComValue nonev(stack_key(none_sym));
     reset_stack();
 

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -72,6 +72,7 @@
 #include <X11/Xatom.h>
 
 #include <Attribute/aliterator.h>
+#include <Attribute/attribute.h>
 #include <Attribute/attrlist.h>
 
 #define TITLE "GrFunc"
@@ -1073,8 +1074,11 @@ BrushFunc::BrushFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 void BrushFunc::execute() {
     if (nargs()==0 && nkeys()==0) {
         /* brush() -- return the current editor brush as a linepat,width
-           literal (valid input to brush(linepat,width)), or the keyword
-           :none for the none brush (valid input by paste or by value) */
+           literal (valid input to brush(linepat,width)), or the attrlist
+           singleton (:none 1) for the none brush.  A keyword-flag literal
+           travels as an attrlist, never as a raw KeywordType value --
+           eager stack_key() scans frames by type, so a stored keyword
+           would become a live keyword in any frame it entered. */
         reset_stack();
         BrushVar* brVar = (BrushVar*) _ed->GetState("BrushVar");
         PSBrush* br = brVar ? brVar->GetBrush() : nil;
@@ -1082,7 +1086,9 @@ void BrushFunc::execute() {
             push_stack(ComValue::nullval());
         } else if (br->None()) {
             static int none_sym = symbol_add("none");
-            ComValue retval(none_sym, 0, ComValue::KeywordType);
+            AttributeList* al = new AttributeList();
+            al->add_attr(none_sym, new AttributeValue(1, AttributeValue::BooleanType));
+            ComValue retval(AttributeList::class_symid(), al);
             push_stack(retval);
         } else {
             AttributeValueList* avl = new AttributeValueList();
@@ -1101,10 +1107,18 @@ void BrushFunc::execute() {
 
     PSBrush* brush = nil;
 
-    if (nonev.is_true() || (bnum.is_key() && bnum.keyid_val()==none_sym)) {
-        /* brush(:none) -- none brush; also accepted positionally BY VALUE
-           (a variable holding the :none keyword returned by bare brush()),
-           so saved=brush(); ...; brush(saved) round-trips the none brush */
+    /* the attrlist singleton (:none 1) returned by bare brush() is accepted
+       back positionally, so saved=brush(); ...; brush(saved) round-trips
+       the none brush */
+    boolean none_by_value = false;
+    if (bnum.is_attributelist()) {
+        AttributeList* bal = (AttributeList*)bnum.geta(AttributeList::class_symid());
+        Attribute* battr = bal ? bal->GetAttr(none_sym) : nil;
+        none_by_value = battr && battr->Value() && battr->Value()->is_true();
+    }
+
+    if (nonev.is_true() || none_by_value) {
+        /* brush(:none) -- none brush */
         brush = new PSBrush();
 
     } else if (bnum.is_array()) {

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -861,6 +861,21 @@ FontFunc::FontFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
 void FontFunc::execute() {
+    if (nargs()==0 && nkeys()==0) {
+        /* font() -- return the current editor font by X name
+           (valid input to fontbyname(fontname)) */
+        reset_stack();
+        FontVar* fntVar = (FontVar*) _ed->GetState("FontVar");
+        PSFont* fnt = fntVar ? fntVar->GetFont() : nil;
+        if (!fnt) {
+            push_stack(ComValue::nullval());
+        } else {
+            ComValue retval(fnt->GetName());
+            push_stack(retval);
+        }
+        return;
+    }
+
     ComValue fnum(stack_arg(0));
     int fn = fnum.int_val();
     reset_stack();
@@ -945,6 +960,21 @@ static char  *psfonttoxfont(char* f)
 }
  /*****************************************************************************/
 void FontByNameFunc::execute() {
+  if (nargs()==0 && nkeys()==0) {
+      /* fontbyname() -- return the current editor font by X name,
+         same getter as bare font() */
+      reset_stack();
+      FontVar* fntVar = (FontVar*) _ed->GetState("FontVar");
+      PSFont* fnt = fntVar ? fntVar->GetFont() : nil;
+      if (!fnt) {
+          push_stack(ComValue::nullval());
+      } else {
+          ComValue retval(fnt->GetName());
+          push_stack(retval);
+      }
+      return;
+  }
+
   ComValue& fontarg = stack_arg(0);
   const char*  fontval = fontarg.string_ptr();
   reset_stack();
@@ -995,6 +1025,25 @@ ColorRgbFunc::ColorRgbFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, 
  }
 
 void ColorRgbFunc::execute() {
+  if (nargs()==0 && nkeys()==0) {
+      /* colorsrgb() -- return the current editor colors as a fgname,bgname
+         literal, same getter as bare colors() */
+      reset_stack();
+      ColorVar* colVar = (ColorVar*) _ed->GetState("ColorVar");
+      PSColor* fgcolor = colVar ? colVar->GetFgColor() : nil;
+      PSColor* bgcolor = colVar ? colVar->GetBgColor() : nil;
+      if (!fgcolor || !bgcolor) {
+          push_stack(ComValue::nullval());
+      } else {
+          AttributeValueList* avl = new AttributeValueList();
+          avl->Append(new ComValue(fgcolor->GetName()));
+          avl->Append(new ComValue(bgcolor->GetName()));
+          ComValue retval(avl);
+          push_stack(retval);
+      }
+      return;
+  }
+
   ComValue& fgarg = stack_arg(0);
   ComValue& bgarg = stack_arg(1);
   const char* fgname = fgarg.string_ptr();
@@ -1022,6 +1071,24 @@ BrushFunc::BrushFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
 void BrushFunc::execute() {
+    if (nargs()==0 && nkeys()==0) {
+        /* brush() -- return the current editor brush as a linepat,width
+           literal (valid input to brush(linepat,width)); nil if none brush */
+        reset_stack();
+        BrushVar* brVar = (BrushVar*) _ed->GetState("BrushVar");
+        PSBrush* br = brVar ? brVar->GetBrush() : nil;
+        if (!br || br->None()) {
+            push_stack(ComValue::nullval());
+        } else {
+            AttributeValueList* avl = new AttributeValueList();
+            avl->Append(new ComValue(br->GetLinePattern()));
+            avl->Append(new ComValue(br->Width()));
+            ComValue retval(avl);
+            push_stack(retval);
+        }
+        return;
+    }
+
     ComValue bnum(stack_arg(0));
     static int none_sym = symbol_add("none");
     ComValue nonev(stack_key(none_sym));
@@ -1068,6 +1135,31 @@ PatternFunc::PatternFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed
 }
 
 void PatternFunc::execute() {
+    if (nargs()==0 && nkeys()==0) {
+        /* pattern() -- return the current editor pattern as its menu number
+           (valid input to pattern(patternnum)); the catalog caches pattern
+           reads, so the state var's pointer matches its menu entry.  nil if
+           the current pattern is not a menu pattern (e.g. patternmask). */
+        reset_stack();
+        PatternVar* patVar = (PatternVar*) _ed->GetState("PatternVar");
+        PSPattern* pat = patVar ? patVar->GetPattern() : nil;
+        Catalog* catalog = unidraw->GetCatalog();
+        int pn = 0;
+        if (pat) {
+            int i = 1;
+            while (catalog->GetAttribute(catalog->Name("pattern", i))) {
+                if (catalog->ReadPattern("pattern", i) == pat) { pn = i; break; }
+                i++;
+            }
+        }
+        if (pn) {
+            ComValue retval(pn);
+            push_stack(retval);
+        } else
+            push_stack(ComValue::nullval());
+        return;
+    }
+
     ComValue pnum(stack_arg(0));
     int pn = pnum.int_val();
     reset_stack();
@@ -1132,6 +1224,25 @@ ColorFunc::ColorFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
 void ColorFunc::execute() {
+    if (nargs()==0 && nkeys()==0) {
+        /* colors() -- return the current editor colors as a fgname,bgname
+           literal (valid input to colors(fgname bgname)) */
+        reset_stack();
+        ColorVar* colVar = (ColorVar*) _ed->GetState("ColorVar");
+        PSColor* fgcolor = colVar ? colVar->GetFgColor() : nil;
+        PSColor* bgcolor = colVar ? colVar->GetBgColor() : nil;
+        if (!fgcolor || !bgcolor) {
+            push_stack(ComValue::nullval());
+        } else {
+            AttributeValueList* avl = new AttributeValueList();
+            avl->Append(new ComValue(fgcolor->GetName()));
+            avl->Append(new ComValue(bgcolor->GetName()));
+            ComValue retval(avl);
+            push_stack(retval);
+        }
+        return;
+    }
+
     ComValue& fgv = stack_arg(0, true);
     if (fgv.is_string()) {
         if (_color_rgb_func == NULL) {

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1075,7 +1075,7 @@ void BrushFunc::execute() {
     if (nargs()==0 && nkeys()==0) {
         /* brush() -- return the current editor brush as a linepat,width
            literal (valid input to brush(linepat,width)), or the attrlist
-           singleton (:none 1) for the none brush.  A keyword-flag literal
+           singleton (:none true) for the none brush.  A keyword-flag literal
            travels as an attrlist, never as a raw KeywordType value --
            eager stack_key() scans frames by type, so a stored keyword
            would become a live keyword in any frame it entered. */
@@ -1107,7 +1107,7 @@ void BrushFunc::execute() {
 
     PSBrush* brush = nil;
 
-    /* the attrlist singleton (:none 1) returned by bare brush() is accepted
+    /* the attrlist singleton (:none true) returned by bare brush() is accepted
        back positionally, so saved=brush(); ...; brush(saved) round-trips
        the none brush */
     boolean none_by_value = false;

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -168,7 +168,7 @@ public:
     BrushFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width (or :none) if no args"; }
+	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width (or attrlist (:none 1)) if no args"; }
 };
 
 //: command for setting pattern state variable in comdraw.

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -168,7 +168,7 @@ public:
     BrushFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width (or attrlist (:none 1)) if no args"; }
+	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width (or attrlist (:none true)) if no args"; }
 };
 
 //: command for setting pattern state variable in comdraw.

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -168,7 +168,7 @@ public:
     BrushFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width if no args"; }
+	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width (or :none) if no args"; }
 };
 
 //: command for setting pattern state variable in comdraw.

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -148,7 +148,7 @@ public:
     FontFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(fontnum) -- set current font from menu order"; }
+	return "%s([fontnum]) -- set current font from menu order; return current font by X name if no args"; }
 };
 
 //: command for setting font state variable by  font name in comdraw.
@@ -158,7 +158,7 @@ class FontByNameFunc : public UnidrawFunc {
   FontByNameFunc(ComTerp*,Editor*);
   virtual void execute();
   virtual const char* docstring() {
-    return "%s(fontname) -- set current font by X font name"; }
+    return "%s([fontname]) -- set current font by X font name; return current font by X name if no args"; }
 };
 
 //: command for setting brush state variable in comdraw.
@@ -168,7 +168,7 @@ public:
     BrushFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(brushnum|:none|linepat,width) -- set current brush from menu order, none brush, or by pattern/width"; }
+	return "%s([brushnum|:none|linepat,width]) -- set current brush from menu order, none brush, or by pattern/width; return current brush as linepat,width if no args"; }
 };
 
 //: command for setting pattern state variable in comdraw.
@@ -178,7 +178,7 @@ public:
     PatternFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(patternnum) -- set current pattern from menu order"; }
+	return "%s([patternnum]) -- set current pattern from menu order; return current patternnum if no args"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	"1  None",
@@ -218,7 +218,7 @@ public:
     ColorFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(fgcolornum bgcolornum | fgcolorname bgcolorname) -- set current colors from menu order or by RGB name"; }
+	return "%s([fgcolornum bgcolornum | fgcolorname bgcolorname]) -- set current colors from menu order or by RGB name; return current colors as fgname,bgname if no args"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	"1  Black",
@@ -246,7 +246,7 @@ class ColorRgbFunc : public UnidrawFunc {
   ColorRgbFunc(ComTerp*,Editor*);
   virtual void execute();
   virtual const char* docstring() {
-    return "%s(fgcolorname bgcolorname) -- set current colors by RGB name.\nThe colorname format is \"#RGB\" for 4 bits, \"#RRGGBB\" for 8 bits,\n\"#RRRGGGBBB\" for 12 bits,\"#RRRRGGGGBBBB\" for 16 bits"; }
+    return "%s([fgcolorname bgcolorname]) -- set current colors by RGB name; return current colors as fgname,bgname if no args.\nThe colorname format is \"#RGB\" for 4 bits, \"#RRGGBB\" for 8 bits,\n\"#RRRGGGBBB\" for 12 bits,\"#RRRRGGGGBBBB\" for 16 bits"; }
 };
 
 //: command to select graphics in comdraw.

--- a/src/comdraw/tests/gsget.comt
+++ b/src/comdraw/tests/gsget.comt
@@ -50,6 +50,19 @@ brush(saved)
 ok=ok&&(brush()==(65535,3))
 print("8 saved=brush(); brush(65535,7); brush(saved) restores (expect {65535,3}): %v\n" brush())
 
+// the none brush returns the :none keyword literal
+brush(:none)
+bn=brush()
+ok=ok&&(print("%v" bn :string)==":none")
+print("9 brush(:none); brush() (expect :none): %v\n" bn)
+
+// and the keyword round-trips BY VALUE: brush(saved-:none) restores none
+brush(65535,4)
+brush(bn)
+bn2=brush()
+ok=ok&&(print("%v" bn2 :string)==":none")
+print("10 brush(65535,4); brush(bn) with bn==:none restores none brush (expect :none): %v\n" bn2)
+
 // put the editor back to startup-ish defaults for any tests that follow
 brush(65535,0)
 pattern(1)

--- a/src/comdraw/tests/gsget.comt
+++ b/src/comdraw/tests/gsget.comt
@@ -50,12 +50,12 @@ brush(saved)
 ok=ok&&(brush()==(65535,3))
 print("8 saved=brush(); brush(65535,7); brush(saved) restores (expect {65535,3}): %v\n" brush())
 
-// the none brush returns the attrlist singleton (:none 1) -- a keyword
+// the none brush returns the attrlist singleton (:none true) -- a keyword
 // literal travels as an attrlist, never as a raw keyword value
 brush(:none)
 bn=brush()
 ok=ok&&(bn.none==true)
-print("9 brush(:none); brush().none (expect (:none 1), .none true): %v %v\n" bn bn.none)
+print("9 brush(:none); brush().none (expect (:none true), .none true): %v %v\n" bn bn.none)
 
 // and the attrlist round-trips BY VALUE: brush(saved) restores none
 brush(65535,4)

--- a/src/comdraw/tests/gsget.comt
+++ b/src/comdraw/tests/gsget.comt
@@ -1,0 +1,59 @@
+// src/comdraw/tests/gsget.comt -- bare graphic-state getters
+//
+// The bare (no-arg) form of each style command returns the literal that
+// reproduces the editor's current default: brush() as linepat,width,
+// colors()/colorsrgb() as fgname,bgname, pattern() as its menu number
+// (nil if not a menu pattern), font()/fontbyname() as the X font name.
+// Each test is a set-then-get round trip.
+//
+// funcs: brush() pattern() patternmask() colors() colorsrgb() font() fontbyname()
+ok=true
+
+brush(65535,3)
+b=brush()
+ok=ok&&(b==(65535,3))
+print("1 brush(65535,3); brush() (expect {65535,3}): %v\n" b)
+
+pattern(2)
+p=pattern()
+ok=ok&&(p==2)
+print("2 pattern(2); pattern() (expect 2): %v\n" p)
+
+patternmask(255)
+pn=pattern()
+ok=ok&&(pn==nil)
+print("3 patternmask(255); pattern() non-menu pattern (expect nil): %v\n" pn)
+
+colorsrgb("#FF0000" "#00FF00")
+c=colors()
+ok=ok&&(at(c 0)=="#FF0000")&&(at(c 1)=="#00FF00")
+print("4 colorsrgb(\"#FF0000\" \"#00FF00\"); colors() (expect {\"#FF0000\",\"#00FF00\"}): %v\n" c)
+
+colors(1 10)
+c2=colorsrgb()
+ok=ok&&(at(c2 0)=="Black")&&(at(c2 1)=="White")
+print("5 colors(1 10); colorsrgb() (expect {\"Black\",\"White\"}): %v\n" c2)
+
+f=font()
+ok=ok&&(f!=nil)
+print("6 font() (expect an X font name): %v\n" f)
+
+fontbyname(f)
+f2=fontbyname()
+ok=ok&&(f==f2)
+print("7 fontbyname(font()); fontbyname() round trip (expect true): %v\n" f==f2)
+
+// save/restore idiom the getters enable: borrow the pen, put it back
+saved=brush()
+brush(65535,7)
+brush(saved)
+ok=ok&&(brush()==(65535,3))
+print("8 saved=brush(); brush(65535,7); brush(saved) restores (expect {65535,3}): %v\n" brush())
+
+// put the editor back to startup-ish defaults for any tests that follow
+brush(65535,0)
+pattern(1)
+colors(1 10)
+
+print("gsget: %v\n" ok)
+ok

--- a/src/comdraw/tests/gsget.comt
+++ b/src/comdraw/tests/gsget.comt
@@ -50,18 +50,19 @@ brush(saved)
 ok=ok&&(brush()==(65535,3))
 print("8 saved=brush(); brush(65535,7); brush(saved) restores (expect {65535,3}): %v\n" brush())
 
-// the none brush returns the :none keyword literal
+// the none brush returns the attrlist singleton (:none 1) -- a keyword
+// literal travels as an attrlist, never as a raw keyword value
 brush(:none)
 bn=brush()
-ok=ok&&(print("%v" bn :string)==":none")
-print("9 brush(:none); brush() (expect :none): %v\n" bn)
+ok=ok&&(bn.none==true)
+print("9 brush(:none); brush().none (expect (:none 1), .none true): %v %v\n" bn bn.none)
 
-// and the keyword round-trips BY VALUE: brush(saved-:none) restores none
+// and the attrlist round-trips BY VALUE: brush(saved) restores none
 brush(65535,4)
 brush(bn)
 bn2=brush()
-ok=ok&&(print("%v" bn2 :string)==":none")
-print("10 brush(65535,4); brush(bn) with bn==:none restores none brush (expect :none): %v\n" bn2)
+ok=ok&&(bn2.none==true)
+print("10 brush(65535,4); brush(bn) restores none brush (expect .none true): %v\n" bn2.none)
 
 // put the editor back to startup-ish defaults for any tests that follow
 brush(65535,0)

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -27,5 +27,9 @@ if(run("./group.comt")
   :then print("pass: group\n")
   :else print("FAIL: group\n");ok=false)
 
+if(run("./gsget.comt")
+  :then print("pass: gsget\n")
+  :else print("FAIL: gsget\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -56,8 +56,9 @@ graphical object assigned to an interpreter variable.
     return current font by X name if no args
  brush([brushnum|:none|linepat,width]) -- set current brush from menu order,
     none brush, or linepat,width;
-    return current brush as linepat,width (or :none) if no args;
-    the returned :none keyword is accepted back positionally, so
+    return current brush as linepat,width if no args,
+    or as the attrlist singleton (:none 1) for the none brush;
+    that attrlist is accepted back positionally, so
     saved=brush(); ...; brush(saved) round-trips the none brush too
  pattern([patternnum]) --  set current pattern from menu;
     return current patternnum if no args (nil if not a menu pattern)

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -56,7 +56,9 @@ graphical object assigned to an interpreter variable.
     return current font by X name if no args
  brush([brushnum|:none|linepat,width]) -- set current brush from menu order,
     none brush, or linepat,width;
-    return current brush as linepat,width if no args
+    return current brush as linepat,width (or :none) if no args;
+    the returned :none keyword is accepted back positionally, so
+    saved=brush(); ...; brush(saved) round-trips the none brush too
  pattern([patternnum]) --  set current pattern from menu;
     return current patternnum if no args (nil if not a menu pattern)
  patternmask(int|list) -- set current pattern from a 16 bit int (4x4)  or a list of 16 ints (16x16)

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -50,13 +50,21 @@ graphical object assigned to an interpreter variable.
 
 .SH GRAPHIC STATE COMMANDS
 
- font(fontnum) -- set current font from menu
- brush(brushnum|linepath,width) -- set current brush from menu order or linepat,width
- pattern(patternnum) --  set current pattern from menu
+ font([fontnum]) -- set current font from menu;
+    return current font by X name if no args
+ fontbyname([fontname]) -- set current font by X font name;
+    return current font by X name if no args
+ brush([brushnum|:none|linepat,width]) -- set current brush from menu order,
+    none brush, or linepat,width;
+    return current brush as linepat,width if no args
+ pattern([patternnum]) --  set current pattern from menu;
+    return current patternnum if no args (nil if not a menu pattern)
  patternmask(int|list) -- set current pattern from a 16 bit int (4x4)  or a list of 16 ints (16x16)
- colors(fgnum|fgstr bgnum|bgstr) -- set current colors from menu order or "#RRGGBB" (see colorsrgb)
- colorsrgb(fgstr bgstr)
-   -- set current colors by RGB name.
+ colors([fgnum|fgstr bgnum|bgstr]) -- set current colors from menu order or "#RRGGBB" (see colorsrgb);
+    return current colors as fgname,bgname if no args
+ colorsrgb([fgstr bgstr])
+   -- set current colors by RGB name;
+      return current colors as fgname,bgname if no args.
       The colorname format is "#RGB" for 4 bits, "#RRGGBB" for 8 bits,
       #RRRGGGBBB for 12 bits, #RRRRGGGGBBBB for 16 bits
  nfonts() -- return size of font menu

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -57,7 +57,7 @@ graphical object assigned to an interpreter variable.
  brush([brushnum|:none|linepat,width]) -- set current brush from menu order,
     none brush, or linepat,width;
     return current brush as linepat,width if no args,
-    or as the attrlist singleton (:none 1) for the none brush;
+    or as the attrlist singleton (:none true) for the none brush;
     that attrlist is accepted back positionally, so
     saved=brush(); ...; brush(saved) round-trips the none brush too
  pattern([patternnum]) --  set current pattern from menu;


### PR DESCRIPTION
## What this does

The bare (no-argument) form of each graphic-state command now returns the literal needed to call the setter again — the get half of a Logo-like pen-state protocol whose set half already existed:

| Command | Bare form returns | Reproduces via |
|---|---|---|
| `brush()` | `65535,3` (linepat,width) — or the attrlist singleton `(:none true)` for the none brush | `brush(65535,3)` / `brush(saved)` |
| `colors()` / `colorsrgb()` | `{"Black","White"}` or `{"#FF0000","#00FF00"}` (fgname,bgname) | `colors(fgname bgname)` |
| `pattern()` | its menu number; nil if the current pattern is not a menu pattern (e.g. set by `patternmask`) | `pattern(patternnum)` |
| `font()` / `fontbyname()` | the X font name string | `fontbyname(name)` |

This enables the save/restore idiom for funcs that borrow the ambient pen state:

```
saved=brush()
brush(65535,7)
...
brush(saved)      // total: restores any brush state, including :none
```

## The literal-carrier rule (why `(:none true)` and not `:none`)

The none brush reproduces via a keyword, and this PR's history documents why a raw `KeywordType` value must not escape into the language: eager `ComFunc::stack_key()` scans evaluated frames by `type()==KeywordType`, so a stored keyword becomes a live keyword in any frame it enters — false keyword matches, misread neighbor slots. (Commit bd50882e tried the raw keyword; commit 6cc9256d replaces it after that analysis.)

The rule that emerged, now the protocol for any future getter:

- a **value literal** travels as itself / a tuple (`65535,3`)
- a **keyword literal** travels as an **attrlist singleton** (`(:none true)`) — inert in any argument frame, printable, dot-accessible (`saved.none`)
- **multiple pieces** travel as a list of positionals in call order plus one singleton per keyword

Setters accept the singleton back positionally (`brush(saved)` routes `(:none true)` to the same branch as a parsed `:none`), so the round trip works by value as well as by paste. This also lines up with the `~~` spread operator's round-trip rule: once attrlist spread lands, `cmd(~~cmd())` becomes the identity law for every getter.

## Implementation notes

- Each `execute()` short-circuits on `nargs()==0 && nkeys()==0` (the `nkeys` check keeps `brush(:none)` on the setter path) and reads the editor's state variables (`BrushVar`, `PatternVar`, `ColorVar`, `FontVar`) — the same vars the creation commands consult.
- `pattern()` recovers its menu number by pointer scan against the catalog cache (menu index isn't stored on a `PSPattern`; the catalog caches reads so the state var's pointer matches its menu entry), with a documented nil fallback for non-menu masks.
- Docstrings and the GRAPHIC STATE COMMANDS section of comdraw.1 updated in sync; comdraw.1 also gains the previously missing `fontbyname` entry and loses a `linepath,width` typo.

## Testing

New `src/comdraw/tests/gsget.comt`, registered in `run_all.comt`: ten set-then-get round trips covering the value forms, the menu-number scan, the nil-for-mask case, the name forms, the save/restore idiom, and the `(:none true)` singleton both as return (`bn.none==true`) and as by-value setter input. Full comdraw suite green (4/4) against the rebuilt binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

