### PR TITLE
Harden ComEditor::keyname()/shiftcapture() against future misuse

### DIFF
--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -468,6 +468,9 @@ void ComEditor::shiftcapture(boolean on) {
     if (on) _shiftcapture_deadline = comeditor_now_seconds() + SHIFTCAPTURE_TIMEOUT;
 }
 
+// impure by design (see comeditor.h): this is the one place the watchdog
+// actually gets checked, so the getter itself has to do the expiring --
+// there is no separate poll/tick callback that could do it instead.
 boolean ComEditor::shiftcapture() {
     if (_shiftcapture_on && comeditor_now_seconds() > _shiftcapture_deadline)
 	_shiftcapture_on = false;           // watchdog lapsed -> auto-restore
@@ -586,6 +589,13 @@ static const char* core_keyname(unsigned long ks, boolean shifted, boolean chord
     return buf;
 }
 
+// returns a pointer into _keyname_buf, a single persistent member -- see
+// the CONTRACT note on the declaration (comeditor.h): valid only until the
+// next keyname() call.  Both current callers (LastKeyFunc, KeynameTestFunc
+// in unifunc.c) are safe because they immediately hand the pointer to
+// ComValue's string constructor, which copies/interns it before any
+// second call could happen -- a future caller that holds onto the raw
+// pointer across two calls would silently read stale data.
 const char* ComEditor::keyname(unsigned long code) {
     boolean shifted = (code & SHIFT_FLAG) != 0;
     boolean ctrl    = (code & CTRL_FLAG)  != 0;

--- a/src/ComUnidraw/comeditor.h
+++ b/src/ComUnidraw/comeditor.h
@@ -129,7 +129,11 @@ public:
     // widest defined keysym space -- with no risk of ever colliding.
     enum { SHIFT_FLAG = 1UL<<32, CTRL_FLAG = 1UL<<33, ALT_FLAG = 1UL<<34, SUPER_FLAG = 1UL<<35 };
     void shiftcapture(boolean on);  // enable/disable + (re)arm
-    boolean shiftcapture();         // live state (false once expired)
+    boolean shiftcapture();         // live state -- NOT a pure query: lazily
+                                     // expires (and clears) the watchdog on
+                                     // read if the deadline has lapsed, so
+                                     // two calls back-to-back can observe
+                                     // true then false with no poll between
     void shiftcapture_poll();       // heartbeat: bump the watchdog
 
     // Portable name for a queued key code: a standard C character literal
@@ -167,6 +171,12 @@ public:
     // the lastkey() surface -- scripts compare names, never raw X
     // keysyms, so a Qt (or other) backend need only map its key codes
     // to the same names.
+    //
+    // CONTRACT: the returned pointer aliases a single persistent buffer
+    // owned by this object (_keyname_buf below) -- it is NOT a copy, and
+    // the NEXT call to keyname() overwrites it.  Consume the string (or
+    // copy it, e.g. via ComValue's own copy-on-construct) before calling
+    // keyname() again; never cache the returned pointer across two calls.
     const char* keyname(unsigned long code);
 
 protected:


### PR DESCRIPTION
## What

Comment-only hardening for two minor, non-blocking findings Greptile flagged on #226 (already merged) -- neither is a live bug today, both are documented as latent footguns for future callers.

## `ComEditor::keyname()` returns a pointer into a shared buffer

`keyname()` returns `const char*` aliasing `_keyname_buf`, a single persistent member -- the next call overwrites it. Today's two callers (`LastKeyFunc`, `KeynameTestFunc` in `unifunc.c`) are safe because they immediately hand the pointer to `ComValue`'s string constructor, which copies/interns it before any second call could happen. A future caller that stores the raw pointer across two `keyname()` calls would silently read stale data.

Fixed by documenting the aliasing contract loudly at both the declaration (`comeditor.h`) and definition (`comeditor.c`) -- no behavior change, no call-site change.

## `ComEditor::shiftcapture()`'s getter mutates state as a side effect

The no-arg getter lazily expires (and clears) the watchdog on read if the deadline has lapsed -- surprising for something that reads like a pure query, and not marked `const`. In practice it's the only place the watchdog *can* be checked (there's no separate poll/tick callback), so the impurity is load-bearing, not a bug -- but it wasn't documented as intentional.

Fixed by documenting it as impure-by-design at both the declaration and definition.

## Verified

Comment-only diff -- confirmed via direct diff against the pre-change files. Rebuilt `ComUnidraw`/`comdraw` from scratch and re-ran `src/comdraw/tests/run_all.comt` (13/13 lastkey assertions included) to confirm zero behavioral regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)