### PR TITLE
Rename symbol_del to symbol_unref

### DIFF
--- a/src/Attribute/attribute.c
+++ b/src/Attribute/attribute.c
@@ -50,7 +50,7 @@ Attribute::Attribute(const Attribute& attr) {
 
 Attribute::~Attribute() {
     if (0 && symbolid != -1)  // need to rewrite symbol table
-	symbol_del(symbolid);
+	symbol_unref(symbolid);
     delete valueptr;
 }
 

--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -1275,8 +1275,8 @@ void AttributeValue::unref_as_needed() {
   }
   else if (_type == AttributeValue::StreamType)
       Resource::unref(_v.streamval.listptr);
-  else if (_type == AttributeValue::StringType)  // only StringType, never for SymbolType
-       symbol_del(string_val());
+  else if (_type == AttributeValue::StringType)  // only StringType, never for SymbolType --
+       symbol_unref(string_val());              // SymAddFunc's closing loop relies on this
 #ifdef RESOURCE_COMPVIEW
   else if (_type == AttributeValue::ObjectType) {
     if (object_compview()) 

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -38,7 +38,7 @@
 
 // extern "C" {
     int symbol_add(const char*);
-    int symbol_del(int);
+    int symbol_unref(int);
     int symbol_reference(int);
     int symbol_find(const char*);
     const char* symbol_pntr(int);

--- a/src/ComTerp/ARCHITECTURE.md
+++ b/src/ComTerp/ARCHITECTURE.md
@@ -265,7 +265,7 @@ void ListFunc::execute() {
 Every keyword a command accepts is registered this way. The symid is then
 passed to `stack_key()` or `stack_key_post_eval()` to retrieve the keyword's
 value from the stack. Symids registered via the static pattern live for the
-process lifetime — `symbol_del()` is reference-counted but ComFunc code
+process lifetime — `symbol_unref()` is reference-counted but ComFunc code
 almost never calls it.
 
 ## Delimiter Semantics

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -137,10 +137,13 @@ void SymAddFunc::execute() {
     push_stack(retval);
   }
 
+  // releases the temporary ref taken above; the returned SymbolType value's
+  // own ref (from ref_as_needed()) is permanent -- SymbolType is never
+  // auto-unref'd (see unref_as_needed()), so this bracket assumes that stays true
   for (int i=0; i<numargs; i++)
-    if(symbol_ids[i]!=-1) 
-      symbol_del(symbol_ids[i]);
-    
+    if(symbol_ids[i]!=-1)
+      symbol_unref(symbol_ids[i]);
+
 }
 
 /*****************************************************************************/

--- a/src/ComUtil/comutil.arg
+++ b/src/ComUtil/comutil.arg
@@ -10,7 +10,7 @@ int mblock_sizes(int id,unsigned *nel,unsigned *size,unsigned long *nbytes);
 /* SYMBOLS.C */
 int symbol_add(const char *string);
 int symbol_find(const char *string);
-int symbol_del (int id);
+int symbol_unref (int id);
 int symbol_reference (int id);
 int symbol_len (int id);
 const char *symbol_pntr(int id);

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -242,8 +242,8 @@ int index;
 /* Free table if one existed previously */
    if( OperatorTable != NULL ) {
       for (index=0; index<NumOperators; index++ ) 
-         if( symbol_del( OperatorTable[index].operid ) ||
-	     symbol_del( OperatorTable[index].commid ))
+         if( symbol_unref( OperatorTable[index].operid ) ||
+	     symbol_unref( OperatorTable[index].commid ))
             KAPUT( "Unable to delete symbol from table" );
       if( dmm_free( (void **)&OperatorTable ))
          KAPUT( "Error in freeing previously existing operator table" );
@@ -369,8 +369,8 @@ int commid;			/* Id of command in symbol table */
       if( table_off < NumOperators &&
 	  strcmp( OPSTR( table_off ), opstr ) == 0 &&
 	  OperatorTable[ table_off ].optype == optype ) {
-	 if( symbol_del( OperatorTable[ table_off ].operid ) ||
-	     symbol_del( OperatorTable[ table_off ].commid ))
+	 if( symbol_unref( OperatorTable[ table_off ].operid ) ||
+	     symbol_unref( OperatorTable[ table_off ].commid ))
 	    KAPUT( "Error in deleting symbols" );
 	 in_place = TRUE;
 	 }
@@ -550,8 +550,8 @@ unsigned table_off = 0;         /* Offset into operator table */
    while( table_off < NumOperators &&
 	  strcmp( OPSTR( table_off ), opstr ) == 0 ) {
       if( OperatorTable[ table_off ].optype == optype ) {
-	 if( symbol_del( OperatorTable[ table_off ].operid ) ||
-	     symbol_del( OperatorTable[ table_off ].commid ))
+	 if( symbol_unref( OperatorTable[ table_off ].operid ) ||
+	     symbol_unref( OperatorTable[ table_off ].commid ))
 	    KAPUT( "Error in deleting symbols" );
 	 /* Slide the remaining entries down by one to close the gap */
 	 if( table_off < NumOperators - 1 )

--- a/src/ComUtil/symbols.c
+++ b/src/ComUtil/symbols.c
@@ -255,10 +255,13 @@ int		id       ;/*   I   Identifier returned by symbol_add() */
 /*!
 Description:
 
-Deletes a symbol previously added with a `symbol_add()` function call.  You
-can delete a symbol by its string also by first using a `symbol_find()` call
-that returns the id.  The symbol will not be deleted until the `instances`
-element of the `symid` structure goes to zero.
+De-references a symbol previously added with a `symbol_add()` function
+call, deleting the symbol if the reference count get to zero.  You can
+delete a symbol by its string also by first using a `symbol_find()`
+call that returns the id.
+
+The symbol will not be deleted until the `instances` element of the
+`symid` structure goes to zero.
 
 See Also:  symbol_add(), symbol_find()
 

--- a/src/ComUtil/symbols.c
+++ b/src/ComUtil/symbols.c
@@ -52,7 +52,7 @@ struct _symid   {
 		  unsigned instances;   /* instances of this symbol */
 		};
 /* instances is incremented every symbol_add() and decremented every */
-/* symbol_del().  When it is zero after a symbol_del() the symbol is removed */
+/* symbol_unref().  When it is zero after a symbol_unref() the symbol is removed */
 
 /*=============*/
 
@@ -123,7 +123,7 @@ Description:
 Adds a symbol to the symbol table.  The symbol must be a NULL terminated
 string in the `string` parameter.  
 
-See Also:  symbol_del(), symbol_find()
+See Also:  symbol_unref(), symbol_find()
 
 Example:
 
@@ -144,17 +144,17 @@ main()
 	/* return a pointer to symbol4 and print it */
 	printf("Returned string for symbol4 is %s\n",symbol_pntr(id4));
 	/* now delete the second symbol */
-	symbol_del(id2);
+	symbol_unref(id2);
 	/* add symbol 4 again using symbol_id() */
 	symbol_id("symbol4");
 	/* delete symbol 4; it should not delete it since there are */
 	/* two instances */
-  	symbol_del(id4);
+  	symbol_unref(id4);
 	/* make sure you can find symbol 4 */
 	if (symbol_find("symbol4") < 0)
 	   printf("ERROR: Can't find symbol4\n");
         /* now delete symbol 4 id5 */
-	symbol_del(id5);
+	symbol_unref(id5);
 	/* now symbol 4 should be gone */
 	if (symbol_find("symbol4") < 0)
 	   printf("ERROR: Symbol 4 should have been deleted but was found\n");
@@ -232,14 +232,14 @@ error_return:		/* return an error code */
 
 /*!
 
-symbol_del	Delete a symbol in the symbol table.
+symbol_unref	Decrement a symbol's reference count in the symbol table.
 
 Summary:
 
 #include <ComUtil/comutil.h>
 */
 
-int symbol_del (int id)
+int symbol_unref (int id)
 
 /*!
 Return Value:  0 if OK, -1 if error.
@@ -310,7 +310,7 @@ Description:
 Increments a reference counter for a symbol previously added with a `symbol_add()` 
 function call.
 
-See Also:  symbol_add(), symbol_del()
+See Also:  symbol_add(), symbol_unref()
 
 !*/
 {
@@ -408,7 +408,7 @@ Description:
 Finds a symbol already in the symbol table that matches `string`.  Will return
 the id of the symbol if found and -1 if not found.
 
-See Also:  symbol_add(), symbol_del()
+See Also:  symbol_add(), symbol_unref()
 
 !*/
 {

--- a/src/ComUtil/symbols.c
+++ b/src/ComUtil/symbols.c
@@ -257,7 +257,7 @@ Description:
 
 De-references a symbol previously added with a `symbol_add()` function
 call, deleting the symbol if the reference count get to zero.  You can
-delete a symbol by its string also by first using a `symbol_find()`
+unref a symbol by its string also by first using a `symbol_find()`
 call that returns the id.
 
 The symbol will not be deleted until the `instances` element of the


### PR DESCRIPTION
## Summary
- `symbol_del()` has always been a reference-count decrement, not an unconditional delete -- the symbol is only actually removed once its `instances` field reaches zero (mirrors `symbol_add()`/`symbol_reference()` incrementing it). Renamed to `symbol_unref`, matching the `Resource::ref()`/`Unref()` convention already used elsewhere for the same pattern.
- Pure rename: the function definition (`ComUtil/symbols.c`), its declarations (`Attribute/attrvalue.h`, `ComUtil/comutil.arg` -- the latter is `#include`d by `comutil.h`, not just a doc listing), every call site (`attrvalue.c`, `attribute.c`, `ComTerp/symbolfunc.c`, `ComUtil/optable.c`), and doc mentions (`symbols.c`'s own doc comments/examples, `ComTerp/ARCHITECTURE.md`). No behavior change.
- Added two terse, cross-referencing comments documenting a real coupling noticed while tracing this: `AttributeValue::unref_as_needed()` deliberately never unrefs `SymbolType` (only `StringType`), and `SymAddFunc`'s closing `symbol_unref()` loop depends on that staying true -- its manual ref-then-unref bracket assumes nothing else will ever auto-unref the `SymbolType` value it returns. If that asymmetry is ever changed, `SymAddFunc`'s bracket needs re-examining at the same time.

## Test plan
- [x] Full rebuild: `ComUtil` -> `Attribute` -> `ComTerp` -> `comterp_`, clean
- [x] `run("./run_all.comt")` -- full suite green
- [x] Direct sanity check: `symvar(symadd("dynvar"))=99; dynvar` returns `99`