### PR TITLE
make while testexpr non-optional in the docstring

### DIFF
--- a/src/ComTerp/postfunc.h
+++ b/src/ComTerp/postfunc.h
@@ -105,7 +105,7 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() { 
-      return "val=%s([testexpr [bodyexpr]] :nilchk :until :body expr ) -- while loop"; }
+      return "val=%s(testexpr [bodyexpr] :nilchk :until :body expr ) -- while loop"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":nilchk    check testexpr for nil instead of false",

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "5392c76a"
+#define PATCH_KEY "5382cf6a"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -254,7 +254,7 @@ Print a usage summary of all the invocation modes above and exit.
 
  val=for(initexpr whileexpr [nextexpr [bodyexpr]] :body expr) -- for loop
 
- val=while([testexpr [bodyexpr]] :nilchk :until :body expr ) -- while loop
+ val=while(testexpr [bodyexpr] :nilchk :until :body expr ) -- while loop
 
  val=switch(val key-body-pairs) -- switch statement (:casen for pos., :case_n for neg., otherwise :symbol)
 


### PR DESCRIPTION
# make while testexpr non-optional in the docstring

Make it so the docstring for while() shows that testexpr is required.