### PR TITLE
Fix global(x)=val reassignment leak -- old-value cleanup was blinded by its own bquote shield

### DIFF
--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -81,16 +81,19 @@ void AssignFunc::execute() {
     if (operand1.type() == ComValue::SymbolType) {
         AttributeList* attrlist = comterp()->get_attributes();
 	/* global() lvalue must be tested BEFORE the func-frame branch:
-	   the whole point of global(x)=val is to escape the frame, and
-	   lookup_symval honors global_flag by skipping _alist and
-	   localtable, so the old-value cleanup stays consistent from
-	   inside a func.  (Until this reordering, global(x)=val inside
-	   a func silently wrote x to the frame attrlist instead.) */
+	   the whole point of global(x)=val is to escape the frame.
+	   The old-value cleanup must read the globaltable DIRECTLY
+	   (globalvalue()), not via lookup_symval: the lvalue symbol
+	   carries bquote (the anti-resolution shield), and lookup_symval
+	   returns nil for bquoted symbols -- so the old cleanup never
+	   fired and every reassignment stacked a fresh table entry over
+	   the orphaned old one (~95 bytes leaked per global(x)=val,
+	   observable as global(:cnt) growth). */
 	if (operand1.global_flag()) {
-	    AttributeValue* oldval = comterp()->lookup_symval(&operand1);
+	    ComValue* oldval = comterp()->globalvalue(operand1.symbol_val());
 	    if (oldval) {
 	      comterp()->globaltable()->remove(operand1.symbol_val());
-	      delete (ComValue*)oldval;
+	      delete oldval;
 	    }
 	    comterp()->globaltable()->insert(operand1.symbol_val(), operand2);
 	} else if (operand1.local_flag()) {

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -74,7 +74,7 @@ static char newline;
    only this key changes -- read the latest key off the banner to confirm the
    newest build took.  Bumping it recompiles this main.c, so its __DATE__/__TIME__
    refresh too; build_stamp() (in ComUtil/util.c) just formats the three. */
-#define PATCH_KEY "ff348cd7"
+#define PATCH_KEY "57ce50ab"
 
 using std::cout;
 using std::cerr;

--- a/src/comterp_/tests/global.comt
+++ b/src/comterp_/tests/global.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/global.comt -- test global() command
 //
-// coverage: 16/17 (94%)
+// coverage: 17/18 (94%)
 // funcs: global
 // missing: ~global(lvalue-return-type) -- in global(sym)=val the return value belongs
 //          to the assign operator, not global(); untestable in isolation for global() alone
@@ -121,6 +121,20 @@ r14=gsf()
 ok=ok&&(at(r14 0)==1)
 ok=ok&&(at(r14 1)==77)
 print("14 gsf=func(gfunc=1; gfunc,global(gfunc)) shadow vs explicit (expect 1 77): %v %v\n\n" at(r14 0) at(r14 1))
+prev_ok=check_fail(:ok ok)
+
+// --- test 15: reassignment replaces the table entry, never stacks ---
+// (regression: the lvalue's old-value cleanup used lookup_symval, which
+//  returns nil for the bquoted lvalue symbol, so every global(x)=val
+//  orphaned the previous entry -- global(:cnt) grew by one per
+//  reassignment and each orphan leaked ~95 bytes)
+global(gstack)=0
+c0=global(:cnt)
+for(i=0 i<100 i++ global(gstack)=i)
+c1=global(:cnt)
+ok=ok&&(c1==c0)
+ok=ok&&(global(gstack)==99)
+print("15 100x global(gstack)=i; global(:cnt) delta (expect 0, value 99): %v %v\n\n" c1-c0 global(gstack))
 prev_ok=check_fail(:ok ok)
 
 print("\nglobal: %v\n" ok)


### PR DESCRIPTION
## The bug

Every `global(x)=val` reassignment leaked ~95 bytes, forever.  200,000 reassignments grew comterp's RSS from 3.5MB to 22.9MB, and `global(:cnt)` counted one new table entry per reassignment — the previous entry was never removed, just buried.

Directly relevant beyond hygiene: drawmo's polling idiom (`global(gevt)=...` written repeatedly, read from another context — the use case global.comt test 10 documents) pays this on every poll cycle in long-running drawserv sessions.

## The cause

`AssignFunc`'s global branch did its old-value cleanup via `lookup_symval(&operand1)` — but the lvalue symbol carries `bquote` (the anti-resolution shield that lets the flagged symbol survive evaluation and reach `AssignFunc` at all), and `lookup_symval` returns nil for bquoted symbols *before* consulting `global_flag`.  So `oldval` was always nil, the remove/delete never fired, and `insert` stacked a fresh entry over the orphaned one (reads stayed correct because `find` returns the newest entry — which is why this hid for so long).

The shield and the cleanup were both doing their jobs; they just couldn't see each other.

## The fix

Read the old value directly from the table with `globalvalue(operand1.symbol_val())` — exactly the `localvalue()` pattern `local()` shipped with in #213 (which is why `local(x)=val` reassignment was already leak-free).  One call site changed.

## Verified

- `global(:cnt)` delta across 100 reassignments: 100 before, **0** after — now pinned as global.comt test 15 (a leak test that needs no LEAKCHECK build, since the stacking was visible through the table's own count).
- RSS peak across 200k reassignments: 22.9MB before, **3.36MB** after — byte-equivalent with `local()` (3.39MB) and bare assignment (3.38MB).
- Full suite green including the new test.
- Measurement footnote for posterity: `/usr/bin/time` is SIP-protected and strips `DYLD_LIBRARY_PATH`, silently re-running the installed (unfixed) libs — the RSS numbers above are from direct `ps` sampling of an unwrapped child instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)