### PR TITLE
doc: eval()'s :alist keyword as the real, first-class way to bundle a func with data

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -740,15 +740,20 @@ counter.n                              // 3 -- the object's own field, genuinely
 method (`:incr`, a `FuncObj`). Passing `counter` itself as `:alist` means
 `incr`'s free variable `n` resolves against `counter`'s own field — the
 same attrlist is simultaneously "the method" and "self." This is a real
-object system (data and behavior bundled together, private to the
-instance that owns them), built entirely from existing pieces — attrlist
-literals, `func()`, dot access, `eval()`'s `:alist` — no new mechanism
-required. A single-method object built this way is exactly a closure (the
-data field is the captured variable, the method is the function body), so
-this subsumes the bake-a-literal technique above as the general case, not
-just an alternative to it.
+object system — data and behavior bundled together, with genuine identity
+and mutation — just without privacy: `counter.n` is directly readable and
+writable from outside (as above), and `incr` itself isn't bound to
+`counter` specifically — it's a plain `FuncObj` value, callable against
+any attrlist via `:alist`. No private/protected keywords, the same way
+plenty of dynamic languages (Python, JavaScript, Lua) leave access control
+to convention rather than enforcement. Built entirely from existing
+pieces — attrlist literals, `func()`, dot access, `eval()`'s `:alist` —
+no new mechanism required. A single-method object built this way is
+exactly a closure (the data field is the captured variable, the method is
+the function body), so this subsumes the bake-a-literal technique above
+as the general case, not just an alternative to it.
 
-One rule carried over from everywhere else tonight: the method reference
+One rule carried over from everywhere else in this doc: the method reference
 (`counter.incr`, or a plain `func(...)`) must be constructed or
 dot-accessed directly in the `eval()` call, never assigned to a plain
 variable and referenced bare first — a bare reference to a `FuncObj` fires

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -708,6 +708,53 @@ can print back out as valid, re-parseable syntax (the same "value
 serializes back into itself" property `feed()`'s contract relies on):
 strings, lists, attrlists, even another already-built `FuncObj`.
 
+**A cleaner way, and real objects for free: `eval()`'s own `:alist`
+keyword.** `eval(cmdstr|funcobj :alist attrlist)` runs its argument with
+the func-local scope (`_alist`) set to the given attrlist first — the
+same lookup tier a func's own keyword args live in, just supplied
+explicitly instead of by the caller passing keywords. That's a first-class
+existing mechanism, not a workaround, and it beats the bake-a-literal
+trick in one real way: attrlists are mutable reference objects (`al.x=99`
+already mutates the same object a caller holds — see *Writing through a
+reference* above), so this supports genuine, *persisting, mutating* state
+across calls, not just a frozen snapshot:
+
+```
+y=42
+eval(func(y) :alist attrlist(:y y))   // 42 -- same capture as the bake-in-literal trick
+```
+
+The real payoff is combining it with dot access on an attrlist that holds
+both data *and* a method, using the attrlist itself as `:alist` — real,
+working `self`-bound method dispatch:
+
+```
+counter=(:n 0 :incr func(n=n+1; n))
+eval(counter.incr :alist counter)     // 1
+eval(counter.incr :alist counter)     // 2
+eval(counter.incr :alist counter)     // 3
+counter.n                              // 3 -- the object's own field, genuinely mutated
+```
+
+`counter` is a single attrlist holding one data field (`:n`) and one
+method (`:incr`, a `FuncObj`). Passing `counter` itself as `:alist` means
+`incr`'s free variable `n` resolves against `counter`'s own field — the
+same attrlist is simultaneously "the method" and "self." This is a real
+object system (data and behavior bundled together, private to the
+instance that owns them), built entirely from existing pieces — attrlist
+literals, `func()`, dot access, `eval()`'s `:alist` — no new mechanism
+required. A single-method object built this way is exactly a closure (the
+data field is the captured variable, the method is the function body), so
+this subsumes the bake-a-literal technique above as the general case, not
+just an alternative to it.
+
+One rule carried over from everywhere else tonight: the method reference
+(`counter.incr`, or a plain `func(...)`) must be constructed or
+dot-accessed directly in the `eval()` call, never assigned to a plain
+variable and referenced bare first — a bare reference to a `FuncObj` fires
+immediately, same niladic-firing rule as always, with no exception for
+being an argument to `eval()`.
+
 Writing through a reference passed in as a keyword arg is not an
 exception to this rule — the symbol is local, but the attrlist object
 it points to lives outside the func and is mutated via that reference:

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "7001680e"
+#define PATCH_KEY "ff4e2b6a"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
Direct follow-on to tonight's closure documentation (PR #290, *func() is closer to a macro*) and #293 (extending #167 to per-instance objects, data + methods).

Discovered in conversation: `eval(cmdstr|funcobj :alist attrlist)` -- already an existing, documented keyword (`help(eval)`) -- sets the func-local scope to a given attrlist before running. This is a strictly better closure-capture mechanism than the bake-a-literal-into-generated-source trick already documented, since attrlists are mutable reference objects -- confirmed with a real accumulating counter (`:n` incrementing 1/2/3 across three separate calls, the object's own field reading back the mutation afterward), which the frozen-snapshot technique couldn't support at all.

The real payoff: dot-accessing a method off the same attrlist passed as its own `:alist` gives working `self`-bound method dispatch --  data and behavior bundled in one attrlist, no new mechanism required beyond pieces that already exist. A single-method object built this way is exactly a closure, so this subsumes the earlier technique as the general case rather than sitting alongside it as an alternative.

## Test plan
- [x] Every example run against the built interpreter before being written down, including the mutating-counter test specifically because the earlier frozen-snapshot technique couldn't have supported it
- [x] Confirmed the same niladic-firing rule applies here too -- the method reference must be constructed/dot-accessed directly in the `eval()` call, never assigned to a plain variable and referenced bare first

Doc-only change, no code touched. Related to #291, #293.