### PR TITLE
istype()/isclass()/iscomm()/isfunc(): inspect a variable's type/class without ever firing it

### DIFF
--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -124,15 +124,18 @@ iscomm(pi)                    // true, no firing
 isfunc(myfunc)                 // true, no firing
 istype(pi CommandType)          // true -- neither argument needs backquoting
 
-// the case this exists for: a func that returns another func
-outer=func(y=42; inner=func(y); inner)
+// the case this exists for: a func that returns another func --
+// the construction has to be the last thing evaluated; naming it first
+// (inner=func(y); inner) fires it immediately, same as any other reference
+outer=func(y=42; func(y))
 escaped=outer()
 isfunc(escaped)               // true -- confirmed without ever calling escaped
 ```
 
 See *istype()/isclass()/iscomm()/isfunc()* in `LANGUAGE.md` for the full
 contract, including why this is a syntactic-shape peek and not a
-"what would this evaluate to" test.
+"what would this evaluate to" test, and why a standalone variable is a
+niladic call site everywhere, with no special case for inside a func body.
 
 ---
 

--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -108,6 +108,34 @@ does for every other stream.
 
 ---
 
+## Checking what a variable holds, without firing it
+
+A bare command name or a `func()`-bound name fires on mere reference --
+even `type()`/`class()` evaluate their argument first, so they report the
+type of whatever got invoked, not of what was actually bound:
+
+```
+pi                          // 3.14159 -- fires
+myfunc=func(1+1)
+type(myfunc)                 // IntType -- the result's type, not myfunc's
+
+// istype()/isclass()/iscomm()/isfunc() are post_eval -- they never fire
+iscomm(pi)                    // true, no firing
+isfunc(myfunc)                 // true, no firing
+istype(pi CommandType)          // true -- neither argument needs backquoting
+
+// the case this exists for: a func that returns another func
+outer=func(y=42; inner=func(y); inner)
+escaped=outer()
+isfunc(escaped)               // true -- confirmed without ever calling escaped
+```
+
+See *istype()/isclass()/iscomm()/isfunc()* in `LANGUAGE.md` for the full
+contract, including why this is a syntactic-shape peek and not a
+"what would this evaluate to" test.
+
+---
+
 ## Functions and scope
 
 ```

--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -172,6 +172,31 @@ fib(:n 10)                // 55
 
 ---
 
+## func() is not a closure -- how to fake one
+
+```
+// no capture -- escaped sees y's CURRENT value, not 42
+y=1
+outer=func(y=42; func(y))
+escaped=outer()
+y=100
+escaped()                 // 100, not 42
+
+// force capture by baking the value into generated source as a literal
+y2=42
+bodystr=print("func(%v)" y2 :str)   // "func(42)"
+escaped2=run(bodystr :str)           // no free variable left to re-resolve
+y2=100
+escaped2()                            // 42 -- immune to y2's later mutation
+```
+
+See *Not a closure -- func() is closer to a macro* in `LANGUAGE.md` for
+why (a `FuncObj` is just saved tokens, re-run fresh against whatever's
+currently in scope -- unhygienic-macro semantics, not closure semantics)
+and how far the bake-a-literal trick generalizes.
+
+---
+
 ## Building data structures
 
 ```

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1812,6 +1812,88 @@ float(3.14)            // explicit conversion to FloatType
 double(3)              // explicit conversion to DoubleType
 ```
 
+### istype()/isclass()/iscomm()/isfunc() — inspecting a variable without firing it
+
+`type()` and `class()`, above, both evaluate their argument the ordinary
+way before looking at it — which means they cannot answer *"what is this
+variable bound to"* for a command name or a `func()`-bound name, because
+referencing either one fires it first:
+
+```
+pi                 // 3.14159 -- bare reference fires the command
+myfunc=func(1+1)
+myfunc              // 2 -- bare reference fires the func too
+type(pi)            // DoubleType -- the type of the fired result, not of pi itself
+```
+
+This isn't just risky when the thing being checked has side effects — it's
+uninformative even when it doesn't:
+
+```
+f=5
+g=func(5)
+type(f)             // IntType
+type(g)             // IntType -- identical; g's func-ness is invisible here
+```
+
+`istype()`, `isclass()`, `iscomm()`, and `isfunc()` are `post_eval` — they
+read their first argument as a raw, unevaluated token (the same mechanism
+`help()` already uses to describe a command without running it) and peek
+at what it resolves to with a single non-invoking table lookup, rather
+than evaluating it:
+
+```
+iscomm(pi)                 // true  -- no firing
+istype(pi CommandType)     // true
+istype(pi `CommandType)    // true -- a redundant backquote on the type
+                            //         name is harmless either way
+```
+
+`isfunc(var)` and `iscomm(var)` are fixed single-argument shortcuts for
+`isclass(var FuncObj)` and `istype(var CommandType)` — the two questions
+this whole feature exists to answer. With one argument, `istype()`/
+`isclass()` partition every value into exactly one of two buckets:
+
+```
+x=99
+istype(x)          // true  -- a plain/regular value type
+isclass(x)          // false -- nothing to ask a class of
+
+f=func(1+1)
+istype(f)           // false -- f is an object (a FuncObj), not "plain"
+isclass(f)           // true  -- and an object has a class
+```
+
+The motivating case — a func that returns another func — is exactly what
+this makes checkable for the first time:
+
+```
+outer=func(y=42; inner=func(y); inner)
+escaped=outer()      // outer() already ran; escaped holds a live FuncObj
+isfunc(escaped)       // true -- confirmed without ever calling escaped
+```
+
+`escaped` genuinely holds `inner`, not a collapsed int — outer's own last
+statement (a bare reference to `inner`) hands the `FuncObj` back intact;
+firing only happens at each later, explicit reference to `escaped` itself.
+
+**Caveat: this is a syntactic-shape peek, not a "what would this evaluate
+to" test.** A compound expression's raw, unevaluated form is a command
+call like any other — `4*3` is a call to `mpy`, and `4..7` is a call to
+`iterate`, indistinguishable in kind at this level:
+
+```
+istype(4*3 CommandType)    // true
+istype(4..7 CommandType)   // true  -- also just a command call
+istype(4..7 StreamType)    // false -- the stream only exists in iterate's
+                            //          *result*, once it actually runs
+```
+
+For a bare name, the peek tells you exactly what you want — is this
+callable, without calling it. For a compound expression, it only tells
+you the outermost command being invoked, never what that command would
+produce.
+
 ### print(:sym) — materializing symbols from formatted strings
 
 `print(:sym)` returns its output as a symbol rather than printing it.

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1868,14 +1868,26 @@ The motivating case — a func that returns another func — is exactly what
 this makes checkable for the first time:
 
 ```
-outer=func(y=42; inner=func(y); inner)
+outer=func(y=42; func(y))
 escaped=outer()      // outer() already ran; escaped holds a live FuncObj
 isfunc(escaped)       // true -- confirmed without ever calling escaped
 ```
 
-`escaped` genuinely holds `inner`, not a collapsed int — outer's own last
-statement (a bare reference to `inner`) hands the `FuncObj` back intact;
-firing only happens at each later, explicit reference to `escaped` itself.
+A standalone variable is a niladic call site everywhere — including inside
+a func's own body. There is no separate case to reason about for "inside
+vs. outside a func": a func-local reference to a `FuncObj`-bound name fires
+exactly like a top-level one does. So the construction above only works
+because `func(y)` — the construction itself — is the last thing outer's
+body evaluates. Naming it first doesn't help:
+
+```
+outer=func(y=42; inner=func(y); inner)   // inner fires here, same as z=inner would
+outer()                                   // NOT a FuncObj -- it's inner's own result
+```
+
+The only way to hand a `FuncObj` back intact is for its construction to be
+the literal last expression evaluated — never a bare reference to a name
+already holding one, anywhere, including a func's own return position.
 
 **Caveat: this is a syntactic-shape peek, not a "what would this evaluate
 to" test.** A compound expression's raw, unevaluated form is a command

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -651,6 +651,63 @@ v=99
 outer()            // 99  -- inner falls through to the top level
 ```
 
+### Not a closure — func() is closer to a macro
+
+A `func()` value does not capture the environment it was defined in.
+Define one while a particular binding is live, let it escape, mutate that
+binding, then call the escaped func — it sees the *current* value, not
+the one that existed at definition time:
+
+```
+y=1
+outer=func(y=42; func(y))   // construction itself must be the last thing
+                              // evaluated -- see "istype()/isclass()..." above
+escaped=outer()
+y=100
+escaped()                    // 100 -- not 42
+```
+
+That's the standard test for closures in any language (define under a
+binding, escape, mutate, call) and `func()` fails it. The reason traces
+directly to what a `FuncObj` actually is: a saved token buffer (`_toks`/
+`_ntoks`, nothing else) that gets *re-run fresh* against whatever's
+currently in `localtable()`/`globaltable()` on each call — not a
+reference to any specific, private, persisting environment. That's not
+closure semantics; it's macro semantics — specifically the *unhygienic*
+kind (C preprocessor, or Lisp before hygiene): a saved chunk of code that
+re-expands at each use site, with any free name resolving against
+whatever's ambient at that moment, not against whatever scope wrote it.
+`func()` gets the same classic failure mode as a result — a free variable
+inside a func body is hostage to whatever anything else in the program
+last set that name to, with no isolation at all.
+
+Where the analogy stops: a real macro isn't a runtime value — it's a
+pure compile-time transform with no existence once expansion is done.
+`FuncObj` doesn't have that limitation. It's a genuine first-class value —
+storable, passable as an argument, returnable from another func — just
+one whose free-variable resolution behaves like a macro's rather than a
+closure's.
+
+**Simulating closure capture, if you want it:** since the mechanism won't
+capture a *reference* for you, eliminate the reference and stage the
+*value* into the generated body text instead — `print(fmtstr val :str)`
+to format it, `run(cmdstr :str)` to parse and execute the result:
+
+```
+y=42
+bodystr=print("func(%v)" y :str)   // "func(42)" -- the value, not the name
+escaped=run(bodystr :str)           // constructs func(42): no free variable at all
+y=100
+escaped()                            // 42 -- immune to y's later mutation
+```
+
+`func()` itself never changes — there's simply nothing left for the
+ambient-environment resolution to override, since the body no longer
+names anything. This generalizes past plain numbers to anything ComTerp
+can print back out as valid, re-parseable syntax (the same "value
+serializes back into itself" property `feed()`'s contract relies on):
+strings, lists, attrlists, even another already-built `FuncObj`.
+
 Writing through a reference passed in as a keyword arg is not an
 exception to this rule — the symbol is local, but the attrlist object
 it points to lives outside the func and is mutated via that reference:
@@ -672,8 +729,9 @@ f(:x 5)            // 10
 ```
 
 But that nil is the func-scope **miss** falling through to local/global —
-the very close-over described next — so "reads as nil" holds **only when
-no outer variable of that name exists**. If the surrounding scope already
+the same fallback described above, not a captured reference to anything —
+so "reads as nil" holds **only when no outer variable of that name
+exists**. If the surrounding scope already
 holds an `x`, an unsupplied `x` reads *that value*, not nil. The slot is
 not zero-initialized; treat it as an uninitialized variable in the C/C++
 sense.

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1650,6 +1650,10 @@ void ComTerp::add_defaults() {
 
     add_command("type", new TypeSymbolFunc(this));
     add_command("class", new ClassSymbolFunc(this));
+    add_command("istype", new IsTypeFunc(this));
+    add_command("isclass", new IsClassFunc(this));
+    add_command("iscomm", new IsCommFunc(this));
+    add_command("isfunc", new IsFuncFunc(this));
 
     add_command("bquote", new BackQuoteFunc(this));
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -553,14 +553,21 @@ void ComTerp::eval_expr_internals(int pedepth) {
       if (_alist) {
 	// cerr << "looking up " << sv.symbol_ptr() << " (" << _alist << ")\n";
 	int id = sv.symbol_val();
-	AttributeValue* val = _alist->find(id);  
-	if (val) {
+	AttributeValue* val = _alist->find(id);
+	/* a func-local FuncObj falls through to the same fire-check below as
+	   every other symbol reference, instead of returning early -- a
+	   standalone variable is a niladic call site regardless of whether
+	   it's read from a func's own local frame or from local/global scope
+	   (comterp.c:566's lookup_symval(sv) rechecks _alist first anyway, so
+	   this isn't a second, different lookup -- just the same one, minus
+	   the early exit that previously skipped the FuncObj check). */
+	if (val && !val->is_object(FuncObj::class_symid())) {
 	  ComValue newval(*val);
 	  push_stack(newval);
 	  return;
 	}
       }
-      
+
       // cerr << "looking up " << sv.symbol_ptr() << "\n";
       const char* funcname = sv.symbol_ptr();
       ComValue val = lookup_symval(sv);

--- a/src/ComTerp/typefunc.c
+++ b/src/ComTerp/typefunc.c
@@ -25,6 +25,7 @@
 #include <ComTerp/typefunc.h>
 #include <ComTerp/comvalue.h>
 #include <ComTerp/comterp.h>
+#include <ComTerp/postfunc.h>
 
 #include <Attribute/attrlist.h>
 #include <Attribute/attrvalue.h>
@@ -119,4 +120,103 @@ void ClassSymbolFunc::execute() {
     }
   }
 
+}
+
+/*****************************************************************************/
+
+/* shared by IsTypeFunc/IsClassFunc/IsCommFunc/IsFuncFunc: resolve a raw,
+   post_eval-read argument to what it's actually bound to, without ever
+   firing it -- a raw arg that's already resolved (a CommandType token like
+   `pi`, a literal, another command's own raw call token) is its own
+   answer; a raw arg that's still a bare SymbolType token (an ordinary
+   variable reference) gets exactly one non-invoking table lookup
+   (ComTerp::lookup_symval, the same primitive ComValue::is_funcobj()
+   already uses internally) to see what it's bound to.  Returns nil for an
+   unbound bare symbol. */
+static AttributeValue* resolve_no_fire(ComTerp* comterp, ComValue& raw) {
+  if (raw.type() != AttributeValue::SymbolType) return &raw;
+  return comterp->lookup_symval(&raw);
+}
+
+/* shared by the two-argument forms of istype()/isclass(): the type/class
+   name argument is always just a symbol, bare (CommandType) or bquoted
+   (`CommandType) -- neither form should ever be resolved as a variable
+   reference (there usually isn't one bound to that name).  A bare token
+   is read directly; anything else (a bquote call being the expected
+   case) is safe to evaluate outright, since bquote itself never fires
+   anything and has no side effects. */
+static int arg_symbol_id(ComFunc* func, ComValue& raw) {
+  if (raw.type() == AttributeValue::SymbolType) return raw.symbol_val();
+  ComValue evaluated(func->stack_arg_post_eval(1, true));
+  return evaluated.symbol_val();
+}
+
+/*****************************************************************************/
+
+IsTypeFunc::IsTypeFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void IsTypeFunc::execute() {
+  ComValue arg0(stack_arg(0, true));
+  boolean two_arg = nargsfixed()>1;
+  AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
+  int subj_symid = resolved ? resolved->type_symid() : -1;
+
+  if (two_arg) {
+    ComValue arg1(stack_arg(1, true));
+    int type_symid = arg_symbol_id(this, arg1);
+    reset_stack();
+    push_stack(subj_symid==type_symid ? ComValue::trueval() : ComValue::falseval());
+  } else {
+    reset_stack();
+    boolean is_obj = resolved && resolved->is_object();
+    push_stack(!is_obj ? ComValue::trueval() : ComValue::falseval());
+  }
+}
+
+/*****************************************************************************/
+
+IsClassFunc::IsClassFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void IsClassFunc::execute() {
+  ComValue arg0(stack_arg(0, true));
+  boolean two_arg = nargsfixed()>1;
+  AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
+  boolean is_obj = resolved && resolved->is_object();
+  int subj_class_symid = is_obj ? resolved->class_symid() : -1;
+
+  if (two_arg) {
+    ComValue arg1(stack_arg(1, true));
+    int class_symid = arg_symbol_id(this, arg1);
+    reset_stack();
+    push_stack((is_obj && subj_class_symid==class_symid) ? ComValue::trueval() : ComValue::falseval());
+  } else {
+    reset_stack();
+    push_stack(is_obj ? ComValue::trueval() : ComValue::falseval());
+  }
+}
+
+/*****************************************************************************/
+
+IsCommFunc::IsCommFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void IsCommFunc::execute() {
+  ComValue arg0(stack_arg(0, true));
+  reset_stack();
+  AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
+  push_stack((resolved && resolved->is_type(AttributeValue::CommandType)) ? ComValue::trueval() : ComValue::falseval());
+}
+
+/*****************************************************************************/
+
+IsFuncFunc::IsFuncFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void IsFuncFunc::execute() {
+  ComValue arg0(stack_arg(0, true));
+  reset_stack();
+  AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
+  push_stack((resolved && resolved->is_object(FuncObj::class_symid())) ? ComValue::trueval() : ComValue::falseval());
 }

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -50,8 +50,60 @@ public:
     ClassSymbolFunc(ComTerp*);
     virtual void execute();
 
-    virtual const char* docstring() { 
+    virtual const char* docstring() {
       return "sym|lst=%s(val [ ...]) -- return class symbol(s) for value(s) of object type"; }
+};
+
+//: command to test a variable's type without ever evaluating it.
+// flag=istype(var [typesym]) -- true if var's type equals typesym, without
+// firing var if it names a command or holds a FuncObj.  With one argument,
+// true if var is a plain/regular value type (not ObjectType).
+class IsTypeFunc : public ComFunc {
+public:
+    IsTypeFunc(ComTerp*);
+    virtual void execute();
+
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "flag=%s(var [typesym]) -- test var's type without evaluating it"; }
+};
+
+//: command to test a variable's class without ever evaluating it.
+// flag=isclass(var [classsym]) -- true if var's class equals classsym,
+// without firing var if it names a command or holds a FuncObj.  With one
+// argument, true if var is of ObjectType at all (there's a class to ask).
+class IsClassFunc : public ComFunc {
+public:
+    IsClassFunc(ComTerp*);
+    virtual void execute();
+
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "flag=%s(var [classsym]) -- test var's class without evaluating it"; }
+};
+
+//: shortcut for istype(var CommandType), without evaluating var.
+// flag=iscomm(var) -- true if var names a command, without invoking it
+class IsCommFunc : public ComFunc {
+public:
+    IsCommFunc(ComTerp*);
+    virtual void execute();
+
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "flag=%s(var) -- true if var names a command, without evaluating it"; }
+};
+
+//: shortcut for isclass(var FuncObj), without evaluating var.
+// flag=isfunc(var) -- true if var holds a func(), without invoking it
+class IsFuncFunc : public ComFunc {
+public:
+    IsFuncFunc(ComTerp*);
+    virtual void execute();
+
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "flag=%s(var) -- true if var holds a func(), without evaluating it"; }
 };
 
 #endif /* !defined(_typefunc_h) */

--- a/src/comterp_/tests/istype.comt
+++ b/src/comterp_/tests/istype.comt
@@ -2,7 +2,7 @@
 // the post_eval type/class predicates that inspect a variable without ever
 // evaluating it (issue #289)
 //
-// coverage: 17/22 (77%)
+// coverage: 18/23 (78%)
 // funcs: istype isclass iscomm isfunc
 // missing: istype(val-neg) istype(val-bool-t) istype(val-bool-f) istype(val-nil)
 //          isclass(:nowait)-style keyword forms (none exist -- N/A, listed for completeness)
@@ -30,6 +30,13 @@
 // type, isclass(var) true when there's a class to ask about at all (test
 // 11-14) -- FuncObj included, since func()'s return value is already an
 // ObjectType, class_symid()-bearing value like FileObj/Attribute.
+//
+// A standalone variable is a niladic call site everywhere, including inside
+// a func's own body -- there is no separate case to reason about for
+// "inside vs outside a func" (test 18).  The only way a func() call
+// reliably hands back a live FuncObj is for the construction itself to be
+// the last thing evaluated (test 17); naming the result first and
+// referencing that name fires it immediately, same as any other reference.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/istype.comt")
@@ -145,13 +152,26 @@ print("   istype(4..7 CommandType) (expect true):  %v\n\n" r16b)
 check_fail(:ok ok)
 
 // --- test 17: isfunc(escaped) -- the motivating case: a func that returns
-// another func.  escaped holds a live FuncObj (inner) the whole time;
-// isfunc() is the first tool that can confirm this without invoking it. ---
-outer=func(y=42; inner=func(y); inner)
+// another func.  A standalone variable is a niladic call site everywhere,
+// including inside a func body, so escaped only ends up holding a live
+// FuncObj because the inner func() construction is itself the last thing
+// evaluated -- naming it first (inner=func(y); inner) would fire it before
+// outer ever returns, same as any other func-local reference (test 18). ---
+outer=func(y=42; func(y))
 escaped=outer()
 r=isfunc(escaped)
 ok=ok&&(r==true)
-print("17 outer=func(y=42; inner=func(y); inner); escaped=outer(); isfunc(escaped) (expect true): %v\n\n" r)
+print("17 outer=func(y=42; func(y)); escaped=outer(); isfunc(escaped) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 18: a func-local FuncObj reference fires just like a top-level
+// one -- no special case for "inside a func body".  z=inner fires inner
+// immediately (its body is just y, so z ends up holding 42, not a FuncObj),
+// the same as if inner were referenced from outside outer entirely. ---
+outer2=func(y=42; inner=func(y); z=inner; isfunc(z))
+r2=outer2()
+ok=ok&&(r2==false)
+print("18 outer2=func(y=42; inner=func(y); z=inner; isfunc(z)); outer2() (expect false -- z already fired): %v\n\n" r2)
 check_fail(:ok ok)
 
 print("\nistype: %v\n" ok)

--- a/src/comterp_/tests/istype.comt
+++ b/src/comterp_/tests/istype.comt
@@ -1,0 +1,158 @@
+// src/comterp_/tests/istype.comt -- test istype()/isclass()/iscomm()/isfunc(),
+// the post_eval type/class predicates that inspect a variable without ever
+// evaluating it (issue #289)
+//
+// coverage: 17/22 (77%)
+// funcs: istype isclass iscomm isfunc
+// missing: istype(val-neg) istype(val-bool-t) istype(val-bool-f) istype(val-nil)
+//          isclass(:nowait)-style keyword forms (none exist -- N/A, listed for completeness)
+//
+// ComTerp's niladic auto-firing (a bare symbol whose value is a FuncObj
+// invokes it on mere reference; a bare command name like pi fires the same
+// way) makes it impossible with any pre-existing tool to ask "what does this
+// variable currently hold" without running it -- type()/class() themselves
+// auto-fire their own argument before they ever see it, so they report the
+// type of whatever got invoked, not the type of what was bound.  istype()/
+// isclass()/iscomm()/isfunc() are post_eval: they read their subject as a
+// raw, unevaluated token and peek at what it resolves to via a single
+// non-invoking table lookup, the same primitive ComValue::is_funcobj()
+// already used internally (comvalue.c).  This is a pure syntactic-shape
+// peek, not a "what would this evaluate to" test -- a compound expression
+// like 4..7 reports as CommandType (a call to iterate), not StreamType,
+// since the stream-ness only exists in iterate's result once it actually
+// runs (test 15/16).  istype(var [typesym]) and isclass(var [classsym])
+// take the type/class name bare or bquoted interchangeably (test 8) --
+// neither argument ever needs backquoting.  iscomm(var) and isfunc(var) are
+// fixed single-argument shortcuts for istype(var CommandType) and
+// isclass(var FuncObj), the two comparisons this whole feature exists for.
+// With one argument, istype(var)/isclass(var) partition every value into
+// exactly one of two buckets: istype(var) true for a plain/regular value
+// type, isclass(var) true when there's a class to ask about at all (test
+// 11-14) -- FuncObj included, since func()'s return value is already an
+// ObjectType, class_symid()-bearing value like FileObj/Attribute.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/istype.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: iscomm(pi) -- a real command name, without firing it ---
+r=iscomm(pi)
+ok=ok&&(r==true)
+print("1 iscomm(pi) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 2: iscomm(x) -- a plain variable is not a command ---
+x=99
+r=iscomm(x)
+ok=ok&&(r==false)
+print("2 x=99; iscomm(x) (expect false): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 3: isfunc(f) on a func-bound name, before any call -- no fire.
+// f's body would print if invoked; nothing prints here. ---
+f=func(print("SHOULD NOT PRINT\n"); 1+1)
+r=isfunc(f)
+ok=ok&&(r==true)
+print("3 f=func(print(...) 1+1); isfunc(f) (expect true, no print above): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 4: isfunc(x) -- a plain variable is not a func ---
+r=isfunc(x)
+ok=ok&&(r==false)
+print("4 isfunc(x) (expect false): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 5: istype(pi CommandType) -- two-arg form, bare type name ---
+r=istype(pi CommandType)
+ok=ok&&(r==true)
+print("5 istype(pi CommandType) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 6: istype(pi StringType) -- two-arg form, wrong type ---
+r=istype(pi StringType)
+ok=ok&&(r==false)
+print("6 istype(pi StringType) (expect false): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 7: istype(x IntType) -- two-arg form on a plain scalar ---
+r=istype(x IntType)
+ok=ok&&(r==true)
+print("7 x=99; istype(x IntType) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 8: istype(pi `CommandType) -- a redundant backquote on the
+// second argument is harmless, same result as the bare form (test 5) ---
+r=istype(pi `CommandType)
+ok=ok&&(r==true)
+print("8 istype(pi `CommandType) redundant backquote (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 9: isclass(f FuncObj) -- two-arg form on a func-bound name ---
+r=isclass(f FuncObj)
+ok=ok&&(r==true)
+print("9 isclass(f FuncObj) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 10: isclass(x FuncObj) -- two-arg form, wrong class ---
+r=isclass(x FuncObj)
+ok=ok&&(r==false)
+print("10 isclass(x FuncObj) (expect false): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 11: istype(x) one-arg -- true for a plain/regular value type ---
+r=istype(x)
+ok=ok&&(r==true)
+print("11 istype(x) one-arg (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 12: istype(f) one-arg -- false, f is an object (FuncObj), not a
+// plain/regular type; still no fire ---
+r=istype(f)
+ok=ok&&(r==false)
+print("12 istype(f) one-arg (expect false, no print above): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 13: isclass(x) one-arg -- false, a plain scalar has no class ---
+r=isclass(x)
+ok=ok&&(r==false)
+print("13 isclass(x) one-arg (expect false): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 14: isclass(f) one-arg -- true, f is an object (has a class) ---
+r=isclass(f)
+ok=ok&&(r==true)
+print("14 isclass(f) one-arg (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 15: istype(4*3 CommandType) -- a compound expression's raw form
+// is a call to mpy, a plain command -- confirmed via postfix(4*3) ---
+r=istype(4*3 CommandType)
+ok=ok&&(r==true)
+print("15 istype(4*3 CommandType) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 16: istype(4..7 StreamType) -- the syntactic-shape-not-result-type
+// caveat: a range's raw, unevaluated form is a call to iterate, not
+// anything stream-shaped -- the stream only exists in iterate's result,
+// once it actually runs.  istype(4..7 CommandType) is the one that's true. ---
+r16a=istype(4..7 StreamType)
+r16b=istype(4..7 CommandType)
+ok=ok&&(r16a==false && r16b==true)
+print("16 istype(4..7 StreamType) (expect false): %v\n" r16a)
+print("   istype(4..7 CommandType) (expect true):  %v\n\n" r16b)
+check_fail(:ok ok)
+
+// --- test 17: isfunc(escaped) -- the motivating case: a func that returns
+// another func.  escaped holds a live FuncObj (inner) the whole time;
+// isfunc() is the first tool that can confirm this without invoking it. ---
+outer=func(y=42; inner=func(y); inner)
+escaped=outer()
+r=isfunc(escaped)
+ok=ok&&(r==true)
+print("17 outer=func(y=42; inner=func(y); inner); escaped=outer(); isfunc(escaped) (expect true): %v\n\n" r)
+check_fail(:ok ok)
+
+print("\nistype: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -110,6 +110,10 @@ if(run("./feed.comt")
   :then print("pass: feed\n")
   :else print("FAIL: feed\n");topok=false)
 
+if(run("./istype.comt")
+  :then print("pass: istype\n")
+  :else print("FAIL: istype\n");topok=false)
+
 if(run("./runfile.comt")
   :then print("pass: runfile\n")
   :else print("FAIL: runfile\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "85317d63"
+#define PATCH_KEY "7001680e"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -242,6 +242,8 @@ Print a usage summary of all the invocation modes above and exit.
 
  cnt=each(strm) -- traverse stream returning its length
 
+ fifo=feed([fifo] [val ...]) -- build or append to a growable FIFO stream
+
  comp=filter(comps classid) -- filter stream of comps for matching classid
 
  attrlst|lst=info(strm :raw) -- return internal list of a stream
@@ -393,6 +395,14 @@ Print a usage summary of all the invocation modes above and exit.
  sym|lst=type(val [val ...]) -- return type symbol(s) for value(s)
 
  sym|lst=class(val [val ...]) -- return class symbol(s) for value(s) of object type
+
+ flag=istype(var [typesym]) -- test var's type without evaluating it
+
+ flag=isclass(var [classsym]) -- test var's class without evaluating it
+
+ flag=iscomm(var) -- true if var names a command, without evaluating it
+
+ flag=isfunc(var) -- true if var holds a func(), without evaluating it
 
  int=ctoi(char) -- convert character to integer
 


### PR DESCRIPTION
## Summary
- Adds `istype(var [typesym])`, `isclass(var [classsym])`, `iscomm(var)`, `isfunc(var)` -- `post_eval` predicates that read their subject as a raw, unevaluated token (the same access pattern `help()` already uses) and peek at what it resolves to via a single non-invoking table lookup, instead of evaluating it.
- Closes the gap that `type()`/`class()` themselves can't fill: both evaluate their argument first, so a bare command name or a `func()`-bound name fires before either command ever sees it -- confirmed even side-effect-free funcs are indistinguishable from plain values this way (`f=5`/`g=func(5)` both report `IntType`).
- `iscomm(var)`/`isfunc(var)` are fixed single-argument shortcuts for `istype(var CommandType)`/`isclass(var FuncObj)` -- the two comparisons this feature exists for.
- One-argument `istype(var)`/`isclass(var)` partition every value into exactly one of two buckets: a plain/regular value type, or an object with a class.
- The type/class name argument accepts bare or backquoted interchangeably -- neither argument ever needs backquoting.

## `comterp.c`: a standalone variable is a niladic call site everywhere, including inside a func's own body
Investigating `istype()`/`isfunc()` surfaced a real inconsistency: `eval_expr_internals`'s `SymbolType` branch had two lookup paths that behaved differently for exactly one thing -- whether a `FuncObj`-bound name fires on reference. A name resolved via `localtable()`/`globaltable()` always fired; a name resolved via `_alist` (the currently-active func's own local frame) took an early-return shortcut that never checked whether the value was callable at all. This meant a func returning another func depended entirely on incidental structure (was the returned func a bare reference to a locally-named variable, or a direct construction?) rather than anything principled.

Fixed by letting the `_alist` branch fall through to the exact same fire-check used everywhere else, instead of short-circuiting. No new plumbing -- a bare reference always carries `narg()==0`/`nkey()==0`, the same shape already proven correct for every other `FuncObj` reference. Consequence: a func can still return a func, but only if the construction itself is the last expression evaluated (`outer=func(y=42; func(y))`) -- never a bare reference to an already-named `FuncObj`, anywhere, including a func's own return position. Docs and `istype.comt` updated to match.

## doc: func() is not a closure, and how to fake one
Direct fallout of the above: proved `func()` doesn't capture its definition-time environment at all (standard closure test, negative result) -- it's closer to an unhygienic macro (saved tokens, re-run fresh against whatever's currently ambient) than a closure. Documented why, and the technique for simulating capture when it's wanted: bake the value into generated body text as a literal via `print(fmtstr val :str)` + `run(cmdstr :str)`, verified working.

## Caveat, documented in LANGUAGE.md
`istype()`/`isclass()`/etc. are a syntactic-shape peek, not a "what would this evaluate to" test. A compound expression's raw form is a command call like any other -- `istype(4..7 CommandType)` is true (a call to `iterate`), `istype(4..7 StreamType)` is false, since the stream-ness only exists in `iterate`'s result once it actually runs.

## Test plan
- [x] `src/comterp_/tests/istype.comt`, 18 tests, added to `run_all.comt`
- [x] Full `run_all.comt` regression suite green after every commit, including after the `comterp.c` behavior change (only our own new test 17 needed updating -- confirmed nothing in ~30 pre-existing test scripts relied on the old asymmetry)
- [x] Verified no-fire behavior with side-effect probes throughout
- [x] Verified the motivating case directly: `outer=func(y=42; func(y)); escaped=outer()` -- `isfunc(escaped)` is `true`
- [x] `doc/LANGUAGE.md`, `doc/APPENDIX-B-COMTERP-EXAMPLES.md`, `src/man/man1/comterp.1` all updated, every example run against the built interpreter first

Closes #289