### PR TITLE
docs: PR closing-keyword convention; paste()/parent() contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,9 @@ C++ work. The essentials:
 - When bumping interpreter internals, the `PATCH_KEY` constant in the relevant
   `main.c` (e.g. `src/comterp_/main.c`) is bumped so the startup banner shows
   the change.
+- **PR description must include a closing keyword** (`Closes #N`, `Fixes #N`,
+  etc.) when the PR resolves a tracked issue, so the issue auto-closes on
+  merge instead of being left open for manual cleanup.
 
 ### ComTerp scripting gotchas (bite C-trained authors)
 - **Everything is an expression**; there are no declarations. `func` is a

--- a/doc/APPENDIX-A-DRAWING-EDITOR.md
+++ b/doc/APPENDIX-A-DRAWING-EDITOR.md
@@ -25,6 +25,13 @@ t=text(150 150 "hello")
 e=ellipse(200 200 80 40)
 ```
 
+**Paste and parenting** — every drawing primitive auto-inserts itself
+into the document by default (`pastemode(0)`); `pastemode(1)`
+suppresses that, so a graphic can be built and held off-screen before
+insertion. `paste(compview)` inserts an explicit graphic, but only if
+it isn't already parented — check with `parent(compview)`, which
+returns `nil` for anything not yet on the canvas.
+
 **Graphic state** — font, brush, pattern, color, all selectable from
 menus or set by command. Colors can be specified by menu index or by
 RGB name in standard hex notation (`#RRGGBB`). Pattern masks can be

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "43b5438a"
+#define PATCH_KEY "00acf60b"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `AGENTS.md`: require a closing keyword (`Closes #N`, `Fixes #N`) in every PR description that resolves a tracked issue -- this was meant to land alongside #278 but got missed before that PR was merged.
- `doc/APPENDIX-A-DRAWING-EDITOR.md`: document the `pastemode(0)`/`pastemode(1)` and `paste()`/`parent()` contract established by #278 -- closes the doc-level gap #42's own first comment asked for ("what paste is good for should be clarified").

No code changes; `PATCH_KEY` bumped per the repo's every-PR convention.