### PR TITLE
Fix global(x)=val inside funcs -- the escape hatch wrote a frame local instead

### DIFF
--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -79,19 +79,25 @@ void AssignFunc::execute() {
 #endif
     if (operand1.type() == ComValue::SymbolType) {
         AttributeList* attrlist = comterp()->get_attributes();
-	if (attrlist) {
-	    Resource::ref(attrlist);
-	    Attribute* attr = new Attribute(operand1.symbol_val(), 
-					    operand2);
-	    attrlist->add_attribute(attr);
-	    Unref(attrlist);
-	} else if (operand1.global_flag()) {
+	/* global() lvalue must be tested BEFORE the func-frame branch:
+	   the whole point of global(x)=val is to escape the frame, and
+	   lookup_symval honors global_flag by skipping _alist and
+	   localtable, so the old-value cleanup stays consistent from
+	   inside a func.  (Until this reordering, global(x)=val inside
+	   a func silently wrote x to the frame attrlist instead.) */
+	if (operand1.global_flag()) {
 	    AttributeValue* oldval = comterp()->lookup_symval(&operand1);
 	    if (oldval) {
 	      comterp()->globaltable()->remove(operand1.symbol_val());
 	      delete (ComValue*)oldval;
 	    }
 	    comterp()->globaltable()->insert(operand1.symbol_val(), operand2);
+	} else if (attrlist) {
+	    Resource::ref(attrlist);
+	    Attribute* attr = new Attribute(operand1.symbol_val(),
+					    operand2);
+	    attrlist->add_attribute(attr);
+	    Unref(attrlist);
 	}
 	else {
 	    AttributeValue* oldval = comterp()->lookup_symval(&operand1);

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -74,7 +74,7 @@ static char newline;
    only this key changes -- read the latest key off the banner to confirm the
    newest build took.  Bumping it recompiles this main.c, so its __DATE__/__TIME__
    refresh too; build_stamp() (in ComUtil/util.c) just formats the three. */
-#define PATCH_KEY "7b1e9c2a"
+#define PATCH_KEY "b082afc8"
 
 using std::cout;
 using std::cerr;

--- a/src/comterp_/tests/global.comt
+++ b/src/comterp_/tests/global.comt
@@ -1,9 +1,13 @@
 // src/comterp_/tests/global.comt -- test global() command
 //
-// coverage: 13/14 (93%)
+// coverage: 16/17 (94%)
 // funcs: global
 // missing: ~global(lvalue-return-type) -- in global(sym)=val the return value belongs
 //          to the assign operator, not global(); untestable in isolation for global() alone
+//
+// tests 12-14 pin the func-frame interaction: global(x)=v inside a func
+// escapes the frame (regression for the AssignFunc branch-order fix),
+// bare reads fall through frame->local->global, frame locals shadow
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/global.comt")
@@ -91,6 +95,32 @@ global(p2)="BYE"
 global(symadd(global(p1)+global(p2)))="SHOULD WORK"
 ok=ok&&(HIBYE=="SHOULD WORK")
 print("11 global(symadd(global(p1)+global(p2)))=\"SHOULD WORK\" nested lhs (expect \"SHOULD WORK\"): %v\n\n" HIBYE)
+prev_ok=check_fail(:ok ok)
+
+// --- test 12: global lvalue assignment from INSIDE a func escapes the frame ---
+// (regression: the frame branch in AssignFunc used to preempt the
+//  global_flag check, so global(x)=v in a func wrote a frame local
+//  that evaporated at return)
+gwf=func(global(gfunc)=77; 0)
+gwf()
+r12=global(gfunc)
+ok=ok&&(r12==77)
+print("12 gwf=func(global(gfunc)=77); gwf(); global(gfunc) func-frame escape (expect 77): %v\n\n" r12)
+prev_ok=check_fail(:ok ok)
+
+// --- test 13: global written inside one func readable by bare fall-through in another ---
+grf=func(gfunc+1)
+r13=grf()
+ok=ok&&(r13==78)
+print("13 grf=func(gfunc+1) bare read falls through frame->local->global (expect 78): %v\n\n" r13)
+prev_ok=check_fail(:ok ok)
+
+// --- test 14: frame-local shadows the global for bare reads; global() still explicit ---
+gsf=func(gfunc=1; gfunc,global(gfunc))
+r14=gsf()
+ok=ok&&(at(r14 0)==1)
+ok=ok&&(at(r14 1)==77)
+print("14 gsf=func(gfunc=1; gfunc,global(gfunc)) shadow vs explicit (expect 1 77): %v %v\n\n" at(r14 0) at(r14 1))
 prev_ok=check_fail(:ok ok)
 
 print("\nglobal: %v\n" ok)


### PR DESCRIPTION
## The bug

`global(x)=val` from inside a func never reached the global table:

```
gf=func(global(gv)=42; 0)
gf()
global(gv)      // nil -- the write landed on the func frame and evaporated
```

The same statement works at top level and inside `for`/`if` bodies — it failed **only** inside funcobj frames, which is precisely the one context where an escape hatch means anything.  FUNC-AND-ARGS-DESIGN.md documents `global(x)=…` as the way to deliberately escape the func scope; until now that documentation was aspirational.

## The cause

`AssignFunc::execute` ordered its symbol-storage branches frame-first:

```c
if (attrlist) { ...write the func frame... }          // wins unconditionally
else if (operand1.global_flag()) { ...globaltable... } // unreachable inside a func
else { ...localtable... }
```

The upstream machinery was all working — the lvalue-marking preamble sets `lhs_assign` on the `global` command token, `GlobalSymbolFunc` returns the symbol with `global_flag(true)` — but inside a func the frame branch preempted the flag test, so the flagged symbol was written to the per-invocation attrlist like any plain local.

## The fix

Test `global_flag()` first.  `lookup_symval` already honors the flag (skips `_alist` and localtable), so the old-value cleanup in the global branch stays consistent when called from inside a frame.

## Verified

- `global(gfunc)=77` inside a func → `global(gfunc)` reads 77 after return; a second func bare-reads it via the frame→local→global fall-through (78); a frame local still shadows the global for bare reads while `global()` reads stay explicit (1 vs 77).  All three are now global.comt tests 12–14 (coverage header updated per TESTING.md).
- Full suite: 20/20 pass (the parser.comt FIRST FAIL marker is the pre-existing check-6 issue addressed separately in #209).
- Debug-instrumented runs confirmed the marking relay (`lhs_assign` → `global_flag`) works at every nesting depth; only the branch order was at fault.

## Related notes

- The compound assigns (`+=` etc.) mutate storage in place through `lookup_symval`, so they already write through to a global when nothing shadows it; they lack the global-lvalue marking preamble entirely, so `global(x)+=1` remains unsupported (unchanged by this PR).
- PATCH_KEY bumped to b082afc8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)