### PR TITLE
strmfunc.c: fix stream-literal dispatch to count bare keywords

### DIFF
--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -76,15 +76,8 @@ StreamFunc::StreamFunc(ComTerp* comterp) : StrmFunc(comterp) {
 void StreamFunc::execute() {
 
   /* stream literal: (val val ...) -- delegate to execute_literal().
-     nargs() alone undercounts a bare (valueless) keyword -- it counts
-     positionals plus any values that follow keywords, but a bare keyword
-     marker itself contributes nothing to nargs(), only to nkeys().  So
-     (0 :standalonekey) -- one positional, one bare keyword -- previously
-     read as nargs()==1 and fell through to the scalar path below, even
-     though it's a genuine two-element stream (confirmed by (0 :key 3),
-     a valued keyword in the same slot, which nargs()==2 already routed
-     correctly).  nargstotal() (nargs()+nkeys(), see doc/POSTFIX-INDEXING.md
-     section 1) is the "everything" count this check actually wants. */
+     nargstotal() (not nargs()) so a bare keyword element still counts;
+     see doc/POSTFIX-INDEXING.md section 1. */
   if (nargstotal() > 1) {
     execute_literal();
     return;

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -75,8 +75,17 @@ StreamFunc::StreamFunc(ComTerp* comterp) : StrmFunc(comterp) {
 
 void StreamFunc::execute() {
 
-  /* stream literal: (val val ...) -- delegate to execute_literal() */
-  if (nargs() > 1) {
+  /* stream literal: (val val ...) -- delegate to execute_literal().
+     nargs() alone undercounts a bare (valueless) keyword -- it counts
+     positionals plus any values that follow keywords, but a bare keyword
+     marker itself contributes nothing to nargs(), only to nkeys().  So
+     (0 :standalonekey) -- one positional, one bare keyword -- previously
+     read as nargs()==1 and fell through to the scalar path below, even
+     though it's a genuine two-element stream (confirmed by (0 :key 3),
+     a valued keyword in the same slot, which nargs()==2 already routed
+     correctly).  nargstotal() (nargs()+nkeys(), see doc/POSTFIX-INDEXING.md
+     section 1) is the "everything" count this check actually wants. */
+  if (nargstotal() > 1) {
     execute_literal();
     return;
   }

--- a/src/comterp_/tests/stream-argcnt.comt
+++ b/src/comterp_/tests/stream-argcnt.comt
@@ -1,5 +1,5 @@
-// stream-argcnt.comt version 1
-print("stream-argcnt.comt version 1\n")
+// stream-argcnt.comt version 2
+print("stream-argcnt.comt version 2\n")
 
 // src/comterp_/tests/stream-argcnt.comt -- verify that the directory argcnt of
 // each stream-literal element is the postfix token count of that element's value
@@ -15,10 +15,10 @@ print("stream-argcnt.comt version 1\n")
 //
 // Tests 1-3 check keyword value argcnt (1, 3, 7).  Test 4 checks a bare keyword
 // in a non-deciding position (well-formed: lone marker, counted as an element).
-// Test 5 probes a bare keyword AS the deciding second element -- a KNOWN
-// construction bug that builds a malformed directory; it is print-only until
-// fixed.  Tests 6-7 check that a positional value span equals the equivalent
-// keyword value span.
+// Test 5 checks a bare keyword AS the deciding second element -- this used to
+// build a malformed directory (see StreamFunc::execute()'s nargstotal() fix)
+// and now matches test 4's shape.  Tests 6-7 check that a positional value span
+// equals the equivalent keyword value span.
 //
 // A stream literal needs positional content to BE a stream (a lone (:key val)
 // is an attrlist literal), so each keyword case carries a leading positional 0;
@@ -70,20 +70,23 @@ ok=ok&&ok4
 print("4 (0 1 :standalonekey) nelem==3 (expect true): %v\n" ok4)
 prev_ok=check_fail(:ok ok)
 
-// --- test 5: bare keyword AS the deciding second element -- KNOWN BUG, probe ---
+// --- test 5: bare keyword AS the deciding second element -- now well-formed ---
 // (0 :standalonekey): the keyword is the element that decides stream-ness.  This
-// currently builds a MALFORMED directory ({0,} -- no FuncObj header, no marker)
-// and info().nelem returns nil.  Contrast with test 4, where the same bare
-// keyword in a non-deciding slot is well-formed.  See issue:
-//   stream literal with a bare keyword as the deciding (second) element builds a
-//   malformed directory.
-// Left as a PRINT-ONLY probe (no assertion) until that construction bug is fixed;
-// once fixed, this should match test 4's shape and become a hard assertion.
-// Style note: the durable fix on the authoring side is to never put a keyword in
-// a deciding position -- keep to positionals-then-keywords even in stream literals.
+// used to build a MALFORMED directory ({0,} -- no FuncObj header, no marker) and
+// info().nelem returned nil, because StreamFunc::execute()'s dispatch check
+// undercounted a bare keyword (it contributes to nkeys() but not nargs()).
+// Fixed by dispatching on nargstotal() (nargs()+nkeys()) instead of nargs()
+// alone.  Directory: {FuncObj,2, 0,1, :standalonekey} -> nelem 2, size 5 --
+// same lone-marker shape test 4 shows for a non-deciding bare keyword.
+// Style note: the durable fix on the authoring side is still to prefer
+// positionals-then-keywords even in stream literals -- this just confirms
+// the deciding-position case is no longer silently broken.
 errmsg(:clear)
 s5=(0 :standalonekey)
-print("5 (0 :standalonekey) [known bug] nelem: %v   raw: %v\n" info(s5).nelem info(s5 :raw))
+ok5=(info(s5).nelem==2)&&(size(info(s5 :raw))==5)
+ok=ok&&ok5
+print("5 (0 :standalonekey) nelem==2, raw size==5 (expect true): %v\n" ok5)
+prev_ok=check_fail(:ok ok)
 
 // --- test 6: positional value uses the SAME span counting -- argcnt 7 ---
 // 1+2+3+5 as a positional element has the same postfix count as a keyword value.

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "64a10e69"
+#define PATCH_KEY "e282cfd8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `StreamFunc::execute()` decided literal-vs-scalar dispatch via `nargs()` alone, but a bare (valueless) keyword contributes only to `nkeys()`, not `nargs()`. When a bare keyword was the *deciding* second element -- `(0 :standalonekey)` -- the check read `nargs()==1`, fell through to the scalar path instead of `execute_literal()`, and built a malformed directory (`info().nelem` returned `nil`).
- Fixed by dispatching on `nargstotal()` (`nargs()+nkeys()`, an existing named `ComFunc` accessor -- see `doc/POSTFIX-INDEXING.md`), which counts every element regardless of whether it's a positional, a valued keyword, or a bare keyword.
- Confirmed against all four acceptance criteria from #132: `info((0 :standalonekey) :raw)` now builds a well-formed directory (`{FuncObj,2,0,1,:standalonekey}`), `.nelem` returns `2` (not `nil`), the bare-keyword marker representation matches the non-deciding case (`(0 1 :standalonekey)` -> same lone-marker shape), and no regressions in `stream-literal.comt`, `stream-info.comt`, `stream-argcnt.comt`, or `attrlist.comt`.
- `stream-argcnt.comt` test 5, previously a print-only probe for this known bug, is now a hard assertion.

## Test plan
- [x] `stream-literal.comt`, `stream-info.comt`, `stream-argcnt.comt`, `attrlist.comt`, and the full `run_all.comt` suite pass locally
- [x] Bumped `PATCH_KEY`
- [ ] CI green

Closes #132