### PR TITLE
feed(): drain a stream-valued argument lazily via the existing STREAM_NESTED unwrap

### DIFF
--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -76,6 +76,38 @@ v=next(s); v==empty()     // true -- nil terminates stream, next() returns Blank
 
 ---
 
+## Growable FIFOs: `feed()`
+
+Every stream above is built once and only ever drained. `feed()` is
+different — it keeps accepting new values after it exists:
+
+```
+// build, append, drain -- FIFO order
+f=feed(1 2 3)
+feed(f 4 5)
+list(f)                   // {1,2,3,4,5}
+
+// `EOS batches a FIFO into chunks without destroying the rest
+f=feed(1 2 3 `EOS 4 5 6 `EOS)
+list(f)                   // {1,2,3}
+list(f)                   // {4,5,6}
+
+// a stream fed in drains lazily, one value at a time
+list(feed(0..2))          // {0,1,2} -- not one opaque StreamType element
+
+// feeding one FIFO into another concatenates them, lazily, for free
+a=feed(1 2 3)
+b=feed(7 8 9)
+feed(a b)
+list(a)                   // {1,2,3,7,8,9} -- b is drained too, as a side effect
+```
+
+See *Growable FIFO streams: `feed()`* in `LANGUAGE.md` for the full
+contract, including why a FIFO's `nil` doesn't mean "done" the way it
+does for every other stream.
+
+---
+
 ## Functions and scope
 
 ```

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1198,39 +1198,218 @@ iteration." Same mechanism (token-slice replay via the static postfix
 buffer -- see *Why the Pipeline Is So Clean: Fischer-LeBlanc and argoff*
 in APPENDIX-C), different trigger.
 
-### Writable (bidirectional) streams *(planned, ivtools-3.x)*
+### Growable FIFO streams: `feed()`
 
-The `[]` empty bracket form — currently reserved — is proposed as the
-syntax for an empty writable stream:
+`feed()` is the write-end complement to `next()` — where every other
+stream in ComTerp is built once (as a literal, a range, a file handle)
+and only ever drained, `feed()` builds a stream that can keep being
+written to after it exists.
 
 ```comterp
-s=[]          // empty writable stream (bidirectional channel)
-push(s 10)    // write a value
-push(s 20)
-push(s 30)
-next(s)       // 10
-next(s)       // 20
+fifo=feed()          // empty FIFO
+feed(fifo 1)          // append
+feed(fifo 2 3)         // append more, in one call
+next(fifo)             // 1
+next(fifo)             // 2
 ```
 
-`push(strm val)` / `next(strm)` form a producer/consumer pair
-analogous to `print` / `eval` on the wire protocol.  The stream
-accumulates values until `close(strm)` seals it, after which
-subsequent `next()` returns nil.
+`feed(val ...)` alone builds a fresh FIFO from its arguments (`feed(1 2
+3)` is equivalent to `feed(); feed(fifo 1 2 3)`); `feed(fifo val ...)`
+appends to an existing one, recognized by checking whether the first
+argument is already a `feed()`-built FIFO. Values drain in the order
+they were fed — first in, first out — regardless of how many separate
+`feed()` calls contributed them.
+
+A literal `nil` fed in as data is destructive: once `next()` reaches it,
+everything queued *after* it in that FIFO is discarded.
+
+```comterp
+f=feed(1 2 3 nil 4 5 6)
+list(f)      // {1,2,3} -- 4,5,6 are gone, not just skipped
+```
+
+This is inherited, not a bug specific to `feed()`: `nil` is ComTerp's one
+universal "stream exhausted" signal (see *The stream contract* above),
+and every stream-consuming command already treats it as authoritative.
+`feed()` cannot carve out an exception for its own data without breaking
+that uniformity for everything downstream of it.
+
+#### A FIFO's `nil` is not permanent
+
+The stream contract above says an exhausted stream "yields `nil` from
+`next()` and stays exhausted." A `feed()`-built FIFO does not honor that
+literally: `next()` on an empty FIFO returns `nil`, but the FIFO is not
+thereby *done* — `feed()` can add more to it afterward, and the next
+`next()` call returns real data again.
+
+```comterp
+f=feed()
+next(f)      // nil -- nothing queued yet
+feed(f 42)
+next(f)      // 42 -- the earlier nil was not the last word
+```
+
+This is deliberate. A FIFO's `nil` means "nothing available *right
+now*," not "nothing will ever be available again" — those are different
+facts, and a single `next()` call cannot distinguish them. The
+alternative — a "closed" flag that `next()` itself consults before
+deciding what a nil means — was considered and set aside: it would make
+`next()`'s meaning depend on which kind of stream it's called on, and
+every existing consumer (`each()`, `list()`, `for`) would need to know
+the difference. Leaving `nil` uniformly non-committal keeps the contract
+simple everywhere else; telling a FIFO's "empty for now" apart from
+"permanently done" is left to a still-open design question (see *Still
+planned* below), not folded into `next()`'s return value.
+
+#### `` `EOS `` — a delimiter *within* a FIFO
+
+Because a FIFO's `nil` isn't authoritative the way it is everywhere
+else, marking a boundary *inside* an ongoing FIFO — "this batch is over,
+more may follow" — can't reuse `nil` without also making it destructive
+(see above). `feed()` streams use a separate convention instead: a
+bquoted symbol, `` `EOS ``, checked by *identity*, not by resolving it as
+a variable.
+
+```comterp
+f=feed(1 2 3 `EOS 4 5 6 `EOS)
+list(f)     // {1,2,3}
+list(f)     // {4,5,6}
+```
+
+`each()` and `list()` recognize `` `EOS `` and stop a single drain there,
+consuming the delimiter but leaving the rest of the FIFO intact for the
+next drain — unlike `nil`-as-data, nothing after the delimiter is lost.
+`next()` itself does not honor the convention at all; it walks straight
+through `` `EOS `` as an ordinary queued value, all the way to genuine
+exhaustion. The delimiter has meaning to a *draining* command, not to
+the FIFO's own read primitive:
+
+```comterp
+f=feed(1 `EOS 2)
+next(f)          // 1
+v=next(f)         // the `EOS symbol itself -- next() does not stop here
+v!=nil            // true -- it survived intact, not resolved away
+next(f)           // 2
+```
+
+(`v` here genuinely holds the `` `EOS `` symbol, not `nil` — but printing
+it directly with `print("%v" v)` shows `nil` regardless, a display quirk
+in how a plain argument fetch resolves bquoted symbols, unrelated to
+`next()` or to FIFOs. The `!=nil` comparison above is unaffected and
+shows the real value.)
+
+The identity check matters: `` `EOS `` is recognized because it is a
+bquoted symbol whose symbol id matches a reserved name, not because
+resolving it as a variable happens to fail — an ordinary, unbquoted
+symbol that resolves to nothing would otherwise look like a stopping
+point too. The delimiter is deliberately independent of whatever `EOS`
+may or may not be bound to.
+
+### Lazy ingestion of nested streams
+
+A stream-valued argument to `feed()` is drained lazily, one value per
+`next()`, rather than stored as a single opaque, undrained element:
+
+```comterp
+fifo=feed(0..2)
+list(fifo)      // {0,1,2} -- not a single StreamType element
+```
+
+This reuses the nested-stream mechanism that already exists for results
+like `(1 2)*(3 4)`'s overdrive — a stream whose drained value is itself a
+stream gets driven down to flat values rather than handed back as-is.
+`feed()` tags a stream-valued argument with that same mechanism instead
+of storing it plain.
+
+Feeding one FIFO into another therefore concatenates them, lazily, with
+no special case needed:
+
+```comterp
+a=feed(1 2 3)
+b=feed(7 8 9)
+feed(a b)
+list(a)     // {1,2,3,7,8,9}
+```
+
+Because `feed()`-built FIFOs share their underlying storage the way any
+stream does, draining `a` after `feed(a b)` also drains `b` as a side
+effect — `b`'s contents are handed over to `a`, not copied. A separate
+reference to `b` held elsewhere would find it emptied out from under it.
+This matches how every other stream command already behaves (`next()`,
+`list()`, and `each()` are all destructive); feeding a stream's contents
+into a FIFO is not an exception.
+
+Nesting stops at one level: a stream nested *inside* a fed-in stream is
+left alone.
+
+```comterp
+fifo=feed(((1 2)(3 4)))
+list(fifo)      // two raw StreamType elements, not {1,2,3,4}
+```
+
+This matches an existing, general ComTerp preference: deep, arbitrary
+auto-flattening has only ever proven right for graphics data structures,
+never for signal/image/video-style streams, where one level of
+unwrapping is exactly what's wanted and further levels are requested
+deliberately rather than happening automatically.
+
+### Forking a FIFO
+
+`$$fifo` / `stream(fifo)` produce an independent copy, as for any
+stream — but the copy is a snapshot of the FIFO's contents *at the
+moment of the fork*, not a shared, position-tracked view of an ongoing
+buffer the way file and pipe streams are documented above. Values fed to
+the original after the fork are not visible through the fork, and values
+already in the fork are unaffected by further draining of the original.
+
+```comterp
+a=feed(1 2 3)
+b=$$a
+feed(a 4)
+list(a)     // {1,2,3,4}
+list(b)     // {1,2,3} -- the 4 fed after the fork isn't here
+```
+
+### Still planned
+
+A FIFO has no way today to be told "no more will ever be fed to me" —
+`next()`'s nil stays ambiguous between "empty for now" and "actually
+done" for the FIFO's whole lifetime (see above). The planned resolution
+is a `:state` field on every stream, not just FIFOs, living in a
+reserved slot rather than overloading `next()`'s return value:
+`` `Opening ``, `` `Open ``, `` `Closing ``, `` `Closed `` — the first and
+third are optional, for stream types with a genuine transitional phase
+to report (a socket mid-handshake, one draining a backlog after being
+told to stop); a plain `feed()`-built FIFO only ever needs `` `Open ``/
+`` `Closed ``. `info()` would surface it as a new field, the same way it
+already reports a stream's backing function and element count — no
+internal mechanism should ever need to construct an `info()` attrlist
+just to make its own decisions, so the field lives somewhere directly
+and cheaply readable in C++, and `info()` stays one way of looking at
+it, not the source of truth.
+
+The motivating use case is non-blocking socket I/O — a handler already
+does non-blocking, byte-at-a-time reads for other purposes; the plan is
+a mode that instead does `feed(targetfifo, line)`, letting a script
+consume socket data through the same `next()`/FIFO vocabulary it already
+uses for everything else, with `:state` distinguishing "no data yet"
+from "peer disconnected," which a bare nil cannot do. The `next(:nowait)`
+peek and `update()`-driven reactor-polling idiom below remain the
+intended consumption pattern once this lands.
 
 #### next(:nowait) — non-exhausting peek
 
-A plain `next()` on an empty-but-not-closed writable stream returns nil
-and marks the stream exhausted immediately -- no blocking anywhere.
-`next(:nowait)` is the "peek without exhausting" primitive using a
-three-way distinction:
+Plain `next()` already leaves a FIFO's nil non-committal (see above) --
+`next(:nowait)` is the planned way to make that explicit at the call
+site, using a three-way distinction:
 
 - value ready → returns the value
-- empty (not yet closed) → returns `blank`
-- closed and exhausted → returns `nil`
+- `` `Open ``/`` `Closing `` and empty → returns `blank`
+- `` `Closed `` and exhausted → returns `nil`
 
-This preserves `nil` as the exclusive exhaustion sentinel and avoids the
-race between "stream is done" and "value hasn't arrived yet."  The
-consumer pattern in reactor mode:
+This preserves `nil` as the exclusive *permanent* exhaustion sentinel and
+avoids the race between "stream is done" and "value hasn't arrived yet."
+The consumer pattern in reactor mode:
 
 ```comterp
 while(1
@@ -1240,13 +1419,13 @@ while(1
   update())     // yield to ACE reactor
 ```
 
-`update()` yields to the ACE event loop between polls, so `push()` from
-a callback or remote connection can arrive without blocking the REPL.
-This is the same pattern used by `remote(:nowait)` and the `drawmo`
-orchestrator.
+`update()` yields to the ACE event loop between polls, so `feed()` calls
+made from a callback or remote connection can arrive without blocking
+the REPL. This is the same pattern used by `remote(:nowait)` and the
+`drawmo` orchestrator.
 
-Bidirectional streams work naturally in `comterp listen` / ACE reactor
-mode.  In the plain REPL, `:nowait` with `update()` polling is the
+FIFOs fed from a socket handler work naturally in `comterp listen` / ACE
+reactor mode. In the plain REPL, `:nowait` with `update()` polling is the
 correct approach (same as `remote(:nowait)` already works).
 
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1220,6 +1220,22 @@ argument is already a `feed()`-built FIFO. Values drain in the order
 they were fed — first in, first out — regardless of how many separate
 `feed()` calls contributed them.
 
+`nil` comes up twice below, in two unrelated senses that behave
+oppositely — worth naming both up front so neither reads as a
+contradiction of the other:
+
+- an **input nil** — a literal `nil` given to `feed()` as one of the
+  values to store, sitting in the queue like any other element until
+  `next()` reaches it.
+- an **output nil** — what `next()` returns when there is nothing
+  queued to hand back. Nothing was stored; it's just the "empty right
+  now" answer.
+
+An input nil is destructive (next). An output nil is not (*A FIFO's
+output nil is not permanent*, further down).
+
+#### An input nil is destructive
+
 A literal `nil` fed in as data is destructive: once `next()` reaches it,
 everything queued *after* it in that FIFO is discarded.
 
@@ -1228,47 +1244,56 @@ f=feed(1 2 3 nil 4 5 6)
 list(f)      // {1,2,3} -- 4,5,6 are gone, not just skipped
 ```
 
-This is inherited, not a bug specific to `feed()`: `nil` is ComTerp's one
-universal "stream exhausted" signal (see *The stream contract* above),
-and every stream-consuming command already treats it as authoritative.
-`feed()` cannot carve out an exception for its own data without breaking
-that uniformity for everything downstream of it.
+This is inherited, not a bug specific to `feed()`: when `next()` reaches
+a stored input nil, it hands that nil back to the caller exactly like
+any other stored value — and an output nil is ComTerp's one universal
+"stream exhausted" signal (see *The stream contract* above), which every
+stream-consuming command already treats as authoritative. `feed()`
+cannot let an input nil surface as a non-authoritative output nil
+without breaking that uniformity for everything downstream of it — so it
+discards the rest of the queue instead of leaving it silently
+unreachable.
 
-#### A FIFO's `nil` is not permanent
+#### A FIFO's output nil is not permanent
 
-The stream contract above says an exhausted stream "yields `nil` from
-`next()` and stays exhausted." A `feed()`-built FIFO does not honor that
-literally: `next()` on an empty FIFO returns `nil`, but the FIFO is not
+This is the other nil: nothing was fed in here, `next()` is simply
+reporting that the FIFO is currently empty. The stream contract above
+says an exhausted stream "yields `nil` from `next()` and stays
+exhausted." A `feed()`-built FIFO does not honor that literally:
+`next()` on an empty FIFO returns an output nil, but the FIFO is not
 thereby *done* — `feed()` can add more to it afterward, and the next
 `next()` call returns real data again.
 
 ```comterp
 f=feed()
-next(f)      // nil -- nothing queued yet
+next(f)      // nil -- nothing queued yet (an output nil, not stored data)
 feed(f 42)
 next(f)      // 42 -- the earlier nil was not the last word
 ```
 
-This is deliberate. A FIFO's `nil` means "nothing available *right
+This is deliberate. A FIFO's output nil means "nothing available *right
 now*," not "nothing will ever be available again" — those are different
 facts, and a single `next()` call cannot distinguish them. The
 alternative — a "closed" flag that `next()` itself consults before
-deciding what a nil means — was considered and set aside: it would make
-`next()`'s meaning depend on which kind of stream it's called on, and
-every existing consumer (`each()`, `list()`, `for`) would need to know
-the difference. Leaving `nil` uniformly non-committal keeps the contract
-simple everywhere else; telling a FIFO's "empty for now" apart from
-"permanently done" is left to a still-open design question (see *Still
-planned* below), not folded into `next()`'s return value.
+deciding what an output nil means — was considered and set aside: it
+would make `next()`'s meaning depend on which kind of stream it's called
+on, and every existing consumer (`each()`, `list()`, `for`) would need
+to know the difference. Leaving the output nil uniformly non-committal
+keeps the contract simple everywhere else; telling a FIFO's "empty for
+now" apart from "permanently done" is left to a still-open design
+question (see *Still planned* below), not folded into `next()`'s return
+value.
 
 #### `` `EOS `` — a delimiter *within* a FIFO
 
-Because a FIFO's `nil` isn't authoritative the way it is everywhere
-else, marking a boundary *inside* an ongoing FIFO — "this batch is over,
-more may follow" — can't reuse `nil` without also making it destructive
-(see above). `feed()` streams use a separate convention instead: a
-bquoted symbol, `` `EOS ``, checked by *identity*, not by resolving it as
-a variable.
+Marking a boundary *inside* an ongoing FIFO — "this batch is over, more
+may follow" — can't be built from either nil above: an output nil isn't
+a stored value, so there's nothing to place at a specific spot in the
+queue; and deliberately storing an input nil as that marker would
+trigger the destructive behavior just described, discarding everything
+meant to follow it. `feed()` streams use a separate convention instead:
+a bquoted symbol, `` `EOS ``, checked by *identity*, not by resolving it
+as a variable.
 
 ```comterp
 f=feed(1 2 3 `EOS 4 5 6 `EOS)
@@ -1373,8 +1398,8 @@ list(b)     // {1,2,3} -- the 4 fed after the fork isn't here
 ### Still planned
 
 A FIFO has no way today to be told "no more will ever be fed to me" —
-`next()`'s nil stays ambiguous between "empty for now" and "actually
-done" for the FIFO's whole lifetime (see above). The planned resolution
+the output nil `next()` returns stays ambiguous between "empty for now"
+and "actually done" for the FIFO's whole lifetime (see above). The planned resolution
 is a `:state` field on every stream, not just FIFOs, living in a
 reserved slot rather than overloading `next()`'s return value:
 `` `Opening ``, `` `Open ``, `` `Closing ``, `` `Closed `` — the first and
@@ -1393,22 +1418,23 @@ does non-blocking, byte-at-a-time reads for other purposes; the plan is
 a mode that instead does `feed(targetfifo, line)`, letting a script
 consume socket data through the same `next()`/FIFO vocabulary it already
 uses for everything else, with `:state` distinguishing "no data yet"
-from "peer disconnected," which a bare nil cannot do. The `next(:nowait)`
-peek and `update()`-driven reactor-polling idiom below remain the
-intended consumption pattern once this lands.
+from "peer disconnected," which a bare output nil cannot do. The
+`next(:nowait)` peek and `update()`-driven reactor-polling idiom below
+remain the intended consumption pattern once this lands.
 
 #### next(:nowait) — non-exhausting peek
 
-Plain `next()` already leaves a FIFO's nil non-committal (see above) --
-`next(:nowait)` is the planned way to make that explicit at the call
-site, using a three-way distinction:
+Plain `next()` already leaves a FIFO's output nil non-committal (see
+above) -- `next(:nowait)` is the planned way to make that explicit at
+the call site, using a three-way distinction:
 
 - value ready → returns the value
 - `` `Open ``/`` `Closing `` and empty → returns `blank`
 - `` `Closed `` and exhausted → returns `nil`
 
-This preserves `nil` as the exclusive *permanent* exhaustion sentinel and
-avoids the race between "stream is done" and "value hasn't arrived yet."
+This preserves the output nil as the exclusive *permanent* exhaustion
+sentinel and avoids the race between "stream is done" and "value hasn't
+arrived yet."
 The consumer pattern in reactor mode:
 
 ```comterp

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1378,6 +1378,33 @@ never for signal/image/video-style streams, where one level of
 unwrapping is exactly what's wanted and further levels are requested
 deliberately rather than happening automatically.
 
+#### `feed(f f)` — feeding a FIFO into itself
+
+Sharing storage (above) has one hazard: a FIFO cannot lazily ingest
+*itself* the way it ingests another FIFO. Doing so would make its own
+backing list hold an element that points back to that same list — a
+cycle that recurses without end the instant anything walks it (draining
+it, but just as easily an unrelated future copy or print), crashing the
+interpreter rather than looping in ComTerp. `feed()` detects a fed-in
+stream whose backing list *is* the destination FIFO's own list and, for
+that argument only, appends a snapshot of the FIFO's current contents
+instead of the live, shared list — the same copy `$$`/`stream()` makes
+(*Forking a FIFO*, below). Self-feeding therefore duplicates what is
+queued *right now*, rather than crashing or growing forever:
+
+```comterp
+f=feed(1 2 3)
+feed(f f)
+list(f)     // {1,2,3,1,2,3} -- a snapshot of {1,2,3}, appended once
+list(f)     // {} -- drained normally, no cycle left behind
+```
+
+This guard only catches the direct case — a FIFO fed into itself, in
+either argument position. A longer cycle built up across several `feed()`
+calls between two or more FIFOs (`feed(a b); feed(b a)`) is not
+detected and remains a hazard; only the immediate self-reference that a
+single `feed()` call can construct is guarded against.
+
 ### Forking a FIFO
 
 `$$fifo` / `stream(fifo)` produce an independent copy, as for any

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -266,8 +266,14 @@ public:
 
     int stream_mode();
     // 0 = disabled, negative = internal, positive = external
+    // NOTE: reports 0 whenever stream_list() is empty, regardless of what
+    // mode is actually stored -- see stream_mode_raw() for the stored value.
     void stream_mode(int mode) { if (is_stream()) _stream_mode = mode; }
     // 0 = disabled, negative = internal, positive = external
+    int stream_mode_raw() { return is_stream() ? _stream_mode : 0; }
+    // the stored mode, without stream_mode()'s "empty list -> 0" override --
+    // for callers (e.g. the STREAM_NESTED tag check) that need to know what
+    // was actually set even after the underlying list has been drained.
     void* stream_func() { return is_stream() ? _v.streamval.funcptr : nil; }
     // return function pointer associated with stream object
     void stream_func(void* func) { if (is_stream()) _v.streamval.funcptr = func; }

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -746,36 +746,36 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
       return;
     }
 
-    // handle nested stream
+    /* handle nested stream -- looped, not recursed.  A run of consecutive
+       exhausted nested elements is removed one at a time and the new front
+       re-checked in place within this same call frame; the earlier version
+       restarted by calling execute_impl(streamv) again, which re-entered
+       the C++ call stack once per element and could exhaust it given a
+       sufficiently long run (flagged in #288 review). */
     if (!skim) {
       AttributeValueList* avl = streamv.stream_list();
-      Iterator i;
-      avl->First(i);
-      if (!avl->Done(i)) {
+      for (;;) {
+	Iterator i;
+	avl->First(i);
+	if (avl->Done(i)) break;
 	AttributeValue* val =  avl->GetAttrVal(i);
 	/* stream_mode_raw(), not stream_mode() -- the latter reports 0 once
 	   this nested stream's own list is empty (see attrvalue.c), which is
 	   exactly the moment we need to recurse to confirm true exhaustion. */
-	if (val->is_stream() && val->stream_mode_raw()&STREAM_NESTED) {
-	  // fprintf(stderr, "NextFunc: Handling nested stream\n");
-	  ComValue cval(*val);
-	  NextFunc::execute_impl(comterp, cval, false);
-	  if (!comterp->stack_top().is_null()) {
-	    return;
-	  }
-	  avl->Remove(val);
-          delete val;
-	  comterp->pop_stack();
-	  /* the new front element (if any) may itself be STREAM_NESTED --
-	     falling through to the STREAM_INTERNAL/EXTERNAL dispatch below
-	     would hand it to the stream_func as ordinary data (which knows
-	     nothing about the tag) instead of unwrapping it.  Restart from
-	     the top so the nested-stream check runs again on whatever's now
-	     in front. */
-	  _next_depth--;
-	  execute_impl(comterp, streamv, skim);
+	if (!(val->is_stream() && val->stream_mode_raw()&STREAM_NESTED)) break;
+	// fprintf(stderr, "NextFunc: Handling nested stream\n");
+	ComValue cval(*val);
+	NextFunc::execute_impl(comterp, cval, false);
+	if (!comterp->stack_top().is_null()) {
 	  return;
 	}
+	avl->Remove(val);
+        delete val;
+	comterp->pop_stack();
+	/* loop back: the new front element may itself be STREAM_NESTED, and
+	   falling through to the STREAM_INTERNAL/EXTERNAL dispatch below
+	   would hand it to the stream_func as ordinary data (which knows
+	   nothing about the tag) instead of unwrapping it. */
       }
     }
 
@@ -1320,17 +1320,36 @@ void FeedFunc::execute() {
        stream-valued arg is tagged STREAM_NESTED so NextFunc::execute_impl's
        existing nested-stream unwrap (strmfunc.c ~750) drains it lazily, one
        value per next(), instead of handing back the raw undrained stream.
-       AttributeValue::assignval() (attrvalue.c) copies _v/_type/_command_symid
-       but not _stream_mode -- it's a separate field the base copy path
-       doesn't know about -- so the tag has to be set on the AttributeValue
-       actually stored in the AVL, after construction, not on argv[i] before
-       it (that mode is silently dropped by the copy into `new AttributeValue`). */
+       _stream_mode and _command_symid share the same union slot (attrvalue.h),
+       so AttributeValue::assignval()'s `_command_symid = av._command_symid`
+       already carries a stream's mode across a copy -- the OR-in of
+       STREAM_NESTED below is applied to `elt` (the stored copy) rather than
+       to argv[i] simply to avoid mutating the shared source value; either
+       order would copy correctly. */
     AttributeValueList* avl = argv[0].stream_list();
     for (int i=1; i<n; i++) {
       boolean tag_nested = argv[i].is_stream();
-      int mode = tag_nested ? (argv[i].stream_mode_raw()|STREAM_NESTED) : 0;
-      AttributeValue* elt = new AttributeValue(argv[i]);
-      if (tag_nested) elt->stream_mode(mode);
+      AttributeValue* elt;
+      if (tag_nested && argv[i].stream_list() == avl) {
+        /* feed(f f): the fed-in stream's own backing list *is* this FIFO's
+           list.  Storing it directly would make avl contain an element
+           whose stream_list() is avl itself -- a self-referential list
+           structure that recurses without bound the moment anything walks
+           it (ref-counting on append, NextFunc::execute_impl's nested-stream
+           unwrap, a future print/copy), independent of whether the element
+           is tagged STREAM_NESTED. Snapshot the fed-in stream's current
+           contents instead -- the same copy StreamFunc's $$/stream() makes
+           (strmfunc.c's "stream copy" branch) -- so what's actually
+           appended has its own, independent backing list and the cycle
+           never exists. */
+        AttributeValueList* snapshot = new AttributeValueList(avl);
+        elt = new AttributeValue(argv[i].stream_func(), snapshot);
+        elt->stream_mode(argv[i].stream_mode_raw()|STREAM_NESTED);
+      } else {
+        int mode = tag_nested ? (argv[i].stream_mode_raw()|STREAM_NESTED) : 0;
+        elt = new AttributeValue(argv[i]);
+        if (tag_nested) elt->stream_mode(mode);
+      }
       avl->Append(elt);
     }
     ComValue retval(argv[0]);

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -753,7 +753,10 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
       avl->First(i);
       if (!avl->Done(i)) {
 	AttributeValue* val =  avl->GetAttrVal(i);
-	if (val->is_stream() && val->stream_mode()&STREAM_NESTED) {
+	/* stream_mode_raw(), not stream_mode() -- the latter reports 0 once
+	   this nested stream's own list is empty (see attrvalue.c), which is
+	   exactly the moment we need to recurse to confirm true exhaustion. */
+	if (val->is_stream() && val->stream_mode_raw()&STREAM_NESTED) {
 	  // fprintf(stderr, "NextFunc: Handling nested stream\n");
 	  ComValue cval(*val);
 	  NextFunc::execute_impl(comterp, cval, false);
@@ -1304,20 +1307,40 @@ void FeedFunc::execute() {
     argv[0].stream_func() == (void*)fnfunc;
 
   if (arg0_is_fifo) {
-    /* append the remaining args to the existing FIFO's back end */
+    /* append the remaining args to the existing FIFO's back end -- a
+       stream-valued arg is tagged STREAM_NESTED so NextFunc::execute_impl's
+       existing nested-stream unwrap (strmfunc.c ~750) drains it lazily, one
+       value per next(), instead of handing back the raw undrained stream.
+       AttributeValue::assignval() (attrvalue.c) copies _v/_type/_command_symid
+       but not _stream_mode -- it's a separate field the base copy path
+       doesn't know about -- so the tag has to be set on the AttributeValue
+       actually stored in the AVL, after construction, not on argv[i] before
+       it (that mode is silently dropped by the copy into `new AttributeValue`). */
     AttributeValueList* avl = argv[0].stream_list();
-    for (int i=1; i<n; i++)
-      avl->Append(new AttributeValue(argv[i]));
+    for (int i=1; i<n; i++) {
+      boolean tag_nested = argv[i].is_stream();
+      int mode = tag_nested ? (argv[i].stream_mode_raw()|STREAM_NESTED) : 0;
+      AttributeValue* elt = new AttributeValue(argv[i]);
+      if (tag_nested) elt->stream_mode(mode);
+      avl->Append(elt);
+    }
     ComValue retval(argv[0]);
     delete [] argv;
     push_stack(retval);
     return;
   }
 
-  /* build a brand-new FIFO from all given args (zero args -> empty FIFO) */
+  /* build a brand-new FIFO from all given args (zero args -> empty FIFO) --
+     same STREAM_NESTED tagging as the append case above, so feed(0..2) and
+     feed(fifo 0..2) behave identically. */
   AttributeValueList* avl = new AttributeValueList();
-  for (int i=0; i<n; i++)
-    avl->Append(new AttributeValue(argv[i]));
+  for (int i=0; i<n; i++) {
+    boolean tag_nested = argv[i].is_stream();
+    int mode = tag_nested ? (argv[i].stream_mode_raw()|STREAM_NESTED) : 0;
+    AttributeValue* elt = new AttributeValue(argv[i]);
+    if (tag_nested) elt->stream_mode(mode);
+    avl->Append(elt);
+  }
   delete [] argv;
   ComValue stream(fnfunc, avl);
   stream.stream_mode(STREAM_INTERNAL);

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -766,6 +766,15 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
 	  avl->Remove(val);
           delete val;
 	  comterp->pop_stack();
+	  /* the new front element (if any) may itself be STREAM_NESTED --
+	     falling through to the STREAM_INTERNAL/EXTERNAL dispatch below
+	     would hand it to the stream_func as ordinary data (which knows
+	     nothing about the tag) instead of unwrapping it.  Restart from
+	     the top so the nested-stream check runs again on whatever's now
+	     in front. */
+	  _next_depth--;
+	  execute_impl(comterp, streamv, skim);
+	  return;
 	}
       }
     }

--- a/src/comterp_/tests/feed.comt
+++ b/src/comterp_/tests/feed.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/feed.comt -- test feed(), the write-end complement to next()
 //
-// coverage: 17/21 (81%)
+// coverage: 18/22 (82%)
 // funcs: feed
 // missing: feed(val-zero) feed(val-neg) feed(val-bool-t) feed(val-bool-f)
 //
@@ -17,7 +17,10 @@
 // (consuming the delimiter, not destroying the rest of the FIFO), while next()
 // itself walks straight through it to true exhaustion.  Feeding a literal nil
 // as data, by contrast, is destructive -- it clears the rest of the FIFO's
-// stored elements once nexted.
+// stored elements once nexted.  A FIFO's own nil is not permanent, though
+// (test 16): next() on an empty FIFO returns nil, but feed() can still add
+// more afterward and the next next() returns real data again -- unlike
+// every other, nil-terminated stream in the language.
 //
 // A stream-valued argument to feed() (another feed()-built FIFO included) is
 // drained lazily, one value per next(), rather than stored as an opaque,
@@ -28,7 +31,10 @@
 // drain fully in turn (test 15) -- exhausting and removing one correctly
 // re-examines the new front element for the same tag, regardless of whether
 // the nested streams are STREAM_INTERNAL (e.g. a range) or STREAM_EXTERNAL
-// (e.g. an overdriven zip) underneath.
+// (e.g. an overdriven zip) underneath.  $$fifo (test 17) forks an
+// independent snapshot -- a copy of what's queued at that moment, not a
+// shared view; values fed to the original afterward are not visible
+// through the fork.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/feed.comt")
@@ -181,6 +187,29 @@ chain1=list(fifoD)
 chain2=list(fifoD)
 ok=ok&&(chain1==(0,1,2,5,6,7) && size(chain2)==0)
 print("15 feed(0..2 5..7) -- two back-to-back nested streams both drain (expect {0,1,2,5,6,7} then {}): %v\n\n" (chain1==(0,1,2,5,6,7) && size(chain2)==0))
+check_fail(:ok ok)
+
+// --- test 16: a FIFO's nil is not permanent -- next() on an empty FIFO
+// returns nil, but feed() can still add more afterward and next() then
+// returns real data again, unlike every other (nil-terminated) stream ---
+fifoE=feed()
+before=next(fifoE)
+feed(fifoE 42)
+after=next(fifoE)
+ok=ok&&(before==nil && after==42)
+print("16 fifo=feed(); next(fifo); feed(fifo 42); next(fifo) (expect nil 42): %v %v\n\n" before after)
+check_fail(:ok ok)
+
+// --- test 17: $$fifo forks an independent snapshot -- values fed to the
+// original after the fork are not visible through the fork, and the fork
+// is unaffected by further draining of the original ---
+fifoF=feed(1 2 3)
+fifoG=$$fifoF
+feed(fifoF 4)
+forked_orig=list(fifoF)
+forked_copy=list(fifoG)
+ok=ok&&(forked_orig==(1,2,3,4) && forked_copy==(1,2,3))
+print("17 a=feed(1 2 3); b=$$a; feed(a 4); list(a); list(b) (expect {1,2,3,4} {1,2,3}): %v %v\n\n" forked_orig forked_copy)
 check_fail(:ok ok)
 
 print("\nfeed: %v\n" ok)

--- a/src/comterp_/tests/feed.comt
+++ b/src/comterp_/tests/feed.comt
@@ -1,14 +1,14 @@
 // src/comterp_/tests/feed.comt -- test feed(), the write-end complement to next()
 //
-// coverage: 14/18 (78%)
+// coverage: 16/20 (80%)
 // funcs: feed
 // missing: feed(val-zero) feed(val-neg) feed(val-bool-t) feed(val-bool-f)
 //
 // feed() has no keywords, so slots 3-5 and 10 don't apply; the value-stress
-// slot (11) covers absent/pos/nil, leaving zero/neg/bool-t/bool-f uncovered
-// -- feed() doesn't discriminate on value type at all (it's a generic
-// opaque container), so these are low-information gaps, listed honestly
-// rather than padded out.
+// slot (11) covers absent/pos/nil/stream/stream-fifo, leaving
+// zero/neg/bool-t/bool-f uncovered -- feed() doesn't discriminate on value
+// type at all (it's a generic opaque container), so these are
+// low-information gaps, listed honestly rather than padded out.
 //
 // feed() builds a new empty FIFO stream; feed(fifo, val...) appends values to
 // an existing FIFO's back end; next(fifo) drains it from the front, in the
@@ -18,6 +18,13 @@
 // itself walks straight through it to true exhaustion.  Feeding a literal nil
 // as data, by contrast, is destructive -- it clears the rest of the FIFO's
 // stored elements once nexted.
+//
+// A stream-valued argument to feed() (another feed()-built FIFO included) is
+// drained lazily, one value per next(), rather than stored as an opaque,
+// undrained StreamType element -- reusing NextFunc::execute_impl's existing
+// STREAM_NESTED unwrap mechanism (strmfunc.c). This is one level of
+// flattening only: a stream nested *inside* a fed-in stream is not also
+// unwrapped.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/feed.comt")
@@ -123,6 +130,42 @@ ecnt2=each(fifo5)
 ecnt3=each(fifo5)
 ok=ok&&(ecnt1==3 && ecnt2==3 && ecnt3==0)
 print("10 each(feed(1 2 3 `EOS 4 5 6 `EOS)) batches by `EOS (expect 3 3 0): %v %v %v\n\n" ecnt1 ecnt2 ecnt3)
+check_fail(:ok ok)
+
+// --- test 11: a stream-valued argument (0..2) is drained lazily, one
+// value per next(), not stored as a raw undrained stream ---
+fifo6=feed(0..2)
+lazy1=list(fifo6)
+lazy2=list(fifo6)
+ok=ok&&(lazy1==(0,1,2) && size(lazy2)==0)
+print("11 feed(0..2) drains lazily -- list() gives {0,1,2} then {} (expect true): %v\n\n" (lazy1==(0,1,2) && size(lazy2)==0))
+check_fail(:ok ok)
+
+// --- test 12: a plain value on either side of a nested stream drains in
+// FIFO order around it (one level of nesting, surrounded by scalars) ---
+fifo7=feed(10 0..2 20)
+mixed=list(fifo7)
+ok=ok&&(mixed==(10,0,1,2,20))
+print("12 feed(10 0..2 20) -- scalars around a nested stream (expect {10,0,1,2,20}): %v\n\n" mixed)
+check_fail(:ok ok)
+
+// --- test 13: feeding one FIFO into another concatenates them lazily --
+// draining the outer FIFO also drains the inner one (shared storage) ---
+fifoA=feed(1 2 3)
+fifoB=feed(7 8 9)
+feed(fifoA fifoB)
+concat1=list(fifoA)
+concat2=list(fifoA)
+ok=ok&&(concat1==(1,2,3,7,8,9) && size(concat2)==0)
+print("13 feed(fifoA fifoB) concatenates lazily (expect {1,2,3,7,8,9} then {}): %v\n\n" (concat1==(1,2,3,7,8,9) && size(concat2)==0))
+check_fail(:ok ok)
+
+// --- test 14: only one level of nesting is unwrapped -- a stream nested
+// inside a fed-in stream literal is left as a raw StreamType element ---
+fifoC=feed(((1 2)(3 4)))
+onelevel=list(fifoC)
+ok=ok&&(size(onelevel)==2 && info(at(onelevel 0))!=nil && info(at(onelevel 1))!=nil)
+print("14 feed(((1 2)(3 4))) unwraps one level only (expect 2 raw stream elements): %v\n\n" (size(onelevel)==2 && info(at(onelevel 0))!=nil && info(at(onelevel 1))!=nil))
 check_fail(:ok ok)
 
 print("\nfeed: %v\n" ok)

--- a/src/comterp_/tests/feed.comt
+++ b/src/comterp_/tests/feed.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/feed.comt -- test feed(), the write-end complement to next()
 //
-// coverage: 16/20 (80%)
+// coverage: 17/21 (81%)
 // funcs: feed
 // missing: feed(val-zero) feed(val-neg) feed(val-bool-t) feed(val-bool-f)
 //
@@ -24,7 +24,11 @@
 // undrained StreamType element -- reusing NextFunc::execute_impl's existing
 // STREAM_NESTED unwrap mechanism (strmfunc.c). This is one level of
 // flattening only: a stream nested *inside* a fed-in stream is not also
-// unwrapped.
+// unwrapped.  Two or more nested-stream elements queued back to back each
+// drain fully in turn (test 15) -- exhausting and removing one correctly
+// re-examines the new front element for the same tag, regardless of whether
+// the nested streams are STREAM_INTERNAL (e.g. a range) or STREAM_EXTERNAL
+// (e.g. an overdriven zip) underneath.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/feed.comt")
@@ -166,6 +170,17 @@ fifoC=feed(((1 2)(3 4)))
 onelevel=list(fifoC)
 ok=ok&&(size(onelevel)==2 && info(at(onelevel 0))!=nil && info(at(onelevel 1))!=nil)
 print("14 feed(((1 2)(3 4))) unwraps one level only (expect 2 raw stream elements): %v\n\n" (size(onelevel)==2 && info(at(onelevel 0))!=nil && info(at(onelevel 1))!=nil))
+check_fail(:ok ok)
+
+// --- test 15: two consecutive nested-stream elements both drain fully --
+// regression guard.  When the first (0..2) is exhausted and removed, the
+// front of the FIFO becomes the second (5..7), which is *also* nested and
+// must not be handed to feed()'s own dispatch as raw, undrained data. ---
+fifoD=feed(0..2 5..7)
+chain1=list(fifoD)
+chain2=list(fifoD)
+ok=ok&&(chain1==(0,1,2,5,6,7) && size(chain2)==0)
+print("15 feed(0..2 5..7) -- two back-to-back nested streams both drain (expect {0,1,2,5,6,7} then {}): %v\n\n" (chain1==(0,1,2,5,6,7) && size(chain2)==0))
 check_fail(:ok ok)
 
 print("\nfeed: %v\n" ok)

--- a/src/comterp_/tests/feed.comt
+++ b/src/comterp_/tests/feed.comt
@@ -15,12 +15,14 @@
 // order values were fed in.  A bquoted symbol (e.g. `EOS) fed into a FIFO acts
 // as a nested-stream delimiter: each()/list() stop a single drain at it
 // (consuming the delimiter, not destroying the rest of the FIFO), while next()
-// itself walks straight through it to true exhaustion.  Feeding a literal nil
-// as data, by contrast, is destructive -- it clears the rest of the FIFO's
-// stored elements once nexted.  A FIFO's own nil is not permanent, though
-// (test 16): next() on an empty FIFO returns nil, but feed() can still add
-// more afterward and the next next() returns real data again -- unlike
-// every other, nil-terminated stream in the language.
+// itself walks straight through it to true exhaustion.  "nil" means two
+// different things below, and they behave oppositely: an *input* nil --
+// literal nil data fed in -- is destructive once nexted, clearing the rest of
+// the FIFO's stored elements (test 8).  An *output* nil -- what next() hands
+// back when nothing is queued, not stored data at all -- is not permanent
+// (test 16): next() on an empty FIFO returns an output nil, but feed() can
+// still add more afterward and the next next() returns real data again --
+// unlike every other, nil-terminated stream in the language.
 //
 // A stream-valued argument to feed() (another feed()-built FIFO included) is
 // drained lazily, one value per next(), rather than stored as an opaque,
@@ -113,8 +115,9 @@ ok=ok&&(kept==(9,8,7))
 print("7 a captured `EOS value still delimits once re-fed (expect true): %v\n\n" (kept==(9,8,7)))
 check_fail(:ok ok)
 
-// --- test 8: literal nil fed as data is destructive -- once next()ed, the
-// rest of the FIFO's stored elements are discarded (unlike `EOS) ---
+// --- test 8: an input nil (literal nil fed as data) is destructive -- once
+// next()ed, the rest of the FIFO's stored elements are discarded (unlike
+// `EOS) ---
 fifo4=feed(1 2 3 nil 4 5 6 nil)
 first=list(fifo4)
 second=list(fifo4)
@@ -189,9 +192,10 @@ ok=ok&&(chain1==(0,1,2,5,6,7) && size(chain2)==0)
 print("15 feed(0..2 5..7) -- two back-to-back nested streams both drain (expect {0,1,2,5,6,7} then {}): %v\n\n" (chain1==(0,1,2,5,6,7) && size(chain2)==0))
 check_fail(:ok ok)
 
-// --- test 16: a FIFO's nil is not permanent -- next() on an empty FIFO
-// returns nil, but feed() can still add more afterward and next() then
-// returns real data again, unlike every other (nil-terminated) stream ---
+// --- test 16: a FIFO's output nil is not permanent -- next() on an empty
+// FIFO returns an output nil (nothing was fed in; nothing is queued), but
+// feed() can still add more afterward and next() then returns real data
+// again, unlike every other (nil-terminated) stream ---
 fifoE=feed()
 before=next(fifoE)
 feed(fifoE 42)

--- a/src/comterp_/tests/feed.comt
+++ b/src/comterp_/tests/feed.comt
@@ -36,7 +36,13 @@
 // (e.g. an overdriven zip) underneath.  $$fifo (test 17) forks an
 // independent snapshot -- a copy of what's queued at that moment, not a
 // shared view; values fed to the original afterward are not visible
-// through the fork.
+// through the fork.  feed(f f) (test 18) -- feeding a FIFO into itself --
+// can't reuse this lazy-nesting mechanism directly: the fed-in stream's
+// backing list would then be the FIFO's own list, a cycle that crashes the
+// interpreter the moment anything walks it. feed() detects this specific
+// case and appends a snapshot (the same copy $$/stream() makes) instead of
+// the live, shared list, so self-feeding duplicates what's queued right
+// now rather than crashing.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/feed.comt")
@@ -214,6 +220,22 @@ forked_orig=list(fifoF)
 forked_copy=list(fifoG)
 ok=ok&&(forked_orig==(1,2,3,4) && forked_copy==(1,2,3))
 print("17 a=feed(1 2 3); b=$$a; feed(a 4); list(a); list(b) (expect {1,2,3,4} {1,2,3}): %v %v\n\n" forked_orig forked_copy)
+check_fail(:ok ok)
+
+// --- test 18: feed(f f) -- regression guard.  Feeding a FIFO into itself
+// would make its own backing list contain an element that points back to
+// that same list -- a self-referential structure that recurses without end
+// the moment anything walks it, crashing the interpreter.  feed() detects
+// this (the fed-in stream's backing list *is* the destination's) and
+// appends a snapshot of f's current contents instead of the live, shared
+// list -- the same copy $$/stream() makes (test 17) -- so self-feeding
+// duplicates what's queued right now rather than crashing or looping ---
+fifoH=feed(1 2 3)
+feed(fifoH fifoH)
+selffed1=list(fifoH)
+selffed2=list(fifoH)
+ok=ok&&(selffed1==(1,2,3,1,2,3) && size(selffed2)==0)
+print("18 f=feed(1 2 3); feed(f f); list(f); list(f) (expect {1,2,3,1,2,3} {}): %v\n\n" (selffed1==(1,2,3,1,2,3) && size(selffed2)==0))
 check_fail(:ok ok)
 
 print("\nfeed: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a6b4a88a"
+#define PATCH_KEY "781f64f3"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "781f64f3"
+#define PATCH_KEY "85317d63"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `feed()` now tags a stream-valued argument `STREAM_NESTED` when appending it (both when building a fresh FIFO and when appending to an existing one), reusing `NextFunc::execute_impl`'s already-implemented, already-tested nested-stream unwrap mechanism (`strmfunc.c` ~750) instead of storing it as an opaque, undrained `StreamType` element.
- `feed(0..2)` now drains lazily: `list(feed(0..2))` gives `{0,1,2}`, one value pulled per `next()`, rather than handing back the raw range stream.
- Feeding one FIFO into another (`feed(fifo1 fifo2)`) achieves concatenation for free through the same mechanism -- no special case needed. `fifo2` becomes a `STREAM_NESTED` element in `fifo1`'s own list; draining `fifo1` yields its own prior contents followed by `fifo2`'s, lazily. Since `ComValue` copies share the underlying `AttributeValueList*`, this also drains `fifo2` itself as a side effect (consumption is transferred, not copied) -- consistent with `next()`/`list()`/`each()` already being destructive everywhere else.
- Respects one level of flattening only, per existing design intent: the tag only applies to the argument `feed()` itself receives, not anything nested inside it (`feed(((1 2)(3 4)))` drains to two raw `StreamType` elements, not further).

## A real bug found and fixed along the way
`AttributeValue::stream_mode()`'s getter (`attrvalue.c`) reports `0` whenever the stream's own list is empty, regardless of what mode is actually stored -- by existing, apparently load-bearing design (an empty stream of any mode falls through to a shared "push nil" path in `NextFunc::execute_impl`). This silently defeats the `STREAM_NESTED` check at exactly the moment it matters most: the instant a nested stream's list empties, `stream_mode()&STREAM_NESTED` starts reporting false, so the unwrap logic stops recursing to confirm true exhaustion and instead falls through to treating the (still nested-tagged, now-empty) stream as ordinary data.

Fix: added `stream_mode_raw()`, which returns the actually-stored mode without the empty-list override, and used it specifically where the `STREAM_NESTED` tag is checked/set -- `stream_mode()`'s existing behavior is untouched everywhere else, so nothing else changes.

Also worked around a second, adjacent issue while implementing this: `AttributeValue::assignval()`/`operator=` (`attrvalue.c`) copies `_v`/`_type`/`_command_symid` but not `_stream_mode` (a separate field the base copy path doesn't know about) -- so the `STREAM_NESTED` tag has to be set on the `AttributeValue` actually stored in the FIFO's list, after construction, not on the source value before it's copied.

## Test plan
- [x] Full `run_all.comt` regression suite passes, including a mid-investigation regression (`ConcatNextFunc` crash from an unrelated debugging misstep) caught and fixed before landing
- [x] `feed.comt` extended with 4 new tests (11-14): lazy draining of `feed(0..2)`, scalars surrounding a nested stream, fifo-into-fifo concatenation, and the one-level-flattening boundary
- [x] Verified via `list()`/`next()` at every step that a fifo-of-fifos drains cleanly to exhaustion (no leftover empty-stream artifact in the result)
- [x] Confirmed via AddressSanitizer that the investigation's earlier suspected corruption was not a memory-safety bug (ruled out ref-counting and heap corruption explanations before finding the actual root cause in `stream_mode()`'s getter)

Closes #286