### PR TITLE
grfunc.c: fix raster() :rgb crash on non-nested pixel values

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -861,12 +861,13 @@ RasterOvComp* CreateRasterFunc::create_from_rgb(ComValue& rgbv, AttributeList* a
             r = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
             g = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
             b = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
+	    raster->poke(col, row, r, g, b, 1.0);
           } else {
             char colorname[8];
             snprintf(colorname, sizeof(colorname), "#%06x", elem->int_val());
-            Color::find(World::current()->display(), colorname, r, g, b);
+            if (Color::find(World::current()->display(), colorname, r, g, b)) 
+	      raster->poke(col, row, r, g, b, 1.0);
           }
-          raster->poke(col, row, r, g, b, 1.0);
         }
       }
     }

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -830,21 +830,45 @@ RasterOvComp* CreateRasterFunc::create_from_rgb(ComValue& rgbv, AttributeList* a
 
     int w = avl->GetAttrVal(i)->int_val(); avl->Next(i);
     int h = avl->GetAttrVal(i)->int_val(); avl->Next(i);
+    int npix = w*h;
+    int nval = avl->Number()-2;
 
     OverlayRaster* raster = new OverlayRaster(w, h, 0);
     OverlayRasterRect* rasterrect = new OverlayRasterRect(raster, stdgraphic);
 
-    for (int row = 0; row < h && !avl->Done(i); row++) {
+    /* pixel data comes in one of three forms, told apart purely by count
+       against w*h: flat r,g,b (three scalars per pixel), nested (r,g,b)
+       triples (one array per pixel), or legacy packed 0xRRGGBB ints (one
+       scalar per pixel) -- see doc/APPENDIX-B-COMTERP-EXAMPLES.md */
+    if (nval == npix*3) {
+      for (int row = 0; row < h && !avl->Done(i); row++) {
         for (int col = 0; col < w && !avl->Done(i); col++) {
-            AttributeValue* triple = avl->GetAttrVal(i); avl->Next(i);
-            AttributeValueList* rgb = triple->array_val();
+          float r = avl->GetAttrVal(i)->int_val()/255.; avl->Next(i);
+          float g = avl->GetAttrVal(i)->int_val()/255.; avl->Next(i);
+          float b = avl->GetAttrVal(i)->int_val()/255.; avl->Next(i);
+          raster->poke(col, row, r, g, b, 1.0);
+        }
+      }
+    } else {
+      for (int row = 0; row < h && !avl->Done(i); row++) {
+        for (int col = 0; col < w && !avl->Done(i); col++) {
+          AttributeValue* elem = avl->GetAttrVal(i); avl->Next(i);
+          float r, g, b;
+          if (elem->is_array()) {
+            AttributeValueList* rgb = elem->array_val();
             ALIterator j;
             rgb->First(j);
-            float r = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
-            float g = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
-            float b = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
-            raster->poke(col, row, r, g, b, 1.0);
+            r = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
+            g = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
+            b = rgb->GetAttrVal(j)->int_val()/255.; rgb->Next(j);
+          } else {
+            char colorname[8];
+            snprintf(colorname, sizeof(colorname), "#%06x", elem->int_val());
+            Color::find(World::current()->display(), colorname, r, g, b);
+          }
+          raster->poke(col, row, r, g, b, 1.0);
         }
+      }
     }
     raster->flush();
 

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -136,8 +136,8 @@ class CreateRasterFunc : public CreateGraphicFunc {
 public:
     CreateRasterFunc(ComTerp*,Editor*);
     virtual void execute();
-    virtual const char* docstring() { 
-	return "compview=%s([x0,y0,x1,y1] :rgb w,h,triplet[,triplet[,...]]) -- create a raster"; }
+    virtual const char* docstring() {
+	return "compview=%s([x0,y0,x1,y1] :rgb w,h,pixels) -- create a raster; pixels is w*h flat r,g,b values, w*h nested (r,g,b) triples, or w*h packed 0xRRGGBB ints"; }
     RasterOvComp* create_from_rgb(ComValue& rgbv, AttributeList* al);
 };
 

--- a/src/comdraw/tests/rasterrgb.comt
+++ b/src/comdraw/tests/rasterrgb.comt
@@ -1,0 +1,71 @@
+// src/comdraw/tests/rasterrgb.comt -- raster()'s :rgb pixel-value forms
+//
+// raster(x0,y0,x1,y1 :rgb w,h,pixels) used to require pixels to be
+// pre-nested (r,g,b) triples; anything else (a flat list of scalars) hit
+// AttributeValue::array_val() on a plain int with no type check -- since
+// AttributeValue stores every type in one C union with no discriminant
+// guard, that's undefined behavior (typically a crash), not a graceful
+// error. pixels is now told apart purely by element count against w*h:
+// flat r,g,b (three scalars per pixel), nested (r,g,b) triples (unchanged,
+// still supported), or legacy packed 0xRRGGBB ints (one scalar per pixel,
+// matching poke()/pokeline()'s existing convention). Alpha is deliberately
+// not part of any of these forms -- OverlayRaster/Raster::poke() accepts
+// an alpha parameter but never stores it (X11 pixmaps have no alpha
+// plane, and Raster::peek() always reports 1.0), so accepting an alpha
+// value here would silently discard it, same landmine already visible
+// in pixelfunc.comt's own commented-out RGBA round-trip tests.
+//
+// Run from inside comdraw:
+//   run("src/comdraw/tests/rasterrgb.comt")
+
+ok=true
+pastemode(1)
+
+// --- test 1: nested (r,g,b) triples -- unchanged, still works ---
+r1=raster(0,0,64,64 :rgb 4,4,
+  (255,0,0),(255,0,0),(255,0,0),(255,0,0),
+  (255,0,0),(255,0,0),(255,0,0),(255,0,0),
+  (255,0,0),(255,0,0),(255,0,0),(255,0,0),
+  (255,0,0),(255,0,0),(255,0,0),(255,0,0))
+ok=ok&&(r1!=nil)
+v1=peek(r1 0 0)
+ok=ok&&(at(v1 0)>0.9&&at(v1 1)<0.1&&at(v1 2)<0.1)
+print("1 nested (r,g,b) triples (expect ~1,0,0,1): %v\n" v1)
+
+// --- test 2: flat r,g,b scalars -- the literal #41 repro, used to crash ---
+r2=raster(0,0,64,64 :rgb 4,4,
+  255,0,0, 255,0,0, 255,0,0, 255,0,0,
+  255,0,0, 255,0,0, 255,0,0, 255,0,0,
+  255,0,0, 255,0,0, 255,0,0, 255,0,0,
+  255,0,0, 255,0,0, 255,0,0, 255,0,0)
+ok=ok&&(r2!=nil)
+v2=peek(r2 0 0)
+ok=ok&&(at(v2 0)>0.9&&at(v2 1)<0.1&&at(v2 2)<0.1)
+print("2 flat r,g,b scalars (expect ~1,0,0,1): %v\n" v2)
+
+// --- test 3: legacy packed 0xRRGGBB int per pixel ---
+r3=raster(0,0,64,64 :rgb 4,4,
+  0xff0000,0xff0000,0xff0000,0xff0000,
+  0xff0000,0xff0000,0xff0000,0xff0000,
+  0xff0000,0xff0000,0xff0000,0xff0000,
+  0xff0000,0xff0000,0xff0000,0xff0000)
+ok=ok&&(r3!=nil)
+v3=peek(r3 0 0)
+ok=ok&&(at(v3 0)>0.9&&at(v3 1)<0.1&&at(v3 2)<0.1)
+print("3 packed 0xRRGGBB int (expect ~1,0,0,1): %v\n" v3)
+
+// --- test 4: literal issue repro -- all-zero flat values (used to segfault) ---
+r4=raster(0,0,64,64 :rgb 4,4,
+  0,0,0, 0,0,0, 0,0,0, 0,0,0,
+  0,0,0, 0,0,0, 0,0,0, 0,0,0,
+  0,0,0, 0,0,0, 0,0,0, 0,0,0,
+  0,0,0, 0,0,0, 0,0,0, 0,0,0)
+ok=ok&&(r4!=nil)
+v4=peek(r4 0 0)
+ok=ok&&(at(v4 0)<0.1&&at(v4 1)<0.1&&at(v4 2)<0.1)
+print("4 all-zero flat values, no crash (expect ~0,0,0,1): %v\n" v4)
+
+pastemode(0)
+
+print("rasterrgb: %v\n" ok)
+ok

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -43,5 +43,9 @@ if(run("./paste.comt")
   :then print("pass: paste\n")
   :else print("FAIL: paste\n");ok=false)
 
+if(run("./rasterrgb.comt")
+  :then print("pass: rasterrgb\n")
+  :else print("FAIL: rasterrgb\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "00acf60b"
+#define PATCH_KEY "ed6505de"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `CreateRasterFunc::create_from_rgb()` called `AttributeValue::array_val()` on every pixel-cell value with no type check first. `AttributeValue` stores every type in one C union with no discriminant guard, so calling `array_val()` on a plain scalar reinterprets its bit pattern as an `AttributeValueList*` and dereferences it -- undefined behavior, typically a crash, whenever the `:rgb` pixel list wasn't pre-nested into `(r,g,b)` triples (exactly the literal repro in the issue).
- Fix: pixel data is now told apart purely by element count against `w*h` -- flat `r,g,b` (three scalars per pixel, the literal repro), nested `(r,g,b)` triples (unchanged, still works), or legacy packed `0xRRGGBB` ints (one scalar per pixel, matching `poke()`/`pokeline()`'s existing convention in `pixelfunc.c`).
- Alpha forms (`r,g,b,a`, `(r,g,b,a)`, `0xRRGGBBAA`) are deliberately **not** supported by this fix -- traced `Raster::poke()`'s alpha parameter all the way through and it's never actually stored anywhere in this raster pipeline (X11 pixmaps have no alpha plane; `Raster::peek()` always reports `1.0` regardless of what was poked). Accepting an alpha value here would just silently discard it, reproducing the same landmine that's why `pixelfunc.comt`'s own RGBA round-trip tests are commented out.

## Test plan
- [x] New `src/comdraw/tests/rasterrgb.comt`, wired into `run_all.comt`: covers nested triples (regression), flat scalars (the fix), packed `0xRRGGBB` ints (new, consistent with `poke()`), and the literal all-zero-values issue repro (previously would segfault).
- [x] Full `src/comdraw/tests/run_all.comt` suite passes locally (pixelfunc, gsexim, group, gsget, dotattr, lastkey, paste, rasterrgb)
- [x] Bumped `PATCH_KEY`

Closes #41