### PR TITLE
FontFunc: delegate to FontByNameFunc for string args via static slipin

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -858,6 +858,8 @@ RasterOvComp* CreateRasterFunc::create_from_rgb(ComValue& rgbv, AttributeList* a
 
 /*****************************************************************************/
 
+static FontByNameFunc* _font_by_name_func = NULL;
+
 FontFunc::FontFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
@@ -874,6 +876,18 @@ void FontFunc::execute() {
             ComValue retval(fnt->GetName());
             push_stack(retval);
         }
+        return;
+    }
+
+    ComValue& fv = stack_arg(0, true);
+    if (fv.is_string()) {
+        if (_font_by_name_func == NULL) {
+            _font_by_name_func = new FontByNameFunc(comterp(), editor());
+        } else {
+            _font_by_name_func->comterp(comterp());
+            _font_by_name_func->editor(editor());
+        }
+        _font_by_name_func->execute();
         return;
     }
 

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -142,13 +142,13 @@ public:
 };
 
 //: command for setting font state variable in comdraw.
-// font(fontnum) -- set current font from menu order
+// font(fontnum|fontname) -- set current font from menu order or by X name
 class FontFunc : public UnidrawFunc {
 public:
     FontFunc(ComTerp*,Editor*);
     virtual void execute();
-    virtual const char* docstring() { 
-	return "%s([fontnum]) -- set current font from menu order; return current font by X name if no args"; }
+    virtual const char* docstring() {
+	return "%s([fontnum|fontname]) -- set current font from menu order or by X name; return current font by X name if no args"; }
 };
 
 //: command for setting font state variable by  font name in comdraw.

--- a/src/comdraw/tests/gsget.comt
+++ b/src/comdraw/tests/gsget.comt
@@ -43,6 +43,14 @@ f2=fontbyname()
 ok=ok&&(f==f2)
 print("7 fontbyname(font()); fontbyname() round trip (expect true): %v\n" f==f2)
 
+// font(fontname) delegates to fontbyname() via the same static-slipin
+// pattern colors(fgname bgname) already uses to reach colorsrgb() --
+// a string arg to font() should set by name, not be misread as a menu index
+font(f)
+f3=font()
+ok=ok&&(f==f3)
+print("7b font(fontname) delegates to fontbyname by string arg (expect true): %v\n" f==f3)
+
 // save/restore idiom the getters enable: borrow the pen, put it back
 saved=brush()
 brush(65535,7)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "de378234"
+#define PATCH_KEY "64a10e69"
 
 #endif /* _patch_h */

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -50,7 +50,7 @@ graphical object assigned to an interpreter variable.
 
 .SH GRAPHIC STATE COMMANDS
 
- font([fontnum]) -- set current font from menu;
+ font([fontnum|fontname]) -- set current font from menu order or by X name;
     return current font by X name if no args
  fontbyname([fontname]) -- set current font by X font name;
     return current font by X name if no args


### PR DESCRIPTION
## Summary

`font(fontnum)` only accepted an integer menu index. `FontByNameFunc` already existed for string-based font selection, but `font()` had no path to it.

## Fix

Mirror the exact pattern `ColorFunc::execute()` already uses to reach `ColorRgbFunc` for a string color argument: peek the first arg with `stack_arg(0, true)`, and if it's a string, delegate to a lazily constructed, cached `FontByNameFunc` (refreshing its `comterp()`/`editor()` before each call), otherwise fall through to the existing integer-menu-index path unchanged.

Updated `FontFunc`'s docstring to document both forms, matching `ColorFunc`'s docstring.

## Test plan

- [x] Confirmed the change compiles cleanly
- [x] Extended `src/comdraw/tests/gsget.comt` with a new case: `font(name)` should set the same font `fontbyname(name)` does, round-tripped through `font()`'s own bare getter — the same shape the file's other getters already use

**Note on verification:** comdraw tests need a live X11 display; CI runs them headlessly under `xvfb-run` on Linux per `src/comdraw/tests/TESTING.md`, but I couldn't reproduce that locally on this Mac (Xvfb can't create its listening socket without root here) — I wasn't able to run this test myself before pushing. The change itself is a small, mechanical mirror of the already-working `ColorFunc`/`ColorRgbFunc` delegation, but flagging this so CI's result here gets weight rather than being assumed redundant with local testing.

Closes #144