### PR TITLE
Fix heap-buffer-overflow in StreamNextFunc: ComValue copy-constructed from base-class AttributeValue via blind downcast

### DIFF
--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -386,9 +386,13 @@ void StreamNextFunc::execute() {
     avl->First(i);
     AttributeValue* retval = avl->Done(i) ? nil : avl->GetAttrVal(i);
 
-    // if FileObj or PipeObj read next newline terminated string and return
-    if (((ComValue*)retval)->is_fileobj() || ((ComValue*)retval)->is_pipeobj()) {
-      ComValue fpobj((ComValue*)retval);
+    // if FileObj or PipeObj read next newline terminated string and return.
+    // retval is a base-class AttributeValue (the internal list is built by
+    // the AttributeValueList copy-ctor), so don't cast it to ComValue* --
+    // the ComValue-only fields lie past the end of the allocation
+    if (retval && (retval->is_object(FileObj::class_symid()) ||
+		   retval->is_object(PipeObj::class_symid()))) {
+      ComValue fpobj(*retval);
       comterp()->push_stack(fpobj);
       GetStringFunc func(comterp());
       func.exec(1,0);

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -74,7 +74,7 @@ static char newline;
    only this key changes -- read the latest key off the banner to confirm the
    newest build took.  Bumping it recompiles this main.c, so its __DATE__/__TIME__
    refresh too; build_stamp() (in ComUtil/util.c) just formats the three. */
-#define PATCH_KEY "b082afc8"
+#define PATCH_KEY "37cf48b3"
 
 using std::cout;
 using std::cerr;


### PR DESCRIPTION
Fixes #215

## What

`StreamNextFunc::execute` downcast the stream's internal-list elements to `ComValue*` for its FileObj/PipeObj check and copy-constructed a `ComValue` through that pointer. But the internal list is built by the `AttributeValueList` copy-ctor (`attrlist.c:310`), which stores plain 40-byte base-class `AttributeValue`s — correct for the Attribute layer, which cannot know `ComValue` exists. The copy therefore read the ComValue-only fields (`_narg` first — the reported READ of size 4 at exactly 0 bytes past the region) beyond the end of the allocation, on **every stream iteration**. Benign in practice in normal builds (strictly a read; the base fields the check actually uses are valid), but real UB, and it aborted every sanitized run at the first stream test.

## The fix (strmfunc.c, +6/-3)

Stop pretending the element is a `ComValue`:

- the FileObj/PipeObj test becomes the AttributeValue-level `is_object(class_symid)` — the exact check `ComValue::is_fileobj()/is_pipeobj()` performed, minus the UB copy — behind a nil guard;
- `fpobj` is built with the `ComValue(AttributeValue&)` constructor (base copy + `zero_vals()`), the promotion path the read sites elsewhere already use (`comterp.c:534`, `push_stack(AttributeValue&)`).

Behavior-identical: `dup_as_needed()` (the only delta vs the old `ComValue(ComValue*)` ctor) is a no-op for ObjectType. The nil guard is pure defense — `next()` on a drained stream is guarded upstream and never reaches this line (verified with a breakpoint).

This is the layering paying off: the stream's internal plumbing stays on the barer Attribute-library representation, and only the interpreter-facing surface promotes to `ComValue`, through the constructor built for exactly that.

## Verification

- **Pre-fix**, ASan build per `config/SANITIZE.md`: heap-buffer-overflow reproduced in `stream.comt`, `stream-literal.comt`, `matrixmult.comt`, `spread.comt` (identical signature, `comvalue.c:143` via `is_fileobj` ← `strmfunc.c:390`, allocation at `attrlist.c:310` ← `strmfunc.c:108`).
- **Post-fix**, same ASan build: all four run clean, and the **whole `run_all.comt` suite passes ASan-clean end-to-end for the first time** (it previously aborted at stream.comt).
- FileObj/PipeObj streams behaviorally confirmed still working under ASan (the branch must still *fire*, not just not crash): `list($$open(file))` returns the file's lines; `list($$open("printf ..." :pipe))` returns command output.
- ASan flags reverted, clean normal rebuild (no ASan residue in binary or dylibs), full `run_all.comt` passes; banner shows PATCH_KEY `37cf48b3`.

## Related

The write-direction sibling found while auditing after this fix — compound assign to a keyword-bound func formal writes ComValue fields past a 40-byte frame `AttributeValue` and crashes stock comterp — is filed as #216 (same fix shape, different file; left out of this PR to keep it one concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
