### PR TITLE
Audit the #208 sibling born-ref sites: one more leak (keyword-element stream drains), rest cleared

### DIFF
--- a/src/Attribute/attrlist.c
+++ b/src/Attribute/attrlist.c
@@ -44,6 +44,7 @@
 
 #ifdef LEAKCHECK
 LeakChecker* AttributeValueList::_leakchecker = nil;
+LeakChecker* AttributeList::_leakchecker = nil;
 #endif
 
 
@@ -53,6 +54,10 @@ using std::cerr;
 int AttributeList::_symid = -1;
 
 AttributeList::AttributeList (AttributeList* s) {
+#ifdef LEAKCHECK
+    if(!_leakchecker) _leakchecker = new LeakChecker("AttributeList");
+    _leakchecker->create();
+#endif
     _alist = new AList;
     _count = 0;
     if (s != nil) {
@@ -65,6 +70,9 @@ AttributeList::AttributeList (AttributeList* s) {
 }
 
 AttributeList::~AttributeList () { 
+#ifdef LEAKCHECK
+    _leakchecker->destroy();
+#endif
     if (_alist) {
         ALIterator i;
 	for (First(i); !Done(i); Next(i)) {

--- a/src/Attribute/attrlist.h
+++ b/src/Attribute/attrlist.h
@@ -170,6 +170,11 @@ protected:
     unsigned int _count;
 
     CLASS_SYMID("AttributeList");
+
+#ifdef LEAKCHECK
+ public:
+    static LeakChecker* _leakchecker;
+#endif
 };
 
 //: list of AttributeValue objects.

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -1083,10 +1083,13 @@ void StreamLiteralNextFunc::execute() {
         keyval = comterpserv()->run(tokbuf + offset, cnt);
       }
 
-      /* construct singleton attrlist (:key val) */
+      /* construct singleton attrlist (:key val).  No manual
+         Resource::ref(al) here: the ComValue (classid, ptr) constructor
+         already refs AttributeList payloads, and an extra unmatched ref
+         pinned one singleton per keyword-element drain forever -- the
+         same born-ref bug fixed in ListFunc::execute (PR #208). */
       AttributeList* al = new AttributeList();
       al->add_attr(key_symid, keyval);
-      Resource::ref(al);
       ComValue result(AttributeList::class_symid(), (void*)al);
       nremval->int_ref()--;
       push_stack(result);

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -74,7 +74,7 @@ static char newline;
    only this key changes -- read the latest key off the banner to confirm the
    newest build took.  Bumping it recompiles this main.c, so its __DATE__/__TIME__
    refresh too; build_stamp() (in ComUtil/util.c) just formats the three. */
-#define PATCH_KEY "b082afc8"
+#define PATCH_KEY "176f8827"
 
 using std::cout;
 using std::cerr;
@@ -103,6 +103,9 @@ static void leakcheck_report() {
   if (AttributeValueList::_leakchecker)
     fprintf(stderr, "LEAKCHECK: AttributeValueList alive = %d\n",
 	    AttributeValueList::_leakchecker->alive());
+  if (AttributeList::_leakchecker)
+    fprintf(stderr, "LEAKCHECK: AttributeList alive = %d\n",
+	    AttributeList::_leakchecker->alive());
 }
 #endif
 


### PR DESCRIPTION
## The audit (#208's flagged follow-up)

#208 flagged two sibling sites using the manual-`Resource::ref` pattern for a separate audit.  Ground truth first: `RESOURCE_COMPVIEW` is unconditionally defined, and the `AttributeValue(int classid, void* ptr)` constructor **explicitly refs** `AttributeList` and `Attribute` payloads (attrvalue.c:264-267), with `unref_as_needed` releasing them.  So ObjectType-held attrlists follow the same ownership rule as ArrayType lists: the constructor takes the one reference; any manual ref on top is a permanent pin.

**Site verdicts:**

| Site | Pattern | Verdict |
|------|---------|---------|
| strmfunc.c ~1089, keyword-element drain | `new AttributeList()` + manual `Resource::ref(al)` + `ComValue(classid, al)` | **LEAK — fixed here** |
| `AttrListFunc` (the `attrlist()` command) | `stack_keys()` (returns refcount-0 list) + constructor ref | balanced |
| `list(:attr)` branch | `new AttributeList()` + constructor ref only | balanced |
| strmfunc.c 350 (spread singletons), 1177/1192 (stream-info reports) | constructor ref only | balanced |
| grfunc.c ×8 (rect/line/ellipse/text/multiline/splines/polygon) | `Resource::ref(al)` … `SetAttributeList` … `Unref(al)` | balanced (correct bracketing idiom) |
| `EvalFunc` old_alist, `ComTerp::set_attributes`, `AssignFunc` frame write | ref/Unref paired | balanced |

## The leak

Draining a keyword element out of a stream literal (e.g. the `:str` in `("[%d %d %d]" 10 20 30 :str)`, exercised by `~~` spread, `next()`, and `list(stream)`) materializes a `(:key val)` singleton attrlist with a manual ref on top of the constructor's — pinning one AttributeList (plus its value) per drain, forever.  Same bug family as #208's `list()` fix, one layer up.

## Verified with the leak checker (now covering AttributeList)

AttributeList had no LEAKCHECK hooks; this PR adds the create/destroy pair mirroring AttributeValueList's, plus the class in comterp's atexit report.  With `#define LEAKCHECK` on:

- control (1,000 attrlist literals + 1,000 `attrlist()` calls): **2 alive** at exit — the two live bindings; the balanced paths really are balanced.
- reproducer (1,000 keyword-carrying stream drains via `for(i=0 i<1000 i++ s=(1 :k 2); l=list(s))`): **1,000 alive** before the fix, **1 alive** after.

Full suite 20/20 (`run_all: true`) on the vanilla rebuild; LEAKCHECK define left off as normal.  PATCH_KEY bumped to 176f8827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)