### PR TITLE
Remove dead !HAVE_ACE code now that HAVE_ACE is always defined (#147 ACE-lite)

### DIFF
--- a/src/ComTerp/comhandler.h
+++ b/src/ComTerp/comhandler.h
@@ -28,8 +28,6 @@
  * ComterpHandler is an ACE handler that can be invoked by an ACE acceptor
  */
 
-#ifdef HAVE_ACE
-
 #ifdef __llvm__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -166,37 +164,7 @@ protected:
 };
 
 //: Specialize a ComterpAcceptor.
-typedef ACE_Acceptor <ComterpHandler, ACE_SOCK_ACCEPTOR> 
+typedef ACE_Acceptor <ComterpHandler, ACE_SOCK_ACCEPTOR>
 	ComterpAcceptor;
-
-
-#else 
-
-#include <ComTerp/comterpserv.h>
-
-class ComTerpServ;
-
-//: version without ACE
-class ComterpHandler {
-public:
-    ComterpHandler(ComTerpServ* serv=nil) {comterp_ = serv ? serv : new ComTerpServ(); _handle = 0; comterp_->add_defaults();}
-    ComterpHandler(int id, ComTerpServ* serv = nil) { comterp_ = serv ? serv : new ComTerpServ(); _handle = id; comterp_->add_defaults();}
-    int get_handle() { return _handle;}
-    int wrfd() { return get_handle(); }   // mirror the ACE handler's interface so comterp.c compiles ACE-free
-
-    FILE* wrfptr() { return nil; }
-    // file pointer for writing to handle
-    
-    FILE* rdfptr() { return nil; }
-    // file pointer for reading from handle
-
-    ComTerp* comterp() { return comterp_; }
-
-protected:
-    int _handle;
-    ComTerpServ* comterp_;
-
-};
-#endif
 
 #endif /* _comterp_handler_ */

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -479,12 +479,8 @@ boolean ComValue::is_pipeobj() {
 }
 
 boolean ComValue::is_socketobj() {
-#ifdef HAVE_ACE
   ComValue tv = *this;
   return tv.is_object(SocketObj::class_symid());
-#else
-  return false;
-#endif
 }
 
 boolean ComValue::is_dateobj() {

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -214,9 +214,6 @@ void RemoteFunc::execute() {
   ComValue strv(stack_key(str_sym));
   reset_stack();
 
-
-#ifdef HAVE_ACE
-
   ACE_SOCK_STREAM *socket = nil;
   ACE_SOCK_Connector *conn = nil;
   SocketObj* socketobj = nil;
@@ -280,13 +277,6 @@ void RemoteFunc::execute() {
 
   return;
 
-#else
-
-  cerr << "for the remote command to work rebuild comterp with ACE\n";
-  return;
-
-#endif
-
 }
 
 /*****************************************************************************/
@@ -299,8 +289,6 @@ void SocketFunc::execute() {
   ComValue hostv(stack_arg(0));
   ComValue portv(stack_arg(1));
   reset_stack();
-
-#ifdef HAVE_ACE
 
   if (hostv.is_string() && portv.is_known()) {
 
@@ -319,12 +307,6 @@ void SocketFunc::execute() {
   }
 
   return;
-
-#else
-  cerr << "for the socket command to work rebuild comterp with ACE\n";
-  return;
-
-#endif
 
 }
 

--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -138,15 +138,8 @@ void ComEditor::Init (OverlayComp* comp, const char* name) {
 }
 
 void ComEditor::InitCommands() {
-    if (!_terp) 
+    if (!_terp)
       _terp = new ComTerpServ();
-      const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
-#ifndef HAVE_ACE
-    if ((!comterplist() || comterplist()->Number()==1) &&
-	(stdin_off_str ? strcmp(stdin_off_str, "false")==0 : true))
-      _terp_iohandler = new ComTerpIOHandler(_terp, stdin);
-    else
-#endif
       _terp_iohandler = nil;
 #if 0
     _terp->add_defaults();

--- a/src/ComUnidraw/unifunc.c
+++ b/src/ComUnidraw/unifunc.c
@@ -404,12 +404,8 @@ ExportFunc::ExportFunc(ComTerp* comterp, Editor* editor,
 }
 
 const char* ExportFunc::docstring() { 
-  const char* df = 
-#ifdef HAVE_ACE
+  const char* df =
     "%s(compview[,compview[,...compview]] [path] :host str :port int :socket :string|:str :eps :idraw) -- export in %s format ";
-#else
-  "%s(compview[,compview[,...compview]] [path] :string|:str :eps :idraw) -- export in %s format ";
-#endif
   if (!_docstring) {
     _docstring = new char[strlen(df)+strlen(appname())+1];
     sprintf(_docstring, df, "%s", appname() );

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -61,14 +61,6 @@ DrawLinkFunc::DrawLinkFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comte
 }
 
 void DrawLinkFunc::execute() {
-#ifndef HAVE_ACE
-
-  reset_stack();
-  fprintf(stderr, "rebuild ivtools with ACE support to get full drawserv functionality\n");
-  push_stack(ComValue::nullval());
-
-#else
-
   ComValue hostv(stack_arg(0, true));
   ComValue linkv(stack_arg(0, false));
   static int port_sym = symbol_add("port");
@@ -250,26 +242,17 @@ void DrawLinkFunc::execute() {
     push_stack(ComValue::nullval());
   
   return;
-  
-#endif
-  
+
 }
 
 #endif
-  
+
 /*****************************************************************************/
 
 SessionIdFunc::SessionIdFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comterp, ed) {
 }
 
 void SessionIdFunc::execute() {
-#ifndef HAVE_ACE
-
-  reset_stack();
-  fprintf(stderr, "rebuild ivtools with ACE support to get full drawserv functionality\n");
-  push_stack(ComValue::nullval());
-
-#else
   static int all_sym = symbol_add("all");
   ComValue allv(stack_key(all_sym));
   static int pid_sym = symbol_add("pid");
@@ -339,7 +322,6 @@ void SessionIdFunc::execute() {
       push_stack(ComValue::nullval());
     }
   }
-#endif
 }
 
 

--- a/src/DrawServ/drawkit.c
+++ b/src/DrawServ/drawkit.c
@@ -579,15 +579,10 @@ void DrawKit::launch_graphdraw() {
 }
 
 OverlaySelection* DrawKit::MakeSelection(Selection* sel) {
-#ifdef HAVE_ACE
   return new LinkSelection((DrawEditor*)GetEditor(), sel);
-#else
-  return FrameKit::MakeSelection(sel);
-#endif
 }
 
 MenuItem * DrawKit::MakeViewersMenu() {
-#ifdef HAVE_ACE
     LayoutKit& lk = *LayoutKit::instance();
     WidgetKit& kit = *WidgetKit::instance();
 
@@ -599,9 +594,6 @@ MenuItem * DrawKit::MakeViewersMenu() {
     mbi->menu()->append_item(menu_item);
 
     return mbi;
-#else
-    return nil;
-#endif
 }
 
 /*****************************************************************************/

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -82,7 +82,6 @@ DrawLink::~DrawLink ()
 
 int DrawLink::open(uuid_t linkid) {
 
-#if defined(HAVE_ACE) && (__GNUC__>3 || __GNUC__==3 && __GNUC_MINOR__>0)
   _addr = new ACE_INET_Addr(_port, _host);
   _socket = new ACE_SOCK_Stream;
   _conn = new ACE_SOCK_Connector;
@@ -144,10 +143,6 @@ int DrawLink::open(uuid_t linkid) {
 
     return 0;
   }
-#else
-  fprintf(stderr, "drawserv requires ACE and >= gcc-3.1 for full functionality\n");
-  return -1;
-#endif
 }
 
 int DrawLink::close() {

--- a/src/DrawServ/drawlinklist.c
+++ b/src/DrawServ/drawlinklist.c
@@ -61,14 +61,10 @@ void DrawLinkList::add_drawlink(DrawLink* new_link) {
 }
 
 DrawLink* DrawLinkList::find_drawlink(GraphicId* grid) {
-#ifdef HAVE_ACE
   void* ptr = nil;
   ((DrawServ*)unidraw)->sessionidtable()->find(ptr, grid->selectorkey());
   SessionId* sessionid = (SessionId*)ptr;
   return (DrawLink*) (sessionid ? sessionid->drawlink() : nil);
-#else
-  return NULL;
-#endif
 }
 
 DrawLink* DrawLinkList::Link (UList* r) {

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -250,7 +250,6 @@ static OptionDesc options[] = {
     { nil }
 };
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "comdraw  drawing editor with comterp scripting\n\
 Usage:  comdraw [file] [options]\n\n\
@@ -283,34 +282,6 @@ Usage:  comdraw [file] [options]\n\n\
 -runfile file               run script file after startup\n\
 -runexpr cmdstr             run command string after startup\n\n\
 any idraw parameter is also accepted (see idraw man page)";
-#else
-static const char usage[] =
-"comdraw  drawing editor with comterp scripting\n\
-Usage:  comdraw [file] [options]\n\n\
--color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
--gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
--opaque_off | -opoff        disable opaque moving/reshaping\n\
--pagecols | -ncols n        number of page columns in tiled view\n\
--pagerows | -nrows n        number of page rows in tiled view\n\
--panner_off | -poff         disable panner\n\
--panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
-                            panner alignment\n\
--rampsize n                 size of color ramp\n\
--scribble_pointer | -scrpt  enable scribble pointer\n\
--slider_off | -soff         disable slider\n\
--stdin_off                  disable stdin command socket\n\
--stripped                   stripped-down tool palette\n\
--toolbarloc | -tbl r|l      toolbar location left or right\n\
--theight | -th n            tile height in pixels\n\
--tile                       enable tiled page view\n\
--comt [file]                inline comterp text-entry pane; if file is\n\
-                            given, enter run(file) into the pane at startup\n\
--twidth | -tw n             tile width in pixels\n\
--zoomer_off | -zoff         disable zoomer\n\
--runfile file               run script file after startup\n\
--runexpr cmdstr             run command string after startup\n\n\
-any idraw parameter is also accepted (see idraw man page)";
-#endif
 
 /*****************************************************************************/
 

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -131,13 +131,6 @@ int main(int argc, char *argv[]) {
     boolean expr_flag = argc>1 && !server_flag && !logger_flag &&
                         !remote_flag && !client_flag && !telcat_flag && !run_flag && !listen_flag;
 
-#ifndef HAVE_ACE
-    if (listen_flag) {
-        cerr << "comterp: listen mode requires ACE (rebuild with HAVE_ACE)\n";
-        return 1;
-    }
-#endif
-
 #ifdef HAVE_ACE
     if (server_flag || logger_flag) {
         ComterpAcceptor* peer_acceptor = 

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -255,7 +255,6 @@ static OptionDesc options[] = {
 
 /*****************************************************************************/
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "drawserv  distributed drawing editor with comterp scripting\n\
 Usage:  drawserv [file] [options]\n\n\
@@ -282,32 +281,6 @@ Usage:  drawserv [file] [options]\n\n\
 -runfile file               run script file after startup\n\
 -runexpr cmdstr             run command string after startup\n\n\
 any idraw parameter is also accepted (see idraw man page)";
-#else
-static const char usage[] =
-"drawserv  distributed drawing editor with comterp scripting\n\
-Usage:  drawserv [file] [options]\n\n\
--color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
--gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
--opaque_off | -opoff        disable opaque moving/reshaping\n\
--pagecols | -ncols n        number of page columns in tiled view\n\
--pagerows | -nrows n        number of page rows in tiled view\n\
--panner_off | -poff         disable panner\n\
--panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
-                            panner alignment\n\
--rampsize n                 size of color ramp\n\
--scribble_pointer | -scrpt  enable scribble pointer\n\
--slider_off | -soff         disable slider\n\
--stdin_off                  disable stdin command socket\n\
--stripped                   stripped-down tool palette\n\
--toolbarloc | -tbl r|l      toolbar location left or right\n\
--theight | -th n            tile height in pixels\n\
--tile                       enable tiled page view\n\
--twidth | -tw n             tile width in pixels\n\
--zoomer_off | -zoff         disable zoomer\n\
--runfile file               run script file after startup\n\
--runexpr cmdstr             run command string after startup\n\n\
-any idraw parameter is also accepted (see idraw man page)";
-#endif
 
 /*****************************************************************************/
 
@@ -415,7 +388,6 @@ int main (int argc, char** argv) {
 
 	unidraw->Open(ed);
 
-#ifdef HAVE_ACE
 	/*  Start up one on stdin, unless -stdin_off (mirror comdraw).  Registering
 	    a live fd-0 handler under -stdin_off means a closed/EOF stdin -- as when
 	    drawmo launches us detached -- fires DrawServHandler::handle_input, which
@@ -433,10 +405,6 @@ int main (int argc, char** argv) {
 	}
 	fprintf(stderr, "ivtools-%s drawserv: type help here for command info\n", VersionString);
 	ed->stdio_prompt(stdin_handler);
-
-#else
-	fprintf(stderr, "ivtools-%s drawserv", VersionString);
-#endif
 
 	/* execute -runfile or -runexpr after editor is fully initialized */
 	ComTerpServ* terp = ed->GetComTerp();

--- a/src/drawtool/main.c
+++ b/src/drawtool/main.c
@@ -213,21 +213,12 @@ static OptionDesc options[] = {
 };
 
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "Usage: drawtool [any idraw parameter] [-color5] [-dithermap] [-gray5] [-gray6] \n\
 [-gray7] [-import port] [-nocolor6] [-opaque_off|-opoff] [-pagecols|-ncols n] \n\
 [-pagerows|-nrows n] [-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc] \n\
 [-panner_off|-poff] [-ptrloc] [-scribble_pointer|-scrpt ] [-slider_off|-soff]\n\
 [-svgexport] [-toolbarloc|-tbl r|l ] [-zoomer_off|-zoff] [file]";
-#else
-static char usage[] =
-"Usage: drawtool [any idraw parameter] [-color5] [-dithermap] [-gray5] [-gray6] \n\
-[-gray7] [-nocolor6] [-opaque_off|-opoff] [-pagecols|-ncols n] \n\
-[-pagerows|-nrows n] [-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc] \n\
-[-panner_off|-poff] [-ptrloc] [-scribble_pointer|-scrpt ] [-slider_off|-soff]\n\
-[-svgexport] [-toolbarloc|-tbl r|l ] [-zoomer_off|-zoff] [file]";
-#endif
 /*****************************************************************************/
 
 int main (int argc, char** argv) {

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -214,7 +214,6 @@ static OptionDesc options[] = {
     { nil }
 };
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "Usage: flipbook [any idraw parameter] [-bookgeom] [-comdraw port] [-color5]\n\
 [-color6] [-import port] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
@@ -223,16 +222,6 @@ static const char usage[] =
 [-scribble_pointer|-scrpt ] [-slideshow sec] [-slider_off|-soff]\n\
 [-stdin_off] [-stripped] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
 [-twidth|-tw n] [-zoomer_off|-zoff] [file]";
-#else
-static char usage[] =
-"Usage: flipbook [any idraw parameter] [-bookgeom]\n\
-[-color5] [-color6] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
-[-scribble_pointer|-scrpt ] [-slideshow sec] [-slider_off|-soff]\n\
- [-stdin_off] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
-[-twidth|-tw n] [-zoomer_off|-zoff] [file]";
-#endif
 /*****************************************************************************/
 
 int main (int argc, char** argv) {

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -200,7 +200,6 @@ static OptionDesc options[] = {
 };
 
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "Usage: graphdraw [any idraw parameter] [-color5] [-color6] [-comdraw port]\n\
 [-import port] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
@@ -208,15 +207,6 @@ static const char usage[] =
 [-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
 [-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
 [-zoomer_off|-zoff] [file]";
-#else
-static char usage[] =
-"Usage: graphdraw [any idraw parameter] [-color5] [-color6]\n\
-[-gray5] [-gray6] [-gray7] [-opaque_off|-opoff] [-pagecols|-ncols n]\n\
-[-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ] \n\
-[-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
-[-zoomer_off|-zoff] [file]";
-#endif
 
 /*****************************************************************************/
 


### PR DESCRIPTION
## Summary
- Since the ACE-lite work (#147), `HAVE_ACE` is unconditionally defined at compile time (`config/params.def`'s `AceCCDefines`, `config/config.defs.in`'s `AceEnabled`) — networking is always available now, either via the in-tree ACE-lite subset or external libACE.
- Every `#ifdef HAVE_ACE` / `#else` / `#endif` and `#ifndef HAVE_ACE` / `#endif` pair across the tree therefore had a permanently-dead branch. This PR removes those dead branches and unwraps the surviving guard so the ACE code path is unconditional: the non-ACE `ComterpHandler` class, `RemoteFunc`/`SocketFunc` stubs, `DrawLinkFunc`/`SessionIdFunc` stubs, `DrawKit`'s non-ACE `MakeSelection`/`MakeViewersMenu`, `DrawLinkList::find_drawlink`'s `NULL` fallback, `DrawLink::open`'s stale-GCC-guard fallback, and the duplicate non-ACE `usage[]` strings/banners in `comdraw`, `comterp_`, `drawserv_`, `drawtool`, `flipbook`, and `graphdraw`'s `main.c`.
- One site (`DrawServ/drawlink.c`'s `DrawLink::open`) was gated by a compound `defined(HAVE_ACE) && __GNUC__>3` condition rather than bare `HAVE_ACE` — also removed, since no supported compiler exercises the pre-gcc-3.1 fallback branch anymore.

## Test plan
- [x] Full top-level `make` from `src/` — clean exit, zero errors/warnings
- [x] `src/comterp_/tests/run_all.comt` — 23 sub-tests, 0 fails
- [x] `src/drawserv_/tests/drawmo` full suite — 10 tests (`updown`, `updown1`, `updown2`, `updown3A/B`, `updown4A/B/C`, `gsexim`, `gsbrushA/B`) all pass, exercising the touched `RemoteFunc`/`SocketFunc`, `DrawLinkFunc`/`SessionIdFunc`, and `DrawLink::open` code paths directly
- [ ] CI (g++/Ubuntu build + headless suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)