### PR TITLE
_parser.c: recognize [] and {} for stream/attrlist literals, not just ()

### DIFF
--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -215,6 +215,11 @@ goto error_return;}
 #define RIGHT_PAREN( toktype ) \
 (toktype == TOK_RPAREN || toktype == TOK_RBRACKET || toktype == TOK_RBRACE || toktype == TOK_RANGBRACK || toktype == TOK_RANGBRACK2)
 
+/* Deliberately narrower than LEFT_PAREN: stream/attrlist-literal
+   recognition applies to (), [], and {} only -- not <> or <<>>. */
+#define LITERAL_DELIM( toktype ) \
+(toktype == TOK_LPAREN || toktype == TOK_LBRACKET || toktype == TOK_LBRACE)
+
 #define PROCEEDING_WHITESPACE( tokstart ) \
 (tokstart == 0 || isspace( buffer[tokstart-1] ))
 
@@ -879,7 +884,7 @@ int status;
 		 on the second element with the first already on the stack. */
 
 	       if( TopOfParenStack >= 0 &&
-	           LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
+	           LITERAL_DELIM( ParenStack[ TopOfParenStack ].paren_type ) &&
 	           ParenStack[ TopOfParenStack ].comm_id == -1 &&
 	           ParenStack[ TopOfParenStack ].narg == 0 ) {
 	         if(stream_symid==-1) stream_symid = symbol_add("stream");
@@ -925,7 +930,7 @@ int status;
 		 OPERSTK_PUSH( 0, OPERATOR);
 		 whitespace_bound=1;
 	         } else if( TopOfParenStack >= 0 &&
-	             LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
+	             LITERAL_DELIM( ParenStack[ TopOfParenStack ].paren_type ) &&
 	             ParenStack[ TopOfParenStack ].comm_id == -1 &&
 	             ParenStack[ TopOfParenStack ].narg == 0 ) {
 	           /* stream literal: bare LPAREN, first value seen */
@@ -1072,13 +1077,13 @@ int status;
 	 if( TopOfParenStack < 0 || ParenStack[ TopOfParenStack ].comm_id < 0 ) {
 	    /* Allow keyword as first token in a bare group -- implicit attrlist() literal */
 	    if( TopOfParenStack >= 0 &&
-	        LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
+	        LITERAL_DELIM( ParenStack[ TopOfParenStack ].paren_type ) &&
 	        ParenStack[ TopOfParenStack ].nkey == 0 &&
 	        expecting == OPTYPE_UNARY_PREFIX ) {
 	      if(attrlist_symid==-1) attrlist_symid = symbol_add("attrlist");
 	      ParenStack[ TopOfParenStack ].comm_id = attrlist_symid;
 	    } else if( TopOfParenStack >= 0 &&
-	        LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
+	        LITERAL_DELIM( ParenStack[ TopOfParenStack ].paren_type ) &&
 	        ParenStack[ TopOfParenStack ].comm_id == -1 &&
 	        expecting == OPTYPE_BINARY ) {
 	      /* keyword after value(s) -- stream literal (0 :key val) or (0 :flag) */
@@ -1150,10 +1155,10 @@ int status;
 	   if( (!PROCEEDING_WHITESPACE( tokstart ) && !_detail_matched_delims) ||
 		 UNEXPECTED_NEW_EXPRESSION ) {
 		 /* stream literal: bare opening delimiter, first element is
-		    itself a bracketed group of any kind */
-		 if( LEFT_PAREN( toktype ) &&
+		    itself a (), [], or {} group */
+		 if( LITERAL_DELIM( toktype ) &&
 		     TopOfParenStack >= 0 &&
-		     LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
+		     LITERAL_DELIM( ParenStack[ TopOfParenStack ].paren_type ) &&
 		     ParenStack[ TopOfParenStack ].comm_id == -1 &&
 		     ParenStack[ TopOfParenStack ].narg == 0 ) {
 		   if(stream_symid==-1) stream_symid = symbol_add("stream");

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -879,7 +879,7 @@ int status;
 		 on the second element with the first already on the stack. */
 
 	       if( TopOfParenStack >= 0 &&
-	           ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
+	           LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
 	           ParenStack[ TopOfParenStack ].comm_id == -1 &&
 	           ParenStack[ TopOfParenStack ].narg == 0 ) {
 	         if(stream_symid==-1) stream_symid = symbol_add("stream");
@@ -925,7 +925,7 @@ int status;
 		 OPERSTK_PUSH( 0, OPERATOR);
 		 whitespace_bound=1;
 	         } else if( TopOfParenStack >= 0 &&
-	             ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
+	             LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
 	             ParenStack[ TopOfParenStack ].comm_id == -1 &&
 	             ParenStack[ TopOfParenStack ].narg == 0 ) {
 	           /* stream literal: bare LPAREN, first value seen */
@@ -1070,15 +1070,15 @@ int status;
       /* Must be inside parenthesis associated with a command */
       /* for a keyword to be legal                            */
 	 if( TopOfParenStack < 0 || ParenStack[ TopOfParenStack ].comm_id < 0 ) {
-	    /* Allow keyword as first token in bare parens -- implicit attrlist() literal */
+	    /* Allow keyword as first token in a bare group -- implicit attrlist() literal */
 	    if( TopOfParenStack >= 0 &&
-	        ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
+	        LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
 	        ParenStack[ TopOfParenStack ].nkey == 0 &&
 	        expecting == OPTYPE_UNARY_PREFIX ) {
 	      if(attrlist_symid==-1) attrlist_symid = symbol_add("attrlist");
 	      ParenStack[ TopOfParenStack ].comm_id = attrlist_symid;
 	    } else if( TopOfParenStack >= 0 &&
-	        ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
+	        LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
 	        ParenStack[ TopOfParenStack ].comm_id == -1 &&
 	        expecting == OPTYPE_BINARY ) {
 	      /* keyword after value(s) -- stream literal (0 :key val) or (0 :flag) */
@@ -1149,10 +1149,11 @@ int status;
 	 if( expecting == OPTYPE_BINARY ) {
 	   if( (!PROCEEDING_WHITESPACE( tokstart ) && !_detail_matched_delims) ||
 		 UNEXPECTED_NEW_EXPRESSION ) {
-		 /* stream literal: bare LPAREN, first element is also LPAREN */
-		 if( toktype == TOK_LPAREN &&
+		 /* stream literal: bare opening delimiter, first element is
+		    itself a bracketed group of any kind */
+		 if( LEFT_PAREN( toktype ) &&
 		     TopOfParenStack >= 0 &&
-		     ParenStack[ TopOfParenStack ].paren_type == TOK_LPAREN &&
+		     LEFT_PAREN( ParenStack[ TopOfParenStack ].paren_type ) &&
 		     ParenStack[ TopOfParenStack ].comm_id == -1 &&
 		     ParenStack[ TopOfParenStack ].narg == 0 ) {
 		   if(stream_symid==-1) stream_symid = symbol_add("stream");

--- a/src/comterp_/tests/bracket-brace-parity.comt
+++ b/src/comterp_/tests/bracket-brace-parity.comt
@@ -1,0 +1,71 @@
+// src/comterp_/tests/bracket-brace-parity.comt -- []/{} parse the same as
+// () for non-empty content
+//
+// Only the EMPTY form of each delimiter has special, fixed meaning: `()`
+// is an empty attrlist, `[]` an empty stream, `{}` an empty list. For
+// non-empty content, all three delimiters are meant to be otherwise
+// equivalent -- the content decides the "kind" (value-first is a stream
+// literal, keyword-first is an attrlist literal), never the bracket
+// character. `ComUtil/_parser.c`'s stream/attrlist-literal recognition
+// checked `paren_type == TOK_LPAREN` at five call sites, so only `()`
+// ever got that recognition; `[...]`/`{...}` hit a parse error
+// ("Unexpected identifier"/"Unexpected literal constant") the moment a
+// second element followed the first. Regression guard: the same content
+// now parses and evaluates identically regardless of which of the three
+// delimiters wraps it.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/bracket-brace-parity.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: a compound expression followed by an identifier used to
+// error in brackets/braces ("Unexpected identifier") but always worked
+// in parens -- now all three produce the same 2-element stream ---
+y=20
+lp=list(((1+2)*3 y))
+lb=list([(1+2)*3 y])
+lc=list({(1+2)*3 y})
+ok=ok&&(lp==lb)
+ok=ok&&(lp==lc)
+print("1 [(1+2)*3 y] and {(1+2)*3 y} match ((1+2)*3 y) (expect true true): %v %v\n\n" (lp==lb) (lp==lc))
+check_fail(:ok ok)
+
+// --- test 2: keyword-first content is an attrlist literal regardless of
+// delimiter -- []/{} used to error ("Unexpected literal constant") the
+// moment a value followed the first keyword ---
+ap=(:x 1 :y 2)
+ab=[:x 1 :y 2]
+ac={:x 1 :y 2}
+ok=ok&&(class(ab)==`AttributeList)
+ok=ok&&(class(ac)==`AttributeList)
+ok=ok&&(ap.x==ab.x && ap.y==ab.y)
+ok=ok&&(ap.x==ac.x && ap.y==ac.y)
+print("2 [:x 1 :y 2] and {:x 1 :y 2} are attrlists matching (:x 1 :y 2) (expect true): %v\n\n" ok)
+check_fail(:ok ok)
+
+// --- test 3: a keyword appearing after positional values is still a
+// stream (not an attrlist) regardless of delimiter -- compared
+// structurally, since == on lists of AttributeList elements is object
+// identity, not value equality ---
+lp2=list(((0 :key 99)))
+lb2=list([0 :key 99])
+lc2=list({0 :key 99})
+same3=(size(lp2)==2 && size(lb2)==2 && size(lc2)==2 &&
+       at(lp2 0)==at(lb2 0) && at(lp2 0)==at(lc2 0) &&
+       at(lp2 1).key==at(lb2 1).key && at(lp2 1).key==at(lc2 1).key)
+ok=ok&&same3
+print("3 [0 :key 99] and {0 :key 99} match (0 :key 99) (expect true): %v\n\n" same3)
+check_fail(:ok ok)
+
+// --- test 4: empty forms keep their own distinct, unchanged meaning --
+// []=stream, {}=list, ()=attrlist -- delimiter choice only matters when
+// there's nothing inside to otherwise decide the kind ---
+ok=ok&&(size({})==0)
+ok=ok&&(class(())==`AttributeList)
+print("4 empty {} and () keep their own distinct meaning (expect true): %v\n\n" ok)
+check_fail(:ok ok)
+
+print("\nbracket-brace-parity: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -122,5 +122,9 @@ if(run("./symboldrain.comt")
   :then print("pass: symboldrain\n")
   :else print("FAIL: symboldrain\n");topok=false)
 
+if(run("./bracket-brace-parity.comt")
+  :then print("pass: bracket-brace-parity\n")
+  :else print("FAIL: bracket-brace-parity\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "e41a2fa4"
+#define PATCH_KEY "9dc5af26"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Only the empty form of each delimiter is meant to have fixed, distinct meaning — `()` an empty attrlist, `[]` an empty stream, `{}` an empty list. For non-empty content, `()`/`[]`/`{}` are meant to be otherwise equivalent: the content decides the kind (value-first is a stream literal, keyword-first is an attrlist literal), never the bracket character. `<>`/`<<>>` are deliberately excluded from this — nothing here documents or implies they behave the same way.

Six call sites in `ComUtil/_parser.c`'s raw postfix-generating state machine checked `ParenStack[...].paren_type == TOK_LPAREN` (or, for a nested first element, `toktype == TOK_LPAREN`) before recognizing "this group is a stream/attrlist literal in progress, allow another element" — so only `()` ever got that recognition. `[...]`/`{...}` hit a parse error the moment a second element followed the first, e.g. `[(1+2)*3 y]` or `[:x 1 :y 2]`.

## Fix

Replace each `TOK_LPAREN`-only check with a new `LITERAL_DELIM(...)` macro matching exactly `TOK_LPAREN`/`TOK_LBRACKET`/`TOK_LBRACE` — deliberately narrower than the file's existing `LEFT_PAREN(...)` macro, which also matches `<>`/`<<>>` and is used elsewhere in this file for a different, unrelated purpose (the general "is the next token any opening delimiter" call-glue check, left untouched). The two delimiter-matching integrity checks (a closing delimiter must match its specific opener) are also untouched, since those are correctly delimiter-specific by design.

## Test plan

- [x] Confirmed pre-fix: `[(1+2)*3 y]` and `[:x 1 :y 2]` error; `((1+2)*3 y)`/`(:x 1 :y 2)` work
- [x] Confirmed post-fix: all three of `()`/`[]`/`{}` produce identical `postfix()` structure and identical evaluated results for the same content
- [x] Confirmed empty forms keep their own distinct, unchanged meaning (`[]`=stream, `{}`=list, `()`=attrlist)
- [x] Full `run_all.comt` regression suite passes
- [x] Added `src/comterp_/tests/bracket-brace-parity.comt` covering the three delimiters across compound-expression, keyword-first, and trailing-keyword content

Closes #270

Note: while testing, found `s=[]` (assigning an empty bracket-stream to a variable) produced several alarming-looking internal diagnostic messages, confirmed pre-existing and unrelated to this fix — flagged separately and already fixed/merged as #272.