### PR TITLE
Add patchkey() command: resolve PATCH_KEY's git tag to its commit id

### DIFF
--- a/.github/workflows/patch-key.yml
+++ b/.github/workflows/patch-key.yml
@@ -51,15 +51,11 @@ jobs:
           base=$(git rev-parse HEAD^1)
           head=$(git rev-parse HEAD^2)
 
-          # Only enforce the bump on PRs that actually touch one of the five
-          # editor binaries patch.h serves -- a docs fix, a build-system
-          # tweak, or a test addition elsewhere in the tree has no PATCH_KEY
-          # to identify and shouldn't be blocked by an unrelated gate.
-          binary_dirs='^src/(comdraw|comterp_|drawserv_|flipbook|graphdraw)/'
-          if ! git diff --name-only "$base" "$head" | grep -qE "$binary_dirs"; then
-            echo "This PR doesn't touch comdraw/comterp_/drawserv_/flipbook/graphdraw -- PATCH_KEY bump not required"
-            exit 0
-          fi
+          # Always require the bump, regardless of which files a PR touches.
+          # PATCH_KEY identifies a patch, and any underlying source change is
+          # a patch -- there's no reliable way to enumerate "this can't have
+          # affected the five editor binaries" from a file-path allowlist, so
+          # this doesn't try; every PR bumps it.
 
           # Compare the KEY VALUE itself, not just whether the file appears in
           # the diff -- a commit that only touches patch.h's comment block (or

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1637,6 +1637,7 @@ void ComTerp::add_defaults() {
 
     add_command("eval", new EvalFunc(this));
     add_command("shell", new ShellFunc(this));
+    add_command("patchkey", new PatchKeyFunc(this));
     add_command("quit", new QuitFunc(this));
     add_command("exit", new ExitFunc(this));
     add_command("mute", new MuteFunc(this));

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -446,7 +446,20 @@ void PatchKeyFunc::execute() {
 	   from git, so resolving it to a commit means asking git to look up
 	   the matching tag pushed at merge time (patch-key.yml).
 
-	   shell_string() (ComUtil/util.c) called directly, not through
+	   A caller-supplied key is reachable over ComTerp's socket interface
+	   (server/listen modes), so it must be rejected -- not merely quoted
+	   -- before it reaches the shell below: reject anything outside the
+	   character set an actual PATCH_KEY tag can contain, closing the
+	   shell-injection path a value like `"; rm -rf ~ ;"` would otherwise
+	   open via snprintf/popen. */
+	static const char* key_charset =
+	    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
+	if (key[0] == '\0' || strspn(key, key_charset) != strlen(key)) {
+	    push_stack(ComValue::nullval());
+	    return;
+	}
+
+	/* shell_string() (ComUtil/util.c) called directly, not through
 	   ShellFunc's stack/exec machinery -- same guard-the-empty-result
 	   discipline local_hostname() uses for a failed/empty scutil call:
 	   a nonexistent tag leaves stdout empty, so an empty result means

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -34,6 +34,8 @@
 #include <ComTerp/postfunc.h>
 #include <ComTerp/socket.h>
 #include <Attribute/attrlist.h>
+#include <ComUtil/util.h>
+#include <patch.h>
 
 #include <wordexp.h>
 
@@ -416,6 +418,45 @@ void ShellFunc::execute() {
     push_stack(retval);
 
     return;
+}
+
+/*****************************************************************************/
+
+PatchKeyFunc::PatchKeyFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void PatchKeyFunc::execute() {
+    static int commitid_sym = symbol_add("commitid");
+    ComValue commitidv(stack_key(commitid_sym));
+    reset_stack();
+
+    if (commitidv.is_true()) {
+	/* PATCH_KEY is a plain committed literal (patch.h), not derived from
+	   git, so resolving it to a commit means asking git to look up the
+	   matching tag pushed at merge time (.github/workflows/patch-key.yml).
+	   `rev-list -n 1` dereferences either tag kind to the commit it names.
+
+	   shell_string() (ComUtil/util.c) called directly, not through
+	   ShellFunc's stack/exec machinery -- same guard-the-empty-result
+	   discipline local_hostname() uses for a failed/empty scutil call:
+	   a nonexistent tag leaves stdout empty, so an empty result means
+	   "unresolved" (not-yet-tagged, or a stale/mistyped key), not an
+	   error to surface as a nonsense value.  Stderr routed to /dev/null
+	   so a failed lookup doesn't leak git's own diagnostic text. */
+	char cmdbuf[BUFSIZ];
+	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 %s 2>/dev/null", PATCH_KEY);
+	const char* commitid = shell_string(cmdbuf);
+	if (commitid && commitid[0] != '\0') {
+	    ComValue keyv(commitid);
+	    push_stack(keyv);
+	} else {
+	    push_stack(ComValue::nullval());
+	}
+	return;
+    }
+
+    ComValue keyv(PATCH_KEY);
+    push_stack(keyv);
 }
 
 /*****************************************************************************/

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -467,7 +467,7 @@ void PatchKeyFunc::execute() {
 	   error to surface as a nonsense value.  Stderr routed to /dev/null
 	   so a failed lookup doesn't leak git's own diagnostic text. */
 	char cmdbuf[BUFSIZ];
-	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 %s 2>/dev/null", key);
+	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 ref/tags/%s 2>/dev/null", key);
 	const char* commitid = shell_string(cmdbuf);
 	if (commitid && commitid[0] != '\0') {
 	    ComValue keyv(commitid);

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -430,11 +430,21 @@ void PatchKeyFunc::execute() {
     ComValue commitidv(stack_key(commitid_sym));
     reset_stack();
 
-    if (commitidv.is_true()) {
-	/* PATCH_KEY is a plain committed literal (patch.h), not derived from
-	   git, so resolving it to a commit means asking git to look up the
-	   matching tag pushed at merge time (.github/workflows/patch-key.yml).
-	   `rev-list -n 1` dereferences either tag kind to the commit it names.
+    /* :commitid resolves a key's git tag to its commit id (rev-list -n 1
+       dereferences either tag kind); a key value after :commitid picks which
+       one, a bare :commitid resolves this build's own PATCH_KEY.  Branch on
+       type rather than is_true(), since a StringType's truthiness isn't a
+       reliable stand-in for "was a key actually supplied". */
+    const char* key = nil;
+    if (commitidv.type() == ComValue::StringType || commitidv.type() == ComValue::SymbolType)
+	key = commitidv.string_ptr();
+    else if (commitidv.is_true())
+	key = PATCH_KEY;
+
+    if (key) {
+	/* PATCH_KEY (and any key passed in) is a plain literal, not derived
+	   from git, so resolving it to a commit means asking git to look up
+	   the matching tag pushed at merge time (patch-key.yml).
 
 	   shell_string() (ComUtil/util.c) called directly, not through
 	   ShellFunc's stack/exec machinery -- same guard-the-empty-result
@@ -444,7 +454,7 @@ void PatchKeyFunc::execute() {
 	   error to surface as a nonsense value.  Stderr routed to /dev/null
 	   so a failed lookup doesn't leak git's own diagnostic text. */
 	char cmdbuf[BUFSIZ];
-	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 %s 2>/dev/null", PATCH_KEY);
+	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 %s 2>/dev/null", key);
 	const char* commitid = shell_string(cmdbuf);
 	if (commitid && commitid[0] != '\0') {
 	    ComValue keyv(commitid);

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -467,7 +467,7 @@ void PatchKeyFunc::execute() {
 	   error to surface as a nonsense value.  Stderr routed to /dev/null
 	   so a failed lookup doesn't leak git's own diagnostic text. */
 	char cmdbuf[BUFSIZ];
-	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 ref/tags/%s 2>/dev/null", key);
+	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 refs/tags/%s 2>/dev/null", key);
 	const char* commitid = shell_string(cmdbuf);
 	if (commitid && commitid[0] != '\0') {
 	    ComValue keyv(commitid);

--- a/src/ComTerp/ctrlfunc.h
+++ b/src/ComTerp/ctrlfunc.h
@@ -163,17 +163,17 @@ public:
 };
 
 //: patch key command for ComTerp.
-// key=patchkey(:commitid) -- return PATCH_KEY, or the commit id its git tag names.
+// key=patchkey(:commitid [key]) -- return PATCH_KEY, or the commit id a key's git tag names.
 class PatchKeyFunc : public ComFunc {
 public:
     PatchKeyFunc(ComTerp*);
 
     virtual void execute();
     virtual const char* docstring() {
-      return "key=%s(:commitid) -- return PATCH_KEY (src/include/ivstd/patch.h), or the commit id its matching git tag names"; }
+      return "key=%s(:commitid [key]) -- return PATCH_KEY (src/include/ivstd/patch.h), or the commit id a key's matching git tag names"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
-	":commitid  resolve PATCH_KEY's git tag to the commit id it points to",
+	":commitid [key]  resolve a key's git tag to its commit id (this build's PATCH_KEY if key omitted)",
 	nil
       };
       return keys;

--- a/src/ComTerp/ctrlfunc.h
+++ b/src/ComTerp/ctrlfunc.h
@@ -162,6 +162,25 @@ public:
 
 };
 
+//: patch key command for ComTerp.
+// key=patchkey(:commitid) -- return PATCH_KEY, or the commit id its git tag names.
+class PatchKeyFunc : public ComFunc {
+public:
+    PatchKeyFunc(ComTerp*);
+
+    virtual void execute();
+    virtual const char* docstring() {
+      return "key=%s(:commitid) -- return PATCH_KEY (src/include/ivstd/patch.h), or the commit id its matching git tag names"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+	":commitid  resolve PATCH_KEY's git tag to the commit id it points to",
+	nil
+      };
+      return keys;
+    }
+
+};
+
 //: usleep sleep microseconds
 // usleep(usec) -- sleep microseconds
 class USleepFunc : public ComFunc {

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "92fca51f"
+#define PATCH_KEY "6b701c26"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b434c732"
+#define PATCH_KEY "92fca51f"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- Back out the PATCH_KEY-bump CI gate's scoping restriction so it's required on every PR again, not just ones touching the five editor binaries -- PATCH_KEY identifies a patch, and there's no reliable file-path allowlist for "this can't have affected the five editor binaries."
- Add `patchkey(:commitid [key])`, resolving a PATCH_KEY value's git tag to the commit it names via `git rev-list -n 1` (through `shell_string()`, same discipline as `local_hostname()`'s guard-the-empty-result pattern) -- bare `patchkey()` still just returns this build's own PATCH_KEY.
- Bump PATCH_KEY.

## Test plan
- [x] `libComTerp`/`comterp_` rebuild clean
- [x] `patchkey()` returns the current build's PATCH_KEY
- [x] `patchkey(:commitid)` returns nil for a not-yet-tagged key
- [x] `patchkey(:commitid "b434c732")` resolves an already-tagged key to its commit id
- [x] `patchkey(:commitid "nonexistent")` returns nil rather than a garbage value or leaked git error
- [x] `help(patchkey)` shows the docstring