### PR TITLE
etchasketch.comt: two knobs, one pen, no lifting -- the knobs are the wire

### DIFF
--- a/src/comdraw/examples/README.md
+++ b/src/comdraw/examples/README.md
@@ -47,6 +47,18 @@ the drawing (and any funcs the script defined) live in the session.
   repulsion when they bump, each spinning on its own axis.
   *The prompt is the control panel.*
 
+- **etchasketch.comt** — two knobs, one pen, no lifting.  `h(n)` and
+  `v(n)` turn the knobs (the knob graphics visibly rotate — each is an
+  ellipse grouped with its tick mark so the tick orbits the axle, the
+  petals.comt trick), each turn etches one line segment, the pen clamps
+  at the glass edges, and `shake()` wiggles the toy and erases only the
+  graphics tagged `kind="etch"`.  Pen state escapes the knob funcs with
+  `local(penx)=` — the session-scope escape from LANGUAGE.md's scoping
+  rules — and a knob turn is just the expression `h(3)`, so anything
+  that can send an expression can turn a knob: a second player over
+  `remote()`, or a trackball daemon split into two axes piping deltas.
+  *The knobs are the wire.*
+
 zoomap.comt is the reference implementation of the "Askable Map"
 pattern; the genre write-up (anatomy, error pedagogy, design rules,
 the drawserv distribution path) is `doc/SPATIAL-APPLICATIONS.md`.

--- a/src/comdraw/examples/etchasketch.comt
+++ b/src/comdraw/examples/etchasketch.comt
@@ -1,5 +1,8 @@
 // etchasketch.comt -- THE ETCH A SKETCH
 //
+// Etch A Sketch is a trademark of Spin Master Ltd.  This example is an
+// affectionate homage in comterp script, not an affiliated product.
+//
 // Two knobs, one pen, no lifting.  The left knob moves the pen
 // sideways, the right knob moves it up and down, and the pen NEVER
 // leaves the glass -- diagonals take two steady hands, curves take

--- a/src/comdraw/examples/etchasketch.comt
+++ b/src/comdraw/examples/etchasketch.comt
@@ -1,0 +1,180 @@
+// etchasketch.comt -- THE ETCH A SKETCH
+//
+// Two knobs, one pen, no lifting.  The left knob moves the pen
+// sideways, the right knob moves it up and down, and the pen NEVER
+// leaves the glass -- diagonals take two steady hands, curves take
+// practice, and mistakes take a good shake.
+//
+// Start it like this:
+//
+//     comdraw -runfile src/comdraw/examples/etchasketch.comt
+//
+// Then try:   etchhelp()
+//
+// HOW IT WORKS (the three layers, same as zoomap and spirograph):
+//   1. the MACHINE  -- h() and v() turn the knobs; each turn draws one
+//                      line segment from where the pen was to where it
+//                      is now, and spins the knob graphic to match
+//   2. the DATA     -- pen position lives in the session's own scope
+//                      (local(penx)= from inside the knob funcs -- the
+//                      func frame can't hold state that must outlive
+//                      the call), and every segment is tagged
+//                      seg.kind="etch" so shake() knows what to erase
+//                      and what is bezel
+//   3. the KNOBS ARE THE WIRE -- a knob turn is just the expression
+//                      h(3) or v(-2), so ANYTHING that can send an
+//                      expression can turn a knob:
+//
+//        two players, one axis each (drawserv or comterp remote):
+//            remote("host" 20002 "h(3)")     // horizontal player
+//            remote("host" 20002 "v(-2)")    // vertical player
+//        a trackball split into two knobs: a tiny daemon reads the
+//        device and pipes deltas as expressions --
+//            echo 'h(1)' | nc host 20002
+//
+//      No protocol to design: the command language IS the protocol.
+
+// ============================================================
+// LAYER 1+2: draw the toy, then wire up the knobs
+// ============================================================
+
+// --- the classic red bezel, the gray glass, two white knobs ---
+select(:clear)
+bezel=rect(60,60, 550,560)
+colorsrgb("#C22020" "#C22020")
+pattern(2)
+bezel.kind="bezel"
+glass=rect(100,150, 510,520)
+colorsrgb("#C8C8C4" "#C8C8C4")
+pattern(2)
+glass.kind="glass"
+// each knob is an ellipse GROUPED with its tick mark: rotating a
+// multi-selection spins each graphic about its OWN center, but a group
+// rotates about the shared center (the petals.comt trick), so the tick
+// orbits the knob axle like a real knob mark
+kh1=ellipse(120,105, 26,26)
+colorsrgb("#EEEEE8" "#FFFFFF")
+pattern(2)
+select(:clear)
+colorsrgb("#888880" "#FFFFFF")
+brush(65535,2)
+kh2=line(120,105, 120,127)
+select(kh1,kh2)
+knobh=group()
+knobh.kind="knob"
+select(:clear)
+kv1=ellipse(490,105, 26,26)
+colorsrgb("#EEEEE8" "#FFFFFF")
+pattern(2)
+select(:clear)
+colorsrgb("#888880" "#FFFFFF")
+brush(65535,2)
+kv2=line(490,105, 490,127)
+select(kv1,kv2)
+knobv=group()
+knobv.kind="knob"
+select(:clear)
+colorsrgb("#000000" "#FFFFFF")
+text(255,90 "Etch A Sketch")
+select(:clear)
+update()
+
+// the pen starts at the center of the glass; CLICKSZ px per knob click.
+// (the variable is NOT named "step" -- that's comterp's built-in stepper
+// command, and variables share the symbol namespace with commands)
+local(penx)=305
+local(peny)=335
+local(clicksz)=4
+
+// clamp(val lo hi) -- the pen stops at the glass edges, like the real toy
+clamp=func(val=arg(0); lo=arg(1); hi=arg(2);
+  if(val<lo :then return(lo));
+  if(val>hi :then return(hi));
+  val)
+
+// etch(nx ny) -- one segment of aluminum powder scraped off the glass.
+// Pen state must OUTLIVE this call, so writes escape the func frame
+// with local()= (see LANGUAGE.md "Escaping the func scope").
+etch=func(nx=arg(0); ny=arg(1);
+  if((nx==penx)&&(ny==peny) :then return(nil));
+  select(:clear);
+  colorsrgb("#3A3A38" "#FFFFFF");
+  brush(65535,2);
+  seg=line(penx,peny, nx,ny);
+  seg.kind="etch";
+  local(penx)=nx;
+  local(peny)=ny;
+  select(:clear);
+  colorsrgb("#000000" "#FFFFFF");
+  brush(65535,0);
+  update())
+
+// h(n) -- turn the LEFT knob n clicks (negative = left)
+h=func(n=arg(0);
+  if(n==nil :then print("Turn the knob a little, like this:  h(3) or h(-3)\n"));
+  if(n==nil :then return(nil));
+  select(knobh); rotate(0-n*9); select(:clear);
+  etch(clamp(penx+n*clicksz 104 506) peny))
+
+// v(n) -- turn the RIGHT knob n clicks (negative = down)
+v=func(n=arg(0);
+  if(n==nil :then print("Turn the knob a little, like this:  v(2) or v(-2)\n"));
+  if(n==nil :then return(nil));
+  select(knobv); rotate(0-n*9); select(:clear);
+  etch(penx clamp(peny+n*clicksz 154 516)))
+
+// shake() -- hold it upside down and shake!  (erases the etching,
+// never the toy: only graphics tagged kind=="etch" are deleted)
+shake=func(
+  handles(false);
+  for(si=0 si<4 si++
+    select(:all); rotate(2); update(30000);
+    rotate(-4); update(30000);
+    rotate(2); update(30000));
+  select(:clear);
+  doomed=list();
+  n=size(frame());
+  for(ci=0 ci<n ci++ g=at(frame() ci); if(g.kind=="etch" :then doomed,g));
+  for(ci=0 ci<size(doomed) ci++ delete(at(doomed ci)));
+  local(penx)=305;
+  local(peny)=335;
+  handles(true);
+  select(:clear);
+  update();
+  print("All clean!  The pen is back in the middle.\n"))
+
+// stair(n) -- a little demo autopilot: the classic staircase
+stair=func(n=arg(0);
+  if(n==nil :then n=5);
+  for(di=0 di<n di++ h(4); v(4));
+  print("Stairs!  Now try curves: alternate h(1) and v(1) quickly.\n"))
+
+// etchhelp() -- remind me how the knobs work
+etchhelp=func(
+  print("*** HOW TO WORK YOUR ETCH A SKETCH ***\n");
+  print("  h(3)    -- left knob: pen goes right 3 clicks (h(-3) for left)\n");
+  print("  v(2)    -- right knob: pen goes up 2 clicks (v(-2) for down)\n");
+  print("  stair() -- watch a staircase draw itself\n");
+  print("  shake() -- erase everything and start over\n");
+  print("THE PEN NEVER LIFTS.  Diagonals need both knobs taking turns --\n");
+  print("that's the whole game.\n");
+  print("TWO PLAYERS: run comdraw with a listening port and give each\n");
+  print("player one knob over the wire:\n");
+  print("  remote(\"host\" 20002 \"h(3)\")   -- the horizontal player\n");
+  print("  remote(\"host\" 20002 \"v(-2)\")  -- the vertical player\n");
+  print("(a knob turn is just an expression -- anything that can send\n");
+  print(" one can turn a knob, even a trackball daemon piping h(1)v(1))\n"))
+
+// ============================================================
+// welcome!
+// ============================================================
+print("\n=================================================\n")
+print("   YOUR ETCH A SKETCH IS READY.\n")
+print("   The pen is in the middle of the glass.\n")
+print("   Try typing:\n")
+print("       h(10)\n")
+print("       v(6)\n")
+print("       stair()\n")
+print("       shake()\n")
+print("       etchhelp()   <- the full knob manual\n")
+print("=================================================\n")

--- a/src/comdraw/examples/etchasketch.comt
+++ b/src/comdraw/examples/etchasketch.comt
@@ -143,6 +143,28 @@ shake=func(
   update();
   print("All clean!  The pen is back in the middle.\n"))
 
+// follow([n]) -- draw with the MOUSE: the pen chases the pointer for n
+// polling frames (default 200), but only the way an Etch A Sketch can --
+// one knob click at a time, alternating axes, knobs visibly turning.
+// pointer() reports the drawing-coordinate location of the last pointer
+// motion, and it keeps updating while this loop runs, so just wiggle
+// the mouse over the glass.  Diagonal mouse strokes come out as tiny
+// staircases, which is not a bug, it is the toy.
+follow=func(n=arg(0);
+  if(n==nil :then n=200);
+  print("Wiggle the mouse over the glass -- following for %v frames...\n" n);
+  for(fi=0 fi<n fi++
+    p=pointer();
+    px=at(p 0); py=at(p 1);
+    if((px!=0)||(py!=0) :then
+      for(bi=0 bi<10 bi++
+        if(px-penx>=clicksz :then h(1));
+        if(penx-px>=clicksz :then h(-1));
+        if(py-peny>=clicksz :then v(1));
+        if(peny-py>=clicksz :then v(-1))));
+    update(50000));
+  print("Done following.  shake() to erase, follow() to draw again.\n"))
+
 // stair(n) -- a little demo autopilot: the classic staircase
 stair=func(n=arg(0);
   if(n==nil :then n=5);
@@ -155,6 +177,8 @@ etchhelp=func(
   print("  h(3)    -- left knob: pen goes right 3 clicks (h(-3) for left)\n");
   print("  v(2)    -- right knob: pen goes up 2 clicks (v(-2) for down)\n");
   print("  stair() -- watch a staircase draw itself\n");
+  print("  follow() -- draw with the mouse! the pen chases the pointer,\n");
+  print("              one knob click at a time (diagonals go staircase)\n");
   print("  shake() -- erase everything and start over\n");
   print("THE PEN NEVER LIFTS.  Diagonals need both knobs taking turns --\n");
   print("that's the whole game.\n");


### PR DESCRIPTION
## What

Scott's idea: an Etch A Sketch drawserv app — because the knobs are *axis-split remote control*, which the command-language-as-wire-protocol provides for free.  A knob turn is just the expression `h(3)`, so anything that can send an expression can turn a knob: a second player over `remote()`, or a trackball daemon split into two axes piping `h(1)`/`v(1)` through `nc`.  This PR is the single-machine prototype; the header documents the two-player and trackball wiring verbatim.

## The toy

Red bezel, gray glass, two white knobs drawn on the canvas.  `h(n)`/`v(n)` turn a knob and etch one line segment; the pen never lifts, clamps at the glass edges like the real thing (knob keeps turning, powder line stops), and `shake()` wiggles the whole toy then erases only graphics tagged `kind="etch"` — bezel and knobs survive.  `stair()` is the demo autopilot; `etchhelp()` is the knob manual.

Three recent language features carry the implementation, each in its first in-tree application:

- **`local(penx)=` (#213)** — pen state must outlive each knob call, so the knob funcs escape their frames to session scope.  This example is why `local()` exists.
- **dot-assignment on comps (#220)** — `seg.kind="etch"` tags every segment; `shake()`'s frame() scan reads it back.
- **`group()` + deferred select (#210)** — each knob is an ellipse grouped with its tick mark (the petals.comt trick) so the tick orbits the axle when `rotate()`d, and the per-segment select/draw churn batches into single repaints.

## follow() -- mouse mode (second commit)

Scott's next step: draw with the pointer.  `follow([n])` polls `pointer()` (which keeps reporting fresh drawing-coordinate motion even while the loop runs -- verified by warping the X pointer mid-loop and watching the polls track it) and chases the mouse the only way the toy can: one knob click at a time, alternating axes, knobs visibly turning, diagonals rendering as staircases.  Live-verified with an `XWarpPointer` driver sweeping paths over the glass: 149 segments etched chasing a two-stroke warp, both knob ticks rotated, screenshot in the thread.  This is the "first x and y from one mouse" phase of the axis-split idea -- the two-device split (one wheel per player/axis) rides the same `h()`/`v()` wire documented in the header.

## Verified live

- `h(10); v(6)` → pen at exactly (345,359); `stair(4)` + a 30-cycle `h(1)v(1)` curve → 59 segments, with the shortfall from the expected 70 being the *clamp working*: the pen reached the glass corner (506,516) and the last 11 clicks turned knobs without etching, real-toy style.
- `shake()` erased all 59 tagged segments, spared bezel/knobs/title, recentered the pen at (305,335).
- Screenshot shows both knob ticks rotated from their turns and proper pixel-stair diagonals on the curve.

## A language sharp-edge found en route

The click-size variable was originally named `step` — which collides with comterp's built-in stepper command and **hangs the load** (`local(step)=4` puts the interpreter into the stepper's interactive pause).  Renamed to `clicksz` with a comment; variables share the symbol namespace with commands, and `step` is a particularly innocent-looking mine.  Possibly worth a future guard: the scope commands could refuse CommandType arguments the way bare `step=4` already warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
