### PR TITLE
eval_expr_internals: drain the arglist when a glued symbol isn't a FuncObj

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -592,12 +592,24 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	_funcobj_active = saved_active;
 	delete [] posvals;
       } else {
+	/* sv carried a pending arglist (same-line adjacency to a following
+	   paren group always means "this is a call attempt"), but val --
+	   what the symbol actually resolves to -- isn't a FuncObj.  Its
+	   narg()+nkey() worth of args were already eagerly evaluated (the
+	   same way they would be for a real command) and are sitting on
+	   the stack below where val is about to go; discard them here the
+	   same way a real command's own reset_stack() would, rather than
+	   stacking val on top of them.  This generalizes true()/false()/
+	   pi()'s existing "wrap any expression, override its result" idiom
+	   to any plain value: the wrapped expression still runs for its
+	   side effects, but the wrapper's own value always wins. */
+	decr_stack(sv.narg() + sv.nkey());
 	push_stack(val);
       }
     }
 
     return;
-    
+
   }
 
   if (sv.is_object(Attribute::class_symid())) {

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -118,5 +118,9 @@ if(run("./optable.comt")
   :then print("pass: optable\n")
   :else print("FAIL: optable\n");topok=false)
 
+if(run("./symboldrain.comt")
+  :then print("pass: symboldrain\n")
+  :else print("FAIL: symboldrain\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/comterp_/tests/symboldrain.comt
+++ b/src/comterp_/tests/symboldrain.comt
@@ -1,0 +1,86 @@
+// src/comterp_/tests/symboldrain.comt -- test SYMBOL (args) when SYMBOL isn't
+// a command or FuncObj
+//
+// Same-line adjacency to a following paren group always means "this is a
+// call attempt" (whitespace doesn't matter, only a newline escapes it) --
+// see doc/LANGUAGE.md.  Three resolutions are possible for the symbol:
+//   - a real command -> dispatches normally
+//   - a variable holding a FuncObj -> invoked properly
+//   - anything else (including undefined) -> the arglist is drained
+// Regression guard: when the symbol was bound to a plain value (not
+// undefined, not a FuncObj), draining its arglist used to push the
+// symbol's value WITHOUT first discarding the already-evaluated arglist,
+// corrupting the interpreter's stack ("func ... pushed more than a single
+// value on stack").  An undefined symbol was never affected -- it's
+// substituted with the built-in NilFunc at compile time, which is
+// post_eval and never even evaluates its arglist, a deliberate idiom for
+// gating a script's behavior on whether an optional command/func was
+// defined before it ran.  This test locks in both: the bound-value case
+// now drains cleanly (generalizing true()/false()/pi()'s "wrap any
+// expression, override its result" idiom to any plain value), and the
+// undefined-symbol gate keeps its distinct never-evaluates property.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/symboldrain.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: symbol bound to a plain value drains its arglist and
+// returns the symbol's own value, evaluating the arglist for its side
+// effect along the way (like true()/false()/pi()) ---
+x=5
+cnt=0
+r=x (cnt=cnt+1)
+ok=ok&&(r==5)
+ok=ok&&(cnt==1)
+print("1 x=5; r=x (cnt=cnt+1) drains arg, returns x's value (expect r=5 cnt=1): %v %v\n\n" r cnt)
+check_fail(:ok ok)
+
+// --- test 2: an undefined symbol's arglist is never evaluated at all --
+// the gate idiom, unaffected by the fix above ---
+cnt2=0
+r2=_symboldrain_undefined_test_xyz (cnt2=cnt2+1)
+ok=ok&&(r2==nil)
+ok=ok&&(cnt2==0)
+print("2 undefined symbol gate never evaluates its arg (expect r2=nil cnt2=0): %v %v\n\n" r2 cnt2)
+check_fail(:ok ok)
+
+// --- test 3: interpreter remains functional afterward (no stack
+// corruption lingering from either case above) ---
+v=1+1
+ok=ok&&(v==2)
+print("3 interpreter still functional after both cases (expect 2): %v\n\n" v)
+check_fail(:ok ok)
+
+// --- test 4: repeated use of the same bound-value symbol in one session
+// drains cleanly every time, not just the first ---
+x2=7
+cnt3=0
+r3a=x2 (cnt3=cnt3+1)
+r3b=x2 (cnt3=cnt3+1)
+ok=ok&&(r3a==7 && r3b==7 && cnt3==2)
+print("4 repeated use of a bound symbol drains cleanly each time (expect r3a=7 r3b=7 cnt3=2): %v %v %v\n\n" r3a r3b cnt3)
+check_fail(:ok ok)
+
+// --- test 5: draining doesn't grow the interpreter's own value stack --
+// the actual regression this guards: each drain used to leave one extra
+// entry behind (visible as "func ... pushed more than a single value on
+// stack"), so repeated drains grew the stack in proportion to how many
+// happened, rather than staying flat. Compare a 3-drain and a 5-drain
+// run: if either leaks, the 5-drain height comes out higher relative to
+// its own baseline than the 3-drain one does. ---
+x3=9
+before3=stackheight()
+h3=(x3 (1); x3 (1); x3 (1); stackheight())
+before5=stackheight()
+h5=(x3 (1); x3 (1); x3 (1); x3 (1); x3 (1); stackheight())
+d3=h3-before3
+d5=h5-before5
+sameheight=(d3==d5)
+ok=ok&&sameheight
+print("5 stackheight() delta is the same for 3 vs 5 drains (expect true): %v %v\n\n" d3 d5)
+check_fail(:ok ok)
+
+print("\nsymboldrain: %v\n" ok)
+ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "5382cf6a"
+#define PATCH_KEY "e41a2fa4"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`SYMBOL (args)` on one line always parses as a call attempt on `SYMBOL` (same-line adjacency, whitespace doesn't matter -- only a newline escapes it). Once `SYMBOL` resolves, three outcomes were already correct:

- a real command dispatches normally
- a variable holding a `FuncObj` is invoked properly via `lookup_symval` + `is_object(FuncObj::class_symid())`
- an undefined symbol is substituted with the built-in `NilFunc` at compile time -- a `post_eval` command that never even evaluates its arglist, a deliberate idiom for gating a script's behavior on whether an optional command/func was defined before it ran

The fourth outcome -- `SYMBOL` bound to a plain, non-callable value -- was buggy: `eval_expr_internals`'s `SymbolType` branch pushed the symbol's value without first discarding the arglist's already-evaluated stack contents (that arglist *is* eagerly evaluated, unlike the undefined case). Confirmed via `stackheight()`: repeated same-session drains accumulated stack debris in direct proportion to how many happened, alongside a `"func ... pushed more than a single value on stack"` warning each time.

## Fix

Discard the arglist's already-evaluated `narg()+nkey()` stack entries before pushing the symbol's value, mirroring what a real command's own `execute()` gets for free via `reset_stack()`. This generalizes `true()`/`false()`/`pi()`'s existing "wrap any expression, override its result" idiom (their docstrings already say "accepts any arguments and returns true/false") to any symbol bound to a plain value -- a variable pointing to a `FuncObj` is dynamic; a variable pointing to a plain value is simply a static `FuncObj` that always returns that value. The undefined-symbol gate is unaffected -- it's a distinct, more valuable property (never evaluating its arglist at all) that this fix doesn't attempt to extend to bound values, since side-effect evaluation for an already-bound plain value is unavoidable without deep parser changes.

## Test plan

- [x] Confirmed pre-fix: `stackheight()` grows in proportion to drain count within one session (8 for 3 drains, 14 for 5)
- [x] Confirmed post-fix: stays flat at a constant delta regardless of drain count
- [x] Confirmed the undefined-symbol gate idiom is unaffected (arglist still never evaluated)
- [x] Confirmed interpreter remains functional after both cases (no lingering corruption)
- [x] Full `run_all.comt` regression suite passes, no `"pushed more than a single value"` warnings anywhere
- [x] Added `src/comterp_/tests/symboldrain.comt` covering all of the above

Closes #265

## Explicitly out of scope (see #265 for full discussion)

- Making stream-literal arity depend on whether a glued symbol resolves to `CommandType`/`FuncObj` at compile time -- the glue decision happens in `ComUtil/_parser.c`'s raw token-stream state machine, which has no symbol-table access at all; a deep, high-risk change. Will be documented instead of fixed.
- A separate bug where `[...]` fails to parse constructs that `(...)` handles fine (e.g. `[(1+2)*3 y]` errors, `((1+2)*3 y)` doesn't) -- unrelated to symbol gluing, tracked separately.