### PR TITLE
Rename CLAUDE.md to AGENTS.md; add no-issue-refs-in-comments convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 Guidance for AI assistants (and humans) working in the **ivtools** repository.
 This file orients you fast; the authoritative deep-dives live in the per-layer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,10 @@ C++ work. The essentials:
   `Fix <bug>; add <file/feature>; add <doc section> to <file>`. The *PR
   description* carries the full narrative; the commit line is the scannable
   `git log` summary.
+- **Code comments never reference GitHub issue/PR numbers** (`#223`, etc.).
+  That context belongs in the commit message and PR description — external,
+  mutable state has no business embedded in the source tree. Explain the
+  *why* directly in the comment instead of pointing at a ticket.
 - When bumping interpreter internals, the `PATCH_KEY` constant in the relevant
   `main.c` (e.g. `src/comterp_/main.c`) is bumped so the startup banner shows
   the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ what makes it approachable. This is the short version of how to land a change.
 
 ## Orient first
 
-Read **`CLAUDE.md`**. It is the fast orientation to the repository for humans and
+Read **`AGENTS.md`**. It is the fast orientation to the repository for humans and
 AI assistants alike: the layer hierarchy, where things live, how to build, how to
 test, and the coding and commit conventions. If you work with an AI assistant,
-point it at `CLAUDE.md` first — the per-layer `ARCHITECTURE.md` / `HACKING.md`
+point it at `AGENTS.md` first — the per-layer `ARCHITECTURE.md` / `HACKING.md`
 docs go deeper, and the tests are the spec.
 
 ## Build
@@ -45,7 +45,7 @@ are mandatory rules for LLM-authored test scripts.
 ## Open a pull request
 
 - Work on a **feature branch**, never directly on `master`.
-- Follow the commit convention in `CLAUDE.md`: a scannable one-line summary
+- Follow the commit convention in `AGENTS.md`: a scannable one-line summary
   calling out each significant change; the PR body carries the narrative.
 - Open the PR against `master`. **CI must be green to land** — the Linux build
   and the `comterp` suite gate every pull request. (The `comdraw` and `drawserv`

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "6b701c26"
+#define PATCH_KEY "feefafef"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
Renames `CLAUDE.md` to `AGENTS.md` and adds a convention to the Patches & commits section: code comments should never reference GitHub issue/PR numbers. That context belongs in the commit message and PR description -- external, mutable GitHub state doesn't belong embedded in the source tree. Comments should explain the *why* directly.

Prompted directly by #252 (symbol_del -> symbol_unref rename), where the coupling comments between `unref_as_needed()` and `SymAddFunc` were kept deliberately issue-free per explicit instruction -- this makes that the standing rule going forward rather than a one-off.

## Test plan
N/A -- documentation-only change.