### PR TITLE
eval_expr_internals: self-heal stray value(s) left on the shared stack

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -515,11 +515,18 @@ void ComTerp::eval_expr_internals(int pedepth) {
     }
     else if (stack_base+1 > _stack_top) {
       fprintf(stderr, "func \"%s\" failed to push a single value on stack\n", symbol_pntr(func->funcid()));
-      /* symmetric recovery: restore the single value every post_eval
-         command's contract promises, so a later statement's argoff anchor
-         lookup finds a real (if null) value at the expected height instead
-         of silently drifting. */
-      push_stack(ComValue::nullval());
+      /* secondary backstop, not the primary handler: a command whose last
+         stack-affecting act was reset_stack() and nothing else is already
+         caught above by the _just_reset check (comfunc.c's reset_stack()
+         sets it, any push_stack() clears it) and backfilled with blankval()
+         there -- that's the common case, and by the time we get here it has
+         already restored stack_base+1.  This branch only still fires for a
+         command that shorts the stack some other way, bypassing
+         reset_stack() entirely.  Use the same blankval() sentinel as that
+         mechanism, not nullval()/nil -- they're not interchangeable
+         elsewhere (is_blank() vs is_nil() are checked separately, and a
+         stray nil reads differently than "no value here" placeholder). */
+      push_stack(ComValue::blankval());
     }
 
     return;

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -500,9 +500,27 @@ void ComTerp::eval_expr_internals(int pedepth) {
       fprintf(stderr, "stack_base %d, stack_top %d\n", stack_base, _stack_top);
       for(int i=stack_base+1; i<=_stack_top; i++)
           std::cerr << i << ":  " << _stack[i] << "\n";
+      /* Trim the stray extra value(s) rather than leaving them behind: an
+         under-consumed post_eval command here (observed from deeply nested
+         stream/next() recursion) otherwise leaves residue on the shared
+         value stack that outlives this statement -- since eval_expr() only
+         resets _stack_top between top-level statements when !nested, a
+         run("file") session (nested=true, see runfile()'s eval_expr(true))
+         carries the stray value into every later statement, where an
+         unrelated post_eval command's stack_top()-based argoff anchor lookup
+         misreads it as its own bookmark (comfunc.c's stack_arg_post family),
+         cascading into "offlimit hit by ComTerp::skip_arg" and similar
+         postfix-bookkeeping errors far from the true cause. */
+      decr_stack(_stack_top - (stack_base+1));
     }
-    else if (stack_base+1 > _stack_top)
+    else if (stack_base+1 > _stack_top) {
       fprintf(stderr, "func \"%s\" failed to push a single value on stack\n", symbol_pntr(func->funcid()));
+      /* symmetric recovery: restore the single value every post_eval
+         command's contract promises, so a later statement's argoff anchor
+         lookup finds a real (if null) value at the expected height instead
+         of silently drifting. */
+      push_stack(ComValue::nullval());
+    }
 
     return;
     

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "9dc5af26"
+#define PATCH_KEY "1a6d43e0"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`run("file")` sessions drive every top-level statement through `eval_expr(nested=true)`, which never resets `_stack_top` between statements (see `runfile()`'s `eval_expr(true)` and `eval_expr()`'s `!nested`-only reset) -- so the value stack is one continuous stack across an entire file's execution, by design.

`eval_expr_internals()` already has a consistency check that detects when a command's `execute()` pushed more (or fewer) than the single value its `post_eval` contract promises, but it only **logged** the anomaly and left the stray value(s) in place. Because the stack is shared across statements, that residue silently persists into every later statement's evaluation. When a later `post_eval` command (e.g. `AssignFunc`) does its own `stack_top()`-based "argoff anchor" lookup (`comfunc.c`'s `stack_arg_post`/`stack_key_post` family), it can misread the leftover residue as its own bookmark -- producing a cascade of `offlimit hit by ComTerp::skip_arg`, `unexpected negative index for _pfcomvals`, and bogus assignment-type warnings in a statement that is otherwise correct in isolation, dozens of lines away from the true cause.

Observed via `src/comterp_/tests/stream-literal.comt`: nested-stream/zip `next()` recursion in `strmfunc.c` occasionally over-pushes (reproduced under an ASan build per `config/SANITIZE.md`; ASan itself never fires, since this is a logic bug rather than an out-of-bounds access), and the residue corrupts an unrelated later statement in the same `run()` call. The over-push is rare and heap-layout-sensitive -- even small unrelated code edits shifted whether it reproduced -- so this fix targets the general mechanism (any command that over/under-pushes) rather than one specific call site.

## Fix

Make the existing detection self-healing: trim the excess on an over-push (`decr_stack`), or push a filler null on an under-push, so a later statement never inherits residue from an earlier one. As a side benefit, the existing diagnostic (`func "%s" pushed more than a single value on stack (line %d)`) now survives cleanly instead of being buried under cascade noise, so if the underlying rare over-push fires again it'll point straight at the culprit.

Also bumps `PATCH_KEY` per repo convention.

## Test plan

- [x] `run_all.comt` still passes clean (no regressions)
- [x] `stream-literal.comt` test 17's "double zipper" output is unchanged (comment stays accurate)
- [x] 1000+ loop iterations of `stream-literal.comt` under an ASan build post-fix show zero cascades
- [ ] Push a tag matching the new `PATCH_KEY` value once merged, per `src/include/ivstd/patch.h`'s convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)