### PR TITLE
unifunc.c: refuse paste() on an already-parented graphic

### DIFF
--- a/src/ComUnidraw/unifunc.c
+++ b/src/ComUnidraw/unifunc.c
@@ -157,6 +157,11 @@ void PasteFunc::execute() {
     /* extract comp and scale/translate before pasting */
     ComponentView* view = (ComponentView*)viewv.obj_val();
     OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
+    if (comp && comp->GetParent()) {
+      fprintf(stderr, "paste: graphic already has a parent, not pasting\n");
+      push_stack(ComValue::nullval());
+      return;
+    }
     Graphic* gr = comp ? comp->GetGraphic() : nil;
     if (gr) {
       if (xscalev.is_num() && yscalev.is_num()) {

--- a/src/ComUnidraw/unifunc.h
+++ b/src/ComUnidraw/unifunc.h
@@ -77,8 +77,8 @@ class PasteFunc : public UnidrawFunc {
 public:
     PasteFunc(ComTerp*,Editor*,OverlayCatalog* = nil);
     virtual void execute();
-    virtual const char* docstring() { 
-	return "compview=%s(compview [xscale yscale xoff yoff | a00,a01,a10,a11,a20,a21]) -- paste graphic into the viewer"; }
+    virtual const char* docstring() {
+	return "compview=%s(compview [xscale yscale xoff yoff | a00,a01,a10,a11,a20,a21]) -- paste graphic into the viewer, compview must have no parent (see parent())"; }
 
 protected:
     OverlayCatalog* _catalog;

--- a/src/comdraw/tests/paste.comt
+++ b/src/comdraw/tests/paste.comt
@@ -1,0 +1,50 @@
+// src/comdraw/tests/paste.comt -- paste() must refuse an already-parented graphic
+//
+// Every Create*Func (rect(), raster(), etc.) auto-inserts its graphic under
+// the default pastemode(0) -- paste()'ing that same return value used to
+// double-append it as a child of the document a second time, corrupting
+// the parent/child tree.  paste() now requires parent()==nil and refuses
+// otherwise.
+//
+// Run from inside comdraw:
+//   run("src/comdraw/tests/paste.comt")
+
+ok=true
+
+// --- test 1: paste() on an already-pasted graphic (default pastemode) -- refused ---
+p=paste(raster(0,0,64,64 :rgb 4,4,
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0),
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0),
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0),
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0)))
+ok=ok&&(p==nil)
+print("1 paste(raster(...)) refused, already parented (expect nil): %v\n" p)
+
+// --- test 2: pastemode(1) -- raster() no longer auto-inserts ---
+pastemode(1)
+r2=raster(0,0,32,32 :rgb 4,4,
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0),
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0),
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0),
+  (0,0,0),(0,0,0),(0,0,0),(0,0,0))
+ok=ok&&(parent(r2)==nil)
+print("2 parent(r2) before paste, pastemode(1) (expect nil): %v\n" parent(r2))
+
+// --- test 3: paste() on a never-inserted graphic -- succeeds ---
+p2=paste(r2)
+ok=ok&&(p2!=nil)
+print("3 paste(r2), first insertion (expect non-nil): %v\n" p2)
+
+// --- test 4: parent(r2) after paste -- no longer nil ---
+ok=ok&&(parent(r2)!=nil)
+print("4 parent(r2) after paste (expect non-nil): %v\n" parent(r2))
+
+// --- test 5: paste() on that now-parented graphic -- refused, same as test 1 ---
+p3=paste(r2)
+ok=ok&&(p3==nil)
+print("5 paste(r2) refused, now parented (expect nil): %v\n" p3)
+
+pastemode(0)
+
+print("paste: %v\n" ok)
+ok

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -39,5 +39,9 @@ if(run("./lastkey.comt")
   :then print("pass: lastkey\n")
   :else print("FAIL: lastkey\n");ok=false)
 
+if(run("./paste.comt")
+  :then print("pass: paste\n")
+  :else print("FAIL: paste\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "e282cfd8"
+#define PATCH_KEY "43b5438a"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- Every `Create*Func` (`rect()`, `raster()`, etc.) auto-inserts its graphic under the default `pastemode(0)`, then also returns that same comp as its value. `PasteFunc::execute()` blindly re-inserted whatever comp it was handed via a raw local `Clipboard`, with no check that it wasn't already parented -- so `paste(raster(...))` double-appended the same object as a child of the document a second time, corrupting the parent/child tree (not a crash, but duplicate refs / double-iteration / double-delete risk).
- Fix: `PasteFunc::execute()` now requires `comp->GetParent()==nil` before pasting -- prints a clear message to stderr and returns `nil` otherwise, rather than silently corrupting document state.
- `parent()` (`GrParentFunc`, already existed in `grfunc.c`/registered in `comeditor.c`) is the primitive scripts can already use to check this themselves; `paste()`'s own docstring now points at it.
- Under `pastemode(1)` (where `Create*Func` doesn't auto-insert), `paste()` continues to work exactly as before -- confirmed by the new test.

## Test plan
- [x] New `src/comdraw/tests/paste.comt`, wired into `run_all.comt`: covers refusal on an already-parented graphic, success on a never-inserted one (`pastemode(1)`), `parent()` transitioning from `nil` to non-nil after paste, and refusal again on a second paste attempt.
- [x] Full `src/comdraw/tests/run_all.comt` suite passes locally (pixelfunc, gsexim, group, gsget, dotattr, lastkey, paste)
- [x] Bumped `PATCH_KEY`
- [ ] CI green

## Related
This was scoped down from a much larger design discussion about `copy()`/`cut()`/`paste()` semantics in comdraw and DrawServ (off-screen graphics, clipboard vs. comterp variables, distributed cut/paste). That design work will land as separate follow-on issue(s) rather than blocking this fix; #277 (DrawServ grid-table cleanup) was already split out from the same discussion.

Closes #42