### PR TITLE
EqualFunc: stop suppressing symbol-variable resolution under :sym

### DIFF
--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -226,11 +226,19 @@ EqualFunc::EqualFunc(ComTerp* comterp) : NumFunc(comterp) {
 }
 
 void EqualFunc::execute() {
-    boolean symflag = stack_key(sym_symid).is_true(); 
-    ComValue& nval = stack_key(n_symid); 
+    boolean symflag = stack_key(sym_symid).is_true();
+    ComValue& nval = stack_key(n_symid);
 
-    ComValue& operand1 = stack_arg(0, symflag);
-    ComValue& operand2 = stack_arg(1, symflag);
+    /* symflag (:sym) is read for docstring compatibility but must NOT be
+       passed to stack_arg as its "symbol" parameter -- that suppresses
+       lookup_symval, which resolves a bare identifier (e.g. a variable
+       holding a SymbolType value) to its bound value.  A literal symbol
+       (`foo) doesn't need that suppression -- lookup_symval already
+       leaves bquoted values untouched -- so the only effect of wiring
+       symflag through was breaking comparisons where one operand was a
+       plain variable rather than a backquoted literal. */
+    ComValue& operand1 = stack_arg(0);
+    ComValue& operand2 = stack_arg(1);
     promote(operand1, operand2);
     ComValue result(operand1);
     result.type(ComValue::BooleanType);

--- a/src/comterp_/tests/symbol.comt
+++ b/src/comterp_/tests/symbol.comt
@@ -4,8 +4,7 @@
 // funcs: ` symadd symid symbol symstr symval symvar strref
 //        eq(:sym) lt(:sym) gt(:sym) not_eq(:sym) lt_or_eq(:sym) gt_or_eq(:sym)
 //        type class print(:sym) split(sym) eval(:symret) switch cond
-// missing: eq(:sym) bug (test 5c -- eq(:sym) diverges from == for symbol() return values)
-//          float() double() conversion commands
+// missing: float() double() conversion commands
 //          print(:sym) label format string interaction (test 14 cosmetic)
 //          symid(sym sym) multi-arg
 //          eval(:alist) keyword
@@ -47,8 +46,8 @@ s2=symbol(id)
 ok=ok&&(s2==`foo)
 print("5a symid(`foo) integer id (expect IntType): %v\n" type(id))
 print("5b symbol(symid(`foo))==`foo round-trip via == (expect true): %v\n" (s2==`foo))
-// NOTE: eq(s2 `foo :sym) returns false here -- bug in eq(:sym) vs ==
-print("5c eq(s2 `foo :sym) bug -- diverges from == (observe, expect false): %v\n" eq(s2 `foo :sym))
+ok=ok&&(eq(s2 `foo :sym))
+print("5c eq(s2 `foo :sym) agrees with == (expect true): %v\n" eq(s2 `foo :sym))
 prev_ok=check_fail(:ok ok)
 
 // --- test 6: symadd/symstr round-trip ---

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "2cb97319"
+#define PATCH_KEY "4fc20f55"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`eq(s1 s2 :sym)` and `==` disagreed whenever one operand was a plain variable holding a `SymbolType` value (e.g. `s2=symbol(id)`) rather than a literal backquoted symbol:

```
id=symid(`foo)
s2=symbol(id)
s2==`foo             // true
eq(s2 `foo :sym)      // false -- bug
eq(`foo `foo :sym)    // true  -- works when both operands are literals
```

## Root cause

`EqualFunc::execute()` passed `symflag` (set by `:sym`) through to `stack_arg()` as its `symbol` parameter, which suppresses `lookup_symval()` — the step that resolves a bare identifier to whatever it's bound to. That's the wrong tool for "symbol comparison": a literal symbol (`` `foo ``) already skips `lookup_symval()` on its own (it short-circuits on `bquote()`), so suppressing it was never doing anything useful for the `:sym` case the docstring describes (`bool=eq(sym1 sym2 :sym) -- symbol comparison`). Its only actual effect was breaking resolution for a plain-variable operand — comparing the variable's own name-symbol (the id for `"s2"`) instead of the value it's bound to (the id for `"foo"`).

`NotEqualFunc`, `GreaterThanOrEqualFunc`, and `LessThanOrEqualFunc` already compute `symflag` but never wire it into `stack_arg` — `EqualFunc` was the outlier still doing so.

## Fix

Stop passing `symflag` to `stack_arg()` in `EqualFunc::execute()`, matching the other three comparison operators.

## Test plan

- [x] Confirmed pre-fix repro matches the issue exactly
- [x] Confirmed post-fix: `eq(s2 `foo :sym)` now returns `true`, agreeing with `==`; `eq(`foo `foo :sym)` still `true`; `eq(`foo `bar :sym)` still `false`
- [x] Updated `symbol.comt` test 5c, which previously documented the divergence as expected/observed, to assert `eq(:sym)` now agrees with `==`
- [x] Full `run_all.comt` regression suite passes

Closes #96