### PR TITLE
etchasketch: keyboard drawing mode (keydrive) + one/two-player + default 720x800 window

### DIFF
--- a/src/comdraw/examples/etchasketch.comt
+++ b/src/comdraw/examples/etchasketch.comt
@@ -208,7 +208,10 @@ keydrive=func(n=arg(0);
   for(fi=0 (fi<n)&&(done==0) fi++
     k=lastkey();
     while((k!=nil)&&(done==0)
-      if(k=="esc" :then done=1);
+      // plain Escape comes back as the raw byte, not the word "esc" --
+      // see lastkey_keytest.comt lines 143/167, the same comparison
+      // every other lastkey()-polling script in the repo uses.
+      if(k=="\x1b" :then done=1);
       // up/down = right knob (both modes; Player 2 in two-player)
       if(k=="UP" :then v(1));
       if(k=="DOWN" :then v(-1));

--- a/src/comdraw/examples/etchasketch.comt
+++ b/src/comdraw/examples/etchasketch.comt
@@ -112,19 +112,25 @@ etch=func(nx=arg(0); ny=arg(1);
   brush(65535,0);
   update())
 
-// h(n) -- turn the LEFT knob n clicks (negative = left)
+// h([n]) -- turn the LEFT knob n clicks (negative = left; default 1)
+// ends in a bare penx so the value shown at the prompt is the pen's new
+// X, not whatever etch()'s own trailing void calls happen to leave
+// behind (';' is seq(), which falls back to its left operand when the
+// right one is blank -- see etch()'s own trailing select/colorsrgb/
+// brush/update calls, all blank).
 h=func(n=arg(0);
-  if(n==nil :then print("Turn the knob a little, like this:  h(3) or h(-3)\n"));
-  if(n==nil :then return(nil));
+  if(n==nil :then n=1);
   select(knobh); rotate(0-n*9); select(:clear);
-  etch(clamp(penx+n*clicksz 104 506) peny))
+  etch(clamp(penx+n*clicksz 104 506) peny);
+  penx)
 
-// v(n) -- turn the RIGHT knob n clicks (negative = down)
+// v([n]) -- turn the RIGHT knob n clicks (negative = down; default 1)
+// ends in a bare peny for the same reason h() ends in penx.
 v=func(n=arg(0);
-  if(n==nil :then print("Turn the knob a little, like this:  v(2) or v(-2)\n"));
-  if(n==nil :then return(nil));
+  if(n==nil :then n=1);
   select(knobv); rotate(0-n*9); select(:clear);
-  etch(penx clamp(peny+n*clicksz 154 516)))
+  etch(penx clamp(peny+n*clicksz 154 516));
+  peny)
 
 // shake() -- hold it upside down and shake!  (erases the etching,
 // never the toy: only graphics tagged kind=="etch" are deleted)
@@ -147,15 +153,15 @@ shake=func(
   print("All clean!  The pen is back in the middle.\n"))
 
 // follow([n]) -- draw with the MOUSE: the pen chases the pointer for n
-// polling frames (default 200), but only the way an Etch A Sketch can --
-// one knob click at a time, alternating axes, knobs visibly turning.
+// polls (default 200), but only the way an Etch A Sketch can -- one
+// knob click at a time, alternating axes, knobs visibly turning.
 // pointer() reports the drawing-coordinate location of the last pointer
 // motion, and it keeps updating while this loop runs, so just wiggle
 // the mouse over the glass.  Diagonal mouse strokes come out as tiny
 // staircases, which is not a bug, it is the toy.
 follow=func(n=arg(0);
   if(n==nil :then n=200);
-  print("Wiggle the mouse over the glass -- following for %v frames...\n" n);
+  print("Wiggle the mouse over the glass -- following for %v polls...\n" n);
   for(fi=0 fi<n fi++
     p=pointer();
     px=at(p 0); py=at(p 1);
@@ -168,40 +174,86 @@ follow=func(n=arg(0);
     update(50000));
   print("Done following.  shake() to erase, follow() to draw again.\n"))
 
+// keydrive([n]) -- draw with the KEYBOARD instead of the mouse.  Click the
+// comdraw canvas so it has the keyboard, then hold Shift (or, hands-free,
+// turn Caps Lock on) and steer:
+//   ONE PLAYER (arrows):  up/down -> right knob, left/right -> left knob
+//   TWO PLAYERS (one knob each, sharing the keyboard):
+//     Player 1:  D / F      -> left knob  (pen left/right)   [left hand]
+//     Player 2:  up / down  -> right knob (pen up/down)      [right hand]
+// -- exactly the real toy split, one knob per person.  (Caps Lock is the
+// natural two-player enable: both just tap, no Shift-holding.)
+// Why modified keys?  Plain arrows already PAN the viewer and plain
+// letters fire tool shortcuts (both since ivtools 1.2.11), so we don't
+// fight that -- lastkey(:shiftcapture true) tells comdraw to route the
+// MODIFIED arrows+letters to us and suppress their normal action, leaving
+// bare-key behavior alone.  It self-disarms: a watchdog bumped by every
+// lastkey() poll restores normal handling within ~2s if this loop ever
+// stops (Esc, end, or a crash), so the mode can't get stuck.  lastkey()
+// pops the next unread keystroke (nil if none), delivering while we poll
+// exactly the way pointer() does for the mouse.
+keydrive=func(n=arg(0);
+  if(n==nil :then n=1000);
+  two=0; if(play2!=nil :then two=1);   // :play2 flag -> two-player mode
+  // lastkey() returns portable NAMES; a captured (Shift/Caps) arrow or
+  // letter comes back UPPERCASE ("UP", "D") -- the same convention a
+  // plain shifted letter already gets for free from its keysym, just
+  // extended to arrows too.  No X keysym numbers here -- see lastkey()
+  // docstring.
+  lastkey(:shiftcapture true);   // capture Shift/Caps + arrows & letters
+  print("KEYBOARD DRAW -- hold Shift or turn Caps Lock on; click canvas first.  Esc stops.\n");
+  if(two==1 :then print("  TWO PLAYERS: P1 = D/F (left knob), P2 = up/down (right knob).\n"));
+  if(two==0 :then print("  ONE PLAYER: arrow keys (up/down and left/right).\n"));
+  done=0;
+  for(fi=0 (fi<n)&&(done==0) fi++
+    k=lastkey();
+    while((k!=nil)&&(done==0)
+      if(k=="esc" :then done=1);
+      // up/down = right knob (both modes; Player 2 in two-player)
+      if(k=="UP" :then v(1));
+      if(k=="DOWN" :then v(-1));
+      // one-player: left/right arrows drive the left knob
+      if((two==0)&&(k=="LEFT") :then h(-1));
+      if((two==0)&&(k=="RIGHT") :then h(1));
+      // two-player: Player 1 owns the left knob via D/F ONLY -- left/right
+      // arrows stay dead so P2 can't reach across into P1's axis
+      if((two==1)&&(k=="D") :then h(-1));
+      if((two==1)&&(k=="F") :then h(1));
+      k=lastkey());
+    update(30000));
+  lastkey(:shiftcapture false);  // restore normal key handling
+  print("Done driving.  shake() to erase, keydrive() again (or keydrive(:play2)).\n"))
+
 // stair(n) -- a little demo autopilot: the classic staircase
 stair=func(n=arg(0);
   if(n==nil :then n=5);
   for(di=0 di<n di++ h(4); v(4));
-  print("Stairs!  Now try curves: alternate h(1) and v(1) quickly.\n"))
+  print("Stairs!  Now try curves: alternate h and v quickly.\n"))
 
-// etchhelp() -- remind me how the knobs work
+// etchhelp() -- remind me how the knobs work.  Bare command names
+// (h, stair, shake, ...) are shown wherever no argument is needed --
+// parens only appear where an argument actually does something, like
+// h(3) or keydrive(:play2).  Kept short so it fits the comt pane with
+// no scrolling.
 etchhelp=func(
-  print("*** HOW TO WORK YOUR ETCH A SKETCH ***\n");
-  print("  h(3)    -- left knob: pen goes right 3 clicks (h(-3) for left)\n");
-  print("  v(2)    -- right knob: pen goes up 2 clicks (v(-2) for down)\n");
-  print("  stair() -- watch a staircase draw itself\n");
-  print("  follow() -- draw with the mouse! the pen chases the pointer,\n");
-  print("              one knob click at a time (diagonals go staircase)\n");
-  print("  shake() -- erase everything and start over\n");
-  print("THE PEN NEVER LIFTS.  Diagonals need both knobs taking turns --\n");
-  print("that's the whole game.\n");
-  print("TWO PLAYERS: run comdraw with a listening port and give each\n");
-  print("player one knob over the wire:\n");
-  print("  remote(\"host\" 20002 \"h(3)\")   -- the horizontal player\n");
-  print("  remote(\"host\" 20002 \"v(-2)\")  -- the vertical player\n");
-  print("(a knob turn is just an expression -- anything that can send\n");
-  print(" one can turn a knob, even a trackball daemon piping h(1)v(1))\n"))
+  print("*** ETCH A SKETCH HELP ***\n");
+  print("v([n])      -- turn the right knob n clicks, default=1\n");
+  print("h([n])      -- turn the left knob n clicks, default=1\n");
+  print("stair([n])  -- watch a staircase draw n steps, default=5\n");
+  print("follow([n]) -- draw with the mouse, default=200\n");
+  print("keydrive([:play2])  -- 1 player: cap-locked arrow keys,\n");
+  print("                       2 players: D/F + UP/DOWN\n");
+  print("shake()     -- erase, start fresh\n");
+  print("PEN NEVER LIFTS: alternate knobs for diagonals -- that's the whole game.\n");
+  print("Remote: remote(\"host\" 20002 \"h(3)\")\n"))
 
 // ============================================================
-// welcome!
+// welcome!  This is all a -comt launch shows before the user does
+// anything, so it opens by announcing what it is, uses the full
+// 80-column pane width, and wastes no lines on padding.
 // ============================================================
-print("\n=================================================\n")
-print("   YOUR ETCH A SKETCH IS READY.\n")
-print("   The pen is in the middle of the glass.\n")
-print("   Try typing:\n")
-print("       h(10)\n")
-print("       v(6)\n")
-print("       stair()\n")
-print("       shake()\n")
-print("       etchhelp()   <- the full knob manual\n")
-print("=================================================\n")
+print("+------------------------------------------------------------------------------+\n")
+print("|                ETCH A SKETCH  --  a comdraw / comterp example                |\n")
+print("+------------------------------------------------------------------------------+\n")
+print("Pen is centered on the glass.  Turn the knobs with h and v or h(3) v(-2)\n")
+print("Try: etchhelp or stair, shake, follow, keydrive\n")

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -80,6 +80,18 @@ static PropertyData properties[] = {
     { "*initialarrow", "none" },
     { "*pagewidth", "8.5" },
     { "*pageheight", "11" },
+    { "*geometry", "720x800" },   /* default window size; -geometry overrides.
+				      Width must clear the comt pane's natural
+				      request (80-column TE_Editor + appicon +
+				      margins/scrollbar, ~716px measured via
+				      Glyph::request() on the assembled window)
+				      or its rightmost columns get clipped;
+				      720 leaves a few px of headroom.  Only
+				      matters once the comt-inline-editor
+				      branch's -comt flag and *TextEditor*columns
+				      bump (40 -> 80) are also present -- this
+				      branch alone has no -comt flag at all, so
+				      700 vs 720 is harmless here on its own. */
     { "*gridxincr", "8" },
     { "*gridyincr", "8" },
     { "*font1", "-*-courier-medium-r-normal-*-8-*-*-*-*-*-*-* Courier 8" },


### PR DESCRIPTION
## What

Adds keyboard drawing to the etch-a-sketch example, plus a default comdraw window size. Built on **#226's `lastkey()`** (merged) -- this branch's diff is just the two files below.

## keydrive()

`follow()` drew with the mouse; `keydrive()` draws with the keyboard, via `lastkey()`. Click the canvas, then hold Shift (or, hands-free, turn Caps Lock on) and:

- **`keydrive()`** -- ONE player: arrow keys drive both knobs (up/down = right knob, left/right = left knob).
- **`keydrive(:play2)`** -- TWO players sharing the keyboard, one knob each, exactly like the real toy:
  - **Player 1**: `D` / `F` -> left knob (pen left/right) [left hand]
  - **Player 2**: `Up` / `Down` -> right knob (pen up/down) [right hand]
  - Cross-axis arrows are disabled in two-player, so neither player can poach the other's axis.

Registered in `etchhelp()`. Esc stops; releasing capture (or the lastkey watchdog) restores normal panning/editing.

Why modified keys: plain arrows pan the viewer and plain letters fire tool shortcuts, so keydrive uses `lastkey(:shiftcapture true)` to capture only the Shift/Caps-modified variants -- bare-key behavior is untouched, and the capture self-disarms if the loop stops. `lastkey()`'s captured-key names come back **UPPERCASE** ("UP", "D") -- the same convention a plain shifted letter already gets for free from its keysym, just extended to arrows too -- so `keydrive()` compares against `"UP"`/`"DOWN"`/`"D"`/`"F"`, not the old `"S-"`-prefixed form.

Also carries the h()/v() default-arg and follow()/etchhelp()/welcome-banner polish from the same development arc (bare `h()`/`v()` now default to 1 click instead of nagging, `follow()` calls polling iterations "polls" not "frames", `etchhelp()`/the welcome banner were rewritten for the 80-column comt pane).

## Default window geometry

Sets comdraw's default window to **720x800** (`*geometry` in the `properties[]` defaults, `main.c`) so the toy opens with even margins all around. `-geometry WxH` still overrides. **Kept in this commit deliberately** (rather than a standalone PR): it's a default the maintainer may want reverted together with the example, so it lives with the example. (720, not 700: headroom for the comt pane's 80-column width once #228's `-comt` flag lands -- harmless on its own without `-comt`.)

## Rebased on master post-#226

This branch originally carried its own duplicate copy of `lastkey()`/`ComEditor::keyname()` (predating #226's final form), which still emitted the old `"S-up"`-style names -- while this branch's own `etchasketch.comt` had already been updated to expect the new `"UP"` convention. That mismatch meant `keydrive()` was silently broken if built from this branch alone. Rebased onto current master (with #226 merged) and dropped the stale duplicate C++ entirely; the branch's real diff is now just `etchasketch.comt` and `main.c`, verified live against master's actual `lastkey()`/`keyname_test()`.

## Verified

Live in comdraw, rebuilt from scratch against master: `keyname_test(up, :shift)` returns `"UP"` (what `keydrive()` compares against); one-player arrows and two-player D/F + up/down both draw correctly; plain arrows still pan, plain letters still fire shortcuts; mouse `follow()` still works (untouched); `h()`/`v()` bare calls default to 1 click; full `src/comdraw/tests/run_all.comt` suite passes (13/13 lastkey assertions included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)