### PR TITLE
Fix -runfile/-runexpr (and comterp/drawserv equivalents) silently discarding their result

### DIFF
--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -412,7 +412,12 @@ int main (int argc, char** argv) {
 		   script resolves against the script's directory, not the cwd
 		   (mirrors comterp's `run` subcommand -- see comterp_/main.c). */
 		RunFunc::set_basepath(runfile);
-		terp->runfile(runfile);
+		/* runfile()'s own error path (ComTerp::runfile(), comterp.c)
+		   calls err_print(), which writes _errbuf2 and stderr but
+		   never touches _errbuf -- so errmsg() (== _errbuf) can't see
+		   a runfile() failure; its return value is the only reliable
+		   signal, same as before this echo was added. */
+		int runfile_status = terp->runfile(runfile);
 		/* echo the file's last expression, same as comterp's own
 		   `run <file>` subcommand does (see comterp_/main.c) --
 		   runfile() already pushes it onto the stack, it just never
@@ -421,7 +426,7 @@ int main (int argc, char** argv) {
 		ComValue::comterp(terp);
 		cout << terp->stack_top() << "\n";
 		cout.flush();
-		if (*terp->errmsg())
+		if (runfile_status < 0)
 		    cerr << "comdraw: error running script file: " << runfile << "\n";
 	    }
 	    const char* runexpr = catalog->GetAttribute("runexpr");

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -411,7 +411,26 @@ int main (int argc, char** argv) {
 		   script resolves against the script's directory, not the cwd
 		   (mirrors comterp's `run` subcommand -- see comterp_/main.c). */
 		RunFunc::set_basepath(runfile);
-		if (terp->runfile(runfile) < 0)
+		/* Route through run("path"), fed to the same load_string() +
+		   explicit ComTerp::run(one_expr, ...) pair that a *typed*
+		   run("path") already uses successfully (see
+		   ComTE_View::newline(), src/ComGlyph/comtextview.c) --
+		   terp->runfile() directly is the silent, programmatic-
+		   embedding primitive that RunFunc itself calls internally;
+		   it just returns the file's last value in C++, with no
+		   assumption anyone's watching, so calling it directly here
+		   (as this used to) never echoed anything -- -runfile
+		   showed only a script's own print() output, unlike every
+		   other way to run the same file.  The explicit ComTerp::
+		   qualifier matters: terp is a ComTerpServ*, which overrides
+		   run(boolean,boolean) with a DIFFERENT method (its own
+		   _fptr/handler()-based reader) -- an unqualified call would
+		   silently pick that one instead. */
+		char runfile_expr[4096];
+		snprintf(runfile_expr, sizeof(runfile_expr), "run(\"%s\")\n", runfile);
+		terp->load_string(runfile_expr);
+		terp->ComTerp::run(true, false);
+		if (*terp->errmsg())
 		    cerr << "comdraw: error running script file: " << runfile << "\n";
 	    }
 	    const char* runexpr = catalog->GetAttribute("runexpr");
@@ -419,7 +438,14 @@ int main (int argc, char** argv) {
 	        int bufsize;
 	        char* runexpr_nl = restore_escapes(runexpr, bufsize);
 	        strncat(runexpr_nl, "\n", bufsize - strlen(runexpr_nl) - 1);
-	        terp->run(runexpr_nl);
+	        /* same reasoning as -runfile above: terp->run(const char*) is
+	           the silent ComTerpServ::run(const char*,boolean) overload
+	           (an exact-match overload beats a bool-conversion match, so
+	           a plain char* here never reached the echoing ComTerp::run
+	           at all) -- load_string() + explicit ComTerp::run(true,...)
+	           is what makes -runexpr behave like typing the expression. */
+	        terp->load_string(runexpr_nl);
+	        terp->ComTerp::run(true, false);
 	        if (*terp->errmsg())
 	            cerr << "comdraw: error running expression: " << runexpr << "\n";
 	        delete [] runexpr_nl;

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -59,6 +59,7 @@
 #include <version.h>
 #include <iostream>
 
+using std::cout;
 using std::cerr;
 
 static int nmsg = 0;
@@ -411,25 +412,15 @@ int main (int argc, char** argv) {
 		   script resolves against the script's directory, not the cwd
 		   (mirrors comterp's `run` subcommand -- see comterp_/main.c). */
 		RunFunc::set_basepath(runfile);
-		/* Route through run("path"), fed to the same load_string() +
-		   explicit ComTerp::run(one_expr, ...) pair that a *typed*
-		   run("path") already uses successfully (see
-		   ComTE_View::newline(), src/ComGlyph/comtextview.c) --
-		   terp->runfile() directly is the silent, programmatic-
-		   embedding primitive that RunFunc itself calls internally;
-		   it just returns the file's last value in C++, with no
-		   assumption anyone's watching, so calling it directly here
-		   (as this used to) never echoed anything -- -runfile
-		   showed only a script's own print() output, unlike every
-		   other way to run the same file.  The explicit ComTerp::
-		   qualifier matters: terp is a ComTerpServ*, which overrides
-		   run(boolean,boolean) with a DIFFERENT method (its own
-		   _fptr/handler()-based reader) -- an unqualified call would
-		   silently pick that one instead. */
-		char runfile_expr[4096];
-		snprintf(runfile_expr, sizeof(runfile_expr), "run(\"%s\")\n", runfile);
-		terp->load_string(runfile_expr);
-		terp->ComTerp::run(true, false);
+		terp->runfile(runfile);
+		/* echo the file's last expression, same as comterp's own
+		   `run <file>` subcommand does (see comterp_/main.c) --
+		   runfile() already pushes it onto the stack, it just never
+		   prints it on its own. */
+		terp->brief(1);
+		ComValue::comterp(terp);
+		cout << terp->stack_top() << "\n";
+		cout.flush();
 		if (*terp->errmsg())
 		    cerr << "comdraw: error running script file: " << runfile << "\n";
 	    }
@@ -438,14 +429,15 @@ int main (int argc, char** argv) {
 	        int bufsize;
 	        char* runexpr_nl = restore_escapes(runexpr, bufsize);
 	        strncat(runexpr_nl, "\n", bufsize - strlen(runexpr_nl) - 1);
-	        /* same reasoning as -runfile above: terp->run(const char*) is
-	           the silent ComTerpServ::run(const char*,boolean) overload
-	           (an exact-match overload beats a bool-conversion match, so
-	           a plain char* here never reached the echoing ComTerp::run
-	           at all) -- load_string() + explicit ComTerp::run(true,...)
-	           is what makes -runexpr behave like typing the expression. */
-	        terp->load_string(runexpr_nl);
-	        terp->ComTerp::run(true, false);
+	        /* same pattern as comterp's own bare-expression mode (see
+	           comterp_/main.c): terp->run(const char*) evaluates and
+	           hands the result back in C++ without printing it, so print
+	           it explicitly here. */
+	        terp->brief(1);
+	        ComValue::comterp(terp);
+	        ComValue comval(terp->run(runexpr_nl));
+	        cout << comval << "\n";
+	        cout.flush();
 	        if (*terp->errmsg())
 	            cerr << "comdraw: error running expression: " << runexpr << "\n";
 	        delete [] runexpr_nl;

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -359,6 +359,7 @@ int main(int argc, char *argv[]) {
 	terp->brief(1);
 	ComValue::comterp(terp);
 	cout << terp->stack_top() << '\n';
+	cout.flush();
 	return 0;
       }
 

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -353,6 +353,12 @@ int main(int argc, char *argv[]) {
 	terp->set_args(argc-2-endcnt, argv+2);
 	RunFunc::set_basepath(rfile);
 	terp->runfile(rfile);
+	// echo the file's last expression, same as `expr` does for a single
+	// one -- runfile() already pushes it onto the stack (see
+	// ComTerp::runfile()), it just never prints it on its own.
+	terp->brief(1);
+	ComValue::comterp(terp);
+	cout << terp->stack_top() << '\n';
 	return 0;
       }
 

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -64,6 +64,7 @@
 #include <ComTerp/comvalue.h>
 #include <ComUtil/util.h>
 
+using std::cout;
 using std::cerr;
 
 static int nmsg = 0;
@@ -462,7 +463,15 @@ int main (int argc, char** argv) {
 	        int bufsize;
 	        char* runexpr_nl = restore_escapes(runexpr, bufsize);
 	        strncat(runexpr_nl, "\n", bufsize - strlen(runexpr_nl) - 1);
-	        terp->run(runexpr_nl);
+	        /* same pattern as comterp's own bare-expression mode (see
+	           comterp_/main.c): terp->run(const char*) evaluates and
+	           hands the result back in C++ without printing it, so print
+	           it explicitly here. */
+	        terp->brief(1);
+	        ComValue::comterp(terp);
+	        ComValue comval(terp->run(runexpr_nl));
+	        cout << comval << "\n";
+	        cout.flush();
 	        if (*terp->errmsg())
 	            cerr << "drawserv: error running expression: " << runexpr << "\n";
 	        delete [] runexpr_nl;


### PR DESCRIPTION
## Summary

`comdraw -runfile`, `comdraw -runexpr`, `comterp run <file>`, and `drawserv -runexpr` all silently discarded the evaluated result instead of printing it — the only visible output was whatever the script's own `print()` calls produced. Every other way to run the same code (typed at the terminal, typed in a `-comt` pane, or `run("path")` issued from either) already echoed correctly.

Root cause: these call sites use `ComTerp::runfile()` / `ComTerpServ::run(const char*, boolean)` directly — silent, programmatic "evaluate and hand the result back in C++" primitives with no assumption a human is watching. The echo-to-user machinery lives specifically in the interactive REPL loop (`ComTerp::run(boolean, boolean)`), which none of these call sites went through.

Reproduced against a from-scratch build of unmodified `origin/master` (no other session changes present) to confirm this predates any recent work rather than being a regression — it's a real, longstanding gap.

## Fix

Mirrors this codebase's own already-correct pattern — `comterp`'s bare-expression mode (any non-flag `argv[1]`):
```cpp
terp->brief(1);
ComValue::comterp(terp);
ComValue comval(terp->run(expr));   // still the silent primitive
cout << comval << '\n';             // ...but now the caller prints it
```
Applied the same shape everywhere:
- `comdraw -runfile` / `-runexpr`
- `comterp run <file>` (turned out to have the identical bug)
- `drawserv -runexpr` (its `-runfile` was intentionally left untouched — not asked for, and it's known-relied-upon as-is)

One real gotcha along the way: `cout`'s stdio buffer is fully-buffered (not line-buffered) once stdout is redirected to a file/pipe, and killing the process a few seconds into a background test run — rather than letting it exit — can lose unflushed output entirely, making a genuinely-working fix look broken. Fixed by adding explicit `cout.flush()` after each new echo site rather than relying on process-exit-time flushing.

## Test plan

- [x] `pi()` and `help(lastkey)` both echo correctly via `comdraw -runfile`, `comdraw -runexpr`, `comterp run <file>`, and `drawserv -runexpr`
- [x] Full `run_all.comt` regression suite clean
- [x] `lastkey_keytest.comt` (whose last statement is a `print()` call) shows no spurious trailing output — confirmed a `nil` `ComValue` renders as an empty string via `cout <<` in brief mode, not the literal word `"nil"`
- [x] `g++ -fsyntax-only` clean on all three touched files
- [x] Reproduced original bug against a clean `origin/master` build to rule out it being caused by other in-flight session work

🤖 Generated with [Claude Code](https://claude.com/claude-code)