### PR TITLE
Examples: teach dot-assignment on comps (comp.key=val is setattr without ceremony)

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -394,6 +394,21 @@ foo.bar=42
 foo.bar          // returns 42
 ```
 
+The dot's lhs may also be a **comp** (a graphic component, in comdraw
+and above): the dot resolves into the comp's attribute list, so
+`comp.key=val` is `setattr(comp :key val)` spelled as plain assignment,
+and `comp.key` reads the fact back:
+
+```
+pig=ellipse(200,220, 25,15)
+pig.legs=4               // setattr(pig :legs 4)
+pig.legs                 // 4 -- and who()/frame() queries see it too
+```
+
+Use `setattr()` to stamp many facts in one call; the dot for one at a
+time.  The mutation rides the comp reference, so it works from inside a
+func even though the symbol binding is frame-local (see *Scoping rules*).
+
 The dot namespace rooted at a symbol is scoped with that symbol — see
 **Attribute Lists** below.
 

--- a/doc/SPATIAL-APPLICATIONS.md
+++ b/doc/SPATIAL-APPLICATIONS.md
@@ -60,6 +60,10 @@ answers the question the other half can't ask.
    setattr(ellie :name "Ellie" :kind "animal" :legs 4 :eats "plants" :moves "stomps")
    ```
 
+   Facts also go on one at a time by dot-assignment — `ellie.mood="happy"`
+   is `setattr(ellie :mood "happy")` — and read back the same way
+   (`ellie.legs`), which is what the query funcs below are doing.
+
    This is the load-bearing move.  The spatial database lives *on* the
    graphics, not beside them — no parallel table, no glue on the canvas.
    Save the drawing and the database goes with it; select a graphic and

--- a/src/comdraw/examples/README.md
+++ b/src/comdraw/examples/README.md
@@ -22,7 +22,8 @@ the drawing (and any funcs the script defined) live in the session.
   *The script is the picture.*
 
 - **zoomap.comt** — a zoo map you can ask questions.  Every animal
-  carries facts attached with `setattr()` (`:name :legs :eats :moves`);
+  carries facts attached with `setattr()` (`:name :legs :eats :moves`)
+  or one at a time by dot-assignment (`pig.legs=4`);
   typed queries walk the component tree (`frame()`, `at()`, dot-access)
   and flash the matches (`select()` + `update()`).  Try `zoohelp()`,
   `who("swims")`, `haslegs(4)`, `countlegs()`, `dance()`.  Written to be
@@ -39,7 +40,8 @@ the drawing (and any funcs the script defined) live in the session.
   filter: divide each radius by its eigenvalue `(2+cos wh)/3` and the
   spline lands exactly on the true curve at every knot, ~10 control
   points per harmonic cycle.  Every curve remembers its parameters via
-  `setattr()`, and `recipes()` prints back the re-typeable `spiro()`
+  dot-assignment (`curve.R=96` — `setattr()` spelled as plain
+  assignment), and `recipes()` prints back the re-typeable `spiro()`
   command for each.  `orbit()` then turns the curves into planets:
   spring-gravity toward the shared center of gravity, short-range
   repulsion when they bump, each spinning on its own axis.

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -105,9 +105,13 @@ spiro=func(
   pattern(1);
   eflag=0;
   if(epi!=nil :then eflag=1);
-  // LAYER 2: the DATA -- the curve remembers its own recipe,
-  // so recipes() can read back the exact command that drew it
-  setattr(curve :name "spiro" :R R :r r :d d :epi eflag :color color :pts n);
+  // LAYER 2: the DATA -- the curve remembers its own recipe, stamped
+  // on with dot-assignment: comp.key=val is setattr(comp :key val)
+  // spelled as plain assignment, and recipes() reads it back the same
+  // way (curve.R).  Use setattr() when you want many facts in one call.
+  curve.name="spiro";
+  curve.R=R; curve.r=r; curve.d=d;
+  curve.epi=eflag; curve.color=color; curve.pts=n;
   // styling the curve also set the editor's CURRENT style -- put it
   // back to the startup default so the next shape isn't born a spiro.
   select(:clear);
@@ -267,6 +271,9 @@ spirohelp=func(
   print("  orbit()          -- the spirographs become planets! (needs 2+)\n");
   print("  clearpaper()     -- fresh sheet\n");
   print("  oops()           -- the machine explains your last error\n");
+  print("SECRETS: every curve is YOURS -- grab one and decorate it:\n");
+  print("  c=surprise(); c.nickname=\"whirly\"; c.nickname\n");
+  print("  (a dot writes a fact on the curve; recipes() reads c.R the same way)\n");
   print("SECRETS: more teeth in common = fewer petals -- petals = R/gcd(R r),\n");
   print("  rolling inside OR outside (the pen's distance from the center\n");
   print("  swells and shrinks R/r times per trip around, r/gcd trips).\n");

--- a/src/comdraw/examples/zoomap.comt
+++ b/src/comdraw/examples/zoomap.comt
@@ -14,6 +14,7 @@
 // HOW IT WORKS (the three layers of every spatial app):
 //   1. the DRAWING  -- shapes on the canvas (rect, ellipse, spline)
 //   2. the DATA     -- setattr() sticks facts onto each shape
+//                      (or one at a time by dot: pig.legs=4)
 //   3. the QUESTIONS-- little funcs walk every shape on the map,
 //                      check its facts, and flash the ones that match
 
@@ -226,8 +227,14 @@ zoohelp=func(
   print("  oops()           -- the map explains your last error\n");
   print("YOUR TURN: add your own animal, then find it --\n");
   print("  pig=ellipse(200,220, 25,15)\n");
-  print("  setattr(pig :name \"Penny\" :kind \"animal\" :legs 4 :eats \"corn\" :moves \"trots\")\n");
-  print("  who(\"Penny\")\n"))
+  print("  pig.name=\"Penny\"\n");
+  print("  pig.kind=\"animal\"\n");
+  print("  pig.legs=4\n");
+  print("  pig.eats=\"corn\"\n");
+  print("  pig.moves=\"trots\"\n");
+  print("  who(\"Penny\")\n");
+  print("(each dot writes one fact on the pig -- setattr(pig :name \"Penny\" :legs 4 ...)\n");
+  print(" stamps them all at once, like the animals above)\n"))
 
 // ============================================================
 // welcome!

--- a/src/comdraw/tests/dotattr.comt
+++ b/src/comdraw/tests/dotattr.comt
@@ -1,0 +1,48 @@
+// src/comdraw/tests/dotattr.comt -- dot-assignment on comps
+//
+// comp.key=val is setattr(comp :key val) spelled as plain assignment:
+// the dot's lhs resolves into the comp's AttributeList and AssignFunc's
+// Attribute branch writes through it (attr->Value).  The symbol binding
+// may be func-frame local; the mutation rides the reference.
+//
+// funcs: dot-assign dot-read setattr frame
+ok=true
+
+r=rect(50,50,150,150)
+r.zap=42
+ok=ok&&(r.zap==42)
+print("1 r.zap=42; r.zap dot-assign creates the attribute (expect 42): %v\n" r.zap)
+
+setattr(r :via 7)
+ok=ok&&(r.via==7)&&(r.zap==42)
+print("2 setattr(r :via 7) coexists with dot-written zap (expect 7 42): %v %v\n" r.via r.zap)
+
+r.zap=43
+ok=ok&&(r.zap==43)
+print("3 r.zap=43 dot-assign overwrites (expect 43): %v\n" r.zap)
+
+r.tag="whirly"
+ok=ok&&(r.tag=="whirly")
+print("4 r.tag=\"whirly\" string fact (expect \"whirly\"): %v\n" r.tag)
+
+r.legs=4
+ok=ok&&(r.legs+1==5)
+print("5 r.legs=4; r.legs+1 numeric read-back arithmetic (expect 5): %v\n" r.legs+1)
+
+stampf=func(g=arg(0); g.stamped=99; 0)
+stampf(r)
+ok=ok&&(r.stamped==99)
+print("6 stampf=func(g=arg(0); g.stamped=99); stampf(r); r.stamped frame-ref write-through (expect 99): %v\n" r.stamped)
+
+ok=ok&&(r.absent==nil)
+print("7 r.absent unwritten attribute reads nil (expect nil): %v\n" r.absent)
+
+// the drawing-as-database read: find the tagged comp by scanning frame()
+found=0
+n=size(frame())
+for(qi=0 qi<n qi++ g=at(frame() qi); if(g.tag=="whirly" :then found++))
+ok=ok&&(found==1)
+print("8 frame() scan for g.tag==\"whirly\" (expect 1): %v\n" found)
+
+print("dotattr: %v\n" ok)
+ok

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -31,5 +31,9 @@ if(run("./gsget.comt")
   :then print("pass: gsget\n")
   :else print("FAIL: gsget\n");ok=false)
 
+if(run("./dotattr.comt")
+  :then print("pass: dotattr\n")
+  :else print("FAIL: dotattr\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -100,7 +100,8 @@ graphical object assigned to an interpreter variable.
 .SH COMPONENT AND ATTRIBUTE COMMANDS
 
  compview=setattr(compview [:keyword value [:keyword value [...]]])
-   -- set attributes of a graphic component
+   -- set attributes of a graphic component.  Equivalently one at a time
+   by dot-assignment: comp.key=val; comp.key reads it back
  attrlist(compview)
    -- return attribute list of component
  compview=frame([index])


### PR DESCRIPTION
## What

Scott's observation: the dot expression also does `setattr` when the dot's lhs is a comp — `comp.key=val` writes the comp's AttributeList through `AssignFunc`'s Attribute branch (`attr->Value(operand2)`), the same write-through-reference mechanism LANGUAGE.md's scoping section documents for attrlists.  Verified live in comdraw before touching anything:

- `r.zap=42` **creates** the attribute (no prior setattr needed) and reads back
- coexists with `setattr()` on the same comp; overwrites work; strings work
- mutates correctly through a func-frame reference (`f=func(g=arg(0); g.stamped=99)`) — consistent with writes-stay-local scoping, because the mutation rides the reference, not the scope

## The brush-up

- **spirograph.comt** — the LAYER 2 recipe stamp becomes dot-assignments (`curve.name="spiro"; curve.R=R; ...`) with a comment naming the equivalence and when `setattr()` still earns its place (many facts, one call).  `spirohelp()` gains the make-it-yours secret: `c=surprise(); c.nickname="whirly"; c.nickname` — the shortest path from playing the demo to owning the objects.
- **zoomap.comt** — the YOUR TURN recipe builds Penny fact-by-fact with dots (`pig.legs=4` reads like talking to the pig), noting the batch `setattr()` spelling used for the animals above; the three-layer header teaches both.
- **examples README** — both entries mention the dot idiom.

## Test (second commit)

New `src/comdraw/tests/dotattr.comt`, registered in that suite's run_all.comt: pins creation-without-setattr, coexistence with `setattr()`, overwrite, string/numeric round-trips, write-through from a func-frame reference, unwritten-attribute-reads-nil, and the `frame()`-scan drawing-as-database query.  Full comdraw suite green under `-stdin_off` (the CI invocation).

## Documentation (third commit)

- **doc/LANGUAGE.md**, *Dot operator*: the comp case — `comp.key=val` is `setattr(comp :key val)` spelled as assignment, reads via `comp.key`, when to prefer each spelling, and the scoping note (the mutation rides the comp reference, so it works from inside a func even though the symbol binding is frame-local).
- **src/man/man1/comdraw.1**: the `setattr` entry notes the dot equivalence.
- **doc/SPATIAL-APPLICATIONS.md**: the Askable-Map data-layer section shows the one-fact-at-a-time spelling, which is what the `who()`-style query funcs were reading all along.

## Verified

Live comdraw runs of both brushed examples: the dot-built Penny is found by `who("Penny")` and counted by `haslegs(4)` (3 now — Ellie, Leo, Penny); the spirograph's dot-stamped recipes read back through `recipes()` exactly as before; the nickname flow round-trips.

Script-only change; no production code touched.  (Note: the working-tree orbit() pacing tweak Scott is iterating on locally is untouched and in a different region of spirograph.comt, so it merges cleanly on top.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

