### PR TITLE
Guard parser.comt's intentional-error fixtures against helpful editors (human or AI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ run("src/comterp_/tests/run_all.comt")   # runs every script, prints pass/FAIL
 
 Each script returns a boolean `ok`; `run_all.comt` aggregates them. The full
 coverage taxonomy, scoring methodology, header format (`// coverage:`,
-`// funcs:`, `// missing:`), and the **four mandatory rules for
+`// funcs:`, `// missing:`), and the **five mandatory rules for
 LLM-authored test scripts** are in **`src/comterp_/tests/TESTING.md`**. Read it
 before adding or editing any `.comt` test. Highlights:
 
@@ -133,6 +133,13 @@ before adding or editing any `.comt` test. Highlights:
   a prose description — the log doubles as documentation.
 - Keep the `print("scriptname: %v\n" ok)` / `ok` footer as the last two lines.
 - Register new scripts in `run_all.comt`.
+- Some tests feed the parser **deliberately malformed text** — the malformed
+  text is the fixture; the `errmsg()` it raises is the behavior under test
+  (e.g. `(4 :x 7 8)`: more than one positional after a keyword). Never edit it
+  into valid syntax. These sites carry an
+  `// intentional error: ... -- do not remove or make valid` comment naming
+  the malformation and print an INTENTIONAL banner into the log just before
+  the error fires (TESTING.md rule 5).
 
 ### DrawServ integration tests — `src/drawserv_/tests/`
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -177,7 +177,7 @@ print("10 sum via while/next($$(1..5)) (expect 15): %v\n" total)
 ### Rules for LLM-assisted authoring
 
 When an LLM generates or edits a `.comt` test script, it must follow
-these four rules without exception. They are mechanical checklist items,
+these five rules without exception. They are mechanical checklist items,
 not stylistic suggestions — violating any one of them produces a broken
 or misleading test file:
 
@@ -202,6 +202,25 @@ or misleading test file:
    Followed by descriptive text if needed. This makes the test log
    self-documenting. See the **Test label convention** section above for
    examples.
+
+5. **Never edit deliberately malformed text into valid syntax.**
+   Some tests feed the parser DELIBERATELY MALFORMED expressions — the
+   malformed text is the test fixture, and the error it raises (retrieved
+   via `errmsg()`) is the behavior under test. A bare `(4 :x 7 8)` on its
+   own line is not a typo to clean up — it is illegal because the bare 8
+   is a second positional after the keyword's value (`:x` takes 7, and
+   nothing may follow it bare); "fixing" it silently disables the test.
+   These sites are marked with an
+   `// intentional error: ... -- do not remove or make valid`
+   comment naming the malformation and print an
+   `(next error is INTENTIONAL ...)` banner just before the error fires,
+   so the run log distinguishes them from real failures. If a language
+   change legalizes a malformed form (this has happened: `(4 :x 7)`,
+   value *before* a keyword, errored for years until stream literals made
+   it legal), do not delete the test — replace the fixture with a form
+   that still errors, or rewrite the test to pin the new behavior, and
+   say which in the comment. When triggering an intentional error in a
+   new test, add both the comment and the banner.
 
 ## Adding Coverage
 

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -1,9 +1,13 @@
 // src/comterp_/tests/parser.comt -- test attrlist literal syntax and parser errors
 //
-// coverage: 28/38 (74%)
+// coverage: 29/39 (74%)
 // funcs: attrlist(:literal) errmsg postfix class type
 // missing: errmsg(:cnt) errmsg(:num) type(non-object) class(non-object)
 //          ~type(list) ~type(stream)
+//
+// (29/39: the test-6 rewrite newly exercises errmsg(:clear), a slot the
+// old 38-slot total never counted -- it appeared in neither the covered
+// count nor the missing list -- so both numbers grow by one.)
 //
 // Tests the attrlist literal syntax (:key val) introduced in ivtools 2.2,
 // and errmsg() for retrieving parser error messages.

--- a/src/comterp_/tests/parser.comt
+++ b/src/comterp_/tests/parser.comt
@@ -10,6 +10,19 @@
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/parser.comt")
+//
+// NOTE TO ALL EDITORS, HUMAN OR AI: several tests below feed the parser
+// DELIBERATELY MALFORMED text -- the malformed text is the test fixture,
+// and errmsg() retrieval of the resulting error is the behavior under
+// test.  The malformation used here is MORE THAN ONE POSITIONAL AFTER A
+// KEYWORD -- in (4 :x 7 8) the keyword :x takes 7, and the bare 8 after
+// it is illegal.  Never edit a malformed expression into valid syntax;
+// that silently disables the test.  If a language change legalizes one
+// of these forms (it has happened: (4 :x 7), value BEFORE a keyword,
+// errored for years until the stream-literal syntax made it legal),
+// replace it with a form that still errors AND update the expectation --
+// see TESTING.md.  Each intentional error prints an INTENTIONAL banner
+// just before it fires, so the run log stays readable.
 
 // line 13 - preamble, reading prior error if any
 print("last: %s\n" s=errmsg(:last :keep);cond(s==nil "nil" s))
@@ -60,37 +73,47 @@ ok=ok&&(v==9)
 print("5 (1+2)*3 plain parens group (expect 9): %v\n" v)
 prev_ok=check_fail(:ok ok)
 
-// --- test 6: value before keyword in bare parens errors ---
-// (4 :x 7) should give: attribute literal must start with :key
-(4 :x 7)
+// --- test 6: value before keyword in bare parens -- once an error, now a stream literal ---
+// HISTORY: pre-stream-literal this errored ("attribute literal must start
+// with :key") and this test asserted the errmsg.  The stream-literal
+// syntax legalized value-before-keyword parens, so the test now pins the
+// NEW truth instead: no error, and the postfix shows a stream.
+errmsg(:clear)
+p6=postfix((4 :x 7))
 e=errmsg(:last)
-ok=ok&&(index(e "attribute literal")!=nil)
-print("6 (4 :x 7) value before keyword errors (expect error msg): %v\n" e)
+ok=ok&&(e==nil)
+ok=ok&&(index(p6 "stream")!=nil)
+print("6 (4 :x 7) value-before-keyword now a stream literal (expect stream postfix, nil errmsg): %v %v\n" p6 e)
 prev_ok=check_fail(:ok ok)
 
 // --- test 7: errmsg(:last) returns nil when no error ---
 (:a 1)
 e=errmsg(:last)
-ok=true
+ok=ok&&(e==nil)
 print("7 (:a 1); errmsg(:last) nil after success (expect nil): %v\n" e)
 prev_ok=check_fail(:ok ok)
 
 // --- test 8: errmsg(:last) clears after retrieval ---
-(4 :x 7 8)  // intentional parser error generation, do not remove
+// (4 :x 7 8) is illegal because 8 is a SECOND positional after the
+// keyword's value -- :x takes 7, and nothing may follow it bare.
+// (value BEFORE a keyword is legal now: that's a stream literal.)
+print("   (next error is INTENTIONAL -- more than one positional after a keyword, generated so errmsg(:last) has one to retrieve)\n")
+(4 :x 7 8)  // intentional error: >1 positional after a keyword -- do not remove or make valid
 e1=errmsg(:last)
 e2=errmsg(:last)
 ok=ok&&(e1!=nil)
 ok=ok&&(e2==nil)
-print("8 errmsg(:last) then errmsg(:last) clears after retrieval (expect non-nil nil): %v %v\n" e1 e2)
+print("8 (4 :x 7 8); errmsg(:last) then errmsg(:last) clears after retrieval (expect non-nil nil): %v %v\n" e1 e2)
 prev_ok=check_fail(:ok ok)
 
 // --- test 9: errmsg(:keep) does not clear ---
-(4 :x 7 8) // intentional parser error generation, do not remove
+print("   (next error is INTENTIONAL -- more than one positional after a keyword, generated so errmsg(:keep) has one to preserve)\n")
+(4 :x 7 8) // intentional error: >1 positional after a keyword -- do not remove or make valid
 e1=errmsg(:keep)
 e2=errmsg(:last)
 ok=ok&&(e1!=nil)
 ok=ok&&(e2!=nil)
-print("9 errmsg(:keep) then errmsg(:last) preserves (expect both non-nil): %v %v\n" (e1!=nil) (e2!=nil))
+print("9 (4 :x 7 8); errmsg(:keep) then errmsg(:last) preserves (expect both non-nil): %v %v\n" (e1!=nil) (e2!=nil))
 prev_ok=check_fail(:ok ok)
 
 // --- test 10: postfix returns attrlist literal token stream as string ---


### PR DESCRIPTION
## The problem

parser.comt deliberately feeds the parser malformed text so the error path and `errmsg()` retrieval get exercised — the malformed text IS the test fixture.  History shows these fixtures are fragile in two distinct ways:

1. **Helpful editors sanitize them.**  A bare `(4 :x 7 8)` on its own line looks like a typo to clean up; a past session did exactly that, and commit ee47d5ae had to restore the errors with "do not remove" comments.  The evidence says in-file markers work: the two sites that carried comments survived every session since; the one unmarked site is the one that went quiet.
2. **The language evolves out from under them.**  `(4 :x 7)` (value before a keyword) errored for years, then the stream-literal syntax legalized it — silently defusing test 6, whose expected errmsg has been permanently nil ever since.  An `ok=true` accumulator reset in test 7 hid the failure, so `parser: true` kept printing while check 6 failed underneath.

## The guardrails (layered)

- **In the run log**: each deliberate error now prints a banner immediately before it fires —
  `(next error is INTENTIONAL -- more than one positional after a keyword, generated so errmsg(:last) has one to retrieve)` — so nobody reading test output (including a future AI session) diagnoses it as a failure.  The banner can't live in the error message itself: the scanner stops at the first bad token and never echoes source, and altering fixture text risks changing which error path fires.
- **At each site**: the comment now names the malformation — `// intentional error: >1 positional after a keyword -- do not remove or make valid`.  (In `(4 :x 7 8)`, `:x` takes the 7; the bare 8 after it is the illegal token.)
- **In parser.comt's header**: a NOTE TO ALL EDITORS, HUMAN OR AI block explaining that malformed text is the fixture, with the `(4 :x 7)` legalization as the cautionary tale.
- **In TESTING.md**: the mandatory rules for LLM-authored test scripts go from four to five — rule 5: never edit deliberately malformed text into valid syntax; when a language change legalizes a fixture, replace it with a still-erroring form or rewrite the test to pin the new behavior, and say which; new intentional-error tests must add both the comment and the banner.
- **In CLAUDE.md**: a matching bullet in the testing highlights, so every session sees it before touching a test.

## Latent bugs fixed while in there

- **Test 6 rewritten** to pin the post-stream-literal truth: `(4 :x 7)` now parses to `stream[2|1|1]` with nil errmsg (asserted via `postfix()`), with a HISTORY comment recording that it used to error.  The old expectation could never pass again.
- **Test 7's `ok=true`** (which reset the accumulator and hid test 6's failure) is now `ok=ok&&(e==nil)`.
- Tests 8/9 print labels now embed the fixture expression per the rule-4 convention.

Full suite: 20/20 pass (`run_all: true`), and parser.comt's pass is now honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)