### PR TITLE
istype()/isclass()/iscomm()/isfunc(): add :sym keyword to return the type/class symbol

### DIFF
--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -130,6 +130,9 @@ istype(pi CommandType)          // true -- neither argument needs backquoting
 outer=func(y=42; func(y))
 escaped=outer()
 isfunc(escaped)               // true -- confirmed without ever calling escaped
+
+// :sym -- same non-firing peek, but return the symbol instead of a flag
+istype(pi :sym)                // `CommandType -- same symbol type(pi) would give, no firing
 ```
 
 See *istype()/isclass()/iscomm()/isfunc()* in `LANGUAGE.md` for the full

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1964,6 +1964,34 @@ callable, without calling it. For a compound expression, it only tells
 you the outermost command being invoked, never what that command would
 produce.
 
+**`:sym` — the symbol itself, not just a flag.** All four take a `:sym`
+keyword: instead of a boolean, return the resolved type/class symbol
+directly (`nil` if there isn't one) — the same non-firing peek, reported
+the way `type()`/`class()` report it for a value that's already been
+fired:
+
+```
+x=99
+istype(x :sym)      // `IntType -- same symbol type(x) would give
+isclass(x :sym)      // nil -- x isn't of ObjectType at all
+
+f=func(1+1)
+isfunc(f :sym)        // `FuncObj -- no firing, same guarantee as isfunc(f)
+```
+
+On `istype()`/`isclass()`, `:sym` wins over a two-arg comparison target
+if both are given — it always reports what the variable actually is,
+not whether it matches something else:
+
+```
+istype(pi IntType :sym)   // `CommandType -- pi's own type, IntType ignored
+```
+
+`iscomm()`/`isfunc()` have no comparison target to begin with (they're
+fixed shortcuts), so `:sym` there is a symbol-or-`nil` version of the
+same flag rather than new information — `` `CommandType``/`` `FuncObj``
+on a match, `nil` otherwise.
+
 ### print(:sym) — materializing symbols from formatted strings
 
 `print(:sym)` returns its output as a symbol rather than printing it.

--- a/src/ComTerp/typefunc.c
+++ b/src/ComTerp/typefunc.c
@@ -151,6 +151,19 @@ static int arg_symbol_id(ComFunc* func, ComValue& raw) {
   return evaluated.symbol_val();
 }
 
+/* shared by all four: push the quoted symbol for a resolved symid, or nil
+   if there isn't one -- the :sym-flag counterpart to the plain boolean
+   push these commands otherwise do. */
+static void push_symid_or_nil(ComFunc* func, int symid) {
+  if (symid<0) {
+    func->push_stack(ComValue::nullval());
+  } else {
+    ComValue retval(symid, AttributeValue::SymbolType);
+    retval.bquote(1);
+    func->push_stack(retval);
+  }
+}
+
 /*****************************************************************************/
 
 IsTypeFunc::IsTypeFunc(ComTerp* comterp) : ComFunc(comterp) {
@@ -159,10 +172,15 @@ IsTypeFunc::IsTypeFunc(ComTerp* comterp) : ComFunc(comterp) {
 void IsTypeFunc::execute() {
   ComValue arg0(stack_arg(0, true));
   boolean two_arg = nargsfixed()>1;
+  static int sym_symid = symbol_add("sym");
+  ComValue symflag(stack_key(sym_symid));
   AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
   int subj_symid = resolved ? resolved->type_symid() : -1;
 
-  if (two_arg) {
+  if (symflag.is_true()) {
+    reset_stack();
+    push_symid_or_nil(this, subj_symid);
+  } else if (two_arg) {
     ComValue arg1(stack_arg(1, true));
     int type_symid = arg_symbol_id(this, arg1);
     reset_stack();
@@ -182,11 +200,16 @@ IsClassFunc::IsClassFunc(ComTerp* comterp) : ComFunc(comterp) {
 void IsClassFunc::execute() {
   ComValue arg0(stack_arg(0, true));
   boolean two_arg = nargsfixed()>1;
+  static int sym_symid = symbol_add("sym");
+  ComValue symflag(stack_key(sym_symid));
   AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
   boolean is_obj = resolved && resolved->is_object();
   int subj_class_symid = is_obj ? resolved->class_symid() : -1;
 
-  if (two_arg) {
+  if (symflag.is_true()) {
+    reset_stack();
+    push_symid_or_nil(this, subj_class_symid);
+  } else if (two_arg) {
     ComValue arg1(stack_arg(1, true));
     int class_symid = arg_symbol_id(this, arg1);
     reset_stack();
@@ -204,9 +227,15 @@ IsCommFunc::IsCommFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void IsCommFunc::execute() {
   ComValue arg0(stack_arg(0, true));
+  static int sym_symid = symbol_add("sym");
+  ComValue symflag(stack_key(sym_symid));
   reset_stack();
   AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
-  push_stack((resolved && resolved->is_type(AttributeValue::CommandType)) ? ComValue::trueval() : ComValue::falseval());
+  boolean match = resolved && resolved->is_type(AttributeValue::CommandType);
+  if (symflag.is_true())
+    push_symid_or_nil(this, match ? resolved->type_symid() : -1);
+  else
+    push_stack(match ? ComValue::trueval() : ComValue::falseval());
 }
 
 /*****************************************************************************/
@@ -216,7 +245,13 @@ IsFuncFunc::IsFuncFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void IsFuncFunc::execute() {
   ComValue arg0(stack_arg(0, true));
+  static int sym_symid = symbol_add("sym");
+  ComValue symflag(stack_key(sym_symid));
   reset_stack();
   AttributeValue* resolved = resolve_no_fire(comterp(), arg0);
-  push_stack((resolved && resolved->is_object(FuncObj::class_symid())) ? ComValue::trueval() : ComValue::falseval());
+  boolean match = resolved && resolved->is_object(FuncObj::class_symid());
+  if (symflag.is_true())
+    push_symid_or_nil(this, match ? resolved->class_symid() : -1);
+  else
+    push_stack(match ? ComValue::trueval() : ComValue::falseval());
 }

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -55,9 +55,12 @@ public:
 };
 
 //: command to test a variable's type without ever evaluating it.
-// flag=istype(var [typesym]) -- true if var's type equals typesym, without
-// firing var if it names a command or holds a FuncObj.  With one argument,
-// true if var is a plain/regular value type (not ObjectType).
+// flag=istype(var [typesym] :sym) -- true if var's type equals typesym,
+// without firing var if it names a command or holds a FuncObj.  With one
+// argument, true if var is a plain/regular value type (not ObjectType).
+// With :sym, returns var's own type symbol (nil if var is unbound)
+// instead of a flag, ignoring typesym if also given -- the post_eval
+// counterpart to what type() returns for the fired value.
 class IsTypeFunc : public ComFunc {
 public:
     IsTypeFunc(ComTerp*);
@@ -65,13 +68,16 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "flag=%s(var [typesym]) -- test var's type without evaluating it"; }
+      return "flag=%s(var [typesym] :sym) -- test var's type without evaluating it"; }
 };
 
 //: command to test a variable's class without ever evaluating it.
-// flag=isclass(var [classsym]) -- true if var's class equals classsym,
-// without firing var if it names a command or holds a FuncObj.  With one
-// argument, true if var is of ObjectType at all (there's a class to ask).
+// flag=isclass(var [classsym] :sym) -- true if var's class equals
+// classsym, without firing var if it names a command or holds a FuncObj.
+// With one argument, true if var is of ObjectType at all (there's a class
+// to ask).  With :sym, returns var's own class symbol (nil if var isn't
+// of ObjectType) instead of a flag, ignoring classsym if also given --
+// the post_eval counterpart to what class() returns for the fired value.
 class IsClassFunc : public ComFunc {
 public:
     IsClassFunc(ComTerp*);
@@ -79,11 +85,13 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "flag=%s(var [classsym]) -- test var's class without evaluating it"; }
+      return "flag=%s(var [classsym] :sym) -- test var's class without evaluating it"; }
 };
 
 //: shortcut for istype(var CommandType), without evaluating var.
-// flag=iscomm(var) -- true if var names a command, without invoking it
+// flag=iscomm(var :sym) -- true if var names a command, without
+// invoking it.  With :sym, returns `CommandType (nil if false) instead
+// of a flag.
 class IsCommFunc : public ComFunc {
 public:
     IsCommFunc(ComTerp*);
@@ -91,11 +99,13 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "flag=%s(var) -- true if var names a command, without evaluating it"; }
+      return "flag=%s(var :sym) -- true if var names a command, without evaluating it"; }
 };
 
 //: shortcut for isclass(var FuncObj), without evaluating var.
-// flag=isfunc(var) -- true if var holds a func(), without invoking it
+// flag=isfunc(var :sym) -- true if var holds a func(), without
+// invoking it.  With :sym, returns `FuncObj (nil if false) instead of a
+// flag.
 class IsFuncFunc : public ComFunc {
 public:
     IsFuncFunc(ComTerp*);
@@ -103,7 +113,7 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "flag=%s(var) -- true if var holds a func(), without evaluating it"; }
+      return "flag=%s(var :sym) -- true if var holds a func(), without evaluating it"; }
 };
 
 #endif /* !defined(_typefunc_h) */

--- a/src/comterp_/tests/istype.comt
+++ b/src/comterp_/tests/istype.comt
@@ -2,7 +2,7 @@
 // the post_eval type/class predicates that inspect a variable without ever
 // evaluating it (issue #289)
 //
-// coverage: 18/23 (78%)
+// coverage: 27/32 (84%)
 // funcs: istype isclass iscomm isfunc
 // missing: istype(val-neg) istype(val-bool-t) istype(val-bool-f) istype(val-nil)
 //          isclass(:nowait)-style keyword forms (none exist -- N/A, listed for completeness)
@@ -37,6 +37,16 @@
 // reliably hands back a live FuncObj is for the construction itself to be
 // the last thing evaluated (test 17); naming the result first and
 // referencing that name fires it immediately, same as any other reference.
+//
+// All four also take a :sym keyword: instead of a flag, return the
+// resolved type/class symbol itself (nil if there isn't one) -- the
+// post_eval counterpart to what type()/class() return for the fired
+// value (test 19, 22).  On istype()/isclass(), :sym wins over a
+// two-arg comparison target if both are given (test 20).  On the
+// iscomm()/isfunc() shortcuts, which have no comparison target to
+// begin with, :sym gives `CommandType/`FuncObj on match and nil
+// otherwise (test 24-27) -- a symbol-or-nil form of the same flag,
+// not new information beyond what the boolean already said.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/istype.comt")
@@ -172,6 +182,64 @@ outer2=func(y=42; inner=func(y); z=inner; isfunc(z))
 r2=outer2()
 ok=ok&&(r2==false)
 print("18 outer2=func(y=42; inner=func(y); z=inner; isfunc(z)); outer2() (expect false -- z already fired): %v\n\n" r2)
+check_fail(:ok ok)
+
+// --- test 19: istype(x :sym) -- return x's own type symbol instead of
+// a flag, same symbol type() would give for the fired value ---
+r=istype(x :sym)
+ok=ok&&(r==`IntType)
+print("19 x=99; istype(x :sym) (expect IntType): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 20: istype(pi IntType :sym) -- :sym wins over a two-arg
+// comparison target, still reporting pi's own (unfired) type ---
+r=istype(pi IntType :sym)
+ok=ok&&(r==`CommandType)
+print("20 istype(pi IntType :sym) (expect CommandType, IntType ignored): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 21: istype(neverbound :sym) -- nil for an unbound variable,
+// same nil-for-unresolved rule the boolean form already has ---
+r=istype(neverbound :sym)
+ok=ok&&(r==nil)
+print("21 istype(neverbound :sym) (expect nil): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 22: isclass(f :sym) -- return f's own class symbol ---
+r=isclass(f :sym)
+ok=ok&&(r==`FuncObj)
+print("22 isclass(f :sym) (expect FuncObj): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 23: isclass(x :sym) -- nil, x isn't of ObjectType at all ---
+r=isclass(x :sym)
+ok=ok&&(r==nil)
+print("23 isclass(x :sym) (expect nil): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 24: iscomm(pi :sym) -- CommandType on match, the type tag
+// istype(pi :sym) would also give, not pi's own name ---
+r=iscomm(pi :sym)
+ok=ok&&(r==`CommandType)
+print("24 iscomm(pi :sym) (expect CommandType): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 25: iscomm(x :sym) -- nil, x doesn't name a command ---
+r=iscomm(x :sym)
+ok=ok&&(r==nil)
+print("25 iscomm(x :sym) (expect nil): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 26: isfunc(f :sym) -- FuncObj on match ---
+r=isfunc(f :sym)
+ok=ok&&(r==`FuncObj)
+print("26 isfunc(f :sym) (expect FuncObj): %v\n\n" r)
+check_fail(:ok ok)
+
+// --- test 27: isfunc(x :sym) -- nil, x doesn't hold a func() ---
+r=isfunc(x :sym)
+ok=ok&&(r==nil)
+print("27 isfunc(x :sym) (expect nil): %v\n\n" r)
 check_fail(:ok ok)
 
 print("\nistype: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "7001680e"
+#define PATCH_KEY "0652c4f7"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -396,13 +396,17 @@ Print a usage summary of all the invocation modes above and exit.
 
  sym|lst=class(val [val ...]) -- return class symbol(s) for value(s) of object type
 
- flag=istype(var [typesym]) -- test var's type without evaluating it
+ flag=istype(var [typesym] :sym) -- test var's type without evaluating it;
+ with :sym, return var's type symbol instead of a flag
 
- flag=isclass(var [classsym]) -- test var's class without evaluating it
+ flag=isclass(var [classsym] :sym) -- test var's class without evaluating it;
+ with :sym, return var's class symbol instead of a flag
 
- flag=iscomm(var) -- true if var names a command, without evaluating it
+ flag=iscomm(var :sym) -- true if var names a command, without evaluating it;
+ with :sym, return `CommandType (nil if false) instead of a flag
 
- flag=isfunc(var) -- true if var holds a func(), without evaluating it
+ flag=isfunc(var :sym) -- true if var holds a func(), without evaluating it;
+ with :sym, return `FuncObj (nil if false) instead of a flag
 
  int=ctoi(char) -- convert character to integer
 


### PR DESCRIPTION
## Summary
Follow-on to PR #290. `type()`/`class()` return the type/class symbol eagerly, but only for the *fired* value. `istype()`/`isclass()`/`iscomm()`/`isfunc()` deliberately never fire their subject, so they could only ever answer true/false, not "what is it."

This adds a `:sym` keyword to all four: instead of a boolean, return the resolved type/class symbol directly (`nil` if there isn't one) -- the post_eval counterpart to what `type()`/`class()` already do for a fired value, reusing the exact same non-firing resolution (`resolve_no_fire`) the boolean form already uses.

- `istype(x :sym)` / `isclass(x :sym)` -- return x's own type/class symbol. If a two-arg comparison target is also given, `:sym` wins and the target is ignored -- it always reports what the variable actually is.
- `iscomm(x :sym)` / `isfunc(x :sym)` -- these are fixed shortcuts with no comparison target to begin with, so `:sym` here is a symbol-or-`nil` version of the same flag (`` `CommandType``/`` `FuncObj`` on match, `nil` otherwise), not new information.

## Test plan
- [x] All 18 existing `istype.comt` tests still pass unchanged
- [x] 9 new tests added (19-27) covering `:sym` on all four commands, the two-arg-override case, and the unbound-variable-returns-nil case -- `run("istype.comt")` passes, `ok=true`
- [x] Full `run_all.comt` regression suite passes, no other test file affected
- [x] Confirmed no firing occurs with `:sym` (e.g. `isfunc(f :sym)` on a func with a side-effecting body prints nothing)

Related: #289, PR #290.