### PR TITLE
LANGUAGE.md: func scopes don't chain -- correct the middle lookup level and name the attrlist frame

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -533,14 +533,29 @@ v=f()              // x is nil, condition is false, returns nil (ivtools-2.2 or 
 Variable lookup follows a three-level priority chain:
 
 - **func scope** — variables local to this invocation, including any
-  `:key val` args set before the body runs
-- **local scope** — the caller's symbol table
+  `:key val` args set before the body runs.  The frame is an attrlist,
+  created for the call and discarded at return — the same structure
+  that carries keyword args and `setattr()` properties everywhere else
+- **local scope** — the interpreter's flat top-level symbol table,
+  where prompt and `run()` assignments live
 - **global scope** — symbols declared with `global()`
 
 A variable can be **read** from any level — func scope wins over local,
 local wins over global. A variable **written** inside a func always goes
 to func scope only, never propagating outward. The only exception is
 `global()` which explicitly reaches the global scope.
+
+Func scopes do **not** chain: a func called from inside another func
+reads its own frame and then the top-level table — never the calling
+func's frame:
+
+```
+inner=func(v)
+outer=func(v=5; inner())
+outer()            // nil -- inner cannot see outer's v
+v=99
+outer()            // 99  -- inner falls through to the top level
+```
 
 Writing through a reference passed in as a keyword arg is not an
 exception to this rule — the symbol is local, but the attrlist object


### PR DESCRIPTION
## What

One correction and two additions to the Scoping rules section of doc/LANGUAGE.md, all verified against the interpreter.

**The correction:** the middle level of the lookup chain was described as "the caller's symbol table."  Func scopes do not chain — a func called from inside another func cannot read its calling func's frame variables:

```
inner=func(v)
outer=func(v=5; inner())
outer()            // nil -- inner cannot see outer's v
v=99
outer()            // 99  -- inner falls through to the top level
```

The middle level is the interpreter's flat top-level symbol table (where prompt and `run()` assignments live).  The old phrasing was only accurate for a func invoked from the top level, where "caller's table" and "top-level table" coincide.

**The additions:** (1) the no-chaining example above, since the fall-through behavior is the part that surprises; (2) a note that the func frame IS an attrlist — created per invocation, pre-populated by `:key val` args, receiving every write in the body, discarded at return — the same data structure that carries keyword args and `setattr()` properties everywhere else in the system.

## Why now

This came out of the greptile review of #207, which claimed spiro()'s `cx` local leaked into orbit()'s sun-position keyword.  Experiments refuted the claim (writes shadow and never propagate — the docs already say so, and FUNC-AND-ARGS-DESIGN.md's `_alist → localtable → globaltable` fall-through plus the "if you test a name for nil, set it nil" rule already cover the real hazard).  The only piece of the verified model the docs had wrong was the caller-chain phrasing, and the attrlist-frame identity was implied but never stated user-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)