### PR TITLE
Fix heap overflow on compound assignment to a keyword-bound func formal (crashes stock comterp)

### DIFF
--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -139,12 +139,12 @@ void ModAssignFunc::execute() {
 	    push_stack(ComValue::nullval());
 	    return;
 	}
-	push_stack(*(ComValue*)op1val);
+	push_stack(*op1val);
 	push_stack(operand2);
 	ModFunc modfunc(comterp());
 	modfunc.exec(2,0);
 	ComValue result(pop_stack());
-        *(ComValue*)op1val = result;
+        op1val->assignval(result);
 	push_stack(result);
     }
 
@@ -168,12 +168,12 @@ void MpyAssignFunc::execute() {
 	    push_stack(ComValue::nullval());
 	    return;
 	}
-	push_stack(*(ComValue*)op1val);
+	push_stack(*op1val);
 	push_stack(operand2);
 	MpyFunc mpyfunc(comterp());
 	mpyfunc.exec(2,0);
 	ComValue result(pop_stack());
-        *(ComValue*)op1val = result;
+        op1val->assignval(result);
 	push_stack(result);
     }
 
@@ -196,12 +196,12 @@ void AddAssignFunc::execute() {
 	    push_stack(ComValue::nullval());
 	    return;
 	}
-	push_stack(*(ComValue*)op1val);
+	push_stack(*op1val);
 	push_stack(operand2);
 	AddFunc addfunc(comterp());
 	addfunc.exec(2,0);
 	ComValue result(pop_stack());
-        *(ComValue*)op1val = result;
+        op1val->assignval(result);
 	push_stack(result);
     }
 
@@ -225,12 +225,12 @@ void SubAssignFunc::execute() {
 	    push_stack(ComValue::nullval());
 	    return;
 	}
-	push_stack(*(ComValue*)op1val);
+	push_stack(*op1val);
 	push_stack(operand2);
 	SubFunc subfunc(comterp());
 	subfunc.exec(2,0);
 	ComValue result(pop_stack());
-        *(ComValue*)op1val = result;
+        op1val->assignval(result);
 	push_stack(result);
     }
 
@@ -254,12 +254,12 @@ void DivAssignFunc::execute() {
 	    push_stack(ComValue::nullval());
 	    return;
 	}
-	push_stack(*(ComValue*)op1val);
+	push_stack(*op1val);
 	push_stack(operand2);
 	DivFunc divfunc(comterp());
 	divfunc.exec(2,0);
 	ComValue result(pop_stack());
-        *(ComValue*)op1val = result;
+        op1val->assignval(result);
 	push_stack(result);
     }
 
@@ -279,7 +279,7 @@ void IncrFunc::execute() {
 	if (!op1val) 
 	    push_stack(ComValue::nullval());
 	else {
-	    push_stack(*(ComValue*)op1val);
+	    push_stack(*op1val);
 	    ComValue one;
 	    one.type(ComValue::IntType);
 	    one.int_ref() = 1;
@@ -287,7 +287,7 @@ void IncrFunc::execute() {
 	    AddFunc addfunc(comterp());
 	    addfunc.exec(2,0);
 	    ComValue result(pop_stack());
-            *(ComValue*)op1val = result;
+            op1val->assignval(result);
 	    push_stack(result);
 	}
     } else 
@@ -310,7 +310,7 @@ void IncrAfterFunc::execute() {
 	if (!op1val)
 	    push_stack(ComValue::nullval());
 	else {
-	    push_stack(*(ComValue*)op1val);
+	    push_stack(*op1val);
 	    ComValue one;
 	    one.type(ComValue::IntType);
 	    one.int_ref() = 1;
@@ -318,8 +318,8 @@ void IncrAfterFunc::execute() {
 	    AddFunc addfunc(comterp());
 	    addfunc.exec(2,0);
 	    ComValue result(pop_stack());
-	    push_stack(*(ComValue*)op1val);
-            *(ComValue*)op1val = result;
+	    push_stack(*op1val);
+            op1val->assignval(result);
 	}
     } else 
         push_stack(ComValue::nullval());
@@ -339,7 +339,7 @@ void DecrFunc::execute() {
 	if (!op1val)
 	    push_stack(ComValue::nullval());
 	else {
-	    push_stack(*(ComValue*)op1val);
+	    push_stack(*op1val);
 	    ComValue one;
 	    one.type(ComValue::IntType);
 	    one.int_ref() = 1;
@@ -347,7 +347,7 @@ void DecrFunc::execute() {
 	    SubFunc subfunc(comterp());
 	    subfunc.exec(2,0);
 	    ComValue result(pop_stack());
-            *(ComValue*)op1val = result;
+            op1val->assignval(result);
 	    push_stack(result);
 	}
     } else 
@@ -369,7 +369,7 @@ void DecrAfterFunc::execute() {
 	if (!op1val)
 	    push_stack(ComValue::nullval());
 	else {
-	    push_stack(*(ComValue*)op1val);
+	    push_stack(*op1val);
 	    ComValue one;
 	    one.type(ComValue::IntType);
 	    one.int_ref() = 1;
@@ -377,8 +377,8 @@ void DecrAfterFunc::execute() {
 	    SubFunc subfunc(comterp());
 	    subfunc.exec(2,0);
 	    ComValue result(pop_stack());
-	    push_stack(*(ComValue*)op1val);
-            *(ComValue*)op1val = result;
+	    push_stack(*op1val);
+            op1val->assignval(result);
 	}
     } else 
         push_stack(ComValue::nullval());

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -74,7 +74,7 @@ static char newline;
    only this key changes -- read the latest key off the banner to confirm the
    newest build took.  Bumping it recompiles this main.c, so its __DATE__/__TIME__
    refresh too; build_stamp() (in ComUtil/util.c) just formats the three. */
-#define PATCH_KEY "601ab65c"
+#define PATCH_KEY "ff348cd7"
 
 using std::cout;
 using std::cerr;

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -228,7 +228,7 @@ To add a new test script:
 | stream.comt   | $$ $ ,, next each size .. **                                 | 1-10    |      46 |    50 | 92% |
 | string.comt   | index substr split join eq size print(+:str) +               | 1-10,11 |      78 |    97 | 80% |
 | global.comt   | global                                                       | 1-10,11 |      13 |    14 | 93% |
-| assignops.comt| mod_assign mpy_assign add_assign sub_assign div_assign incr incr_after decr decr_after | 1-9,11 | 24 | 44 | 55% |
+| assignops.comt| mod_assign mpy_assign add_assign sub_assign div_assign incr incr_after decr decr_after | 1-9,11 | 33 | 53 | 62% |
 | attrlist.comt | dot list(:attr) attrlist at size attrname attrval + -        | 1-10    |      42 |    55 | 76% |
 | print.comt    | print                                                        | 1-9     |      22 |    35 | 63% |
 | parser.comt   | attrlist(:literal) errmsg postfix class type                 | 1-9     |      28 |    38 | 74% |

--- a/src/comterp_/tests/assignops.comt
+++ b/src/comterp_/tests/assignops.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/assignops.comt -- test compound assignment operators
 //
-// coverage: 24/44 (55%)
+// coverage: 33/53 (62%)
 // funcs: mod_assign mpy_assign add_assign sub_assign div_assign incr incr_after decr decr_after
 // missing: ~all(return-type) mpy_assign(unset-nil) add_assign(unset-nil)
 //          sub_assign(unset-nil) div_assign(unset-nil) incr(unset-nil)
@@ -14,6 +14,17 @@
 // ModAssignFunc::execute).  Tests 3, 5, and 6 stress the three storage
 // paths mutated in place: repeated local-table writes, the func-frame
 // attrlist, and the global table.
+//
+// tests 18-27 pin every compound-assign/incr/decr op against a
+// keyword-bound func formal (issue #216): those bindings are stored as
+// plain 40-byte AttributeValues in the frame attrlist, and every
+// assignfunc.c compound-assign body used to read and write them through
+// a ComValue* cast -- the write landed the ComValue-only fields past the
+// end of the allocation, corrupting the heap and crashing stock comterp
+// a statement or two later in the ~Attribute/~AttributeList teardown
+// cascade.  (Locals created inside the body, as in test 5, were never
+// affected -- AssignFunc stores a heap ComValue for those; only
+// keyword-bound formals hit the plain-AttributeValue path.)
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/assignops.comt")
@@ -149,6 +160,77 @@ while(i<5 (total+=i; i++))
 ok=ok&&(total==10)
 ok=ok&&(i==5)
 print("17 while(i<5 (total+=i; i++)) (expect total=10 i=5): %v %v\n" total i)
+prev_ok=check_fail(:ok ok)
+
+// --- test 18: += on a keyword-bound func formal (issue #216) ---
+f18=func(kk+=1; kk)
+r18=f18(:kk 5)
+ok=ok&&(r18==6)
+print("18 f18=func(kk+=1; kk); f18(:kk 5) (expect 6): %v\n" r18)
+prev_ok=check_fail(:ok ok)
+
+// --- test 19: -= on a keyword-bound func formal ---
+f19=func(kk-=2; kk)
+r19=f19(:kk 5)
+ok=ok&&(r19==3)
+print("19 f19=func(kk-=2; kk); f19(:kk 5) (expect 3): %v\n" r19)
+prev_ok=check_fail(:ok ok)
+
+// --- test 20: *= on a keyword-bound func formal ---
+f20=func(kk*=3; kk)
+r20=f20(:kk 5)
+ok=ok&&(r20==15)
+print("20 f20=func(kk*=3; kk); f20(:kk 5) (expect 15): %v\n" r20)
+prev_ok=check_fail(:ok ok)
+
+// --- test 21: /= on a keyword-bound func formal ---
+f21=func(kk/=4; kk)
+r21=f21(:kk 20)
+ok=ok&&(r21==5)
+print("21 f21=func(kk/=4; kk); f21(:kk 20) (expect 5): %v\n" r21)
+prev_ok=check_fail(:ok ok)
+
+// --- test 22: %= on a keyword-bound func formal ---
+f22=func(kk%=3; kk)
+r22=f22(:kk 10)
+ok=ok&&(r22==1)
+print("22 f22=func(kk%=3; kk); f22(:kk 10) (expect 1): %v\n" r22)
+prev_ok=check_fail(:ok ok)
+
+// --- test 23: prefix ++ on a keyword-bound func formal ---
+f23=func(pre=++kk; pre+kk)
+r23=f23(:kk 5)
+ok=ok&&(r23==12)
+print("23 f23=func(pre=++kk; pre+kk); f23(:kk 5) (expect 12): %v\n" r23)
+prev_ok=check_fail(:ok ok)
+
+// --- test 24: postfix ++ on a keyword-bound func formal ---
+f24=func(old=kk++; old+kk)
+r24=f24(:kk 5)
+ok=ok&&(r24==11)
+print("24 f24=func(old=kk++; old+kk); f24(:kk 5) (expect 11): %v\n" r24)
+prev_ok=check_fail(:ok ok)
+
+// --- test 25: prefix -- on a keyword-bound func formal ---
+f25=func(pre=--kk; pre+kk)
+r25=f25(:kk 5)
+ok=ok&&(r25==8)
+print("25 f25=func(pre=--kk; pre+kk); f25(:kk 5) (expect 8): %v\n" r25)
+prev_ok=check_fail(:ok ok)
+
+// --- test 26: postfix -- on a keyword-bound func formal ---
+f26=func(old=kk--; old+kk)
+r26=f26(:kk 5)
+ok=ok&&(r26==9)
+print("26 f26=func(old=kk--; old+kk); f26(:kk 5) (expect 9): %v\n" r26)
+prev_ok=check_fail(:ok ok)
+
+// --- test 27: repeated compound assigns on the same keyword formal ---
+// (each op rewrites the same frame AttributeValue in place)
+f27=func(kk+=1; kk+=2; kk%=4; kk)
+r27=f27(:kk 5)
+ok=ok&&(r27==0)
+print("27 f27=func(kk+=1; kk+=2; kk%=4; kk); f27(:kk 5) (expect 0): %v\n" r27)
 prev_ok=check_fail(:ok ok)
 
 print("\nassignops: %v\n" ok)


### PR DESCRIPTION
Fixes #216 — the write-direction sibling of #215.

## The bug

Any compound assignment (`+=` `-=` `*=` `/=` `%=` `++` `--`) applied to a **keyword-bound func formal** corrupted the heap and crashed stock, non-ASan comterp:

```
f=func(k+=1; k)
f(:k 5)          // prints 6 -- "works"
g=func(k++; k)
g(:k 7)          // prints 8 -- "works"
h=func(k%=3; k)  // heap already corrupted; this or any later
h(:k 10)         //  frame teardown segfaults in ~Attribute/~AttributeList
```

The values print correctly and the corruption detonates a statement or two later in the `~Attribute`/`~AttributeList` teardown cascade — the deferred-crash signature of a heap overwrite.

## Root cause

FuncObj keyword actuals are bound into the frame `AttributeList` via `al->add_attr(keyv.keyid_val(), valv)`, which stores a plain 40-byte `new AttributeValue(value)` (`attrlist.c:89-91`). Every *read* path already expects base-class storage and promotes via the `ComValue(AttributeValue&)` ctor — but all nine compound-assign/incr/decr bodies in `assignfunc.c` accessed it through a `ComValue*` cast:

```c
push_stack(*(ComValue*)op1val);   // read overflow (full ComValue copy)
*(ComValue*)op1val = result;      // WRITE overflow: ComValue::operator=
                                  // lands _narg/_nkey/_nids/_pedepth/_flags/_linenum
                                  // past the 40-byte allocation
```

Positional formals are unaffected (they ride `_funcobj_argvals`, never the attrlist), and body-locals (`x=10; x+=1`) are safe because `AssignFunc` stores a heap `ComValue` in the frame attribute. Only keyword-bound formals hit the plain-`AttributeValue` path — which is why this survived so long.

## The fix

Same shape as the #215 fix — the storage legitimately *is* an `AttributeValue`; stop pretending otherwise at the access site. In each of the nine bodies:

- `push_stack(*(ComValue*)op1val)` → `push_stack(*op1val)` — the `push_stack(AttributeValue&)` overload promotes safely;
- `*(ComValue*)op1val = result` → `op1val->assignval(result)` — `AttributeValue::assignval` copies exactly the base fields, preserving in-place mutation for both ComValue-backed table storage and AttributeValue-backed frame storage.

Builds on #218 (merged): the write-back in `ModAssignFunc` would itself have been a use-after-free before that stray `delete` was removed.

## Verification

- **Pre-fix, ASan build** (per `config/SANITIZE.md`): exact report — `heap-buffer-overflow ... in ComValue::operator=(ComValue const&) comvalue.c:143`, reached from `AddAssignFunc::execute`, `0 bytes after 40-byte region` allocated by `AttributeList::add_attr` `attrlist.c:90`.
- **Pre-fix, stock build**: the repro above segfaults in the `~Attribute`/`~AttributeList` cascade.
- **Post-fix**: repro prints 6/8/1 and exits cleanly on both ASan and stock builds.
- **Full `run_all.comt` suite**: 21/21 pass on the stock (flags-reverted) build. Under ASan, the suite runs clean through and past assignops; the only remaining report is the known pre-existing #215 read overflow in `StreamNextFunc` (its fix lives on `streamnext-downcast-fix`) — with that branch's `strmfunc.c` hunk applied locally, the entire suite runs ASan-clean end-to-end.

## Tests

Adds tests 18–27 to `src/comterp_/tests/assignops.comt` (introduced by #218): each of the nine ops driven through a keyword-bound formal (`f=func(kk+=1; kk); f(:kk 5)` etc., with prefix/postfix `++`/`--` asserting both the returned and stored values), plus a repeated-compound-assign stress that rewrites the same frame `AttributeValue` three times. Coverage header 24/44 → 33/53 and the TESTING.md table row updated.

PATCH_KEY bumped to `ff348cd7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
