### PR TITLE
lastkey()/keyname(): return Esc/ESC instead of the raw \x1b byte

### DIFF
--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -494,19 +494,32 @@ void ComEditor::shiftcapture_poll() {
    without the two concerns tangled into one control flow.
 
    `chorded` is true when the caller is about to prefix the result with
-   Ctrl/Alt/Super.  It only changes anything for the six control-
-   character keys: Esc/Tab/Backspace already had a readable uppercase
-   name for real Shift; Enter/Space/true-Delete didn't (no established
-   Shift+Enter/Space/Delete convention -- see keyname()'s docstring).
-   But gluing a raw \r/space/\x7f byte onto a "Ctrl-" prefix would leave
-   an unprintable, hard-to-compare chord string, so `chorded` borrows the
-   same readable-name treatment for those three too, without changing
-   their BARE (unchorded, unshifted) behavior at all. */
+   Ctrl/Alt/Super.  It only changes anything for the five remaining
+   control-character keys: Tab/Backspace already had a readable
+   uppercase name for real Shift; Enter/Space/true-Delete didn't (no
+   established Shift+Enter/Space/Delete convention -- see keyname()'s
+   docstring).  But gluing a raw \r/space/\x7f byte onto a "Ctrl-"
+   prefix would leave an unprintable, hard-to-compare chord string, so
+   `chorded` borrows the same readable-name treatment for those three
+   too, without changing their BARE (unchorded, unshifted) behavior at
+   all.
+
+   Escape is always readable ("Esc"/"ESC"), never the raw \x1b byte:
+   unlike Tab/Backspace/Enter/Space, which return their genuine C
+   escape-sequence literal (\t, \b, \r) or a directly-typeable
+   printable char (' ') when bare -- a real, first-class representation
+   in the language -- Escape has no such literal in standard C/C++ (no
+   \e), so \x1b was never "Esc as itself" the way \t is "Tab as
+   itself"; it was just the generic numeric-byte escape doing double
+   duty, spelling out a byte value with no more claim to being "Esc"
+   than \x41 has to being 'A'. Scripts comparing against \x1b (matching
+   what a terminal would send) is what caused the original keydrive()
+   Esc-detection bug this PR's sibling caught -- see git log. */
 static const char* core_keyname(unsigned long ks, boolean shifted, boolean chorded,
 				 char* buf, size_t bufsz) {
     boolean textual = shifted || chorded;
     switch (ks) {
-      case XK_Escape:    return textual ? "ESC"    : "\x1b";
+      case XK_Escape:    return textual ? "ESC"    : "Esc";
       case XK_space:     return chorded ? "SPACE"  : " ";
       case XK_Return:    return chorded ? "ENTER"  : "\r";
       case XK_Tab:       return textual ? "TAB"    : "\t";

--- a/src/ComUnidraw/comeditor.h
+++ b/src/ComUnidraw/comeditor.h
@@ -140,21 +140,27 @@ public:
     // for keys that have one -- every printable-ASCII key (letters,
     // digits, and all punctuation: brackets, braces, parens, quotes,
     // colon/semicolon, comma/period, every shifted-numeric symbol, etc.)
-    // as itself, plus " " space and "\r" enter (always); "\x1b" esc,
-    // "\t" tab, "\b" backspace when unshifted, else the fixed name
-    // uppercase ("ESC"/"TAB"/"DEL" -- Shift-Tab is an established
-    // reverse-focus/indent convention, Shift-Esc/Shift-Backspace get
-    // the same uppercasing for uniformity); "\x7f" delete (always --
-    // distinct from Backspace, no shifted form); "up"/"down"/"left"/
-    // "right"/"ins" for keys with a meaningful shifted form; "F1".."F12"/
-    // "Home"/"End"/"PgUp"/"PgDn" fixed, always that capitalization -- no
-    // established shifted convention exists for any of these; else the
-    // decimal keysym.  If shift or caps lock was down, arrows/ins come
-    // back UPPERCASE ("UP", "INS") -- for letters and shifted-symbol
-    // punctuation this already falls out of the keysym itself (Shift+d
-    // arrives as XK_D, Shift+[ arrives as XK_braceleft i.e. '{'), for
-    // arrows/ins/esc/tab/backspace keyname() applies it explicitly,
-    // since they have no natural shifted form to fall back on.
+    // as itself, plus " " space and "\r" enter (always); "\t" tab, "\b"
+    // backspace when unshifted, else the fixed name uppercase
+    // ("TAB"/"DEL" -- Shift-Tab is an established reverse-focus/indent
+    // convention, Shift-Backspace gets the same uppercasing for
+    // uniformity); "\x7f" delete (always -- distinct from Backspace, no
+    // shifted form); "up"/"down"/"left"/"right"/"ins" for keys with a
+    // meaningful shifted form; "F1".."F12"/"Home"/"End"/"PgUp"/"PgDn"
+    // fixed, always that capitalization -- no established shifted
+    // convention exists for any of these; else the decimal keysym.
+    // Escape is always "Esc"/"ESC" (shift/caps-lock uppercases it same
+    // as Tab/Backspace) -- NOT the raw \x1b byte: unlike \t/\b/\r/' ',
+    // which are genuine C literals returned as themselves, standard
+    // C/C++ has no \e escape for Escape, so \x1b was never "Esc as
+    // itself" the way \t is "Tab as itself" -- it was just the generic
+    // numeric-byte escape, no more "Esc" than \x41 is 'A'.  If shift or
+    // caps lock was down, arrows/ins come back UPPERCASE ("UP", "INS")
+    // -- for letters and shifted-symbol punctuation this already falls
+    // out of the keysym itself (Shift+d arrives as XK_D, Shift+[
+    // arrives as XK_braceleft i.e. '{'), for arrows/ins/esc/tab/
+    // backspace keyname() applies it explicitly, since they have no
+    // natural shifted form to fall back on.
     //
     // If Ctrl, Alt, and/or Super was held, the name above is prefixed
     // "Ctrl-"/"Alt-"/"Super-" (that fixed order, chained when more than

--- a/src/comdraw/examples/etchasketch.comt
+++ b/src/comdraw/examples/etchasketch.comt
@@ -208,10 +208,10 @@ keydrive=func(n=arg(0);
   for(fi=0 (fi<n)&&(done==0) fi++
     k=lastkey();
     while((k!=nil)&&(done==0)
-      // plain Escape comes back as the raw byte, not the word "esc" --
-      // see lastkey_keytest.comt lines 143/167, the same comparison
-      // every other lastkey()-polling script in the repo uses.
-      if(k=="\x1b" :then done=1);
+      // both forms: Caps Lock (the hands-free :play2 enable) sets the
+      // same shift bit a literal Shift-hold does, so Esc pressed with
+      // Caps Lock on comes back "ESC", not "Esc" -- see keyname().
+      if((k=="Esc")||(k=="ESC") :then done=1);
       // up/down = right knob (both modes; Player 2 in two-player)
       if(k=="UP" :then v(1));
       if(k=="DOWN" :then v(-1));

--- a/src/comdraw/examples/lastkey_keytest.comt
+++ b/src/comdraw/examples/lastkey_keytest.comt
@@ -21,24 +21,32 @@
 //
 // WHAT TO EXPECT (see keyname()'s docstring for the authoritative list):
 //   char-literal keys -- Space and Enter come back AS themselves
-//                        (comterp's own " " \r) no matter what; Esc, Tab,
-//                        Backspace do too when unmodified (\x1b \t \b),
-//                        but UPPERCASE NAME when shifted, see "shift/caps
+//                        (comterp's own " " \r) no matter what; Tab and
+//                        Backspace do too when unmodified (\t \b), but
+//                        UPPERCASE NAME when shifted, see "shift/caps
 //                        lock" below; Delete (forward-delete, distinct
 //                        from Backspace) is always \x7f, no shifted form.
-//                        This script prints a readable LABEL for the raw
-//                        control bytes instead of the byte itself -- an
-//                        actual ESC byte sent to a real terminal can be
-//                        interpreted as the start of its own escape
-//                        sequence, which would garble the display; the
-//                        label is only for this script's own output
-//                        ("Esc", "Tab", "Del" for backspace -- on current
-//                        Mac keyboards the key labeled delete IS
-//                        backspace, "Del" matches the keycap), not part
-//                        of what lastkey() actually returns to a caller.
-//                        The shifted forms ("ESC" "TAB" "DEL") are
-//                        already plain text, so they print as-is with no
-//                        label needed.
+//                        Esc is the one exception to "raw byte when
+//                        unmodified": standard C/C++ has no \e escape,
+//                        so unlike \t/\b (genuine C literals), a raw
+//                        \x1b byte would just be a numeric-escape stand-in
+//                        with no more claim to meaning "Esc" than \x41
+//                        has to meaning 'A' -- keyname() returns the
+//                        readable "Esc"/"ESC" instead, always.
+//                        This script prints a readable LABEL for the
+//                        remaining raw control bytes (Tab, Backspace)
+//                        instead of the byte itself -- e.g. an actual
+//                        backspace byte sent to a real terminal would
+//                        erase the previous character on screen rather
+//                        than display as text; the label is only for
+//                        this script's own output ("Tab", "Del" for
+//                        backspace -- on current Mac keyboards the key
+//                        labeled delete IS backspace, "Del" matches the
+//                        keycap), not part of what lastkey() actually
+//                        returns to a caller.  The shifted forms
+//                        ("TAB" "DEL"), and Esc/ESC always, are already
+//                        plain text, so they print as-is with no label
+//                        needed.
 //   arrows/ins        -- "up" "down" "left" "right" "ins" -- case varies
 //                        with shift, see below
 //   fixed named keys  -- "F1".."F12" "Home" "End" "PgUp" "PgDn", always
@@ -65,7 +73,7 @@
 //                        conventions, but Shift+F1 and Shift+Home aren't
 //                        -- try it and see.  NOTE: keytest()'s own Esc-
 //                        quits-early check only matches PLAIN (unshifted)
-//                        Esc ("\x1b") -- Shift-Esc ("ESC") does not quit.
+//                        Esc ("Esc") -- Shift-Esc ("ESC") does not quit.
 //   bare modifier keys-- Shift/Ctrl/CapsLock/Alt/Meta/Super/Hyper pressed
 //                        ALONE (no other key) is never returned by
 //                        lastkey() at all -- it isn't a "key", its effect
@@ -111,12 +119,11 @@ focushint=func("Move focus to canvas. ")
 // describe(k) -- human-readable label for a lastkey() result, for THIS
 // script's printing only; not part of lastkey()'s actual contract
 describe=func(k=arg(0);
-  if(k=="\x1b" :then return("Esc"));
-  if(k==" "    :then return("SPACE"));
-  if(k=="\r"   :then return("ENTER"));
+  if(k==" "    :then return("Space"));
+  if(k=="\r"   :then return("Enter"));
   if(k=="\t"   :then return("Tab"));
   if(k=="\b"   :then return("Del"));
-  if(k=="\x7f" :then return("DELETE"));
+  if(k=="\x7f" :then return("DEL"));
   k)
 
 // keytest([n] [:shiftcapture]) -- plain (uncaptured) keys: arrows,
@@ -140,7 +147,7 @@ keytest=func(n=arg(0);
     k=lastkey();
     while((k!=nil)&&(done==0)
       print("%v\n" describe(k));
-      if(k=="\x1b" :then done=1);
+      if(k=="Esc" :then done=1);
       k=lastkey());
     update(30000));
   print("keytest done.\n"))
@@ -164,7 +171,7 @@ lastkey_shiftcapture=func(n=arg(0);
     k=lastkey();
     while((k!=nil)&&(done==0)
       print("%v\n" describe(k));
-      if(k=="\x1b" :then done=1);
+      if(k=="Esc" :then done=1);
       k=lastkey());
     update(30000));
   lastkey(:shiftcapture false);

--- a/src/comdraw/tests/lastkey.comt
+++ b/src/comdraw/tests/lastkey.comt
@@ -74,8 +74,8 @@ print("9 keyname_test(0xff52 :shift) XK_Up shifted (expect \"UP\"): %v\n" keynam
 ok=ok&&(keyname_test(0x78 :ctrl)=="Ctrl-X")
 print("10 keyname_test(0x78 :ctrl) Ctrl+x (expect \"Ctrl-X\"): %v\n" keyname_test(0x78 :ctrl))
 
-ok=ok&&(keyname_test(0xff1b)=="\x1b")
-print("11 keyname_test(0xff1b) XK_Escape plain (expect the raw ESC byte): %v\n" (keyname_test(0xff1b)=="\x1b"))
+ok=ok&&(keyname_test(0xff1b)=="Esc")
+print("11 keyname_test(0xff1b) XK_Escape plain (expect \"Esc\"): %v\n" keyname_test(0xff1b))
 
 ok=ok&&(keyname_test(0xff1b :shift)=="ESC")
 print("12 keyname_test(0xff1b :shift) XK_Escape shifted (expect \"ESC\"): %v\n" keyname_test(0xff1b :shift))


### PR DESCRIPTION
## What

`ComEditor::keyname()` now returns the readable name `"Esc"` (unshifted) / `"ESC"` (Shift or Caps Lock) for the Escape key, instead of the raw control byte `"\x1b"`.

## Why

Unlike Tab/Backspace/Enter/Space -- which return a genuine C escape-sequence literal (`\t`, `\b`, `\r`) or a directly-typeable printable character (`' '`) when bare, a real, first-class representation already built into the language -- Escape has no such literal in standard C/C++ (no `\e`). `\x1b` was never "Esc as itself" the way `\t` is "Tab as itself"; it was just the generic numeric-byte escape doing double duty, spelling out a byte value with no more claim to meaning "Esc" than `\x41` has to meaning `'A'`. That asymmetry is exactly what caused the real bug in #227 (`keydrive()`'s `k=="esc"` never matching `"\x1b"`) -- the raw-byte convention is surprising and non-obvious even to an experienced systems person, which is the whole reason a script author would need to know ASCII/C-escape trivia to guess the right comparison in the first place.

This also makes `keyname()`'s naming vocabulary strictly more uniform: every other non-printable named key (arrows, Home/End/PgUp/PgDn/F1-F12, Ins) already returns a readable name unconditionally, with case doing the shift-signaling where applicable. Esc was the only one with a raw-byte-when-bare exception, and only because of an accident of C typography (having a numeric escape mechanism available at all), not a deliberate ergonomic choice.

## Changes

- `comeditor.c`/`.h`: `core_keyname()`'s `XK_Escape` case now returns `"Esc"`/`"ESC"` instead of `"\x1b"`/`"ESC"`; updated the docstring and the block comment above `core_keyname()` to match.
- `etchasketch.comt`: `keydrive()`'s Esc-quit check now checks `k=="Esc"||k=="ESC"` -- Caps Lock (the documented hands-free `:play2` two-player enable) sets the same shift bit a literal Shift-hold does, so Esc pressed with Caps Lock on comes back `"ESC"`, not `"Esc"`; a single-form check would silently never quit in that case.
- `lastkey_keytest.comt`: Esc-quit checks (×2) now compare against `"Esc"` instead of `"\x1b"` -- deliberately kept single-form (unlike `keydrive()`), matching the script's own pre-existing documented intent: a tester can press Shift-Esc and see `"ESC"` printed without ending the demo early. `describe()`'s now-redundant `\x1b`->`"Esc"` translation line is removed since `lastkey()` returns the readable name directly. Also folds in an unrelated cleanup already made locally: lowercase `Space`/`Enter` labels (matching `Tab`/`Del`'s existing style) and `DELETE`->`DEL` (matching the keycap -- both Backspace and the forward-Delete key are labeled "delete" on current Mac keyboards).
- `src/comdraw/tests/lastkey.comt`: test 11 now asserts `keyname_test(0xff1b)=="Esc"` instead of the raw byte.

## Verified

Full clean `autoreconf`/`configure`/`make` build from scratch in an isolated worktree. `src/comdraw/tests/run_all.comt` green (13/13 lastkey assertions, including the updated test 11/12). Confirmed live via `keyname_test()`: plain Esc -> `"Esc"`, shifted Esc -> `"ESC"`. Both `etchasketch.comt` and `lastkey_keytest.comt` parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)