### PR TITLE
LANGUAGE.md: document the symbol-then-parens call-glue rule

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -283,6 +283,83 @@ counter=0
 Global variables persist across script runs and are visible to all
 interpreters (e.g. UI and network interpreters in drawserv).
 
+### Symbol-then-parens is always a call attempt
+
+`SYMBOL (args)` on one line is always parsed as a call attempt on
+`SYMBOL` — whitespace never matters, only a newline between the symbol
+and the `(` escapes it:
+
+```
+undefinedsym (print("side effect\n"))   // nothing prints -- glued, drained unevaluated
+undefinedsym
+print("side effect\n")                  // "side effect" prints -- newline
+                                         //   makes these two unrelated statements
+```
+
+This is deliberate, minimal-verbiage syntax (`(args)` immediately after
+any identifier means "call it"), not something to work around. What
+happens next depends on what `SYMBOL` resolves to:
+
+- **A registered command** — dispatches normally.
+- **A variable holding a `FuncObj`** (`f=func(...)`) — invoked properly,
+  args and all. This is the *dynamic* case: the call actually runs code.
+- **Anything else — including an undefined symbol** — the arglist is
+  evaluated (for side effects) and discarded, and the call's result is
+  whatever `SYMBOL` itself resolves to. A variable holding a plain value
+  behaves like a *static* `FuncObj`: it "runs" (its arglist still gets
+  evaluated), but always returns the same thing regardless of what it
+  was given — the same idiom `true()`/`false()`/`pi()` already use
+  deliberately ("wrap any expression, override its result"), just
+  generalized to any bound value:
+
+  ```
+  x=5
+  x (print("side effect runs\n"))   // prints, then evaluates to 5
+  ```
+
+  An **undefined** symbol is the one case where the arglist is never
+  evaluated at all (not even for side effects) — internally it's
+  substituted with the built-in, argument-draining `nil` command before
+  anything runs. This is a genuinely useful idiom in its own right: a
+  `.comt` script can gate a whole feature on whether an optional
+  command or func happens to be defined before the script runs —
+  `hook (doWork())` silently no-ops if `hook` was never defined, and
+  calls it for real the moment it is:
+
+  ```
+  // script.comt -- runs doWork() only if the caller predefined `hook`
+  hook (doWork())
+  ```
+
+  ```
+  run("./script.comt")            // hook undefined -- silent no-op
+  hook=func(print("hooked\n"))
+  run("./script.comt")            // hook now defined -- runs for real
+  ```
+
+The same unconditional glue rule applies inside a **stream literal**,
+and it is decided once, at parse time, before anything is known about
+what the symbol will resolve to — so a stream's *length* can depend on
+it in a way that's worth knowing about rather than discovering by
+surprise:
+
+```
+x=5
+y=20
+(x (3) y)       // a 2-element stream: {x(3), y} -- always, regardless
+                //   of what x is, since the glue to (3) is decided
+                //   before x is ever looked up
+postfix(x (3) y)  // "3 x{1|0} y" -- confirms it: only one arg got
+                  //   attached, to x, and y is untouched
+```
+
+If `x` had been a real command or a `FuncObj`, this would be the
+*correct* reading (a call followed by a second stream element). Since
+`x` is a plain value here, the second element is "surprising" only
+until you know the rule: the parser can't see three elements, because
+it never considers *not* gluing an identifier to an immediately
+following same-line paren group.
+
 ## Arguments: Fixed Before Keywords — Always
 
 Every ComTerp command accepts fixed positional arguments followed by

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -303,7 +303,7 @@ happens next depends on what `SYMBOL` resolves to:
 - **A registered command** — dispatches normally.
 - **A variable holding a `FuncObj`** (`f=func(...)`) — invoked properly,
   args and all. This is the *dynamic* case: the call actually runs code.
-- **Anything else — including an undefined symbol** — the arglist is
+- **Anything else -- except for an undefined symbol** — the arglist is
   evaluated (for side effects) and discarded, and the call's result is
   whatever `SYMBOL` itself resolves to. A variable holding a plain value
   behaves like a *static* `FuncObj`: it "runs" (its arglist still gets

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -628,7 +628,7 @@ Variable lookup follows a three-level priority chain:
   `:key val` args set before the body runs.  The frame is an attrlist,
   created for the call and discarded at return — the same structure
   that carries keyword args and `setattr()` properties everywhere else
-- **local scope** — the interpreter's flat top-level symbol table,
+- **local scope** — the interpreter's flat top-level variable table,
   where prompt and `run()` assignments live; `local(x)` reads and
   writes it explicitly (see *Escaping the func scope* below)
 - **global scope** — symbols declared with `global()`; `global(x)`
@@ -722,7 +722,7 @@ call.
 When a func genuinely needs to write outside its own frame, two
 commands name the outer scopes explicitly, as both lvalue and rvalue:
 
-- **`local(x)`** — the interpreter's default symbol table: the scope
+- **`local(x)`** — the interpreter's default variable table: the scope
   bare assignment already uses *outside* a func, named so it can be
   reached from *inside* one.  As an lvalue, `local(x)=val` writes that
   table, skipping the frame; as an rvalue, `local(x)` reads that table
@@ -1488,8 +1488,9 @@ Single-quoted literals are chars, not strings: `'a'`, printed with `%c`.
 ## Symbols
 
 A symbol is an interned string — a unique integer id associated with a
-name, stored once in a global symbol table. Symbols are the basis of
-variable names, command names, keywords, and type names in ComTerp.
+name, stored once in a global symbol table (not to be confused with the
+global variable table). Symbols are the basis of variable names, command
+names, keywords, and type names in ComTerp.
 
 ### Creating and converting symbols
 
@@ -1774,9 +1775,9 @@ language* — and that training reflects the real mechanism, not just convention
 build key never gets dispatched on; it is displayed and compared; it is
 string-nature. A color name gets dispatched on by id; it is symbol-nature.
 
-(Implementation: the symbol *is* the interned string; the intern table holds both
-forms. The split is one of rarity and use, recovered at the surface by which
-quote the author reaches for.)
+(Implementation: the symbol *is* the interned string; the intern table, aka symbol
+table, holds both forms. The split is one of rarity and use, recovered at the
+surface by which quote the author reaches for.)
 
 ## See Also
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "e41a2fa4"
+#define PATCH_KEY "1a582943"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Follow-up to #265/#266. Documents the rule those fixed: same-line adjacency between an identifier and a following paren group (whitespace never matters, only a newline escapes it) always means "this is a call attempt" — deliberate, minimal-verbiage syntax, not something to work around.

Covers:
- The three resolutions: a real command (dispatches normally), a variable holding a `FuncObj` (the *dynamic* case — actually runs code), and anything else including undefined (the *static* case).
- The undefined-symbol gate idiom: a `.comt` script can silently no-op a feature depending on whether an optional command/func was predefined before it ran.
- The generalization of `true()`/`false()`/`pi()`'s "wrap any expression, override its result" idiom to any symbol bound to a plain value (what #266 actually fixed).
- The stream-literal arity surprise this same unconditional glue rule produces — a stream's length can depend on what a glued symbol turns out to be, decided once at parse time before that's known.

Every code example in this PR was verified against a live build before being written down.

## Note

While verifying the stream-literal example, found a separate, pre-existing bug (confirmed unrelated to #266, reproduces before that fix too): materializing (`list()`/`next()`) a stream literal whose first element drains a glued symbol call triggers a stack-imbalance warning. Filed separately as #267 — not fixed here, and the doc example was written to demonstrate the concept via `postfix()` instead of tripping it.