### PR TITLE
Remove dead !HAVE_ACE code now that HAVE_ACE is always defined (#147 ACE-lite)

### DIFF
--- a/src/ComTerp/comhandler.h
+++ b/src/ComTerp/comhandler.h
@@ -28,8 +28,6 @@
  * ComterpHandler is an ACE handler that can be invoked by an ACE acceptor
  */
 
-#ifdef HAVE_ACE
-
 #ifdef __llvm__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -166,37 +164,7 @@ protected:
 };
 
 //: Specialize a ComterpAcceptor.
-typedef ACE_Acceptor <ComterpHandler, ACE_SOCK_ACCEPTOR> 
+typedef ACE_Acceptor <ComterpHandler, ACE_SOCK_ACCEPTOR>
 	ComterpAcceptor;
-
-
-#else 
-
-#include <ComTerp/comterpserv.h>
-
-class ComTerpServ;
-
-//: version without ACE
-class ComterpHandler {
-public:
-    ComterpHandler(ComTerpServ* serv=nil) {comterp_ = serv ? serv : new ComTerpServ(); _handle = 0; comterp_->add_defaults();}
-    ComterpHandler(int id, ComTerpServ* serv = nil) { comterp_ = serv ? serv : new ComTerpServ(); _handle = id; comterp_->add_defaults();}
-    int get_handle() { return _handle;}
-    int wrfd() { return get_handle(); }   // mirror the ACE handler's interface so comterp.c compiles ACE-free
-
-    FILE* wrfptr() { return nil; }
-    // file pointer for writing to handle
-    
-    FILE* rdfptr() { return nil; }
-    // file pointer for reading from handle
-
-    ComTerp* comterp() { return comterp_; }
-
-protected:
-    int _handle;
-    ComTerpServ* comterp_;
-
-};
-#endif
 
 #endif /* _comterp_handler_ */

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -479,12 +479,8 @@ boolean ComValue::is_pipeobj() {
 }
 
 boolean ComValue::is_socketobj() {
-#ifdef HAVE_ACE
   ComValue tv = *this;
   return tv.is_object(SocketObj::class_symid());
-#else
-  return false;
-#endif
 }
 
 boolean ComValue::is_dateobj() {

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -214,9 +214,6 @@ void RemoteFunc::execute() {
   ComValue strv(stack_key(str_sym));
   reset_stack();
 
-
-#ifdef HAVE_ACE
-
   ACE_SOCK_STREAM *socket = nil;
   ACE_SOCK_Connector *conn = nil;
   SocketObj* socketobj = nil;
@@ -280,13 +277,6 @@ void RemoteFunc::execute() {
 
   return;
 
-#else
-
-  cerr << "for the remote command to work rebuild comterp with ACE\n";
-  return;
-
-#endif
-
 }
 
 /*****************************************************************************/
@@ -299,8 +289,6 @@ void SocketFunc::execute() {
   ComValue hostv(stack_arg(0));
   ComValue portv(stack_arg(1));
   reset_stack();
-
-#ifdef HAVE_ACE
 
   if (hostv.is_string() && portv.is_known()) {
 
@@ -319,12 +307,6 @@ void SocketFunc::execute() {
   }
 
   return;
-
-#else
-  cerr << "for the socket command to work rebuild comterp with ACE\n";
-  return;
-
-#endif
 
 }
 

--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -138,15 +138,8 @@ void ComEditor::Init (OverlayComp* comp, const char* name) {
 }
 
 void ComEditor::InitCommands() {
-    if (!_terp) 
+    if (!_terp)
       _terp = new ComTerpServ();
-      const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
-#ifndef HAVE_ACE
-    if ((!comterplist() || comterplist()->Number()==1) &&
-	(stdin_off_str ? strcmp(stdin_off_str, "false")==0 : true))
-      _terp_iohandler = new ComTerpIOHandler(_terp, stdin);
-    else
-#endif
       _terp_iohandler = nil;
 #if 0
     _terp->add_defaults();

--- a/src/ComUnidraw/unifunc.c
+++ b/src/ComUnidraw/unifunc.c
@@ -404,12 +404,8 @@ ExportFunc::ExportFunc(ComTerp* comterp, Editor* editor,
 }
 
 const char* ExportFunc::docstring() { 
-  const char* df = 
-#ifdef HAVE_ACE
+  const char* df =
     "%s(compview[,compview[,...compview]] [path] :host str :port int :socket :string|:str :eps :idraw) -- export in %s format ";
-#else
-  "%s(compview[,compview[,...compview]] [path] :string|:str :eps :idraw) -- export in %s format ";
-#endif
   if (!_docstring) {
     _docstring = new char[strlen(df)+strlen(appname())+1];
     sprintf(_docstring, df, "%s", appname() );

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -61,14 +61,6 @@ DrawLinkFunc::DrawLinkFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comte
 }
 
 void DrawLinkFunc::execute() {
-#ifndef HAVE_ACE
-
-  reset_stack();
-  fprintf(stderr, "rebuild ivtools with ACE support to get full drawserv functionality\n");
-  push_stack(ComValue::nullval());
-
-#else
-
   ComValue hostv(stack_arg(0, true));
   ComValue linkv(stack_arg(0, false));
   static int port_sym = symbol_add("port");
@@ -250,26 +242,17 @@ void DrawLinkFunc::execute() {
     push_stack(ComValue::nullval());
   
   return;
-  
-#endif
-  
+
 }
 
 #endif
-  
+
 /*****************************************************************************/
 
 SessionIdFunc::SessionIdFunc(ComTerp* comterp, DrawEditor* ed) : UnidrawFunc(comterp, ed) {
 }
 
 void SessionIdFunc::execute() {
-#ifndef HAVE_ACE
-
-  reset_stack();
-  fprintf(stderr, "rebuild ivtools with ACE support to get full drawserv functionality\n");
-  push_stack(ComValue::nullval());
-
-#else
   static int all_sym = symbol_add("all");
   ComValue allv(stack_key(all_sym));
   static int pid_sym = symbol_add("pid");
@@ -339,7 +322,6 @@ void SessionIdFunc::execute() {
       push_stack(ComValue::nullval());
     }
   }
-#endif
 }
 
 

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -327,7 +327,6 @@ void SessionIdFunc::execute() {
 
 /*****************************************************************************/
 
-#ifdef HAVE_ACE
 GraphicIdFunc::GraphicIdFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
@@ -459,8 +458,6 @@ void GraphicIdFunc::execute() {
   }
 
 }
-
-#endif /* defined(HAVE_ACE) */
 
 /*****************************************************************************/
 

--- a/src/DrawServ/drawkit.c
+++ b/src/DrawServ/drawkit.c
@@ -579,15 +579,10 @@ void DrawKit::launch_graphdraw() {
 }
 
 OverlaySelection* DrawKit::MakeSelection(Selection* sel) {
-#ifdef HAVE_ACE
   return new LinkSelection((DrawEditor*)GetEditor(), sel);
-#else
-  return FrameKit::MakeSelection(sel);
-#endif
 }
 
 MenuItem * DrawKit::MakeViewersMenu() {
-#ifdef HAVE_ACE
     LayoutKit& lk = *LayoutKit::instance();
     WidgetKit& kit = *WidgetKit::instance();
 
@@ -599,9 +594,6 @@ MenuItem * DrawKit::MakeViewersMenu() {
     mbi->menu()->append_item(menu_item);
 
     return mbi;
-#else
-    return nil;
-#endif
 }
 
 /*****************************************************************************/

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -57,19 +57,16 @@ DrawLink::DrawLink (const char* hostname, int portnum, int state)
   uuid_clear(_linkid);
   _state = state;
 
-#ifdef HAVE_ACE
   _addr = nil;
   _socket = nil;
   _conn = nil;
-#endif
 
   _comhandler = nil;
   _ackhandler = nil;
 }
 
-DrawLink::~DrawLink () 
+DrawLink::~DrawLink ()
 {
-#ifdef HAVE_ACE
     if (_socket->close () == -1)
         ACE_ERROR ((LM_ERROR, "%p\n", "close"));
     delete _conn;
@@ -77,7 +74,6 @@ DrawLink::~DrawLink ()
     delete _addr;
     delete _host;
     delete _althost;
-#endif
 }
 
 int DrawLink::open(uuid_t linkid) {
@@ -146,8 +142,7 @@ int DrawLink::open(uuid_t linkid) {
 }
 
 int DrawLink::close() {
-#ifdef HAVE_ACE
-  fprintf(stderr, "Closing link to %s (%s) port # %d (lid=%.8s)\n", 
+  fprintf(stderr, "Closing link to %s (%s) port # %d (lid=%.8s)\n",
 	  hostname(), althostname(), portnum(), linkid_str());
   if (comhandler()) comhandler()->drawlink(nil);
   if (_socket) {
@@ -161,7 +156,6 @@ int DrawLink::close() {
     if (_socket->close () == -1)
       ACE_ERROR ((LM_ERROR, "%p\n", "close"));
   }
-#endif
   return 1;
 }
 
@@ -180,11 +174,9 @@ void DrawLink::althostname(const char* althost) {
 }
 
 int DrawLink::handle() {
-#ifdef HAVE_ACE
-  if (_socket) 
+  if (_socket)
     return _socket->get_handle();
-  else 
-#endif
+  else
     return -1;
 }
 

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -82,7 +82,6 @@ DrawLink::~DrawLink ()
 
 int DrawLink::open(uuid_t linkid) {
 
-#if defined(HAVE_ACE) && (__GNUC__>3 || __GNUC__==3 && __GNUC_MINOR__>0)
   _addr = new ACE_INET_Addr(_port, _host);
   _socket = new ACE_SOCK_Stream;
   _conn = new ACE_SOCK_Connector;
@@ -144,10 +143,6 @@ int DrawLink::open(uuid_t linkid) {
 
     return 0;
   }
-#else
-  fprintf(stderr, "drawserv requires ACE and >= gcc-3.1 for full functionality\n");
-  return -1;
-#endif
 }
 
 int DrawLink::close() {

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -67,7 +67,7 @@ DrawLink::DrawLink (const char* hostname, int portnum, int state)
 
 DrawLink::~DrawLink ()
 {
-    if (_socket->close () == -1)
+    if (_socket && _socket->close () == -1)
         ACE_ERROR ((LM_ERROR, "%p\n", "close"));
     delete _conn;
     delete _socket;

--- a/src/DrawServ/drawlinklist.c
+++ b/src/DrawServ/drawlinklist.c
@@ -61,14 +61,10 @@ void DrawLinkList::add_drawlink(DrawLink* new_link) {
 }
 
 DrawLink* DrawLinkList::find_drawlink(GraphicId* grid) {
-#ifdef HAVE_ACE
   void* ptr = nil;
   ((DrawServ*)unidraw)->sessionidtable()->find(ptr, grid->selectorkey());
   SessionId* sessionid = (SessionId*)ptr;
   return (DrawLink*) (sessionid ? sessionid->drawlink() : nil);
-#else
-  return NULL;
-#endif
 }
 
 DrawLink* DrawLinkList::Link (UList* r) {

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -255,7 +255,6 @@ static OptionDesc options[] = {
     { nil }
 };
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "comdraw  drawing editor with comterp scripting\n\
 Usage:  comdraw [file] [options]\n\n\
@@ -288,34 +287,6 @@ Usage:  comdraw [file] [options]\n\n\
 -runfile file               run script file after startup\n\
 -runexpr cmdstr             run command string after startup\n\n\
 any idraw parameter is also accepted (see idraw man page)";
-#else
-static const char usage[] =
-"comdraw  drawing editor with comterp scripting\n\
-Usage:  comdraw [file] [options]\n\n\
--color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
--gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
--opaque_off | -opoff        disable opaque moving/reshaping\n\
--pagecols | -ncols n        number of page columns in tiled view\n\
--pagerows | -nrows n        number of page rows in tiled view\n\
--panner_off | -poff         disable panner\n\
--panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
-                            panner alignment\n\
--rampsize n                 size of color ramp\n\
--scribble_pointer | -scrpt  enable scribble pointer\n\
--slider_off | -soff         disable slider\n\
--stdin_off                  disable stdin command socket\n\
--stripped                   stripped-down tool palette\n\
--toolbarloc | -tbl r|l      toolbar location left or right\n\
--theight | -th n            tile height in pixels\n\
--tile                       enable tiled page view\n\
--comt [file]                inline comterp text-entry pane; if file is\n\
-                            given, enter run(file) into the pane at startup\n\
--twidth | -tw n             tile width in pixels\n\
--zoomer_off | -zoff         disable zoomer\n\
--runfile file               run script file after startup\n\
--runexpr cmdstr             run command string after startup\n\n\
-any idraw parameter is also accepted (see idraw man page)";
-#endif
 
 /*****************************************************************************/
 

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -43,11 +43,9 @@
 #include <InterViews/display.h>
 #include <IV-X11/xdisplay.h>
 
-#ifdef HAVE_ACE
 #include <ComUnidraw/comterp-acehandler.h>
 #include <OverlayUnidraw/aceimport.h>
 #include <AceDispatch/ace_dispatcher.h>
-#endif
 
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/comvalue.h>
@@ -191,14 +189,12 @@ static PropertyData properties[] = {
     { "*opaque_off",    "false"  },
     { "*stripped",      "false"  },
     { "*stdin_off",   "false"  },
-#ifdef HAVE_ACE
     { "*import",        "20001" },
     { "*comdraw",       "20002" },
     { "*wbmaster",      "false" },
     { "*wbslave",       "false" },
     { "*wbhost",        "localhost" },
     { "*wbport",        "20002" },
-#endif
     { "*help",          "false"  },
     { "*runfile",       ""  },
     { "*runexpr",       ""  },
@@ -239,14 +235,12 @@ static OptionDesc options[] = {
     { "-opoff", "*opaque_off", OptionValueImplicit, "true" },
     { "-stripped", "*stripped", OptionValueImplicit, "true" },
     { "-stdin_off", "*stdin_off", OptionValueImplicit, "true" },
-#ifdef HAVE_ACE
     { "-import", "*import", OptionValueNext },
     { "-comdraw", "*comdraw", OptionValueNext },
     { "-wbmaster", "*wbmaster", OptionValueImplicit, "true" },
     { "-wbslave", "*wbslave", OptionValueImplicit, "true" },
     { "-wbhost", "*wbhost", OptionValueNext },
     { "-wbport", "*wbport", OptionValueNext },
-#endif
     { "-help", "*help", OptionValueImplicit, "true" },
     { "--help", "*help", OptionValueImplicit, "true" },
     { "-font", "*font", OptionValueNext },
@@ -314,9 +308,7 @@ int main (int argc, char** argv) {
        restore tty echo first if tty_echo_off() ever ran, issue #76. */
     tty_echo_install_signal_handlers();
     const char* comtfile = extract_comtfile(argc, argv);
-#ifdef HAVE_ACE
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
-#endif
     OverlayCreator creator;
     OverlayCatalog* catalog = new OverlayCatalog("comdraw", &creator);
     OverlayUnidraw* unidraw = new OverlayUnidraw(
@@ -327,8 +319,6 @@ int main (int argc, char** argv) {
       cerr << usage << "\n";
       return 0;
     }
-
-#ifdef HAVE_ACE
 
     UnidrawImportAcceptor* import_acceptor = new UnidrawImportAcceptor();
 
@@ -360,17 +350,6 @@ int main (int argc, char** argv) {
     else
         cerr << "accepting comdraw port (" << portnum << ") connections\n";
 
-
-    // Register COMTERP_QUIT_HANDLER to receive SIGINT commands.  When received,
-    // COMTERP_QUIT_HANDLER becomes "set" and thus, the event loop below will
-    // exit.
-#if 0
-    if (ComterpHandler::reactor_singleton()->register_handler 
-	     (SIGINT, COMTERP_QUIT_HANDLER::instance ()) == -1)
-        cerr << "comdraw:  unable to register quit handler with ACE reactor\n";
-#endif
-
-#endif
     int exit_status = 0;
     boolean starter_line = false;
 
@@ -384,8 +363,6 @@ int main (int argc, char** argv) {
 
 	unidraw->Open(ed);
 
-#ifdef HAVE_ACE
-	
 	/*  Start up one on stdin */
 	const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
 	UnidrawComterpHandler* stdin_handler = nil;
@@ -403,15 +380,12 @@ int main (int argc, char** argv) {
 	  starter_line = true;
 	  ed->stdio_setup(stdin_handler);
 	}
-#endif
 	if (!starter_line) {
 	  fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info %s\n", VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY));
 	}
 
-#ifdef HAVE_ACE
 	ed->stdio_prompt(stdin_handler);
-#endif
-	
+
 	XSync(unidraw->GetWorld()->display()->rep()->display_,false);
 	
 	/* execute -runfile or -runexpr after editor is fully initialized */

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -134,7 +134,10 @@ int main(int argc, char *argv[]) {
     boolean expr_flag = argc>1 && !server_flag && !logger_flag &&
                         !remote_flag && !client_flag && !telcat_flag && !run_flag && !listen_flag;
 
+<<<<<<< Updated upstream
 #ifdef HAVE_ACE
+=======
+>>>>>>> Stashed changes
     if (server_flag || logger_flag) {
         ComterpAcceptor* peer_acceptor = 
 	    new ComterpAcceptor(ComterpHandler::reactor_singleton());
@@ -318,7 +321,6 @@ int main(int argc, char *argv[]) {
 
     return 0;
     }
-#endif /* defined(HAVE_ACE) */
 
     if (server_flag || remote_flag) {
       ComTerpServ* terp = new ComTerpServ(BUFSIZ*BUFSIZ);

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -134,10 +134,6 @@ int main(int argc, char *argv[]) {
     boolean expr_flag = argc>1 && !server_flag && !logger_flag &&
                         !remote_flag && !client_flag && !telcat_flag && !run_flag && !listen_flag;
 
-<<<<<<< Updated upstream
-#ifdef HAVE_ACE
-=======
->>>>>>> Stashed changes
     if (server_flag || logger_flag) {
         ComterpAcceptor* peer_acceptor = 
 	    new ComterpAcceptor(ComterpHandler::reactor_singleton());

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -134,13 +134,6 @@ int main(int argc, char *argv[]) {
     boolean expr_flag = argc>1 && !server_flag && !logger_flag &&
                         !remote_flag && !client_flag && !telcat_flag && !run_flag && !listen_flag;
 
-#ifndef HAVE_ACE
-    if (listen_flag) {
-        cerr << "comterp: listen mode requires ACE (rebuild with HAVE_ACE)\n";
-        return 1;
-    }
-#endif
-
 #ifdef HAVE_ACE
     if (server_flag || logger_flag) {
         ComterpAcceptor* peer_acceptor = 

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -27,12 +27,10 @@
  * drawserv main program.
  */
 
-#ifdef HAVE_ACE
 #include <DrawServ/drawserv-handler.h>
 #include <OverlayUnidraw/aceimport.h>
 #include <AceDispatch/ace_dispatcher.h>
 #include <ComTerp/comhandler.h>
-#endif
 
 #include <DrawServ/drawcatalog.h>
 #include <DrawServ/drawcreator.h>
@@ -203,10 +201,8 @@ static PropertyData properties[] = {
     { "*opaque_off",    "false"  },
     { "*stripped",      "false"  },
     { "*stdin_off",   "false"  },
-#ifdef HAVE_ACE
     { "*import",        "20001" },
     { "*comdraw",          "20002" },
-#endif
     { "*help",          "false"  },
     { "*runfile",       ""  },
     { "*runexpr",       ""  },
@@ -246,10 +242,8 @@ static OptionDesc options[] = {
     { "-opoff", "*opaque_off", OptionValueImplicit, "true" },
     { "-stripped", "*stripped", OptionValueImplicit, "true" },
     { "-stdin_off", "*stdin_off", OptionValueImplicit, "true" },
-#ifdef HAVE_ACE
     { "-import", "*import", OptionValueNext },
     { "-comdraw", "*comdraw", OptionValueNext },
-#endif
     { "-help", "*help", OptionValueImplicit, "true" },
     { "--help", "*help", OptionValueImplicit, "true" },
     { "-font", "*font", OptionValueNext },
@@ -317,9 +311,7 @@ int main (int argc, char** argv) {
 #endif
 #endif
   
-#ifdef HAVE_ACE
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
-#endif
     DrawCreator creator;
     DrawCatalog* catalog = new DrawCatalog("ivtools drawserv", &creator);
     DrawServ* unidraw = new DrawServ(
@@ -330,8 +322,6 @@ int main (int argc, char** argv) {
       cerr << usage << "\n";
       return 0;
     }
-
-#ifdef HAVE_ACE
 
     UnidrawImportAcceptor* import_acceptor = new UnidrawImportAcceptor();
 
@@ -363,22 +353,9 @@ int main (int argc, char** argv) {
     else
         cerr << "accepting comdraw port (" << portnum << ") connections\n";
 
-
-    // Register COMTERP_QUIT_HANDLER to receive SIGINT commands.  When received,
-    // COMTERP_QUIT_HANDLER becomes "set" and thus, the event loop below will
-    // exit.
-#if 0
-    if (ComterpHandler::reactor_singleton()->register_handler 
-	     (SIGINT, COMTERP_QUIT_HANDLER::instance ()) == -1)
-        cerr << "drawserv:  unable to register quit handler with ACE reactor\n";
-#endif
-
-#endif
-
     OverlayEditor::add_edlauncher("Comdraw", &launch_comdraw);
     OverlayEditor::add_edlauncher("Flipbook", &launch_flipbook);
     OverlayEditor::add_edlauncher("Graphdraw", &launch_graphdraw);
-
 
     int exit_status = 0;
 

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -260,7 +260,6 @@ static OptionDesc options[] = {
 
 /*****************************************************************************/
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "drawserv  distributed drawing editor with comterp scripting\n\
 Usage:  drawserv [file] [options]\n\n\
@@ -287,32 +286,6 @@ Usage:  drawserv [file] [options]\n\n\
 -runfile file               run script file after startup\n\
 -runexpr cmdstr             run command string after startup\n\n\
 any idraw parameter is also accepted (see idraw man page)";
-#else
-static const char usage[] =
-"drawserv  distributed drawing editor with comterp scripting\n\
-Usage:  drawserv [file] [options]\n\n\
--color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
--gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
--opaque_off | -opoff        disable opaque moving/reshaping\n\
--pagecols | -ncols n        number of page columns in tiled view\n\
--pagerows | -nrows n        number of page rows in tiled view\n\
--panner_off | -poff         disable panner\n\
--panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
-                            panner alignment\n\
--rampsize n                 size of color ramp\n\
--scribble_pointer | -scrpt  enable scribble pointer\n\
--slider_off | -soff         disable slider\n\
--stdin_off                  disable stdin command socket\n\
--stripped                   stripped-down tool palette\n\
--toolbarloc | -tbl r|l      toolbar location left or right\n\
--theight | -th n            tile height in pixels\n\
--tile                       enable tiled page view\n\
--twidth | -tw n             tile width in pixels\n\
--zoomer_off | -zoff         disable zoomer\n\
--runfile file               run script file after startup\n\
--runexpr cmdstr             run command string after startup\n\n\
-any idraw parameter is also accepted (see idraw man page)";
-#endif
 
 /*****************************************************************************/
 
@@ -423,7 +396,6 @@ int main (int argc, char** argv) {
 
 	unidraw->Open(ed);
 
-#ifdef HAVE_ACE
 	/*  Start up one on stdin, unless -stdin_off (mirror comdraw).  Registering
 	    a live fd-0 handler under -stdin_off means a closed/EOF stdin -- as when
 	    drawmo launches us detached -- fires DrawServHandler::handle_input, which
@@ -445,10 +417,6 @@ int main (int argc, char** argv) {
 	}
 	fprintf(stderr, "ivtools-%s drawserv: type help here for command info %s\n", VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY));
 	ed->stdio_prompt(stdin_handler);
-
-#else
-	fprintf(stderr, "ivtools-%s drawserv", VersionString);
-#endif
 
 	/* execute -runfile or -runexpr after editor is fully initialized */
 	ComTerpServ* terp = ed->GetComTerp();

--- a/src/drawtool/main.c
+++ b/src/drawtool/main.c
@@ -213,21 +213,12 @@ static OptionDesc options[] = {
 };
 
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "Usage: drawtool [any idraw parameter] [-color5] [-dithermap] [-gray5] [-gray6] \n\
 [-gray7] [-import port] [-nocolor6] [-opaque_off|-opoff] [-pagecols|-ncols n] \n\
 [-pagerows|-nrows n] [-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc] \n\
 [-panner_off|-poff] [-ptrloc] [-scribble_pointer|-scrpt ] [-slider_off|-soff]\n\
 [-svgexport] [-toolbarloc|-tbl r|l ] [-zoomer_off|-zoff] [file]";
-#else
-static char usage[] =
-"Usage: drawtool [any idraw parameter] [-color5] [-dithermap] [-gray5] [-gray6] \n\
-[-gray7] [-nocolor6] [-opaque_off|-opoff] [-pagecols|-ncols n] \n\
-[-pagerows|-nrows n] [-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc] \n\
-[-panner_off|-poff] [-ptrloc] [-scribble_pointer|-scrpt ] [-slider_off|-soff]\n\
-[-svgexport] [-toolbarloc|-tbl r|l ] [-zoomer_off|-zoff] [file]";
-#endif
 /*****************************************************************************/
 
 int main (int argc, char** argv) {

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -240,31 +240,6 @@ Usage:  flipbook [file] [options]\n\n\
 -twidth | -tw n             tile width in pixels\n\
 -zoomer_off | -zoff         disable zoomer\n\n\
 any idraw parameter is also accepted (see idraw man page)";
-#else
-static const char usage[] =
-"flipbook  frame/slideshow editor with comterp scripting\n\
-Usage:  flipbook [file] [options]\n\n\
--bookgeom                   book-style facing-page layout\n\
--color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
--gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
--opaque_off | -opoff        disable opaque moving/reshaping\n\
--pagecols | -ncols n        number of page columns in tiled view\n\
--pagerows | -nrows n        number of page rows in tiled view\n\
--panner_off | -poff         disable panner\n\
--panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
-                            panner alignment\n\
--scribble_pointer | -scrpt  enable scribble pointer\n\
--slideshow sec              auto-advance pages every sec seconds\n\
--slider_off | -soff         disable slider\n\
--stdin_off                  disable stdin command socket\n\
--stripped                   stripped-down tool palette\n\
--toolbarloc | -tbl r|l      toolbar location left or right\n\
--theight | -th n            tile height in pixels\n\
--tile                       enable tiled page view\n\
--twidth | -tw n             tile width in pixels\n\
--zoomer_off | -zoff         disable zoomer\n\n\
-any idraw parameter is also accepted (see idraw man page)";
-#endif
 /*****************************************************************************/
 
 int main (int argc, char** argv) {

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -214,7 +214,6 @@ static OptionDesc options[] = {
     { nil }
 };
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "Usage: flipbook [any idraw parameter] [-bookgeom] [-comdraw port] [-color5]\n\
 [-color6] [-import port] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
@@ -223,16 +222,6 @@ static const char usage[] =
 [-scribble_pointer|-scrpt ] [-slideshow sec] [-slider_off|-soff]\n\
 [-stdin_off] [-stripped] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
 [-twidth|-tw n] [-zoomer_off|-zoff] [file]";
-#else
-static char usage[] =
-"Usage: flipbook [any idraw parameter] [-bookgeom]\n\
-[-color5] [-color6] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
-[-pagecols|-ncols n] [-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
-[-scribble_pointer|-scrpt ] [-slideshow sec] [-slider_off|-soff]\n\
- [-stdin_off] [-toolbarloc|-tbl r|l ] [-theight|-th n] [-tile]\n\
-[-twidth|-tw n] [-zoomer_off|-zoff] [file]";
-#endif
 /*****************************************************************************/
 
 int main (int argc, char** argv) {

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -26,11 +26,9 @@
  * Frame editor main program.
  */
 
-#ifdef HAVE_ACE
 #include <ComUnidraw/comterp-acehandler.h>
 #include <OverlayUnidraw/aceimport.h>
 #include <AceDispatch/ace_dispatcher.h>
-#endif
 
 #include <FrameUnidraw/framecatalog.h>
 #include <FrameUnidraw/framecreator.h>
@@ -164,10 +162,8 @@ static PropertyData properties[] = {
     { "*slideshow",     "0"  },
     { "*stripped",      "false"  },
     { "*stdin_off",   "false"  },
-#ifdef HAVE_ACE
     { "*comdraw",       "20002" },
     { "*import",        "20003" },
-#endif
     { "*help",          "false"  },
     { "*font",          "-adobe-helvetica-medium-r-normal--14-140-75-75-p-77-iso8859-1"  },
     { nil }
@@ -206,10 +202,8 @@ static OptionDesc options[] = {
     { "-slideshow", "*slideshow", OptionValueNext },
     { "-stripped", "*stripped", OptionValueImplicit, "true" },
     { "-stdin_off", "*stdin_off", OptionValueImplicit, "true" },
-#ifdef HAVE_ACE
     { "-import", "*import", OptionValueNext },
     { "-comdraw", "*comdraw", OptionValueNext },
-#endif
     { "-help", "*help", OptionValueImplicit, "true" },
     { "-font", "*font", OptionValueNext },
     { nil }
@@ -246,9 +240,7 @@ int main (int argc, char** argv) {
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
        restore tty echo first if tty_echo_off() ever ran, issue #76. */
     tty_echo_install_signal_handlers();
-#ifdef HAVE_ACE
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
-#endif
     int exit_status = 0;
     FrameCreator creator;
     OverlayCatalog* catalog = new FrameCatalog("flipbook", &creator);
@@ -259,8 +251,6 @@ int main (int argc, char** argv) {
       cerr << usage << "\n";
       return 0;
     }
-
-#ifdef HAVE_ACE
 
     UnidrawImportAcceptor* import_acceptor = new UnidrawImportAcceptor();
 
@@ -292,17 +282,6 @@ int main (int argc, char** argv) {
     else
         cerr << "accepting comdraw port (" << portnum << ") connections\n";
 
-
-    // Register IMPORT_QUIT_HANDLER to receive SIGINT commands.  When received,
-    // IMPORT_QUIT_HANDLER becomes "set" and thus, the event loop below will
-    // exit.
-#if 0
-    if (ComterpHandler::reactor_singleton()->register_handler 
-	     (SIGINT, IMPORT_QUIT_HANDLER::instance ()) == -1)
-        cerr << "flipbook:  unable to register quit handler with ACE reactor\n";
-#endif
-
-#endif
     if (argc > 2) {
 	cerr << usage << "\n";
 	exit_status = 1;
@@ -313,7 +292,6 @@ int main (int argc, char** argv) {
 
 	unidraw->Open(ed);
 
-#ifdef HAVE_ACE
 	/*  Start up one on stdin, unless -stdin_off (mirror comdraw). */
 	const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
 	UnidrawComterpHandler* stdin_handler = nil;
@@ -328,13 +306,10 @@ int main (int argc, char** argv) {
 	                        // with no self-echo ever registered to replace it
 	    ed->stdio_setup(stdin_handler);
 	}
-#endif
 
 	fprintf(stderr, "ivtools-%s flipbook: see \"man flipbook\" or type help here for command info\n", VersionString);
 
-#ifdef HAVE_ACE
 	ed->stdio_prompt(stdin_handler);
-#endif
 
 	/* Seed update: the mandatory first update() that wins the X11
 	   map/realize race (see comdraw/main.c).  It pumps the event loop so the

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -26,11 +26,9 @@
  * Graph editor main program.
  */
 
-#ifdef HAVE_ACE
 #include <ComUnidraw/comterp-acehandler.h>
 #include <OverlayUnidraw/aceimport.h>
 #include <AceDispatch/ace_dispatcher.h>
-#endif
 
 #include <GraphUnidraw/graphcatalog.h>
 #include <GraphUnidraw/graphcreator.h>
@@ -159,10 +157,8 @@ static PropertyData properties[] = {
     { "*zoomer_off",    "false"  },
     { "*opaque_off",    "false"  },
     { "*stdin_off",   "false"  },
-#ifdef HAVE_ACE
     { "*comdraw",       "20002" },
     { "*import",        "20003" },
-#endif
     { "*help",          "false"  },
     { "*font",          "-adobe-helvetica-medium-r-normal--14-140-75-75-p-77-iso8859-1"  },
     { nil }
@@ -191,10 +187,8 @@ static OptionDesc options[] = {
     { "-opaque_off", "*opaque_off", OptionValueImplicit, "true" },
     { "-opoff", "*opaque_off", OptionValueImplicit, "true" },
     { "-stdin_off", "*stdin_off", OptionValueImplicit, "true" },
-#ifdef HAVE_ACE
     { "-import", "*import", OptionValueNext },
     { "-comdraw", "*comdraw", OptionValueNext },
-#endif
     { "-help", "*help", OptionValueImplicit, "true" },
     { "-font", "*font", OptionValueNext },
     { nil }
@@ -226,9 +220,7 @@ int main (int argc, char** argv) {
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
        restore tty echo first if tty_echo_off() ever ran, issue #76. */
     tty_echo_install_signal_handlers();
-#ifdef HAVE_ACE
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
-#endif
     int exit_status = 0;
     GraphCreator creator;
     GraphCatalog* catalog = new GraphCatalog("graphdraw", &creator);
@@ -240,8 +232,6 @@ int main (int argc, char** argv) {
       cerr << usage << "\n";
       return argc > 2 ? 1 : 0;
     }
-
-#ifdef HAVE_ACE
 
     UnidrawImportAcceptor* import_acceptor = new UnidrawImportAcceptor();
 
@@ -274,22 +264,11 @@ int main (int argc, char** argv) {
         cerr << "accepting comdraw port (" << portnum << ") connections\n";
 
 
-    // Register IMPORT_QUIT_HANDLER to receive SIGINT commands.  When received,
-    // IMPORT_QUIT_HANDLER becomes "set" and thus, the event loop below will
-    // exit.
-#if 0
-    if (ComterpHandler::reactor_singleton()->register_handler 
-	     (SIGINT, IMPORT_QUIT_HANDLER::instance ()) == -1)
-        cerr << "graphdraw:  unable to register quit handler with ACE reactor\n";
-#endif
-#endif
-
     const char* initial_file = (argc == 2) ? argv[1] : nil;
     GraphEditor* ed = new GraphEditor(initial_file);
     
     unidraw->Open(ed);
     
-#ifdef HAVE_ACE
     /*  Start up one on stdin, unless -stdin_off (mirror comdraw). */
     const char* stdin_off_str = unidraw->GetCatalog()->GetAttribute("stdin_off");
     UnidrawComterpHandler* stdin_handler = nil;
@@ -304,14 +283,11 @@ int main (int argc, char** argv) {
 	                    // with no self-echo ever registered to replace it
 	ed->stdio_setup(stdin_handler);
     }
-#endif
 
     cerr << "ivtools-" << VersionString
 	 << " graphdraw: see \"man graphdraw\" or type help here for command info\n";
 
-#ifdef HAVE_ACE
     ed->stdio_prompt(stdin_handler);
-#endif
 
     /* Seed update: the mandatory first update() that wins the X11
        map/realize race (see comdraw/main.c).  It pumps the event loop so the

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -200,7 +200,6 @@ static OptionDesc options[] = {
 };
 
 
-#ifdef HAVE_ACE
 static const char usage[] =
 "Usage: graphdraw [any idraw parameter] [-color5] [-color6] [-comdraw port]\n\
 [-import port] [-gray5] [-gray6] [-gray7] [-opaque_off|-opoff]\n\
@@ -208,15 +207,6 @@ static const char usage[] =
 [-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ]\n\
 [-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
 [-zoomer_off|-zoff] [file]";
-#else
-static char usage[] =
-"Usage: graphdraw [any idraw parameter] [-color5] [-color6]\n\
-[-gray5] [-gray6] [-gray7] [-opaque_off|-opoff] [-pagecols|-ncols n]\n\
-[-pagerows|-nrows n] [-panner_off|-poff]\n\
-[-panner_align|-pal tl|tc|tr|cl|c|cr|cl|bl|br|l|r|t|b|hc|vc ] \n\
-[-scribble_pointer|-scrpt ] [-slider_off|-soff] [-stdin_off]\n\
-[-zoomer_off|-zoff] [file]";
-#endif
 
 /*****************************************************************************/
 

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -219,24 +219,6 @@ Usage:  graphdraw [file] [options]\n\n\
 -stdin_off                  disable stdin command socket\n\
 -zoomer_off | -zoff         disable zoomer\n\n\
 any idraw parameter is also accepted (see idraw man page)";
-#else
-static const char usage[] =
-"graphdraw  graph editor with comterp scripting\n\
-Usage:  graphdraw [file] [options]\n\n\
--color5 | -color6           use 5x5x5 or 6x6x6 color cube\n\
--gray5 | -gray6 | -gray7    use 5, 6, or 7 level grayscale ramp\n\
--opaque_off | -opoff        disable opaque moving/reshaping\n\
--pagecols | -ncols n        number of page columns in tiled view\n\
--pagerows | -nrows n        number of page rows in tiled view\n\
--panner_off | -poff         disable panner\n\
--panner_align | -pal tl|tc|tr|cl|c|cr|bl|bc|br|l|r|t|b|hc|vc\n\
-                            panner alignment\n\
--scribble_pointer | -scrpt  enable scribble pointer\n\
--slider_off | -soff         disable slider\n\
--stdin_off                  disable stdin command socket\n\
--zoomer_off | -zoff         disable zoomer\n\n\
-any idraw parameter is also accepted (see idraw man page)";
-#endif
 
 /*****************************************************************************/
 


### PR DESCRIPTION
Supersedes #236, closed in favor of this branch (`remove-dead-have-ace-code` instead of the auto-generated `claude/*` name) after Greptile's review of #236 found two files left inconsistently cleaned. Rebased onto current `master` (which picked up #235's tty-echo work in the meantime, touching some of the same `main.c` files) rather than the stale base #236 was opened against.

## Summary
- Since the ACE-lite work (#147), `HAVE_ACE` is unconditionally defined at compile time (`config/params.def`'s `AceCCDefines`, `config/config.defs.in`'s `AceEnabled`) — networking is always available now, either via the in-tree ACE-lite subset or external libACE.
- Removes every dead `!defined(HAVE_ACE)` branch across the tree and unwraps the surviving guard so the ACE code path is unconditional: the non-ACE `ComterpHandler` class, `RemoteFunc`/`SocketFunc` stubs, `DrawLinkFunc`/`SessionIdFunc` stubs, `DrawKit`'s non-ACE `MakeSelection`/`MakeViewersMenu`, `DrawLinkList::find_drawlink`'s `NULL` fallback, `DrawLink::open`'s stale-GCC-guard fallback, and the duplicate non-ACE `usage[]` strings/banners in `comdraw`, `comterp_`, `drawserv_`, `drawtool`, `flipbook`, and `graphdraw`'s `main.c`.
- **Follow-up commit** addresses Greptile's #236 findings: `DrawLink::handle()`/`close()`/constructor/destructor (`drawlink.c`) and the `GraphicIdFunc` block (`drawfunc.c`) were bare `#ifdef HAVE_ACE` wrappers with no dead branch, but left inconsistently un-cleaned in files this PR otherwise rewrote — now unwrapped the same way as everything else.
- Left `drawlink.h`'s own `HAVE_ACE`-guarded member declarations alone — that header isn't otherwise touched by this PR; extending into untouched files is a separate cleanup from finishing what this PR's own diff left half-done.

## Test plan
- [x] Full top-level `make Makefiles && make` from `src/` — clean exit, zero errors/warnings
- [x] `src/comterp_/tests/run_all.comt` — 23 sub-tests, 0 fails
- [x] `src/drawserv_/tests/drawmo` full suite — 10 tests (`updown`, `updown1`, `updown2`, `updown3A/B`, `updown4A/B/C`, `gsexim`, `gsbrushA/B`) all pass, exercising `RemoteFunc`/`SocketFunc`, `DrawLinkFunc`/`SessionIdFunc`, `DrawLink::open`/`close`/`handle`, and `GraphicIdFunc`'s grid-selection arbitration directly
- [ ] CI (g++/Ubuntu build + headless suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)