### PR TITLE
optable(): make :table respect :bypri/:bycom/:byopr

### DIFF
--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -359,6 +359,11 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
     return;
   }
 
+  /* :table's own pre-existing contract (unlike the print form below) is
+     natural table order when no sort flag is given at all -- track that
+     explicitly rather than defaulting sort to OPBY_PRIORITY and treating
+     an unflagged call the same as :bypri. */
+  boolean sort_requested = bypriflag.is_true() || bycomflag.is_true() || byoprflag.is_true();
   int sort = OPBY_PRIORITY;
   if (bycomflag.is_true()) { sort = OPBY_COMMAND; }
   if (byoprflag.is_true()) { sort = OPBY_OPERATOR; }
@@ -383,7 +388,7 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
        opr_tbl_print does for the non-:table form below. */
     int* indirect = new int[n];
     for (unsigned i = 0; i < n; i++) indirect[i] = i;
-    if (sort != OPBY_OPERATOR) {
+    if (sort_requested && sort != OPBY_OPERATOR) {
       for (unsigned i = 1; i < n; i++) {
         int key = indirect[i];
         unsigned j = i;

--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -279,6 +279,18 @@ void HelpFunc::execute() {
 
 /*****************************************************************************/
 
+// insertion-sort predicate for optable(:table)'s indirect index array:
+// true if operator table entry a belongs before entry b.  sort is one of
+// OPBY_PRIORITY or OPBY_COMMAND (OPBY_OPERATOR never reaches this -- see
+// the comment where it's called).  Matches opr_tbl_print's own two
+// directions -- priority highest-first, command name alphabetical --
+// which aren't the same direction as each other.
+static boolean optable_index_before(int a, int b, int sort) {
+  if (sort == OPBY_COMMAND)
+    return strcmp(symbol_pntr(opr_tbl_commid(a)), symbol_pntr(opr_tbl_commid(b))) < 0;
+  return opr_tbl_priority(a) > opr_tbl_priority(b);
+}
+
 OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
@@ -347,6 +359,11 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
     return;
   }
 
+  int sort = OPBY_PRIORITY;
+  if (bycomflag.is_true()) { sort = OPBY_COMMAND; }
+  if (byoprflag.is_true()) { sort = OPBY_OPERATOR; }
+  if (bypriflag.is_true()) { sort = OPBY_PRIORITY; }
+
   if (tableflag.is_true()) {
     // return list of attrlists, one per operator entry
     static int opr_symid = symbol_add("opr");
@@ -358,9 +375,29 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
     static int prefix_symid = symbol_add("UNARY PREFIX");
     static int postfix_symid = symbol_add("UNARY POSTFIX");
 
-    AttributeValueList* avl = new AttributeValueList();
     unsigned n = opr_tbl_numop_get();
-    for (unsigned i = 0; i < n; i++) {
+
+    /* opr_tbl_insert keeps the table itself sorted by operator string (for
+       parser lookup), so :byopr's order is just the table's natural order
+       -- only :bypri/:bycom need an explicit reorder here, same as
+       opr_tbl_print does for the non-:table form below. */
+    int* indirect = new int[n];
+    for (unsigned i = 0; i < n; i++) indirect[i] = i;
+    if (sort != OPBY_OPERATOR) {
+      for (unsigned i = 1; i < n; i++) {
+        int key = indirect[i];
+        unsigned j = i;
+        while (j > 0 && optable_index_before(key, indirect[j-1], sort)) {
+          indirect[j] = indirect[j-1];
+          j--;
+        }
+        indirect[j] = key;
+      }
+    }
+
+    AttributeValueList* avl = new AttributeValueList();
+    for (unsigned idx = 0; idx < n; idx++) {
+      unsigned i = indirect[idx];
       AttributeList* al = new AttributeList();
       AttributeValue opr_val((const char *)symbol_pntr(opr_tbl_operid(i)));
       AttributeValue cmd_val((const char *)symbol_pntr(opr_tbl_commid(i)));
@@ -379,15 +416,11 @@ OptableFunc::OptableFunc(ComTerp* comterp) : ComFunc(comterp) {
       AttributeValue* av = new AttributeValue(AttributeList::class_symid(), al);
       avl->Append(av);
     }
+    delete [] indirect;
     ComValue retval(avl);
     push_stack(retval);
     return;
   }
-
-  int sort = OPBY_PRIORITY;
-  if (bycomflag.is_true()) { sort = OPBY_COMMAND; }
-  if (byoprflag.is_true()) { sort = OPBY_OPERATOR; }
-  if (bypriflag.is_true()) { sort = OPBY_PRIORITY; }
 
   opr_tbl_print(stdout, sort);
   return;

--- a/src/comterp_/tests/optable.comt
+++ b/src/comterp_/tests/optable.comt
@@ -58,5 +58,15 @@ ok=ok&&(size(t)==n && size(t2)==n && size(t3)==n)
 print("4 sorted tables all have the same entry count (expect true): %v\n\n" (size(t)==n && size(t2)==n && size(t3)==n))
 check_fail(:ok ok)
 
+// --- test 5: an unflagged :table call is unaffected -- still natural
+// (operator-alphabetical) order, same as :table :byopr, not silently
+// defaulted to :bypri order ---
+t4=optable(:table)
+same_as_byopr=true
+for(i=0 i<n i++ same_as_byopr=same_as_byopr&&(at(t4 i).opr==at(t3 i).opr))
+ok=ok&&same_as_byopr
+print("5 optable(:table) unflagged matches :byopr order (expect true): %v\n\n" same_as_byopr)
+check_fail(:ok ok)
+
 print("\noptable: %v\n" ok)
 ok

--- a/src/comterp_/tests/optable.comt
+++ b/src/comterp_/tests/optable.comt
@@ -1,0 +1,62 @@
+// src/comterp_/tests/optable.comt -- test optable(:table)'s sort flags
+//
+// Regression guard: optable(:bypri)/optable(:bycom)/optable(:byopr) sort
+// the printed operator table, but optable(:table :bypri) etc used to
+// ignore the sort flags entirely and always return entries in the table's
+// natural (operator-alphabetical) order.  optable(:table) now honors the
+// same sort key.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/optable.comt")
+
+run("./testlib.comt")
+ok=true
+
+// char-by-char string "<=" (ComTerp has no built-in string relational ops)
+strleq=func(
+  n1=size(s1);
+  n2=size(s2);
+  i=0;
+  result=nil;
+  while(result==nil && i<n1 && i<n2
+    c1=at(s1 i);
+    c2=at(s2 i);
+    if(c1<c2 :then result=true);
+    if(c1>c2 :then result=false);
+    i=i+1);
+  if(result==nil :then result=(n1<=n2));
+  result)
+
+// --- test 1: :table :bypri is non-increasing by priority ---
+t=optable(:table :bypri)
+n=size(t)
+sorted=true
+for(i=1 i<n i++ sorted=sorted&&(at(t i-1).pri>=at(t i).pri))
+ok=ok&&sorted
+print("1 optable(:table :bypri) non-increasing priority (expect true): %v\n\n" sorted)
+check_fail(:ok ok)
+
+// --- test 2: :table :bycom is non-decreasing alphabetically by command ---
+t2=optable(:table :bycom)
+sorted2=true
+for(i=1 i<n i++ sorted2=sorted2&&strleq(:s1 at(t2 i-1).cmd :s2 at(t2 i).cmd))
+ok=ok&&sorted2
+print("2 optable(:table :bycom) alphabetical by command (expect true): %v\n\n" sorted2)
+check_fail(:ok ok)
+
+// --- test 3: :table :byopr is non-decreasing alphabetically by operator
+// (the table's own natural order, since opr_tbl_insert keeps it that way) ---
+t3=optable(:table :byopr)
+sorted3=true
+for(i=1 i<n i++ sorted3=sorted3&&strleq(:s1 at(t3 i-1).opr :s2 at(t3 i).opr))
+ok=ok&&sorted3
+print("3 optable(:table :byopr) alphabetical by operator (expect true): %v\n\n" sorted3)
+check_fail(:ok ok)
+
+// --- test 4: no entries lost or duplicated by any sort flag ---
+ok=ok&&(size(t)==n && size(t2)==n && size(t3)==n)
+print("4 sorted tables all have the same entry count (expect true): %v\n\n" (size(t)==n && size(t2)==n && size(t3)==n))
+check_fail(:ok ok)
+
+print("\noptable: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -114,5 +114,9 @@ if(run("./filter.comt")
   :then print("pass: filter\n")
   :else print("FAIL: filter\n");topok=false)
 
+if(run("./optable.comt")
+  :then print("pass: optable\n")
+  :else print("FAIL: optable\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "4fc20f55"
+#define PATCH_KEY "9af99434"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`optable(:bypri)`/`optable(:bycom)`/`optable(:byopr)` sort the printed operator table via `opr_tbl_print`'s own `merge_sort`, but `optable(:table)`'s `AttributeValueList` was always built by walking the table in raw index order (`0..n-1`), ignoring all three sort flags.

## Fix

`opr_tbl_insert` keeps the table natively sorted by operator string (the parser needs that for lookup), so `:byopr`'s requested order is simply the table's existing natural order and needs no extra work. `:bypri` and `:bycom` do need an explicit reorder, done here with a small stable insertion sort over an indirect index array, matching `opr_tbl_print`'s two established (and different from each other — priority highest-first, command name alphabetical) sort directions so `:table`'s order and the printed order agree for the same flag.

## Test plan

- [x] Confirmed pre-fix: `optable(:table :bypri)` and `optable(:table :bycom)` return entries in natural table order regardless of the flag
- [x] Confirmed post-fix: both now correctly sorted, matching the direction of the equivalent `optable(:bypri)`/`optable(:bycom)` printed output
- [x] Confirmed `:byopr` (already correct before, since it equals natural order) still works and no entries are lost or duplicated by any flag
- [x] Full `run_all.comt` regression suite passes
- [x] Added `src/comterp_/tests/optable.comt` covering all three sort flags plus an entry-count sanity check

Closes #101