### PR TITLE
remove question mark for comterp help since it gets blocked by the shell

### DIFF
--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -125,8 +125,7 @@ int main(int argc, char *argv[]) {
     boolean telcat_flag = argc>1 && strcmp(argv[1], "telcat") == 0;
     boolean run_flag = argc>1 && strcmp(argv[1], "run") == 0;
     boolean listen_flag = argc>1 && strcmp(argv[1], "listen") == 0;
-    boolean help_flag = argc>1 && (strcmp(argv[1], "-help") == 0 || strcmp(argv[1], "--help") == 0 ||
-                        strcmp(argv[1], "-?") == 0 || strcmp(argv[1], "--?") == 0);
+    boolean help_flag = argc>1 && (strcmp(argv[1], "-help") == 0 || strcmp(argv[1], "--help") == 0);
     boolean expr_flag = argc>1 && !server_flag && !logger_flag &&
                         !remote_flag && !client_flag && !telcat_flag && !run_flag && !listen_flag && !help_flag;
 
@@ -143,7 +142,7 @@ int main(int argc, char *argv[]) {
 "  comterp remote                     large-buffer interactive/piped mode, for embedding via IPC\n"
 "  comterp client host [port [file]]  connect to a comterp/comterp_listen server and relay stdin/replies\n"
 "  comterp telcat host [port [file]]  like client, but with raw pass-through (no reply echoing)\n"
-"  comterp -help | --help | -? | --?\n"
+"  comterp -help | --help\n"
 "                                      print this message and exit\n",
                 VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY), ACE_DEFAULT_SERVER_PORT_STR);
         return 0;

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "aaccee00"
+#define PATCH_KEY "aaffffaa"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -29,7 +29,7 @@ run "file"
 listen "portnum" ["file"]
 .br
 .B comterp
--help | --help | -? | --?
+-help | --help
 .br
 .SH DESCRIPTION
 comterp demonstrates the command interpreter incorporated into
@@ -103,7 +103,7 @@ comterp listen "portnum" ["file" [arg1 [arg2 [...argn]]]]
 Listen on portnum then run contents of file then take commands from
 both until exit.
 
-comterp -help | --help | -? | --?
+comterp -help | --help
 
 Print a usage summary of all the invocation modes above and exit.
 


### PR DESCRIPTION
# remove question mark for comterp help since it gets blocked by the shell

comterp -? doesn't really work, it takes comterp -\? which isn't what's desired.  So just reverting comterp to using -help and --help.