### PR TITLE
Fix empty bracket stream literal [] cascading internal errors

### DIFF
--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -81,28 +81,38 @@ void StreamFunc::execute() {
     return;
   }
 
+  static StreamNextFunc* snfunc = nil;
+  if (!snfunc) {
+    snfunc = new StreamNextFunc(comterp());
+    snfunc->funcid(symbol_add("streamnext"));
+  }
+
+  if (nargs() == 0) {
+    /* empty stream literal: [] -- returns nil on first next() */
+    reset_stack();
+    AttributeValueList* avl = new AttributeValueList();
+    ComValue stream(snfunc, avl);
+    stream.stream_mode(STREAM_INTERNAL);
+    push_stack(stream);
+    return;
+  }
+
   ComValue operand1(stack_arg_post_eval(0));
-  
+
   reset_stack();
-  
+
   if (operand1.is_stream()) {
-    
+
     /* stream copy */
     AttributeValueList* old_avl = operand1.stream_list();
     AttributeValueList* new_avl = new AttributeValueList(old_avl);
     ComValue retval(operand1.stream_func(), new_avl);
     retval.stream_mode(operand1.stream_mode());
     push_stack(retval);
-    
-  } else {
-    
-    /* conversion operator */
 
-    static StreamNextFunc* snfunc = nil;
-    if (!snfunc) {
-      snfunc = new StreamNextFunc(comterp());
-      snfunc->funcid(symbol_add("streamnext"));
-    }
+  } else {
+
+    /* conversion operator */
 
     if (operand1.is_array()) {
       AttributeValueList* avl = new AttributeValueList(operand1.array_val());

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -1384,6 +1384,9 @@ int status;
 	     } else if (toktype == TOK_RPAREN) {
 	       if(attrlist_symid==-1) attrlist_symid = symbol_add("attrlist");
 	       PFOUT( TOK_COMMAND, attrlist_symid, 0, 0, toktype );
+	     } else if (toktype == TOK_RBRACKET) {
+	       if(stream_symid==-1) stream_symid = symbol_add("stream");
+	       PFOUT( TOK_COMMAND, stream_symid, 0, 0, toktype );
 	     } else {
 	       PFOUT_LITERAL( TOK_BLANK, token );
 	     }

--- a/src/comterp_/tests/stream-literal.comt
+++ b/src/comterp_/tests/stream-literal.comt
@@ -1,13 +1,14 @@
-// stream-literal.comt version 4
-print("stream-literal.comt version 4\n")
+// stream-literal.comt version 5
+print("stream-literal.comt version 5\n")
 
 // src/comterp_/tests/stream-literal.comt -- stream literal syntax tests
 //
-// coverage: 18 tests of stream literal feature
+// coverage: 19 tests of stream literal feature
 // funcs: postfix() errmsg() index() next() list() each() size() class() trace()
 // tests 1-8:   parser tests (postfix inspection)
 // tests 9-14:  stream literal runtime behavior
 // tests 15-18: stream-of-streams construction, zip behavior, mixed elements
+// test 19:     empty bracket literal []
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/stream-literal.comt")
@@ -252,6 +253,28 @@ r18d=next(s18)
 ok18=ok18&&(r18d==nil)
 ok=ok&&ok18
 print("18 next((1 (2 3) :key 4)) -- mixed scalar+stream+keyword (expect 1 StreamType{2,3} (:key 4) nil): %v %v %v %v\n" r18a r18b r18c r18d)
+prev_ok=check_fail(:ok ok)
+
+// =========================================================
+// PART 4: Empty bracket literal
+// =========================================================
+
+// --- test 19: [] is an empty stream, nil on first next() ---
+// BEFORE fix: cascade of internal errors ("offlimit hit by
+// ComTerp::skip_arg" etc.) -- empty brackets fell through to a bare
+// blank token instead of constructing a stream, corrupting postfix
+// bookkeeping and confusing AssignFunc.
+// AFTER fix: [] parses like a zero-arg stream() call, matching how {}
+// and () construct an empty list/attrlist; next() returns nil right away.
+errmsg(:clear)
+s19=[]
+e19=errmsg(:last)
+ok19=(e19==nil)
+ok19=ok19&&(class(s19)==`StreamType)
+r19=next(s19)
+ok19=ok19&&(r19==nil)
+ok=ok&&ok19
+print("19 s=[]; next(s) -- empty stream literal (expect no error, StreamType, nil): %v %v\n" class(s19) r19)
 prev_ok=check_fail(:ok ok)
 
 print("stream-literal: %v\n" ok)


### PR DESCRIPTION
## Summary
- `s=[]` (assigning an empty bracket-stream literal) produced a cascade of internal errors ("offlimit hit by ComTerp::skip_arg" x2, "unexpected negative index for _pfcomvals", "stack empty, blank returned", a bogus AssignFunc warning, and a stray "0") even though the statement didn't crash.
- Root cause: `{}` and `()` already had explicit parser cases (`_parser.c`) emitting zero-arg `list`/`attrlist` commands for the empty case, giving each delimiter pair a concrete value. `[]` had no such case and fell through to a bare `TOK_BLANK` placeholder token instead, which corrupted `ComTerp::skip_arg`'s postfix bookkeeping (it expects a blank token to prefix a following real value, not stand alone as the entire RHS).
- Fix gives `[]` parity with `{}` and `()`: the parser now emits a zero-arg `stream` command for empty brackets, and `StreamFunc::execute()` handles the 0-arg case by building a genuinely empty stream instead of trying to pop a nonexistent argument off the stack.
- `next()` on the resulting empty stream returns `nil` immediately — the intended semantics for use as a placeholder in future two-way streams.

## Test plan
- [x] Added test 19 to `src/comterp_/tests/stream-literal.comt` covering `s=[]`, no error, `class(s)==StreamType`, `next(s)==nil`
- [x] Full test suite (`run_all.comt`) passes, run 5x to check for flakiness
- [x] Manually verified `{}`→`ListType`/empty-list and `()`→attrlist parity unaffected, and non-empty stream literals like `(1 2 3)` still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)