### PR TITLE
DotFunc: obj.method(args) -- fire an attrlist's FuncObj attribute self-bound (#295)

### DIFF
--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -142,6 +142,40 @@ niladic call site everywhere, with no special case for inside a func body.
 
 ---
 
+## Objects: attrlists with methods, called directly
+
+An attrlist that bundles data fields with `FuncObj` methods is a real,
+mutating object -- `obj.method(args)` fires the method self-bound to
+`obj`, with `args` reaching `arg(n)` inside the body:
+
+```
+counter=(:n 0 :incr func(n=n+1; n))
+counter.incr()                        // 1
+counter.incr()                        // 2
+counter.n                              // 2 -- genuinely mutated, not a copy
+
+al=(:addto func(n=n+arg(0); n) :n 0)
+al.addto(2)                            // 2
+al.addto(5)                            // 7
+al.n                                    // 7
+```
+
+Bare access (no parens) still just returns the `FuncObj`, unfired -- only
+a trailing arglist, empty or not, fires it. Calling something that isn't a
+method warns and returns `nil` instead of erroring:
+
+```
+x=counter.incr; isfunc(x)              // true -- no fire
+al=(:x 10)
+al.x(1)                                // WARNING: "x" is not a func-valued attribute -- nil
+```
+
+See *`obj.method(args)` — sugar for the same thing* in `LANGUAGE.md` for
+the full contract -- what this desugars to (`eval(obj.method :alist obj)`),
+why arguments evaluate in the caller's own scope, and nested self-binding.
+
+---
+
 ## Functions and scope
 
 ```

--- a/doc/APPENDIX-B-COMTERP-EXAMPLES.md
+++ b/doc/APPENDIX-B-COMTERP-EXAMPLES.md
@@ -170,6 +170,20 @@ al=(:x 10)
 al.x(1)                                // WARNING: "x" is not a func-valued attribute -- nil
 ```
 
+A keyword argument to a method call sticks only if the method itself
+writes to it -- merely reading it reverts after the call, like any
+ordinary func() keyword-local would:
+
+```
+c=(:incr func(cnt++) :cnt 0)
+c.incr(:cnt 10)                        // 10 -- cnt++ writes 11
+c.cnt                                   // 11 -- the write persists
+
+t=(:tell func(cnt) :cnt 0)
+t.tell(:cnt 99)                        // 99 -- reads the keyword value
+t.cnt                                   // 0 -- never written, reverts
+```
+
 See *`obj.method(args)` — sugar for the same thing* in `LANGUAGE.md` for
 the full contract -- what this desugars to (`eval(obj.method :alist obj)`),
 why arguments evaluate in the caller's own scope, and nested self-binding.

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -810,9 +810,34 @@ outer.bump()                           // 1
 outer.inner.bump()                      // 101 -- inner's own :cnt, untouched by outer's
 ```
 
-Only positional arguments are supported today — a keyword argument to a
-method call (`al.method(:key val)`) is accepted but ignored, with a
-warning, rather than silently doing something unexpected.
+**Keyword arguments to a method call are ephemeral, unless the method
+writes them.** `al.method(:key val)` writes `key` onto `al` before firing
+— exactly as if you'd written `al.key=val` first — then compares it back
+afterward: unchanged means nothing inside the call touched it, so it
+reverts (removed entirely if `al` never had that field before this call);
+different means the method's own body assigned a new value there,
+self-bound, and that assignment persists same as any other write would.
+Reading a keyword-supplied value never makes it stick — only writing to it
+does:
+
+```
+c=(:incr func(cnt++) :cnt 0)
+c.incr(:cnt 10)                        // 10 -- cnt++ reads 10, writes 11
+c.cnt                                   // 11 -- the write's own result persists
+
+t=(:tell func(cnt) :cnt 0)
+t.tell(:cnt 99)                        // 99 -- reads the keyword value
+t.cnt                                   // 0 -- never written, reverts to what it was
+
+u=(:show func(nope))
+u.show(:nope 5)                        // 5 -- nope never existed on u at all
+u.nope                                  // nil -- read-only, so never added for real
+```
+
+A keyword naming a field the object never had works the same way as one
+overriding an existing field — it's added before the call and, if nothing
+writes to it, removed again afterward, not left behind as a stray
+attribute.
 
 Writing through a reference passed in as a keyword arg is not an
 exception to this rule — the symbol is local, but the attrlist object

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -760,6 +760,60 @@ variable and referenced bare first — a bare reference to a `FuncObj` fires
 immediately, same niladic-firing rule as always, with no exception for
 being an argument to `eval()`.
 
+**`obj.method(args)` — sugar for the same thing.** Writing out
+`eval(obj.method :alist obj)` every time is more ceremony than the pattern
+needs, so a dot access with parentheses attached fires the method directly,
+self-bound the same way, with any arguments reaching `arg(n)` inside the
+body:
+
+```
+counter=(:n 0 :incr func(n=n+1; n))
+counter.incr()                        // 1
+counter.incr()                        // 2
+counter.n                              // 2 -- same real mutation as eval(:alist)
+
+al=(:addto func(n=n+arg(0); n) :n 0)
+al.addto(2)                            // 2
+al.addto(5)                            // 7 -- arg(0) is the call's own positional
+al.n                                    // 7
+```
+
+Bare access (`counter.incr`, no parens) is completely unaffected — it still
+returns the raw `FuncObj`, unfired, exactly as it always has (that's what
+lets `eval(counter.incr :alist counter)` work in the first place). Only a
+dot access with a trailing arglist — empty parens included — fires. A call
+on an attribute that isn't a `FuncObj`, or a method name the attrlist
+doesn't have, warns and returns `nil` rather than erroring:
+
+```
+al=(:x 10)
+al.x(1)                                // WARNING: "x" is not a func-valued attribute -- nil
+al.nosuchmethod(1)                      // WARNING: "nosuchmethod" is not a func-valued attribute -- nil
+```
+
+Arguments are evaluated in the *caller's* own scope, before `self` is
+switched in — so a variable reference in an argument resolves normally,
+not against the object being called:
+
+```
+src=(:val func(cnt) :cnt 7)
+dst=(:store func(cnt=arg(0)) :cnt 0)
+dst.store(src.val())                   // 7 -- src.val() runs in the caller's scope
+```
+
+Nested attrlists self-bind independently — a method on an inner attrlist
+sees only its own fields, never the outer one's:
+
+```
+outer=(:cnt 0 :bump func(cnt=cnt+1; cnt) :inner (:cnt 100 :bump func(cnt=cnt+1; cnt)))
+outer.bump()                           // 1
+outer.inner.bump()                      // 101 -- inner's own :cnt, untouched by outer's
+```
+
+Only positional arguments are supported today — a keyword argument to a
+method call (`al.method(:key val)`) is accepted but ignored, with a
+warning, rather than silently doing something unexpected.
+
 Writing through a reference passed in as a keyword arg is not an
 exception to this rule — the symbol is local, but the attrlist object
 it points to lives outside the func and is mutated via that reference:

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -839,6 +839,31 @@ overriding an existing field — it's added before the call and, if nothing
 writes to it, removed again afterward, not left behind as a stray
 attribute.
 
+**Making a keyword arg actually stick, on purpose.** `c.incr(:cnt 10)`
+sticks *because* `cnt++` writes `cnt` as a side effect of what it was
+already going to do, not because anyone asked for the keyword itself to be
+kept. A `cnt=cnt` re-assignment written specifically to try to keep it
+doesn't work, and can't be made to: after that line runs, `al` looks
+identical whether the assignment happened or not — the value's the
+same either way, so there is nothing left to distinguish "genuinely
+written" from "never touched" by inspecting the object afterward. Two
+ways to actually get a persisting set, both already just working today:
+
+- **Set it directly**, no method call needed: `al.cnt=10` is a plain
+  attribute write, no keyword-ephemerality involved at all.
+- **Use a differently-named setter.** Give the keyword parameter and the
+  field it sets different names, and the ambiguity disappears — the
+  parameter is genuinely read-only (reverts, correctly) and the field is a
+  genuine write to a *different* name (persists, correctly, the same
+  self-bound mutation that makes `cnt++` work):
+
+```
+c=(:cnt 0 :setcnt func(cnt=val))
+c.setcnt(:val 8)                       // 8
+c.cnt                                   // 8 -- a real write, to a name the keyword never used
+c.val                                   // nil -- the keyword's own name, untouched, reverts
+```
+
 Writing through a reference passed in as a keyword arg is not an
 exception to this rule — the symbol is local, but the attrlist object
 it points to lives outside the func and is mutated via that reference:

--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -283,15 +283,29 @@ command calls with explicit parens:
   with nids set to -1  used as a key lookup against the attrlist.
   Never dispatches as a command, even if the name is a registered
   zero-arg command.
-- **Command with parens** (`a.type()`, `a.print("k_%v" n :sym)`) —
-  emits `TOK_COMMAND`, dispatches normally, result used as key.
+- **Name with parens** (`a.type()`, `a.incr(1)`) — emits `TOK_COMMAND`
+  with nids != -1. `DotFunc` (`post_eval`, comterp.h/.c) looks the name
+  up as an attribute of `a` directly and, if it's a `FuncObj`, fires it
+  self-bound to `a` (`a`'s own `_alist` swapped in for the call, so
+  reads/writes of `a`'s fields inside the body are real mutation — see
+  *`obj.method(args)`* in `doc/LANGUAGE.md`). If the name isn't a
+  `FuncObj`-valued attribute of `a` — including when it happens to also
+  be a registered global command, like `type` or `print` — this warns
+  and returns nil rather than falling through to that global command.
+  That's a deliberate change from the pre-#295 behavior (parens used to
+  mean "evaluate this as an ordinary sub-expression first," which for a
+  registered name fired the *global* command, ignoring `a` entirely);
+  dot access is now consistently "look in the object" whether or not
+  parens follow.
 
 This is implemented in `_parser.c` at the bare identifier emission
 point (line ~1028): when the top of the operator stack is the `dot`
 operator and no left paren follows, emit `TOK_COMMAND` with nids
 set to -1 instead of `TOK_COMMAND`. A `dot_symid` static
 (initialized lazily) identifies the dot operator by its command
-symid via `opr_tbl_commid()`.
+symid via `opr_tbl_commid()`. `DotFunc` reads this `nids` value (via a
+non-evaluating peek, so it never risks firing the wrong thing) to
+choose between the two paths above.
 
 The chain form `a.type.class.exit` works automatically — each bare
 identifier after `.` hits the same emission point with dot on top of

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -124,6 +124,21 @@ ComValue& ComFunc::stack_dotname(int n) {
 ComValue ComFunc::stack_arg_post_eval(int n, boolean symbol, ComValue& dflt) {
   ComValue argoff(comterp()->stack_top());
   int offtop = argoff.int_val()-comterp()->_pfnum;
+  /* same anchor-recovered-offtop guard as stack_key_post_eval (see note
+     there) -- this one was missed when that hardening landed, and it's the
+     path DotFunc/GrDotFunc use to fire arg 0 (e.g. at(grid(:table)) in
+     at(grid(:table)).grid), so a corrupt anchor here doesn't crash, it
+     just walks _pfcomvals from the wrong position and returns whatever
+     garbage token happens to sit there -- observed as a bogus CommandType
+     value routinely, not a crash, which is what made this so hard to
+     pin down. */
+  if (offtop > 0 || comterp()->_pfnum + offtop < 1) {
+    fprintf(stderr, "comterp: stack_arg_post_eval: offtop out of range "
+            "(offtop=%d nkeys=%d argoff=%d _pfnum=%d) -- argoff anchor missing "
+            "or corrupt; upstream command likely failed to push its bookmark\n",
+            offtop, nkeys(), argoff.int_val(), (int)comterp()->_pfnum);
+    return dflt;
+  }
   int argcnt;
   for (int i=0; i<nkeys(); i++) {
     argcnt = 0;

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -122,6 +122,15 @@ ComValue& ComFunc::stack_dotname(int n) {
 }
 
 ComValue ComFunc::stack_arg_post_eval(int n, boolean symbol, ComValue& dflt) {
+  /* No keys to skip and no fixed arg at position n -> there is definitively
+     nothing to fire, so there is nothing that needs a valid anchor either.
+     Mirrors stack_key_post_eval's nkeys()==0 bail-out: an empty {}/[]
+     literal's internal construction calls this with nargsfixed()==0, and
+     that's a normal, silent no-op, not evidence of anything wrong -- check
+     it before reading the anchor so that case never reaches the guard
+     below and never warns. */
+  if (nkeys()==0 && n>=nargsfixed()) return dflt;
+
   ComValue argoff(comterp()->stack_top());
   int offtop = argoff.int_val()-comterp()->_pfnum;
   /* same anchor-recovered-offtop guard as stack_key_post_eval (see note

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -332,6 +332,17 @@ public:
     // number of positional args of the current FuncObj invocation.
     ComValue& funcobj_arg(int n);
     // nth positional arg (eager value) of the current FuncObj invocation.
+    ComValue* funcobj_argvals() { return _funcobj_argvals; }
+    // return the current positional-argument array itself (nil if inactive),
+    // for a caller that needs to save it before installing its own.
+    void set_funcobj_args(ComValue* argvals, int nargs, boolean active) {
+      _funcobj_argvals = argvals; _funcobj_nargs = nargs; _funcobj_active = active; }
+    // install the per-invocation positional-argument channel that arg()/
+    // narg() read inside a func body -- caller saves funcobj_argvals()/
+    // funcobj_narg()/funcobj_active() first and restores them after, the
+    // same bracketing set_attributes()/get_attributes() use around an
+    // _alist swap (see DotFunc, which needs both at once to self-bind an
+    // attrlist method call and still serve its positional args).
 
     void set_args(int argc, char** argv);
     // set command line arguments

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -27,6 +27,7 @@
 #include <ComTerp/comterp.h>
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/postfunc.h>
+#include <ComTerp/boolfunc.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attribute.h>
 #include <iostream>
@@ -42,6 +43,50 @@ using std::cerr;
 int DotFunc::_symid = -1;
 
 DotFunc::DotFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+/* true if a and b hold the same value -- reuses EqualFunc's own
+   type-promoting comparison (numeric promotion, nil/blank handling, etc.)
+   rather than re-deriving it, by pushing both values and invoking it
+   directly the way ComFunc::exec() lets any command be called out of
+   band. */
+static boolean values_equal(ComTerp* comterp, AttributeValue& a, AttributeValue& b) {
+  ComValue va(a), vb(b);
+  comterp->push_stack(va);
+  comterp->push_stack(vb);
+  EqualFunc eqf(comterp);
+  eqf.exec(2, 0);
+  ComValue result(comterp->pop_stack());
+  return result.is_true();
+}
+
+/* bookkeeping for one keyword arg to a method call -- see the comment on
+   the keyword-handling block in fire_attrlist_method for what "ephemeral
+   unless written" means here. */
+struct KwPending {
+  int symid;
+  boolean existed;
+  AttributeValue oldval;
+  AttributeValue injectedval;
+};
+
+static void apply_kw(AttributeList* al, int symid, AttributeValue& newval, KwPending& pending) {
+  pending.symid = symid;
+  Attribute* existing = al->GetAttr(symid);
+  pending.existed = existing!=nil;
+  if (pending.existed) pending.oldval = *existing->Value();
+  pending.injectedval = newval;
+  al->add_attr(symid, newval);
+}
+
+static void restore_kw_if_unwritten(ComTerp* comterp, AttributeList* al, KwPending& pending) {
+  Attribute* now = al->GetAttr(pending.symid);
+  if (!now || !values_equal(comterp, *now->Value(), pending.injectedval))
+    return;   // written during the call (or vanished outright) -- leave it
+  if (pending.existed)
+    *now->Value() = pending.oldval;
+  else
+    al->Remove(now);
 }
 
 /* obj.method(args) -- fire a FuncObj-valued attribute self-bound to obj.
@@ -86,25 +131,30 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
   }
   FuncObj* fo = (FuncObj*) attr->Value()->obj_val();
 
-  /* echoresult owns poslist's storage (a ComValue destructor unrefs its
-     list) -- keep it alive across both the extraction below and this whole
-     block, not just the narrower "did echo run" scope. */
+  /* echoresult owns poslist's/kwlist's storage (a ComValue destructor
+     unrefs its list/attrlist) -- keep it alive across both the extraction
+     below and this whole block, not just the narrower "did echo run"
+     scope. */
   ComValue echoresult;
   AttributeValueList* poslist = nil;
+  AttributeList* kwlist = nil;
   int npos = 0;
   if (method_narg>0 || method_nkey>0) {
     static int echo_symid = symbol_add("echo");
     method_tok.v.symbolid = echo_symid;
     echoresult = self->comterpserv()->run(argtoks, nargtoks);
     if (echoresult.is_list()) {
+      /* positionals present -- echo tails the list with one singleton
+	 attrlist per keyword (see echo()'s own docstring); trailing
+	 method_nkey entries are those singletons, not positionals. */
       poslist = echoresult.list_val();
       npos = poslist->Number() - method_nkey;
       if (npos<0) npos = 0;
+    } else if (echoresult.is_attributelist()) {
+      /* no positionals -- echo returns the keywords bare, as one
+	 multi-attribute attrlist. */
+      kwlist = (AttributeList*) echoresult.obj_val();
     }
-    if (method_nkey>0)
-      cout << "WARNING: keyword arguments to \"" << symbol_pntr(method_symid)
-	   << "\" ignored -- attrlist methods only take positional args"
-	   << " (line " << self->funcstate()->linenum() << ")\n";
   }
   delete [] argtoks;
 
@@ -112,6 +162,34 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
   if (npos>0) {
     for (int i=0; i<npos; i++)
       posvals[i] = *poslist->Get(i);
+  }
+
+  /* keyword args are ephemeral unless the method's own body writes that
+     same name -- reading it (or ignoring it) leaves al exactly as it was;
+     only a write (self-bound, so it lands on al) makes it stick.  Apply
+     each keyword now (saving what it's replacing), fire below, then
+     compare-and-revert after: unchanged from what was just injected means
+     nothing wrote it, so put the old value back (or remove it entirely if
+     the name didn't exist on al before this call). */
+  int nkw = method_nkey;
+  KwPending* kwpending = nkw>0 ? new KwPending[nkw] : nil;
+  if (nkw>0) {
+    if (poslist) {
+      for (int i=0; i<nkw; i++) {
+	AttributeList* singleton = (AttributeList*) poslist->Get(npos+i)->obj_val();
+	ALIterator it;
+	singleton->First(it);
+	Attribute* a = singleton->GetAttr(it);
+	apply_kw(al, a->SymbolId(), *a->Value(), kwpending[i]);
+      }
+    } else if (kwlist) {
+      ALIterator it;
+      int i = 0;
+      for (kwlist->First(it); !kwlist->Done(it); kwlist->Next(it), i++) {
+	Attribute* a = kwlist->GetAttr(it);
+	apply_kw(al, a->SymbolId(), *a->Value(), kwpending[i]);
+      }
+    }
   }
 
   AttributeList* old_alist = comterp->get_attributes();
@@ -130,6 +208,10 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
 
   comterp->set_attributes(old_alist);
   Unref(old_alist);
+
+  for (int i=0; i<nkw; i++)
+    restore_kw_if_unwritten(comterp, al, kwpending[i]);
+  delete [] kwpending;
 
   self->push_stack(result);
 }

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -32,6 +32,7 @@
 #include <Attribute/attribute.h>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 #define TITLE "DotFunc"
 
@@ -41,6 +42,13 @@ using std::cerr;
 /*****************************************************************************/
 
 int DotFunc::_symid = -1;
+
+/* off by default -- capturing the pre-fire source text of both args (see
+   execute() below) costs a cout redirect + two print_stack_arg_post_eval
+   calls on every dot-expression, even the overwhelmingly common case where
+   nothing goes wrong.  Flip to true (in a debugger, or edit+rebuild) only
+   while chasing a "expression before/after dot" warning. */
+static boolean dotfunc_debug_expr = false;
 
 DotFunc::DotFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
@@ -216,32 +224,59 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
   self->push_stack(result);
 }
 
-void DotFunc::execute() {
-    ComValue before_part(stack_arg(0, true));
+void DotFunc::peek_and_fire(ComValue& before_part, ComValue& after_raw, int& after_nids,
+			     std::string& before_expr_text, std::string& after_expr_text) {
+    /* Grab the raw, unfired source text of both args for the warnings
+       below *before* either can be evaluated -- stack_arg_post_eval(0)
+       just below fires arg 0 when it's a nested dot (node.left.val),
+       which moves the stack bookmark print_stack_arg_post_eval relies
+       on; capturing after that point prints garbage (confirmed: showed
+       a stale offset int instead of the real argument). */
+    if (dotfunc_debug_expr) {
+      std::ostringstream before_expr_stream, after_expr_stream;
+      std::streambuf* saved_cout = cout.rdbuf(before_expr_stream.rdbuf());
+      print_stack_arg_post_eval(0);
+      cout.rdbuf(after_expr_stream.rdbuf());
+      print_stack_arg_post_eval(1);
+      cout.rdbuf(saved_cout);
+      before_expr_text = before_expr_stream.str();
+      after_expr_text = after_expr_stream.str();
+    }
+
+    before_part = stack_arg(0, true);
     if (before_part.type()==ComValue::CommandType) {
       /* a real command reference (e.g. the inner dot of node.left.val) --
 	 fire it to get its actual value.  A bare, unbound symbol (the
 	 compound-variable-on-first-use case just below) never gets promoted
 	 to CommandType by ComTerp::token_to_comvalue in the first place, so
-	 this never fires on a name DotFunc's own lookup below needs raw. */
-      before_part = stack_arg_post_eval(0, true);
+	 this never fires on a name DotFunc's own lookup below needs raw.
+	 symbol=false (the default) here, not true: this needs pop_stack's
+	 full finalization (resolve a symbol, unwrap an Attribute down to
+	 its own Value()), not the raw, unprocessed result. */
+      before_part = stack_arg_post_eval(0);
     }
-    ComValue after_raw(stack_arg(1, true));
-    int after_nids = after_raw.nids();
+    after_raw = stack_arg(1, true);
+    after_nids = after_raw.nids();
+}
 
+void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_nids,
+			    const std::string& before_expr_text, const std::string& after_expr_text) {
     if (!before_part.is_symbol() &&
 	!(before_part.is_attribute() &&
 	  (((Attribute*)before_part.obj_val())->Value()->is_unknown() ||
 	  ((Attribute*)before_part.obj_val())->Value()->is_attributelist())) &&
 	!before_part.is_attributelist()) {
-      reset_stack();
       cout << "WARNING: expression before \".\" needs to evaluate to a symbol or <AttributeList> (instead of "
 	   << symbol_pntr(before_part.type_symid());
       if (before_part.is_object())
         cout << " of class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
-      cout << "expression after dot:  ";
-      cout << after_raw << "\n";
+      if (dotfunc_debug_expr)
+        cout << "expression before dot:  " << before_expr_text;
+      else
+        cout << "(set dotfunc_debug_expr=true in dotfunc.c and rebuild to see the expression before the dot)\n";
+      cout << "expression after dot:  " << after_raw << "\n";
+      reset_stack();
 
       return;
     }
@@ -252,12 +287,16 @@ void DotFunc::execute() {
        and not itself a malformed-expression signal.  Only the bare/string
        rhs path needs this check. */
     if (after_nids==-1 && nargsfixed()>1 && !after_raw.is_string() && !after_raw.is_symbol()) {
-      reset_stack();
       cout << "WARNING: expression after \".\" needs to be a symbol or evaluate to a symbol (instead of "
 	   << symbol_pntr(after_raw.type_symid());
       if (before_part.is_object())
 	cout << " for class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
+      if (dotfunc_debug_expr)
+        cout << "expression after dot:  " << after_expr_text;
+      else
+        cout << "(set dotfunc_debug_expr=true in dotfunc.c and rebuild to see the expression after the dot)\n";
+      reset_stack();
       return;
     }
 
@@ -321,6 +360,14 @@ void DotFunc::execute() {
       ComValue retval(AttributeList::class_symid(), al);
       push_stack(retval);
     }
+}
+
+void DotFunc::execute() {
+    ComValue before_part, after_raw;
+    int after_nids;
+    std::string before_expr_text, after_expr_text;
+    peek_and_fire(before_part, after_raw, after_nids, before_expr_text, after_expr_text);
+    execute_core(before_part, after_raw, after_nids, before_expr_text, after_expr_text);
 }
 
 /*****************************************************************************/

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -46,8 +46,9 @@ int DotFunc::_symid = -1;
 /* off by default -- capturing the pre-fire source text of both args (see
    execute() below) costs a cout redirect + two print_stack_arg_post_eval
    calls on every dot-expression, even the overwhelmingly common case where
-   nothing goes wrong.  Flip to true (in a debugger, or edit+rebuild) only
-   while chasing a "expression before/after dot" warning. */
+   nothing goes wrong.  Toggle at runtime with dot(:dbg true)/dot(:dbg false)
+   -- see DotFunc::execute() -- only while chasing a "expression before/after
+   dot" warning. */
 static boolean dotfunc_debug_expr = false;
 
 DotFunc::DotFunc(ComTerp* comterp) : ComFunc(comterp) {
@@ -274,7 +275,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (dotfunc_debug_expr)
         cout << "expression before dot:  " << before_expr_text;
       else
-        cout << "(set dotfunc_debug_expr=true in dotfunc.c and rebuild to see the expression before the dot)\n";
+        cout << "(dot(:dbg true) to see the expression before the dot)\n";
       cout << "expression after dot:  " << after_raw << "\n";
       reset_stack();
 
@@ -295,7 +296,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (dotfunc_debug_expr)
         cout << "expression after dot:  " << after_expr_text;
       else
-        cout << "(set dotfunc_debug_expr=true in dotfunc.c and rebuild to see the expression after the dot)\n";
+        cout << "(dot(:dbg true) to see the expression after the dot)\n";
       reset_stack();
       return;
     }
@@ -363,6 +364,25 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 }
 
 void DotFunc::execute() {
+    /* dot(:dbg [true|false]) -- get/set dotfunc_debug_expr at runtime, so a
+       live session (a running drawserv, say) can turn on the "expression
+       before/after dot" detail in the malformed-expression warning without
+       an edit+rebuild.  Checked first and unconditionally: an ordinary
+       a.b expression never supplies a :dbg keyword, so this never touches
+       the normal dispatch path below. */
+    static int dbg_symid = symbol_add("dbg");
+    static int dbg_bare_symid = symbol_add("__dot_dbg_bare__");
+    ComValue dbg_bare_sentinel(dbg_bare_symid, ComValue::SymbolType);
+    ComValue dbgv(stack_key_post_eval(dbg_symid, false, dbg_bare_sentinel));
+    if (!dbgv.is_unknown()) {
+      reset_stack();
+      boolean is_bare = dbgv.is_type(ComValue::SymbolType) && dbgv.symbol_val()==dbg_bare_symid;
+      if (!is_bare) dotfunc_debug_expr = dbgv.is_true();
+      ComValue retval(dotfunc_debug_expr);
+      push_stack(retval);
+      return;
+    }
+
     ComValue before_part, after_raw;
     int after_nids;
     std::string before_expr_text, after_expr_text;

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -25,6 +25,8 @@
 #include <ComTerp/dotfunc.h>
 #include <ComTerp/comvalue.h>
 #include <ComTerp/comterp.h>
+#include <ComTerp/comterpserv.h>
+#include <ComTerp/postfunc.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attribute.h>
 #include <iostream>
@@ -42,37 +44,143 @@ int DotFunc::_symid = -1;
 DotFunc::DotFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
+/* obj.method(args) -- fire a FuncObj-valued attribute self-bound to obj.
+   Evaluates args in the caller's own scope (before any _alist swap, so a
+   variable reference in an arg resolves against the caller, not obj), then
+   temporarily swaps _alist to obj -- the same mechanism eval(fo :alist obj)
+   already uses (ctrlfunc.c's EvalFunc) -- and runs the method's own token
+   buffer directly, so self-bound reads/writes of obj's own fields mutate
+   the real object, not a per-call copy.  Positional args flow through the
+   funcobj_args channel (set_funcobj_args/funcobj_argvals, comterp.h) the
+   same way an ordinary FuncObj invocation's arg()/narg() are served.
+
+   Getting at args without evaluating "method" itself: a symbol with an
+   attached arglist that isn't a registered global command gets rebound to
+   the nil command by ComTerp::token_to_comvalue at expression-conversion
+   time, unconditionally, before any command (including this one) runs --
+   that check only ever consults the global command table, never _alist, so
+   there is no way to make "method(args)" resolve through obj by evaluating
+   it as an ordinary sub-expression.  Instead: look "method" up in obj
+   directly (the same GetAttr() the bare-access path below already uses),
+   and get the args evaluated by retargeting a copy of just the arg tokens
+   at the existing echo() command -- an ordinary (non-post_eval) command
+   that already packages positionals/keywords into an inspectable value for
+   the ~~ round-trip -- so ordinary dispatch does the evaluation, still
+   never touching "method" as a symbol at all. */
+static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
+				  AttributeList* al, postfix_token* argtoks,
+				  int nargtoks) {
+  postfix_token& method_tok = argtoks[nargtoks-1];
+  int method_symid = method_tok.v.symbolid;
+  int method_narg = method_tok.narg;
+  int method_nkey = method_tok.nkey;
+
+  Attribute* attr = al ? al->GetAttr(method_symid) : nil;
+  if (!attr || !attr->Value()->is_object(FuncObj::class_symid())) {
+    cout << "WARNING: \"" << symbol_pntr(method_symid)
+	 << "\" is not a func-valued attribute -- line "
+	 << self->funcstate()->linenum() << "\n";
+    delete [] argtoks;
+    self->push_stack(ComValue::nullval());
+    return;
+  }
+  FuncObj* fo = (FuncObj*) attr->Value()->obj_val();
+
+  /* echoresult owns poslist's storage (a ComValue destructor unrefs its
+     list) -- keep it alive across both the extraction below and this whole
+     block, not just the narrower "did echo run" scope. */
+  ComValue echoresult;
+  AttributeValueList* poslist = nil;
+  int npos = 0;
+  if (method_narg>0 || method_nkey>0) {
+    static int echo_symid = symbol_add("echo");
+    method_tok.v.symbolid = echo_symid;
+    echoresult = self->comterpserv()->run(argtoks, nargtoks);
+    if (echoresult.is_list()) {
+      poslist = echoresult.list_val();
+      npos = poslist->Number() - method_nkey;
+      if (npos<0) npos = 0;
+    }
+    if (method_nkey>0)
+      cout << "WARNING: keyword arguments to \"" << symbol_pntr(method_symid)
+	   << "\" ignored -- attrlist methods only take positional args"
+	   << " (line " << self->funcstate()->linenum() << ")\n";
+  }
+  delete [] argtoks;
+
+  ComValue* posvals = npos>0 ? new ComValue[npos] : nil;
+  if (npos>0) {
+    for (int i=0; i<npos; i++)
+      posvals[i] = *poslist->Get(i);
+  }
+
+  AttributeList* old_alist = comterp->get_attributes();
+  Resource::ref(old_alist);
+  comterp->set_attributes(al);
+
+  ComValue* saved_argvals = comterp->funcobj_argvals();
+  int saved_nargs = comterp->funcobj_narg();
+  boolean saved_active = comterp->funcobj_active();
+  comterp->set_funcobj_args(posvals, npos, true);
+
+  ComValue result(self->comterpserv()->run(fo->toks(), fo->ntoks()));
+
+  comterp->set_funcobj_args(saved_argvals, saved_nargs, saved_active);
+  delete [] posvals;
+
+  comterp->set_attributes(old_alist);
+  Unref(old_alist);
+
+  self->push_stack(result);
+}
+
 void DotFunc::execute() {
     ComValue before_part(stack_arg(0, true));
-    ComValue after_part(stack_arg(1, true));
-    reset_stack();
+    if (before_part.type()==ComValue::CommandType) {
+      /* a real command reference (e.g. the inner dot of node.left.val) --
+	 fire it to get its actual value.  A bare, unbound symbol (the
+	 compound-variable-on-first-use case just below) never gets promoted
+	 to CommandType by ComTerp::token_to_comvalue in the first place, so
+	 this never fires on a name DotFunc's own lookup below needs raw. */
+      before_part = stack_arg_post_eval(0, true);
+    }
+    ComValue after_raw(stack_arg(1, true));
+    int after_nids = after_raw.nids();
 
-    if (!before_part.is_symbol() && 
-	!(before_part.is_attribute() && 
-	  (((Attribute*)before_part.obj_val())->Value()->is_unknown() || 
+    if (!before_part.is_symbol() &&
+	!(before_part.is_attribute() &&
+	  (((Attribute*)before_part.obj_val())->Value()->is_unknown() ||
 	  ((Attribute*)before_part.obj_val())->Value()->is_attributelist())) &&
 	!before_part.is_attributelist()) {
+      reset_stack();
       cout << "WARNING: expression before \".\" needs to evaluate to a symbol or <AttributeList> (instead of "
 	   << symbol_pntr(before_part.type_symid());
       if (before_part.is_object())
         cout << " of class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
       cout << "expression after dot:  ";
-      cout << after_part << "\n";
+      cout << after_raw << "\n";
 
       return;
     }
-    if (nargs()>1 && !after_part.is_string()) {
+    /* An arglist-attached rhs (after_nids != -1, e.g. al.method(2)) is
+       validated later, in fire_attrlist_method -- by the time this token
+       reaches here it has already been converted to CommandType (rebound
+       to nil, see the note above fire_attrlist_method), which is expected
+       and not itself a malformed-expression signal.  Only the bare/string
+       rhs path needs this check. */
+    if (after_nids==-1 && nargsfixed()>1 && !after_raw.is_string() && !after_raw.is_symbol()) {
+      reset_stack();
       cout << "WARNING: expression after \".\" needs to be a symbol or evaluate to a symbol (instead of "
-	   << symbol_pntr(after_part.type_symid());
+	   << symbol_pntr(after_raw.type_symid());
       if (before_part.is_object())
-        cout << " for class " << symbol_pntr(before_part.class_symid());
+	cout << " for class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
       return;
     }
 
     /* lookup value of before variable */
-    void* vptr = nil; 
+    void* vptr = nil;
     AttributeList* al = nil;
     if (!before_part.is_attribute() && !before_part.is_attributelist()) {
       int before_symid = before_part.symbol_val();
@@ -94,7 +202,7 @@ void DotFunc::execute() {
 	  comterp()->globaltable()->insert(before_symid, comval);
       }
     } else if (!before_part.is_attributelist()) {
-      if (((Attribute*)before_part.obj_val())->Value()->is_attributelist()) 
+      if (((Attribute*)before_part.obj_val())->Value()->is_attributelist())
 	al = (AttributeList*) ((Attribute*) before_part.obj_val())->Value()->obj_val();
       else {
 	al = new AttributeList();
@@ -104,11 +212,21 @@ void DotFunc::execute() {
     } else
       al = (AttributeList*) before_part.obj_val();
 
-    if (nargs()>1) {
-      int after_symid = after_part.symbol_val();
-      if (after_part.type()==ComValue::StringType) {
-        symbol_reference(after_symid);	
+    if (after_nids!=-1) {
+      /* al.method(args) -- fire, self-bound, not a plain attribute fetch.
+	 copy_stack_arg_post_eval needs the argoff bookmark still on the
+	 stack, so it must run before reset_stack(), same as every other
+	 stack_arg* read here. */
+      int nargtoks;
+      postfix_token* argtoks = copy_stack_arg_post_eval(1, nargtoks);
+      reset_stack();
+      fire_attrlist_method(this, comterp(), al, argtoks, nargtoks);
+    } else if (nargs()>1) {
+      int after_symid = after_raw.symbol_val();
+      if (after_raw.type()==ComValue::StringType) {
+        symbol_reference(after_symid);
       }
+      reset_stack();
       Attribute* attr = al ? al->GetAttr(after_symid) :  nil;
       if (!attr) {
 	attr = new Attribute(after_symid, new AttributeValue());
@@ -117,6 +235,7 @@ void DotFunc::execute() {
       ComValue retval(Attribute::class_symid(), attr);
       push_stack(retval);
     } else {
+      reset_stack();
       ComValue retval(AttributeList::class_symid(), al);
       push_stack(retval);
     }

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -30,6 +30,7 @@
 #define _dotfunc_h
 
 #include <ComTerp/numfunc.h>
+#include <string>
 
 //: . (dot) operator, for compound variables | dotlst=dot(name) -- construct empty dottted pair list.
 // obj.method(args) also fires a FuncObj-valued attribute self-bound to
@@ -44,6 +45,23 @@ public:
       return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list"; }
 
     CLASS_SYMID("DotFunc");
+
+protected:
+    /* Peek both raw args, firing arg 0 if it's an unfired nested command
+       reference (e.g. the inner dot of node.left.val, or at(grid(:table))
+       in general).  Split out of execute() so a post_eval-aware subclass
+       (GrDotFunc, which needs to inspect/rewrite before_part -- unwrapping
+       a ComponentView -- before the shared dispatch below runs) can call
+       this itself instead of re-peeking the stack, which would either see
+       stale post_eval() args or double-fire arg 0.  Must run before
+       reset_stack(). */
+    void peek_and_fire(ComValue& before_part, ComValue& after_raw, int& after_nids,
+			std::string& before_expr_text, std::string& after_expr_text);
+    /* Everything after peek_and_fire(): the before/after validity checks,
+       attrlist lookup-or-create, and the actual dispatch (attribute
+       fetch, or obj.method(args) self-bound firing). */
+    void execute_core(ComValue before_part, ComValue after_raw, int after_nids,
+		       const std::string& before_expr_text, const std::string& after_expr_text);
 };
 
 //: name returns name field of a dotted pair

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -42,7 +42,7 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list"; }
+      return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list | dot(:dbg [true|false]) -- get/set whether the malformed-dot-expression warning prints expression detail"; }
 
     CLASS_SYMID("DotFunc");
 

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -32,12 +32,15 @@
 #include <ComTerp/numfunc.h>
 
 //: . (dot) operator, for compound variables | dotlst=dot(name) -- construct empty dottted pair list.
+// obj.method(args) also fires a FuncObj-valued attribute self-bound to
+// obj, evaluating args in the caller's own scope first -- see execute().
 class DotFunc : public ComFunc {
 public:
     DotFunc(ComTerp*);
 
     virtual void execute();
-    virtual const char* docstring() { 
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
       return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list"; }
 
     CLASS_SYMID("DotFunc");

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -101,7 +101,7 @@ public:
 
     virtual void execute();
     virtual const char* docstring() {
-      return "val=%s(arg[,arg...] [:key val...]) -- return evaluated args in ~~-passable form (positional list with tail attrlist singletons, or a bare attrlist)"; }
+      return "val=%s(arg [arg [...]] [:key val...]) -- return evaluated args in ~~-passable form (positional list with tail attrlist singletons, or a bare attrlist)"; }
 };
 
 //: info command for stream objects.

--- a/src/ComUnidraw/grdotfunc.c
+++ b/src/ComUnidraw/grdotfunc.c
@@ -45,44 +45,34 @@ GrDotFunc::GrDotFunc(ComTerp* comterp) : DotFunc(comterp) {
 
 void GrDotFunc::execute() {
 
-    ComValue& before_part(stack_arg(0, true));
-    ComValue& after_part(stack_arg(1, true));
-    if (!before_part.is_symbol() && 
-	!(before_part.is_attribute() && 
-          (((Attribute*)before_part.obj_val())->Value()->is_unknown() || 
-	  ((Attribute*)before_part.obj_val())->Value()->is_attributelist() ||
-          ((Attribute*)before_part.obj_val())->Value()->object_compview())) &&
-        !(before_part.is_attributelist()) && 
-	!(before_part.object_compview())) {
-      cout << "WARNING: expression before \".\" needs to evaluate to a symbol or <AttributeList> (instead of "
-	   << symbol_pntr(before_part.type_symid());
-      if (before_part.is_object())
-        cout << " of class " << symbol_pntr(before_part.class_symid());
-      cout << ") -- line " << funcstate()->linenum() << "\n";
-      cout << "expression after dot:  ";
-      cout << after_part << "\n";
-      reset_stack();
-      return;
-    }
-    if (!after_part.is_string()) {
-      cout << "WARNING: expression after \".\" needs to be a symbol or evaluate to a symbol (instead of "
-	   << symbol_pntr(after_part.type_symid());
-      if (before_part.is_object())
-        cout << " of class " << symbol_pntr(before_part.class_symid());
-      cout << ") -- line " << funcstate()->linenum() << "\n";
-      reset_stack();
-      return;
-    }
+    /* peek_and_fire (inherited from DotFunc) fires arg 0 exactly once if
+       it's an unfired nested command reference -- e.g. grid(:table) in
+       at(grid(:table)).grid -- leaving before_part a real value rather
+       than a raw CommandType token.  before_part is a local copy here
+       (unlike the pre-post_eval version of this method, which held a
+       reference onto the live stack slot and mutated it in place before
+       delegating to DotFunc::execute() to re-peek): arg 0 can only be
+       fired once, so there's no stack slot left to re-peek after firing,
+       and the resolved value has to be threaded through explicitly to
+       execute_core() below instead. */
+    ComValue before_part, after_part;
+    int after_nids;
+    std::string before_expr_text, after_expr_text;
+    peek_and_fire(before_part, after_part, after_nids, before_expr_text, after_expr_text);
 
-    /* handle ComponentView case */
-    if (before_part.is_symbol()) 
+    /* unwrap a ComponentView (or an Attribute wrapping one) to its
+       underlying attribute list -- execute_core()'s dot-dispatch only
+       understands symbols/attributes/attributelists, the same as it did
+       pre-post_eval; a raw compview value or attribute-wrapped compview
+       never reaches it unconverted. */
+    if (before_part.is_symbol())
       lookup_symval(before_part);
     if (before_part.is_object() && before_part.object_compview()) {
       ComponentView* compview = (ComponentView*)before_part.obj_val();
       OverlayComp* comp = (OverlayComp*)compview->GetSubject();
       if (comp) {
 	ComValue stuffval(AttributeList::class_symid(), (void*)comp->GetAttributeList());
-	before_part.assignval(stuffval);
+	before_part = stuffval;
       } else {
 	cerr << "nil subject on compview value\n";
 	reset_stack();
@@ -90,14 +80,14 @@ void GrDotFunc::execute() {
 	return;
       }
 
-    } else if (before_part.is_object() && before_part.is_attribute() && 
+    } else if (before_part.is_object() && before_part.is_attribute() &&
 	       ((Attribute*)before_part.obj_val())->Value()->object_compview()) {
       AttributeValue* av = ((Attribute*)before_part.obj_val())->Value();
       ComponentView* compview = (ComponentView*)av->obj_val();
       OverlayComp* comp = (OverlayComp*)compview->GetSubject();
       if (comp) {
 	ComValue stuffval(AttributeList::class_symid(), (void*)comp->GetAttributeList());
-	before_part.assignval(stuffval);
+	before_part = stuffval;
       } else {
 	cerr << "nil subject on compview value\n";
 	reset_stack();
@@ -106,8 +96,7 @@ void GrDotFunc::execute() {
       }
 
     }
-    DotFunc::execute();
-    
+    execute_core(before_part, after_part, after_nids, before_expr_text, after_expr_text);
 }
 
 /*****************************************************************************/

--- a/src/ComUnidraw/grdotfunc.h
+++ b/src/ComUnidraw/grdotfunc.h
@@ -36,7 +36,15 @@ public:
     GrDotFunc(ComTerp*);
 
     virtual void execute();
-    virtual const char* docstring() { 
+    /* Explicit, not just inherited: GrDotFunc predates DotFunc becoming
+       post_eval (issue #295/#301) and originally relied on its args
+       already being fired eagerly by the framework -- silently inheriting
+       post_eval()==true from DotFunc broke that (arg 0 arrived as a raw,
+       unfired CommandType token instead of a real value) without anyone
+       updating execute() to match, until this override made the mismatch
+       obvious and execute() was rewritten below to be post_eval-aware. */
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
       return "%s(.) makes compound variables, and gives access to ComponentView AttributeList's."; }
 
     CLASS_SYMID("GrDotFunc");

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,9 +1,9 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 51/64 (80%)
+// coverage: 55/68 (81%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
-//          dot(func-local-scope-isolation) -(empty-rhs) dot-method(keyword-args)
+//          dot(func-local-scope-isolation) -(empty-rhs)
 //
 // Tests the dot (.) compound variable / attribute list access operator,
 // list(:attr) attribute list construction, and the attrlist() command
@@ -12,8 +12,11 @@
 // with positional args reaching arg(n) inside the body (tests 30-38), and
 // that self-binding covers plain reads of sibling fields too, not just
 // arg(n) and mutation (test 39).  Keyword args to a method call
-// (al.method(:key val)) are accepted but currently ignored with a
-// warning -- not yet covered here.
+// (al.method(:key val)) write onto the object before the call and are
+// compared back after: unchanged means nothing wrote them, so they revert
+// (or are removed, if the name didn't exist before) -- different means
+// the method's own body wrote a new value there, self-bound, and that
+// write persists (tests 40-43).
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")
@@ -323,6 +326,37 @@ duck=(:times 3 :quack func(times))
 r39=duck.quack()
 ok=ok&&(r39==3)
 print("39 duck=(:times 3 :quack func(times)); duck.quack() (expect 3 -- reads times, never passed as arg): %v\n\n" r39)
+prev_ok=check_fail(:ok ok)
+
+// --- test 40: a keyword arg to a method call that only gets read reverts
+// after the call -- ephemeral by default ---
+t40=(:tell func(cnt) :cnt 0)
+r40=t40.tell(:cnt 99)
+ok=ok&&(r40==99 && t40.cnt==0)
+print("40 t40=(:tell func(cnt) :cnt 0); t40.tell(:cnt 99) (expect 99, t40.cnt reverts to 0): %v %v\n\n" r40 t40.cnt)
+prev_ok=check_fail(:ok ok)
+
+// --- test 41: a keyword arg an existing field a method writes sticks --
+// the write's own result persists, not the keyword's raw value ---
+c41=(:incr func(cnt++) :cnt 0)
+r41=c41.incr(:cnt 10)
+ok=ok&&(r41==10 && c41.cnt==11)
+print("41 c41=(:incr func(cnt++) :cnt 0); c41.incr(:cnt 10) (expect 10, c41.cnt=11 -- the increment's result, not 10): %v %v\n\n" r41 c41.cnt)
+prev_ok=check_fail(:ok ok)
+
+// --- test 42: a keyword naming a field the object never had, read-only --
+// the injected field is removed afterward, not left dangling ---
+u42=(:show func(nope))
+r42=u42.show(:nope 5)
+ok=ok&&(r42==5 && u42.nope==nil)
+print("42 u42=(:show func(nope)); u42.show(:nope 5) (expect 5, u42.nope stays nil -- never existed, not left behind): %v %v\n\n" r42 u42.nope)
+prev_ok=check_fail(:ok ok)
+
+// --- test 43: same as 42 but the method writes the new field -- it sticks ---
+v43=(:setit func(nope=nope+1; nope))
+r43=v43.setit(:nope 5)
+ok=ok&&(r43==6 && v43.nope==6)
+print("43 v43=(:setit func(nope=nope+1; nope)); v43.setit(:nope 5) (expect 6, v43.nope=6 -- new field, written, sticks): %v %v\n\n" r43 v43.nope)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 50/63 (79%)
+// coverage: 51/64 (80%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
 //          dot(func-local-scope-isolation) -(empty-rhs) dot-method(keyword-args)
@@ -9,9 +9,11 @@
 // list(:attr) attribute list construction, and the attrlist() command
 // introduced in PR #85 (closes #82).  Also tests dot(al.method(args)) --
 // firing a FuncObj-valued attribute self-bound to its owning attrlist,
-// with positional args reaching arg(n) inside the body (tests 30-38).
-// Keyword args to a method call (al.method(:key val)) are accepted but
-// currently ignored with a warning -- not yet covered here.
+// with positional args reaching arg(n) inside the body (tests 30-38), and
+// that self-binding covers plain reads of sibling fields too, not just
+// arg(n) and mutation (test 39).  Keyword args to a method call
+// (al.method(:key val)) are accepted but currently ignored with a
+// warning -- not yet covered here.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")
@@ -312,6 +314,15 @@ c38=(:n 0 :incr func(n=n+1; n))
 r38=eval(c38.incr :alist c38)
 ok=ok&&(r38==1 && c38.n==1)
 print("38 eval(c38.incr :alist c38) (expect 1, c38.n=1): %v %v\n\n" r38 c38.n)
+prev_ok=check_fail(:ok ok)
+
+// --- test 39: self-binding covers reads too, not just writes -- a method
+// can read a sibling field it was never passed as arg(n), purely via the
+// ambient scope self-binding puts it in ---
+duck=(:times 3 :quack func(times))
+r39=duck.quack()
+ok=ok&&(r39==3)
+print("39 duck=(:times 3 :quack func(times)); duck.quack() (expect 3 -- reads times, never passed as arg): %v\n\n" r39)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,13 +1,17 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 42/55 (76%)
+// coverage: 50/63 (79%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
-//          dot(func-local-scope-isolation) -(empty-rhs)
+//          dot(func-local-scope-isolation) -(empty-rhs) dot-method(keyword-args)
 //
 // Tests the dot (.) compound variable / attribute list access operator,
 // list(:attr) attribute list construction, and the attrlist() command
-// introduced in PR #85 (closes #82).
+// introduced in PR #85 (closes #82).  Also tests dot(al.method(args)) --
+// firing a FuncObj-valued attribute self-bound to its owning attrlist,
+// with positional args reaching arg(n) inside the body (tests 30-38).
+// Keyword args to a method call (al.method(:key val)) are accepted but
+// currently ignored with a warning -- not yet covered here.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")
@@ -243,6 +247,71 @@ merged=al1+al2
 merged.x=99
 ok=ok&&(al1.x==10)
 print("29 merged=al1+al2; merged.x=99; al1.x unchanged (expect 10): %v\n\n" al1.x)
+prev_ok=check_fail(:ok ok)
+
+// --- test 30: al.method(args) -- self-bound call, real mutation (issue #295) ---
+obj=(:n 0 :addto func(n=n+arg(0); n))
+r30=obj.addto(2)
+ok=ok&&(r30==2 && obj.n==2)
+print("30 obj=(:n 0 :addto func(n=n+arg(0); n)); obj.addto(2) (expect 2, obj.n=2): %v %v\n\n" r30 obj.n)
+prev_ok=check_fail(:ok ok)
+
+// --- test 31: a second call keeps mutating the same object, not a per-call copy ---
+r31=obj.addto(5)
+ok=ok&&(r31==7 && obj.n==7)
+print("31 obj.addto(5) again (expect 7, obj.n=7): %v %v\n\n" r31 obj.n)
+prev_ok=check_fail(:ok ok)
+
+// --- test 32: zero-arg method call, empty parens fires (unlike bare access) ---
+ctr=(:n 0 :incr func(n=n+1; n))
+r32a=ctr.incr()
+r32b=ctr.incr()
+ok=ok&&(r32a==1 && r32b==2)
+print("32 ctr.incr(); ctr.incr() (expect 1, 2): %v %v\n\n" r32a r32b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 33: bare access (no parens) still returns the raw FuncObj, unfired --
+// regression guard: #295 must not change #293/#294's bare-access contract ---
+x33=obj.addto
+ok=ok&&(isfunc(x33) && obj.n==7)
+print("33 x=obj.addto; isfunc(x) (expect true, obj.n still 7 -- no fire): %v %v\n\n" isfunc(x33) obj.n)
+prev_ok=check_fail(:ok ok)
+
+// --- test 34: multiple positional args reach arg(0)/arg(1)/arg(2) ---
+al3=(:sum3 func(arg(0)+arg(1)+arg(2)))
+r34=al3.sum3(1 2 3)
+ok=ok&&(r34==6)
+print("34 al3.sum3(1 2 3) (expect 6): %v\n\n" r34)
+prev_ok=check_fail(:ok ok)
+
+// --- test 35: calling a non-func attribute warns and returns nil, no crash ---
+al4=(:x 10)
+r35=al4.x(1)
+ok=ok&&(r35==nil)
+print("35 al4=(:x 10); al4.x(1) (expect nil, WARNING above): %v\n\n" r35)
+prev_ok=check_fail(:ok ok)
+
+// --- test 36: calling an undefined method warns and returns nil, no crash ---
+r36=al4.nosuchmethod(1)
+ok=ok&&(r36==nil)
+print("36 al4.nosuchmethod(1) (expect nil, WARNING above): %v\n\n" r36)
+prev_ok=check_fail(:ok ok)
+
+// --- test 37: nested attrlists self-bind independently -- outer.bump() and
+// outer.inner.bump() must not share or clobber each other's scope ---
+outer37=(:cnt 0 :bump func(cnt=cnt+1; cnt) :inner (:cnt 100 :bump func(cnt=cnt+1; cnt)))
+r37a=outer37.bump()
+r37b=outer37.inner.bump()
+ok=ok&&(r37a==1 && r37b==101 && outer37.cnt==1 && outer37.inner.cnt==101)
+print("37 outer.bump(); outer.inner.bump() (expect 1, 101, cnt=1, inner.cnt=101): %v %v %v %v\n\n" r37a r37b outer37.cnt outer37.inner.cnt)
+prev_ok=check_fail(:ok ok)
+
+// --- test 38: eval(obj.method :alist obj), the #294 mechanism .method(args)
+// is sugar for, still works unchanged ---
+c38=(:n 0 :incr func(n=n+1; n))
+r38=eval(c38.incr :alist c38)
+ok=ok&&(r38==1 && c38.n==1)
+print("38 eval(c38.incr :alist c38) (expect 1, c38.n=1): %v %v\n\n" r38 c38.n)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "0652c4f7"
+#define PATCH_KEY "2212fc8d"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -145,6 +145,7 @@ Print a usage summary of all the invocation modes above and exit.
     ,          tuple          35          L-to-R      binary
     ,,         stream concat  33          L-to-R      binary
     $          list           32          R-to-L      unary-prefix
+    ~~         spread         32          R-to-L      unary-prefix
     %=         mod_assign     30          R-to-L      binary
     *=         mpy_assign     30          R-to-L      binary
     +=         add_assign     30          R-to-L      binary
@@ -362,9 +363,11 @@ Print a usage summary of all the invocation modes above and exit.
 
  val=remote(hoststr|sockobj [portnum] cmdstr :nowait :str) -- remotely evaluate command string then locally evaluate result string
 
- val=eval(cmdstr|funcobj [cmdstr|funcobj ...] :symret ) -- evaluate string (or funcobj) as commands, optionally return symbol instead of nil
+ val=eval(cmdstr|funcobj [cmdstr|funcobj ...] :symret :alist attrlist) -- evaluate string (or funcobj) as commands, optionally return symbol instead of nil, with the given attrlist as func-local scope
 
  funcobj=func(body :echo) -- encapsulate a body of commands into an executable object
+
+ val=echo(arg [arg [...]] :key val ...) -- return evaluated args in ~~-passable form (positional list with tail attrlist singletons, or a bare attrlist)
 
  status=shell(cmdstr) -- evaluate command in shell
 


### PR DESCRIPTION
## Summary
Closes #295. `obj.method(args)` now fires a `FuncObj`-valued attribute of `obj`, self-bound, with `args` reaching `arg(n)` inside the body -- sugar for the `eval(obj.method :alist obj)` pattern from #294, without the ceremony.

`DotFunc` becomes `post_eval` so it can peek `nids()` on the rhs before anything is independently evaluated. This is necessary, not cosmetic: a symbol with an attached arglist that isn't a registered global command gets unconditionally rebound to the `nil` command by `ComTerp::token_to_comvalue` at expression-conversion time -- that check only ever consults the global command table, never `_alist` -- so `method(args)` can never resolve through `obj` by evaluating it as an ordinary sub-expression, no matter when `_alist` is swapped.

Instead: `DotFunc` looks `method` up in `obj` directly (the same `GetAttr()` bare access already uses, so `method` as a symbol is never independently evaluated at all), gets the call's own args evaluated by retargeting a copy of just those tokens at the existing `echo()` command (an ordinary, non-`post_eval` command already built to package positionals/keywords into an inspectable value for the `~~` round-trip -- so normal dispatch does the evaluation), then fires the found `FuncObj` the same way `eval(:alist)` already does: swap `comterp()`'s `_alist` to `obj`, run the `FuncObj`'s token buffer directly via `comterpserv()->run()`, so self-bound reads/writes are real mutation, not a per-call copy. Positional args reach `arg(n)` via two small new `ComTerp` accessors (`funcobj_argvals()`/`set_funcobj_args()`, comterp.h), mirroring the existing `set_attributes()`/`get_attributes()` pattern already used for `_alist`.

**Keyword arguments are ephemeral unless the method writes them.** `al.method(:key val)` writes `key` onto `al` before firing -- exactly as if you'd written `al.key=val` first -- then compares it back afterward: unchanged means nothing inside the call touched that name, so it reverts (removed entirely if `al` never had it before this call); different means the method's own body assigned a new value there, self-bound, so that write persists. Reading a keyword-supplied value alone never makes it stick:

```
c=(:incr func(cnt++) :cnt 0)
c.incr(:cnt 10)                        // 10 -- cnt++ reads 10, writes 11
c.cnt                                   // 11 -- the write persists

t=(:tell func(cnt) :cnt 0)
t.tell(:cnt 99)                        // 99 -- reads the keyword value
t.cnt                                   // 0 -- never written, reverts
```

The comparison reuses `EqualFunc`'s own type-promoting equality (pushed values, invoked directly via `ComFunc::exec()`) rather than re-deriving it.

**Scope**: bare access (no parens) is completely unaffected -- still returns the raw `FuncObj`, unfired, same guarantee #293/#294 rely on. A call on an attribute that isn't a `FuncObj`, or a method name the attrlist doesn't have, warns and returns `nil` rather than erroring.

**Behavior change, documented in `HACKING.md`**: a name with parens that also happens to be a registered global command (`a.type()`, `a.print(...)`) used to fall through and fire that *global* command, ignoring `a` entirely -- an artifact of the rhs being independently pre-evaluated before `DotFunc` ever ran. Dot access is now consistently "look in the object" whether or not parens follow, the same namespace isolation `HACKING.md` already documented for plain attribute reads, now extended uniformly to method calls too.

**Small aside while in the man page for this**: `echo()` and the `~~` spread operator were missing from it entirely, and `eval()`'s entry was missing `:alist` from #294 -- added all three.

## Test plan
- [x] 13 new tests (30-43) in `src/comterp_/tests/attrlist.comt`: self-bound mutation across two successive calls, zero-arg methods, bare-access-stays-unfired regression guard, multiple positional args reaching `arg(0..2)`, calling a non-`FuncObj` attribute (warns, nil, no crash), calling an undefined method (warns, nil, no crash), independent self-binding on nested attrlists, `eval(obj.method :alist obj)` unaffected, self-binding covers plain reads of sibling fields (not just `arg(n)`), and all four combinations of keyword args (existing field read-only vs written, newly-introduced field read-only vs written)
- [x] Full `run_all.comt` regression suite green, including the pre-existing `attrlist.comt` "compound variable on first use" idiom (`foo.bar=55` for an unbound `foo`) and chained bare access (`node.left.val`), both of which needed a real fix mid-implementation (raw-peek vs. evaluate distinction for the lhs) to keep working
- [x] Verified empirically against the built interpreter throughout, including nesting/recursion, a 50-iteration call loop (no leaks/crashes), and cross-object method calls (`dst.store(src.val())`, confirming args evaluate in the caller's own scope before `self` switches in)