### PR TITLE
EivTextBuffer::load(): guard against integer overflow/wraparound on very large files

### DIFF
--- a/src/IVGlyph/textbuff.c
+++ b/src/IVGlyph/textbuff.c
@@ -19,8 +19,9 @@
 #define _GCC_SIZE_T /* workaround for _G_size_t conflict */
 #endif
 
+#include <limits.h>
 #include <stdio.h>
-#include <fcntl.h> 
+#include <fcntl.h>
 #include <sys/stat.h>
 extern "C" {
 #include <malloc.h>
@@ -50,8 +51,13 @@ extern "C" {
 #endif
 
 // allocate 25% extra space to prepare for expansion without
-// the need to expand buffer
-static const float allocate_extra = 0.25;
+// the need to expand buffer.  double, not float: float's ~24-bit
+// mantissa can't exactly represent a large int (e.g. a file size near
+// the 32-bit boundary), so `len * allocate_extra` below would silently
+// round to a slightly-too-large add_size for a big len, eating into the
+// safety margin load()'s size guard depends on; double has 52 mantissa
+// bits, exact for any 32-bit int.
+static const double allocate_extra = 0.25;
 
 EivTextBuffer::EivTextBuffer()
 : TextBuffer((char *)malloc(1024), 0, 1024) // we always allocate 1k buffer
@@ -86,6 +92,21 @@ int EivTextBuffer::load(const char* path)
    if (fstat(fd, &info) < 0) {
       close(fd);
       return OpenError;		// can't access file
+   }
+   // info.st_size is an off_t (64-bit on modern systems); len and
+   // add_size below are int, and add_size = len * allocate_extra, so
+   // len + add_size = len * (1 + allocate_extra).  A file whose size
+   // wraps or overflows through that arithmetic could either land on a
+   // huge realloc() request (fails safely, already handled below) or --
+   // worse -- wrap around to a small positive int, silently truncating
+   // a huge file down to whatever tiny window st_size happens to alias
+   // to mod 2^32, with no error at all.  Reject before either can
+   // happen; threshold is tied to allocate_extra so it stays exact if
+   // that constant ever changes, rather than a separately-maintained
+   // magic number.
+   if (info.st_size > (off_t)(INT_MAX / (1.0 + allocate_extra))) {
+      close(fd);
+      return SizeError;		// file too large to load safely
    }
    int len = (int) info.st_size;
 

--- a/src/IVGlyph/textbuff.h
+++ b/src/IVGlyph/textbuff.h
@@ -30,7 +30,7 @@ class EivTextBuffer : public TextBuffer {
    ~EivTextBuffer();
 
    // load/save buffer from/into file
-   enum { OpenError, MemoryError, SizeError, ReadError, ReadOk, WriteError, WriteOk };
+  enum { OpenError, MemoryError, ReadError, ReadOk, WriteError, WriteOk, SizeError };
    int load(const char* path);
    int save();
    int save(const char* path);

--- a/src/IVGlyph/textbuff.h
+++ b/src/IVGlyph/textbuff.h
@@ -30,7 +30,7 @@ class EivTextBuffer : public TextBuffer {
    ~EivTextBuffer();
 
    // load/save buffer from/into file
-   enum { OpenError, MemoryError, ReadError, ReadOk, WriteError, WriteOk };
+   enum { OpenError, MemoryError, SizeError, ReadError, ReadOk, WriteError, WriteOk };
    int load(const char* path);
    int save();
    int save(const char* path);

--- a/src/IVGlyph/textview.c
+++ b/src/IVGlyph/textview.c
@@ -199,6 +199,10 @@ void TE_View::load_popup()
 	    style_->attribute("caption", "File not read, Out Of Memory!");
 	 error = true;
 	    break;
+	case EivTextBuffer::SizeError:
+	    style_->attribute("caption", "File too large to load, Retry!");
+	    error = true;
+	    break;
 	case EivTextBuffer::ReadError:
 	    style_->attribute("caption", "Can't read file.");
 	    error = true;


### PR DESCRIPTION
## What

Takes over #231 (reported by @orbisai0security), with a corrected root-cause/severity writeup and a fixed implementation. Leaving #231 open with a comment linking here rather than force-pushing to their fork, since I can't push to it directly (cross-repo PR) and want to leave a clear trail if they come back to it.

## What #231 got right

There's a real bug in `EivTextBuffer::load()`: `info.st_size` (an `off_t`, 64-bit on modern systems) gets cast straight to `int`, and `len + add_size` (`add_size = len * allocate_extra`) is computed in `int` arithmetic with no bounds check. For a large enough file, this is genuine, unguarded integer overflow/wraparound (CWE-190) -- #231 was right that this needed a fix.

## What #231 got wrong

Traced the actual consequences instead of trusting the scanner's classification: this is **not** CWE-120 (heap buffer overflow) as claimed, and not "likely exploitable" for memory corruption. `read(fd, buffer, len)` is always bounded by the *same* (possibly-wrapped) `len` used to size the buffer -- there is no code path where more bytes get written than were allocated. Worked through all three cases with a standalone harness mirroring the real arithmetic:

- A ~1.86 GB file: `len` itself stays valid, but `len+add_size` overflows to negative, converts to a ~18-exabyte `size_t` for `realloc()`, which fails -- hits the existing safe `MemoryError` bailout. No overflow, no corruption, just (before this PR) a slightly wrong error message.
- A 3 GB file: `len` itself wraps negative in the initial cast -- same safe-failure path.
- A file at exactly 4 GiB + 100 bytes: `len` wraps to 100. `realloc()` succeeds for a small buffer, and `read()` -- bounded by that same wrapped `len` -- reads only 100 bytes into it. **No overflow.** The file is silently truncated to whatever tiny window `st_size` happens to alias to mod 2^32.

So the actual, verified impact is **silent data truncation on very large files** (a real bug, a text editor could silently show a corrupted/incomplete view of a huge file), not memory corruption. Greptile's review of #231 (4/5, "safe to merge") didn't catch this either -- it accepted the PR's own severity framing and only flagged two minor style nits.

#231's bundled "regression test" also doesn't fit this codebase at all: it calls a nonexistent function (`EivTextBuffer_load` vs. the real `EivTextBuffer::load()`) and uses `check.h`, a C unit-test framework this repo doesn't use anywhere -- clearly unadapted boilerplate, not included here.

## The fix

- `textbuff.c`: reject with a new `SizeError` before the risky cast, rather than let a huge file fall through to be silently truncated. Threshold is `INT_MAX / (1.0 + allocate_extra)` -- tied exactly to the existing `allocate_extra` constant rather than a separately-maintained magic number (this addresses one of Greptile's #231 nits: their suggested threshold was too loose, and a flat hardcoded constant drifts out of sync if `allocate_extra` ever changes).
- **A second bug found while fixing the first**: `allocate_extra` was declared `static const float`. `float`'s ~24-bit mantissa can't exactly represent a large `int` (e.g. a file size near the 32-bit boundary) -- `len * allocate_extra` was silently rounding to a slightly-too-large `add_size` for big `len`, eating into the very safety margin the new guard depends on. Verified directly: at `len=1717986916` (just under my first-pass threshold), `float` arithmetic gave `add_size=429496736` and `len+add_size` wrapped negative anyway; `double` arithmetic gives the mathematically exact `add_size=429496729`, staying safely under `INT_MAX`. Promoted `allocate_extra` to `double` (also used by `expand_buffer()`, same fix applies there).
- `textbuff.h`: adds `SizeError` to the return-code enum.
- `textview.c`: addresses Greptile's other #231 nit -- reusing `MemoryError` for this case would show a real user a misleading "Out Of Memory" dialog for a file that has nothing to do with available memory. Added a distinct `SizeError` case with its own message.

## Verified

Full clean `autoreconf`/`configure`/`make` build from scratch in an isolated worktree. `src/comdraw/tests/run_all.comt` green (broad regression check -- this code path isn't reachable from any `.comt` script, since `EivTextBuffer::load()` is only reachable through a real GUI file-open dialog interaction, not exposed to comterp scripting). Boundary arithmetic verified with a standalone harness mirroring the exact real expressions (both the overflow scenarios and the float-vs-double precision issue), extracted the same way `keyname_test()`-style verification was done elsewhere in this codebase's history for similar hard-to-script bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)