### PR TITLE
Add code-comments guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,20 @@ C++ work. The essentials:
 - No `dynamic_cast` anywhere — use virtual dispatch.
 - New methods/members go at the **bottom** of the header and source file.
 
+### Code comments
+- Keep comments embedded in source code fairly terse declaratives that add
+  context the variable and function names don't already document. Code is
+  the SPOT for what it does and should be read as code.
+- Reserve paragraph-length explanation for the related `.md` file (this
+  one, a layer's `HACKING.md`/`ARCHITECTURE.md`, or `doc/`) — a short
+  in-code comment can point there instead of inlining the essay.
+- Exception: when a locale genuinely needs the long version to head off a
+  likely misreading by a future developer that would cause chaos, leave it
+  in place.
+- If you encounter an existing paragraph-length comment that doesn't meet
+  that bar, shorten it and move the substantive content to the relevant
+  `.md` file.
+
 ### Naming
 - `comterp` (lowercase) = the interpreter / binary / `.comt` scripts / REPL.
 - `ComTerp` (PascalCase) = the C++ library and its classes.

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "e41a2fa4"
+#define PATCH_KEY "38ade1be"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- Adds a "Code comments" subsection to AGENTS.md's conventions: keep in-source comments terse declaratives that add context beyond what names already document; push paragraph-length explanation into the related `.md` file instead, except where a locale genuinely needs the long version to head off a likely misreading.
- Also directs future cleanup: shorten any existing paragraph-length comment found not meeting that bar, moving its substance to the relevant `.md`.