### PR TITLE
Extend issue #76's tty-echo fix to flipbook and graphdraw

### DIFF
--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -41,6 +41,7 @@
 #include <InterViews/world.h>
 
 #include <ComTerp/comterpserv.h>
+#include <ComTerp/comvalue.h>
 
 #include <stdio.h>
 #include <stream.h>
@@ -192,7 +193,7 @@ static OptionDesc options[] = {
     { "-slider_off", "*slider_off", OptionValueImplicit, "true" },
     { "-soff", "*slider_off", OptionValueImplicit, "true" },
     { "-theight", "*theight", OptionValueNext },
-    { "-tw", "*theight", OptionValueNext },
+    { "-th", "*theight", OptionValueNext },
     { "-tile", "*tile", OptionValueImplicit, "true" },
     { "-toolbarloc", "*toolbarloc", OptionValueNext },
     { "-tbl", "*toolbarloc", OptionValueNext },
@@ -216,22 +217,54 @@ static OptionDesc options[] = {
 
 #ifdef HAVE_ACE
 static const char usage[] =
-"Usage: flipbook [any idraw parameter] [-bookgeom] [-comdraw port] [-color5]\n\
-[-color6] [-import port] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
-[-scribble_pointer|-scrpt ] [-slideshow sec] [-slider_off|-soff]\n\
-[-stdin_off] [-stripped] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
-[-twidth|-tw n] [-zoomer_off|-zoff] [file]";
+"flipbook  frame/slideshow editor with comterp scripting\n\
+Usage:  flipbook [file] [options]\n\n\
+-comdraw port               port number for comdraw command socket\n\
+-import portnum             port number for import socket\n\
+-bookgeom                   book-style facing-page layout\n\
+-color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
+-gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
+-opaque_off | -opoff        disable opaque moving/reshaping\n\
+-pagecols | -ncols n        number of page columns in tiled view\n\
+-pagerows | -nrows n        number of page rows in tiled view\n\
+-panner_off | -poff         disable panner\n\
+-panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
+                            panner alignment\n\
+-scribble_pointer | -scrpt  enable scribble pointer\n\
+-slideshow sec              auto-advance pages every sec seconds\n\
+-slider_off | -soff         disable slider\n\
+-stdin_off                  disable stdin command socket\n\
+-stripped                   stripped-down tool palette\n\
+-toolbarloc | -tbl r|l      toolbar location left or right\n\
+-theight | -th n            tile height in pixels\n\
+-tile                       enable tiled page view\n\
+-twidth | -tw n             tile width in pixels\n\
+-zoomer_off | -zoff         disable zoomer\n\n\
+any idraw parameter is also accepted (see idraw man page)";
 #else
-static char usage[] =
-"Usage: flipbook [any idraw parameter] [-bookgeom]\n\
-[-color5] [-color6] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
-[-scribble_pointer|-scrpt ] [-slideshow sec] [-slider_off|-soff]\n\
- [-stdin_off] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
-[-twidth|-tw n] [-zoomer_off|-zoff] [file]";
+static const char usage[] =
+"flipbook  frame/slideshow editor with comterp scripting\n\
+Usage:  flipbook [file] [options]\n\n\
+-bookgeom                   book-style facing-page layout\n\
+-color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
+-gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
+-opaque_off | -opoff        disable opaque moving/reshaping\n\
+-pagecols | -ncols n        number of page columns in tiled view\n\
+-pagerows | -nrows n        number of page rows in tiled view\n\
+-panner_off | -poff         disable panner\n\
+-panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
+                            panner alignment\n\
+-scribble_pointer | -scrpt  enable scribble pointer\n\
+-slideshow sec              auto-advance pages every sec seconds\n\
+-slider_off | -soff         disable slider\n\
+-stdin_off                  disable stdin command socket\n\
+-stripped                   stripped-down tool palette\n\
+-toolbarloc | -tbl r|l      toolbar location left or right\n\
+-theight | -th n            tile height in pixels\n\
+-tile                       enable tiled page view\n\
+-twidth | -tw n             tile width in pixels\n\
+-zoomer_off | -zoff         disable zoomer\n\n\
+any idraw parameter is also accepted (see idraw man page)";
 #endif
 /*****************************************************************************/
 
@@ -249,7 +282,7 @@ int main (int argc, char** argv) {
         catalog, argc, argv, options, properties
     );
     if (strcmp(catalog->GetAttribute("help"), "true")==0) {
-      cerr << usage;
+      cerr << usage << "\n";
       return 0;
     }
 
@@ -307,24 +340,47 @@ int main (int argc, char** argv) {
 	unidraw->Open(ed);
 
 #ifdef HAVE_ACE
-	/*  Start up one on stdin */
-	UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
+	/*  Start up one on stdin, unless -stdin_off (mirror comdraw). */
+	const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
+	UnidrawComterpHandler* stdin_handler = nil;
+	if (!stdin_off_str || strcmp(stdin_off_str, "false")==0) {
+	    stdin_handler = new UnidrawComterpHandler();
+	    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							  ACE_Event_Handler::READ_MASK)==-1)
-	  cerr << "flipbook: unable to open stdin with ACE\n";
-	else
-	  tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
-	                    // handler is actually live, or OS echo goes off
-	                    // with no self-echo ever registered to replace it
-	ed->stdio_setup(stdin_handler);
+	      cerr << "flipbook: unable to open stdin with ACE\n";
+	    else
+	      tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
+	                        // handler is actually live, or OS echo goes off
+	                        // with no self-echo ever registered to replace it
+	    ed->stdio_setup(stdin_handler);
+	}
 #endif
 
 	fprintf(stderr, "ivtools-%s flipbook: see \"man flipbook\" or type help here for command info\n", VersionString);
-	
+
 #ifdef HAVE_ACE
 	ed->stdio_prompt(stdin_handler);
 #endif
-	
+
+	/* Seed update: the mandatory first update() that wins the X11
+	   map/realize race (see comdraw/main.c).  It pumps the event loop so the
+	   window maps and the viewer's canvas is bound before any GUI command
+	   can run -- a client connecting to the import/comdraw command socket
+	   can send a GUI command as the very first event processed inside
+	   Run(), before the window's Configure/Expose has bound the canvas,
+	   which would otherwise dereference a null canvas and crash.  Mapping
+	   the window here, before Run() owns the loop, closes that window.
+	   Not something the user typed -- one-shot suppress its self-echo
+	   (issue #76, ttyecho.c; see comdraw/main.c's fuller comment for why
+	   a one-shot flag, not a held-open disable_prompt(), is the
+	   reentrancy-safe way to suppress a single internal eval like
+	   this one). */
+	ComTerpServ* terp = ed->GetComTerp();
+	if (terp) {
+	  tty_echo_suppress_next();
+	  terp->run("update(1000000)\n");
+	}
+
 	unidraw->Run();
     }
 

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -236,6 +236,9 @@ static char usage[] =
 /*****************************************************************************/
 
 int main (int argc, char** argv) {
+    /* Ctrl-C (SIGINT) is the common way an interactive session ends --
+       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+    tty_echo_install_signal_handlers();
 #ifdef HAVE_ACE
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
 #endif
@@ -306,9 +309,13 @@ int main (int argc, char** argv) {
 #ifdef HAVE_ACE
 	/*  Start up one on stdin */
 	UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
+	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							  ACE_Event_Handler::READ_MASK)==-1)
 	  cerr << "flipbook: unable to open stdin with ACE\n";
+	else
+	  tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
+	                    // handler is actually live, or OS echo goes off
+	                    // with no self-echo ever registered to replace it
 	ed->stdio_setup(stdin_handler);
 #endif
 

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -39,6 +39,7 @@
 #include <OverlayUnidraw/ovunidraw.h>
 
 #include <ComTerp/comterpserv.h>
+#include <ComTerp/comvalue.h>
 
 #include <InterViews/world.h>
 
@@ -202,20 +203,40 @@ static OptionDesc options[] = {
 
 #ifdef HAVE_ACE
 static const char usage[] =
-"Usage: graphdraw [any idraw parameter] [-color5] [-color6] [-comdraw port]\n\
-[-import port] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
-[-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
-[-zoomer_off|-zoff] [file]";
+"graphdraw  graph editor with comterp scripting\n\
+Usage:  graphdraw [file] [options]\n\n\
+-comdraw port               port number for comdraw command socket\n\
+-import portnum             port number for import socket\n\
+-color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
+-gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
+-opaque_off | -opoff        disable opaque moving/reshaping\n\
+-pagecols | -ncols n        number of page columns in tiled view\n\
+-pagerows | -nrows n        number of page rows in tiled view\n\
+-panner_off | -poff         disable panner\n\
+-panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
+                            panner alignment\n\
+-scribble_pointer | -scrpt  enable scribble pointer\n\
+-slider_off | -soff         disable slider\n\
+-stdin_off                  disable stdin command socket\n\
+-zoomer_off | -zoff         disable zoomer\n\n\
+any idraw parameter is also accepted (see idraw man page)";
 #else
-static char usage[] =
-"Usage: graphdraw [any idraw parameter] [-color5] [-color6]\n\
-[-gray5] [-gray6] [-gray7] [-opaque_off|-opoff] [-pagecols|-ncols n]\n\
-[-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ] \n\
-[-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
-[-zoomer_off|-zoff] [file]";
+static const char usage[] =
+"graphdraw  graph editor with comterp scripting\n\
+Usage:  graphdraw [file] [options]\n\n\
+-color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
+-gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
+-opaque_off | -opoff        disable opaque moving/reshaping\n\
+-pagecols | -ncols n        number of page columns in tiled view\n\
+-pagerows | -nrows n        number of page rows in tiled view\n\
+-panner_off | -poff         disable panner\n\
+-panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
+                            panner alignment\n\
+-scribble_pointer | -scrpt  enable scribble pointer\n\
+-slider_off | -soff         disable slider\n\
+-stdin_off                  disable stdin command socket\n\
+-zoomer_off | -zoff         disable zoomer\n\n\
+any idraw parameter is also accepted (see idraw man page)";
 #endif
 
 /*****************************************************************************/
@@ -288,25 +309,48 @@ int main (int argc, char** argv) {
     unidraw->Open(ed);
     
 #ifdef HAVE_ACE
-    /*  Start up one on stdin */
-    UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
+    /*  Start up one on stdin, unless -stdin_off (mirror comdraw). */
+    const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
+    UnidrawComterpHandler* stdin_handler = nil;
+    if (!stdin_off_str || strcmp(stdin_off_str, "false")==0) {
+	stdin_handler = new UnidrawComterpHandler();
+	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							      ACE_Event_Handler::READ_MASK)==-1)
-      cerr << "graphdraw: unable to open stdin with ACE\n";
-    else
-      tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
-                        // handler is actually live, or OS echo goes off
-                        // with no self-echo ever registered to replace it
-    ed->stdio_setup(stdin_handler);
+	  cerr << "graphdraw: unable to open stdin with ACE\n";
+	else
+	  tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
+	                    // handler is actually live, or OS echo goes off
+	                    // with no self-echo ever registered to replace it
+	ed->stdio_setup(stdin_handler);
+    }
 #endif
-    
-    cerr << "ivtools-" << VersionString 
+
+    cerr << "ivtools-" << VersionString
 	 << " graphdraw: see \"man graphdraw\" or type help here for command info\n";
-    
+
 #ifdef HAVE_ACE
     ed->stdio_prompt(stdin_handler);
 #endif
-    
+
+    /* Seed update: the mandatory first update() that wins the X11
+       map/realize race (see comdraw/main.c).  It pumps the event loop so the
+       window maps and the viewer's canvas is bound before any GUI command
+       can run -- a client connecting to the import/comdraw command socket
+       can send a GUI command as the very first event processed inside
+       Run(), before the window's Configure/Expose has bound the canvas,
+       which would otherwise dereference a null canvas and crash.  Mapping
+       the window here, before Run() owns the loop, closes that window.
+       Not something the user typed -- one-shot suppress its self-echo
+       (issue #76, ttyecho.c; see comdraw/main.c's fuller comment for why
+       a one-shot flag, not a held-open disable_prompt(), is the
+       reentrancy-safe way to suppress a single internal eval like
+       this one). */
+    ComTerpServ* terp = ed->GetComTerp();
+    if (terp) {
+      tty_echo_suppress_next();
+      terp->run("update(1000000)\n");
+    }
+
     unidraw->Run();
     
     delete unidraw;

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -221,6 +221,9 @@ static char usage[] =
 /*****************************************************************************/
 
 int main (int argc, char** argv) {
+    /* Ctrl-C (SIGINT) is the common way an interactive session ends --
+       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+    tty_echo_install_signal_handlers();
 #ifdef HAVE_ACE
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
 #endif
@@ -287,9 +290,13 @@ int main (int argc, char** argv) {
 #ifdef HAVE_ACE
     /*  Start up one on stdin */
     UnidrawComterpHandler* stdin_handler = new UnidrawComterpHandler();
-    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler, 
+    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							      ACE_Event_Handler::READ_MASK)==-1)
       cerr << "graphdraw: unable to open stdin with ACE\n";
+    else
+      tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
+                        // handler is actually live, or OS echo goes off
+                        // with no self-echo ever registered to replace it
     ed->stdio_setup(stdin_handler);
 #endif
     

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -268,7 +268,7 @@ int main (int argc, char** argv) {
     int importnum = atoi(importstr);
     if (import_acceptor->open 
 	(ACE_INET_Addr (importnum)) == -1)
-        cerr << "flipbook:  unable to open import port " << importnum << "\n";
+        cerr << "graphdraw:  unable to open import port " << importnum << "\n";
 
     else if (ComterpHandler::reactor_singleton()->register_handler 
 	     (import_acceptor, ACE_Event_Handler::READ_MASK) == -1)


### PR DESCRIPTION
## Summary
- Extends the tty-echo fix from #235 (issue #76) to `flipbook` and `graphdraw`, which share the same `ComEditor`/`UnidrawComterpHandler` stdin-registration pattern as `comdraw`/`drawserv_` but never got the fix.
- Adds `tty_echo_install_signal_handlers()` near the top of `main()` in both, so Ctrl-C (SIGINT)/SIGTERM restores tty echo before the process dies, instead of leaving the terminal dark.
- Adds `tty_echo_off()` right after the stdin ACE handler registers successfully (gated on `register_handler` actually succeeding, matching the P1 fix already applied to comdraw/drawserv_), so pasted/typed input echoes correctly interleaved with output rather than all at once.
- Adds the same seed `update(1000000)` (wrapped in `tty_echo_suppress_next()`) that comdraw/drawserv_ use: both binaries accept GUI commands over their own ACE import/comdraw command sockets, so they're equally exposed to the X11 map/realize race that call guards against — a client connecting immediately and sending a GUI command before the first Configure/Expose has bound the canvas would dereference a null canvas and crash.
- Gates stdin-handler registration on `-stdin_off`, matching comdraw's exact pattern. Neither binary previously honored that flag at all (registered the handler unconditionally) — a real, separate bug, just noticed and fixed while extending this one.
- Rewrites both binaries' `-help` output to comdraw/drawserv_'s one-flag-per-line format, reflecting each binary's actual option set.
- Fixes two incidental bugs caught along the way: flipbook's `OptionDesc` table mapped `-tw` to both `*theight` and `*twidth` (now `-th`/`*theight`, `-tw`/`*twidth`), and graphdraw's import-port error message said "flipbook:" instead of "graphdraw:" (copy-paste, caught by Greptile).
- Neither binary declares a `PATCH_KEY`/`build_stamp()` banner marker — left that convention out since it's a separate concern from this fix.

## Test plan
- [x] Full top-level `make Makefiles && make` from `src/` — clean, zero errors
- [x] `src/comterp_/tests/run_all.comt` — 23 sub-tests, 0 fails (unaffected regression check)
- [x] Verified against the real termios ECHO bit under a pty (not just output text) for both binaries: `false` after startup once the stdin handler registers, `true` if `-stdin_off` is passed, flips back to `true` after SIGINT
- [x] Typed input over a pty transcript shows no leaked `update(1000000)` self-echo and evaluates correctly
- [x] CI (g++/Ubuntu build + headless suites) — passing
- [x] Greptile review — addressed (stale PR description, graphdraw copy-paste bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)