### PR TITLE
GlobalSymbolFunc/LocalSymbolFunc: fix silent -1 symbol-id corruption, refuse command references safely

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -676,6 +676,22 @@ through it stays in the current scope like any other write.  Use
 `local()`/`global()` to escape; use `return` (possibly of an attrlist)
 to hand results to the caller.
 
+`local(x)`/`global(x)`'s deeper job, as an lvalue, is to designate `x`
+as a symbol instance scoped specifically to that table — internally
+they hand back a raw, backquoted symbol reference, not a value:
+evaluation stops at the symbol rather than collapsing it, exactly so
+`x=val`'s assignment machinery has an identity to write through rather
+than a value to overwrite (a symbol is a symbol until something
+actually asks for its value). This only matters if `x`'s name collides
+with a registered command: a *bare* command reference self-invokes
+during ordinary argument evaluation before `local()`/`global()` ever
+see it — harmless for a niladic constant, not so for one with side
+effects — so both refuse outright, bare or backquoted, the same
+"assignment to command ... not allowed" way bare `x=val` already does.
+There is no way to shadow a command through `local()`/`global()`; a
+colliding name simply isn't usable as a variable there, matching the
+rule everywhere else in the language.
+
 ### Multi-value returns
 
 A func returns a single value — the result of its last expression. Two

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -38,6 +38,8 @@
 #include <ctype.h>
 #include <vector>
 
+using std::cout;
+
 #define TITLE "SymbolFunc"
 
 /*****************************************************************************/
@@ -497,8 +499,32 @@ void GlobalSymbolFunc::execute() {
     ComValue& val = stack_arg(i, true);
     if (val.is_symbol())
       symbol_ids[i] = val.symbol_val();
-    else 
-      symbol_ids[i] = -1;
+    else if (val.is_command()) {
+      /* only reachable via an explicit backquote (a bare command name
+	 self-invokes during ordinary eager argument evaluation, long before
+	 this loop ever sees it).  Backquote's role is safety, not override:
+	 it lets this is-it-a-command test succeed without the self-invoke
+	 side effect, same as the existing step=0 bare-assignment guard --
+	 it does not grant permission to use a command name as a variable. */
+      std::cout << "WARNING:  \"" << val.command_name() << "\" is a command"
+		   " -- global() can't use it as a variable name -- line "
+		<< funcstate()->linenum() << "\n";
+      reset_stack();
+      push_stack(ComValue::nullval());
+      return;
+    } else {
+      /* val resolved to neither a symbol nor a command -- most likely a
+	 bare command name self-invoked (e.g. a niladic constant command)
+	 and its return value landed here instead.  No usable identifier;
+	 fail loudly instead of silently keying off a shared, meaningless -1
+	 slot (which used to make unrelated collisions clobber each other). */
+      std::cout << "WARNING:  global() argument did not resolve to a symbol"
+		   " (if its name collides with a command, backquote it to"
+		   " confirm) -- line " << funcstate()->linenum() << "\n";
+      reset_stack();
+      push_stack(ComValue::nullval());
+      return;
+    }
   }
   boolean assign_next = comterp()->stack_top(nargs()+nkeys()).lhs_assign();
 
@@ -509,7 +535,7 @@ void GlobalSymbolFunc::execute() {
     ComValue retval(avl);
     for (int i=0; i<numargs; i++) {
       if (!clearflag) {
-	ComValue* av = 
+	ComValue* av =
 	  new ComValue(symbol_ids[i], AttributeValue::SymbolType);
 	if (assign_next) {
 	  av->global_flag(true);
@@ -594,8 +620,32 @@ void LocalSymbolFunc::execute() {
     ComValue& val = stack_arg(i, true);
     if (val.is_symbol())
       symbol_ids[i] = val.symbol_val();
-    else
-      symbol_ids[i] = -1;
+    else if (val.is_command()) {
+      /* only reachable via an explicit backquote (a bare command name
+	 self-invokes during ordinary eager argument evaluation, long before
+	 this loop ever sees it).  Backquote's role is safety, not override:
+	 it lets this is-it-a-command test succeed without the self-invoke
+	 side effect, same as the existing step=0 bare-assignment guard --
+	 it does not grant permission to use a command name as a variable. */
+      std::cout << "WARNING:  \"" << val.command_name() << "\" is a command"
+		   " -- local() can't use it as a variable name -- line "
+		<< funcstate()->linenum() << "\n";
+      reset_stack();
+      push_stack(ComValue::nullval());
+      return;
+    } else {
+      /* val resolved to neither a symbol nor a command -- most likely a
+	 bare command name self-invoked (e.g. a niladic constant command)
+	 and its return value landed here instead.  No usable identifier;
+	 fail loudly instead of silently keying off a shared, meaningless -1
+	 slot (which used to make unrelated collisions clobber each other). */
+      std::cout << "WARNING:  local() argument did not resolve to a symbol"
+		   " (if its name collides with a command, backquote it to"
+		   " confirm) -- line " << funcstate()->linenum() << "\n";
+      reset_stack();
+      push_stack(ComValue::nullval());
+      return;
+    }
   }
   boolean assign_next = comterp()->stack_top(nargs()+nkeys()).lhs_assign();
 

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -506,7 +506,7 @@ void GlobalSymbolFunc::execute() {
 	 it lets this is-it-a-command test succeed without the self-invoke
 	 side effect, same as the existing step=0 bare-assignment guard --
 	 it does not grant permission to use a command name as a variable. */
-      std::cout << "WARNING:  \"" << val.command_name() << "\" is a command"
+      cout << "WARNING:  \"" << val.command_name() << "\" is a command"
 		   " -- global() can't use it as a variable name -- line "
 		<< funcstate()->linenum() << "\n";
       reset_stack();
@@ -518,7 +518,7 @@ void GlobalSymbolFunc::execute() {
 	 and its return value landed here instead.  No usable identifier;
 	 fail loudly instead of silently keying off a shared, meaningless -1
 	 slot (which used to make unrelated collisions clobber each other). */
-      std::cout << "WARNING:  global() argument did not resolve to a symbol"
+      cout << "WARNING:  global() argument did not resolve to a symbol"
 		   " (if its name collides with a command, backquote it to"
 		   " confirm) -- line " << funcstate()->linenum() << "\n";
       reset_stack();
@@ -627,7 +627,7 @@ void LocalSymbolFunc::execute() {
 	 it lets this is-it-a-command test succeed without the self-invoke
 	 side effect, same as the existing step=0 bare-assignment guard --
 	 it does not grant permission to use a command name as a variable. */
-      std::cout << "WARNING:  \"" << val.command_name() << "\" is a command"
+      cout << "WARNING:  \"" << val.command_name() << "\" is a command"
 		   " -- local() can't use it as a variable name -- line "
 		<< funcstate()->linenum() << "\n";
       reset_stack();
@@ -639,7 +639,7 @@ void LocalSymbolFunc::execute() {
 	 and its return value landed here instead.  No usable identifier;
 	 fail loudly instead of silently keying off a shared, meaningless -1
 	 slot (which used to make unrelated collisions clobber each other). */
-      std::cout << "WARNING:  local() argument did not resolve to a symbol"
+      cout << "WARNING:  local() argument did not resolve to a symbol"
 		   " (if its name collides with a command, backquote it to"
 		   " confirm) -- line " << funcstate()->linenum() << "\n";
       reset_stack();

--- a/src/ComTerp/symbolfunc.h
+++ b/src/ComTerp/symbolfunc.h
@@ -155,14 +155,14 @@ public:
 
 
 //: command to make assign a global variable
-// val=global(sym)|global(sym)=val|global(sym :clear)|global(:dump) -- make symbol global
+// sym=global(sym)|global(sym)=val|global(sym :clear)|global(:dump) -- designate a symbol instance as global
 class GlobalSymbolFunc : public ComFunc {
 public:
     GlobalSymbolFunc(ComTerp*);
     virtual void execute();
 
     virtual const char* docstring() {
-      return "val=%s(sym)|global(sym)=val|global(sym :clear)|global(:dump) -- make symbol global"; }
+      return "sym=%s(sym)|global(sym)=val|global(sym :clear)|global(:dump) -- designate a symbol instance as global"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":clear     clear symbol from global table",
@@ -175,17 +175,18 @@ public:
 
 
 //: command to read/write the interpreter's default (local) symbol table
-// val=local(sym)|local(sym)=val|local(sym :clear)|local(:cnt) -- read/write
-// the default symbol table by name, skipping any func frame.  local() names
-// the scope that bare assignment already uses outside a func; inside a func
-// it escapes the per-invocation frame the way global() escapes everything.
+// sym=local(sym)|local(sym)=val|local(sym :clear)|local(:cnt) -- designate a
+// symbol instance as local: the default symbol table by name, skipping any
+// func frame.  local() names the scope that bare assignment already uses
+// outside a func; inside a func it escapes the per-invocation frame the way
+// global() escapes everything.
 class LocalSymbolFunc : public ComFunc {
 public:
     LocalSymbolFunc(ComTerp*);
     virtual void execute();
 
     virtual const char* docstring() {
-      return "val=%s(sym)|local(sym)=val|local(sym :clear)|local(:cnt) -- read/write the default symbol table, skipping any func frame"; }
+      return "sym=%s(sym)|local(sym)=val|local(sym :clear)|local(:cnt) -- designate a symbol instance as local, skipping any func frame"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":clear     clear symbol from the default symbol table",

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "aaffffaa"
+#define PATCH_KEY "de38efa2"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
Last piece of the local()/global() command-name investigation (the debugfunc.c EOF fix and symbolfunc.h docstring fix already landed via #247).

- **Real bug fixed**: a bare command-name argument to `local()`/`global()` (e.g. `pi`, a niladic constant command) self-invokes during ordinary eager argument evaluation, before this loop ever sees it -- `local()`/`global()` stay eager by design (it's what lets a stream argument overdrive them). The resulting value is neither a symbol nor a command, and used to silently fall through to `symbol_ids[i]=-1` -- meaning `global(pi)=3` never touched anything named `pi`; it wrote into a shared, meaningless `-1` table slot that any other colliding name would also land in and clobber. Write and read happened to use the same wrong key, so it looked like it worked. Now it fails loudly instead.
- **Command references stay refused, safely**: the only way an un-invoked command reference reaches this code at all is via explicit backquote (bare references always self-invoke first). Backquote's role here is safety, not override -- it lets the is-it-a-command test succeed without the self-invoke side effect, but doesn't grant permission to use a command name as a variable. `global(\`pi)=3` and `local(\`pi)=42` are refused the same as the bare form, consistent with the existing rule that a symbol resolving to a command can't be used on the lhs of an assign (matches `AssignFunc`'s own `step=0` -> `"WARNING: assignment to command ... not allowed"` precedent).

The existing bare-assignment guard (`step=0`) remains the primary, zero-risk way a programmer discovers a name collision at all; this is the narrower follow-up making `local()`/`global()` fail the same way instead of silently corrupting shared state.

## Test plan
- [x] Ordinary symbol (`local(x)=10`) unaffected
- [x] Bare `global(pi)=3` -- warns instead of silently corrupting
- [x] Backquoted `global(\`pi)=3.0` / `local(\`pi)=42` -- both refused with a clear "is a command" message
- [x] Bare `pi` reference confirmed unaffected (still `3.14159`) after all of the above -- no shadowing occurs
- [x] Backquoted read on an ordinary (non-colliding) symbol still works
- [x] Full `run_all.comt` suite green, no regressions