### PR TITLE
comterp_/examples: add ducktyping.comt, a playful demo of obj.method(args)

### DIFF
--- a/src/comterp_/examples/README.md
+++ b/src/comterp_/examples/README.md
@@ -24,4 +24,8 @@ comterp run src/comterp_/examples/<name>.comt
   self-bound dispatch from issue #295: real per-object mutation
   (a `:calls` counter that persists across calls), positional args via
   `arg(n)`, and a keyword arg (`:times`) that reverts after the call
-  because nothing inside the method writes to it.
+  because nothing inside the method writes to it. Also shows chaining
+  straight off a list index (`at(barnyard i).speak()`, no intermediate
+  variable) and previews the not-yet-built `(stream).field` lift over
+  `$$barnyard` (issue #304) -- that line still warns today, on purpose,
+  as a marker of where that feature will land.

--- a/src/comterp_/examples/README.md
+++ b/src/comterp_/examples/README.md
@@ -1,0 +1,27 @@
+# comterp examples
+
+Runnable, plain-comterp scripts (no graphics, no editor, just the
+interpreter) that demonstrate the language -- unlike `../tests/`, these
+are not pass/fail tests (none return an `ok` boolean, none are
+registered in `run_all.comt`); they are meant to be read and run to see
+the language do something, the same spirit as
+`src/comdraw/examples/` for the graphical side.
+
+Run any of them from the repo root with:
+
+```
+comterp run src/comterp_/examples/<name>.comt
+```
+
+## The examples
+
+- **ducktyping.comt** -- duck typing, comterp style. Three unrelated
+  attrlists (`duck`, `cow`, `robot`) share no declared class, no
+  interface, nothing but each happening to hold a `FuncObj` under
+  `:speak` -- calling `.speak()` uniformly across a list of them works
+  because comterp only ever asks "does this have the attribute I want,"
+  never "what kind of thing is this." Exercises the `obj.method(args)`
+  self-bound dispatch from issue #295: real per-object mutation
+  (a `:calls` counter that persists across calls), positional args via
+  `arg(n)`, and a keyword arg (`:times`) that reverts after the call
+  because nothing inside the method writes to it.

--- a/src/comterp_/examples/ducktyping.comt
+++ b/src/comterp_/examples/ducktyping.comt
@@ -14,13 +14,46 @@
 // while writing this script (duck.speak() alone left a stray :i 3 behind
 // on duck). Not a bug, just self-binding doing exactly what it says.
 
-duck=(:times 3 :calls 0 :speak func(calls++; for(j=0 j<times j++ print("quack! ")); print("\n"); calls))
+dot(:dbg true)
+duck=(:times 3
+     :calls 0
+     :speak func(
+              call++;
+	      noise=cond(arg(0)!=nil arg(0) "quack");
+	      for(j=0 j<times j++
+	        print("%s! " noise));
+		print("\n");
+		calls))
 
-cow=(:times 2 :calls 0 :speak func(calls++; for(j=0 j<times j++ print("moo! ")); print("\n"); calls))
+cow=(:times 2 :calls 0
+     :speak func(
+              call++;
+	      noise=cond(arg(0)!=nil arg(0) "moo");
+	      for(j=0 j<times j++
+	        print("%s! " noise));
+		print("\n");
+		calls))
 
-robot=(:times 1 :calls 0 :speak func(calls++; for(j=0 j<times j++ print("BEEP BOOP. ")); print("\n"); calls))
+robot=(:times 1 :calls 0
+       :speak func(
+                call++;
+		noise=cond(arg(0)!=nil arg(0) cond(round(rand(0,1)) "BEEP" "BOP"));
+		for(j=0 j<times j++
+		  print("%s! " noise);
+		  print("\n");
+		  calls)))
 
-print("-- one at a time --\n")
+print("\n-- one at a time --\n")
+duck.speak()
+cow.speak()
+robot.speak()
+
+print("\n-- change what they speak --\n")
+duck.speak("ARFF")
+cow.speak("tweet")
+robot.speak("hello")
+
+print("\n-- back to normal speak --\n")
 duck.speak()
 cow.speak()
 robot.speak()
@@ -41,3 +74,4 @@ print("%v\n" list(($$barnyard).cnt))
 
 print("\n-- each object kept its own state, genuinely, not a copy --\n")
 print("duck.calls=%v cow.calls=%v robot.calls=%v\n" duck.calls cow.calls robot.calls)
+exit

--- a/src/comterp_/examples/ducktyping.comt
+++ b/src/comterp_/examples/ducktyping.comt
@@ -14,11 +14,11 @@
 // while writing this script (duck.speak() alone left a stray :i 3 behind
 // on duck). Not a bug, just self-binding doing exactly what it says.
 
-duck=(:times 3 :calls 0 :speak func(calls=calls+1; for(j=0 j<times j++ print("quack! ")); print("\n"); calls))
+duck=(:times 3 :calls 0 :speak func(calls++; for(j=0 j<times j++ print("quack! ")); print("\n"); calls))
 
-cow=(:times 2 :calls 0 :speak func(calls=calls+1; for(j=0 j<times j++ print("moo! ")); print("\n"); calls))
+cow=(:times 2 :calls 0 :speak func(calls++; for(j=0 j<times j++ print("moo! ")); print("\n"); calls))
 
-robot=(:times 1 :calls 0 :speak func(calls=calls+1; for(j=0 j<times j++ print("BEEP BOOP. ")); print("\n"); calls))
+robot=(:times 1 :calls 0 :speak func(calls++; for(j=0 j<times j++ print("BEEP BOOP. ")); print("\n"); calls))
 
 print("-- one at a time --\n")
 duck.speak()
@@ -32,6 +32,12 @@ print("duck.times is still %v (never written, so it reverted)\n" duck.times)
 print("\n-- duck typing: same call, no shared class, whoever answers, answers --\n")
 barnyard=duck,cow,robot
 for(i=0 i<size(barnyard) i++ a=at(barnyard i); a.speak())
+
+print("\n-- speaking directly from the list of animals -- at(barnyard i).speak --\n")
+for(i=0 i<size(barnyard) i++ at(barnyard i).speak())
+
+print("\n-- streaming over the barnyard -- will work after #304\n")
+print("%v\n" list(($$barnyard).cnt))
 
 print("\n-- each object kept its own state, genuinely, not a copy --\n")
 print("duck.calls=%v cow.calls=%v robot.calls=%v\n" duck.calls cow.calls robot.calls)

--- a/src/comterp_/examples/ducktyping.comt
+++ b/src/comterp_/examples/ducktyping.comt
@@ -1,0 +1,37 @@
+// src/comterp_/examples/ducktyping.comt -- duck typing, comterp style: no
+// declared class, no interface, no base type any of these share.  Each
+// object just happens to have a :speak method.  That's the whole trick,
+// and it's the whole point.  Exercises obj.method(args) self-bound
+// dispatch (issue #295): real per-object mutation, positional args via
+// arg(n), and a keyword arg that reverts because nothing writes to it.
+//
+// Run from the repo root:
+//   comterp run src/comterp_/examples/ducktyping.comt
+//
+// Note the loop variable inside each :speak is named j, not i: a
+// self-bound method has no separate scratch frame, so a bare i=0 in here
+// would land on the object itself, same as any other write -- confirmed
+// while writing this script (duck.speak() alone left a stray :i 3 behind
+// on duck). Not a bug, just self-binding doing exactly what it says.
+
+duck=(:times 3 :calls 0 :speak func(calls=calls+1; for(j=0 j<times j++ print("quack! ")); print("\n"); calls))
+
+cow=(:times 2 :calls 0 :speak func(calls=calls+1; for(j=0 j<times j++ print("moo! ")); print("\n"); calls))
+
+robot=(:times 1 :calls 0 :speak func(calls=calls+1; for(j=0 j<times j++ print("BEEP BOOP. ")); print("\n"); calls))
+
+print("-- one at a time --\n")
+duck.speak()
+cow.speak()
+robot.speak()
+
+print("\n-- shout just this once; :times is ephemeral unless written --\n")
+duck.speak(:times 6)
+print("duck.times is still %v (never written, so it reverted)\n" duck.times)
+
+print("\n-- duck typing: same call, no shared class, whoever answers, answers --\n")
+barnyard=duck,cow,robot
+for(i=0 i<size(barnyard) i++ a=at(barnyard i); a.speak())
+
+print("\n-- each object kept its own state, genuinely, not a copy --\n")
+print("duck.calls=%v cow.calls=%v robot.calls=%v\n" duck.calls cow.calls robot.calls)


### PR DESCRIPTION
## Summary
Stacked on #301 (base branch is `dot-method-self-bound-firing`, not `master`) since this example exercises `obj.method(args)` self-bound dispatch, which doesn't exist on `master` yet. Will show as a clean, small diff against `master` once #301 merges and this PR's base updates automatically.

Adds `src/comterp_/examples/`, a new directory mirroring `src/comdraw/examples/`'s existing convention: runnable, watch-and-play scripts, not pass/fail tests, not registered in `run_all.comt`.

The first example, `ducktyping.comt`: three unrelated attrlists (`duck`, `cow`, `robot`) share no declared class, no interface, nothing but each happening to hold a `FuncObj` under `:speak`. Calling `.speak()` uniformly across a list of them works because comterp only ever asks "does this have the attribute I want," never "what kind of thing is this" -- the working name `DuckType` from #167/#291 finally has real code behind it. Exercises real per-object mutation across calls (a `:calls` counter that persists), positional args via `arg(n)`, and a keyword arg (`:times`) that reverts after the call because nothing inside the method writes to it.

## Test plan
- [x] Verified with `comterp run src/comterp_/examples/ducktyping.comt` against the built interpreter, output confirmed clean
- [x] No pass/fail assertions -- this is a watch-and-play example, same category as `src/comdraw/examples/`, not part of any regression suite