### PR TITLE
runfile(): drain the ERR_UNEXPECTED_EOF error before returning

### DIFF
--- a/src/ComTerp/comterpserv.c
+++ b/src/ComTerp/comterpserv.c
@@ -440,6 +440,26 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
         COMERR_SET1( ERR_UNEXPECTED_EOF, _linenum );
         *inbuf = '\0';
         parser_reset();
+
+        /* COMERR_SET1 pushes onto ComUtil's process-global error stack
+           (errsys.c), and nothing above drains it the way the *inbuf-error
+           branch above does via err_str().  Left unconsumed, it silently
+           outlives this runfile() call and gets misattributed to the next
+           unrelated err_str() call anywhere in the interpreter -- observed
+           as ComTerpServ::run(postfix_token*,int) (used to invoke a
+           user-defined func() body) mistaking it for a failure of that
+           unrelated call, which makes it substitute nullval() *without*
+           popping the value eval_expr() already pushed -- a stray value
+           left on the stack that later trips the "func ... pushed more
+           than a single value on stack" consistency check. */
+        char eofbuf[BUFSIZ];
+        char location[BUFSIZ];
+        snprintf(location, BUFSIZ, "error in %s:%d", filename, _linenum);
+        err_str(eofbuf, BUFSIZ, location);
+        if (*eofbuf) {
+            status = -1;
+            fprintf(stderr, "%s\n", eofbuf);
+        }
     }
 
     load_postfix(tokbuf, toklen, tokoff);

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "d48bbf6a"
+#define PATCH_KEY "72e28c8d"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Fixes a stack-imbalance bug distinct from #153/#256, found while investigating that fix.

`ComTerpServ::runfile()`'s post-loop EOF handling calls `COMERR_SET1(ERR_UNEXPECTED_EOF, ...)`, which pushes onto ComUtil's process-global error stack (`src/ComUtil/errsys.c`). Nothing drained it, unlike the sibling mid-loop parse-error branch a few lines above, which does via `err_str()`. Left unconsumed, the error silently outlived the `runfile()` call and got misattributed to the *next* unrelated `err_str()` call anywhere in the interpreter.

That next call is typically `ComTerpServ::run(postfix_token*,int)`, used to invoke a user-defined `func()` body: it calls `err_str()` right after `eval_expr()` and, seeing the stale non-empty buffer, substitutes `nullval()` **without** popping the value `eval_expr()` had just legitimately pushed for the func's return. The un-popped value sits on the shared stack, later tripping the `"func ... pushed more than a single value on stack"` consistency check on whichever enclosing `run()` next notices the imbalance.

Repro: from a wrapper `.comt` script, `run()` a file that testlib's `check_fail` runs after, followed by `run()`-ing a file with a genuinely incomplete top-level expression at EOF, then call any user-defined `func()` (e.g. `check_fail(:ok ok)`). The stack-imbalance diagnostic fires on the *outer* `run()`, even though `ok`/return values are all correct — purely cosmetic stderr noise, but confusing. Reproduces identically on master with or without #256 applied.

Draining the error here also means the "Unexpected end-of-file" diagnostic now actually reaches stderr for `run("file")`'s plain (non-`:str`) form, which previously swallowed it silently.

## Test plan

- [x] Rebuilt `libComTerp` and reproduced the bug against an unpatched build (both with and without #256's fix layered in, per the issue's own verification note)
- [x] Applied the fix, rebuilt, confirmed the "pushed more than a single value on stack" warning disappears and the EOF diagnostic is printed instead
- [x] Ran `src/comterp_/tests/runfile.comt` (added by #256) end-to-end: all three `check_fail()` calls run clean, `runfile: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)