### PR TITLE
Fix 27-year-old memory leak: every list() call pinned its AttributeValueList forever

### DIFF
--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -99,7 +99,10 @@ void ListFunc::execute() {
     } else if (nargs())
       avl->Append(new AttributeValue(listv));
   }
-  Resource::ref(avl);
+  /* no manual Resource::ref(avl) here: the ComValue constructor refs the
+     list (AttributeValue(AttributeValueList*) does Resource::ref), and an
+     extra unmatched ref pinned every list() result in memory forever --
+     ~27 years of one leaked AttributeValueList per list() call. */
   ComValue retval(avl);
   push_stack(retval);
 }

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -74,7 +74,7 @@ static char newline;
    only this key changes -- read the latest key off the banner to confirm the
    newest build took.  Bumping it recompiles this main.c, so its __DATE__/__TIME__
    refresh too; build_stamp() (in ComUtil/util.c) just formats the three. */
-#define PATCH_KEY "7b1e9c2a"
+#define PATCH_KEY "f60c44dd"
 
 using std::cout;
 using std::cerr;
@@ -92,8 +92,25 @@ void stack_trace_handler(int sig) {
   exit(1);
 }
 
+#ifdef LEAKCHECK
+/* the per-class LeakCheckers are lazily new'ed statics (never deleted), so
+   their report-on-destruct never fires -- print alive counts at exit instead */
+#include <Attribute/attrlist.h>
+static void leakcheck_report() {
+  if (AttributeValue::_leakchecker)
+    fprintf(stderr, "LEAKCHECK: AttributeValue alive = %d\n",
+	    AttributeValue::_leakchecker->alive());
+  if (AttributeValueList::_leakchecker)
+    fprintf(stderr, "LEAKCHECK: AttributeValueList alive = %d\n",
+	    AttributeValueList::_leakchecker->alive());
+}
+#endif
+
 int main(int argc, char *argv[]) {
 
+#ifdef LEAKCHECK
+    atexit(leakcheck_report);
+#endif
     signal(SIGSEGV, stack_trace_handler);
     /* ignore SIGPIPE: a peer that closed its socket should make a write return
        EPIPE (which remote()/the socket path handles) instead of terminating the


### PR DESCRIPTION
## The bug

`ListFunc::execute` (src/ComTerp/listfunc.c) ended with:

    Resource::ref(avl);        // unmatched -- the leak
    ComValue retval(avl);      // this constructor ALREADY refs
    push_stack(retval);

InterViews `Resource` is born at refcount 0 and deletes at 0.  The `AttributeValue(AttributeValueList*)` constructor takes the one legitimate reference; the manual `Resource::ref(avl)` was never matched by any unref, so the refcount could never return to zero and every `list()` result was pinned in memory forever.  `git log -S` dates the line to the initial ivtools-1.2.11 import (~1999).

## How it surfaced

Scott ran `orbit()` (spirograph.comt, #207) in a `while` loop for two hours with 28 spirographs and watched RSS grow ~1MB per 5 minutes — each `orbit()` call makes five `list()` locals.  Every comterp/comdraw/drawserv session since 1999 has leaked one AttributeValueList (plus its elements) per `list()` call; comdraw leaks ~12MB just starting up.

## The hunt (and why it hid for 27 years)

- RSS-delta probes bisected it to funcobj-with-list workloads, but single-shot `list()` calls looked clean — sub-megabyte deltas drown in malloc noise, which is why nobody ever saw it.
- macOS `leaks` reported **zero** leaked blocks: the lists are still referenced (pinned by the stale refcount), so they are not classic malloc leaks.
- The in-tree **LeakChecker** (src/include/ivstd/leakchecker.h, dormant since 1998) closed the case: with `#define LEAKCHECK` on, alive-instance counts showed exactly +1 AttributeValueList per `list()` evaluation (1,000 loop iterations → 1001 alive; 10,000 → 10,001).  After the fix: 1 (the baseline).

## The fix

Delete the manual `Resource::ref(avl)` (with a comment explaining the ownership rule).  Verified:

- LEAKCHECK alive counts: 10,001 → 1 on the reproducer; every remaining count is a live binding.
- Worst RSS probe: 329MB leaked → 16KB (allocator noise).
- comdraw startup RSS: ~23MB → ~11.7MB.
- Full test suite (`run_all.comt`): 20/20 pass, byte-identical results to the pre-fix engine.

## Also in this PR

- `src/comterp_/main.c`: a LEAKCHECK-guarded `atexit` report printing AttributeValue / AttributeValueList alive counts — the per-class checkers are lazily new'ed statics whose report-on-destruct never fires, so this makes the dormant leak checker actually usable: uncomment one `#define` in leakchecker.h, rebuild Attribute + ComTerp, and every comterp exit prints the counts.  Compiled out entirely when LEAKCHECK is off (the normal state, including this PR).
- PATCH_KEY bumped to f60c44dd.

## Sibling sites left for follow-up

The same manual-ref pattern appears in strmfunc.c:1089 and AttrListFunc (AttributeList rather than AttributeValueList, via the generic ObjectType ComValue constructor whose ref semantics differ) — flagged for a separate audit rather than batched into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)