### PR TITLE
dotfunc: check func scope (_alist) before local/global for dot access (#292)

### DIFF
--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -307,21 +307,38 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
     if (!before_part.is_attribute() && !before_part.is_attributelist()) {
       int before_symid = before_part.symbol_val();
       boolean global = before_part.global_flag();
-      if (!global) {
-	comterp()->localtable()->find(vptr, before_symid);
-	if (!vptr) comterp()->globaltable()->find(vptr, before_symid);
+      /* func scope (_alist) is checked before local/global, same order
+	 ComTerp::lookup_symval uses -- otherwise a func-local variable
+	 (e.g. a keyword-bound param whose value only lives in _alist, never
+	 in localtable()) is invisible to dot access from inside the func
+	 body (#292). */
+      AttributeList* funcscope = !global ? comterp()->get_attributes() : nil;
+      AttributeValue* fsval = funcscope ? funcscope->find(before_symid) : nil;
+      if (fsval) {
+	if (fsval->is_attributelist())
+	  al = (AttributeList*) fsval->obj_val();
+	else {
+	  al = new AttributeList();
+	  AttributeValue newval(AttributeList::class_symid(), (void*) al);
+	  *fsval = newval;
+	}
       } else {
-	comterp()->globaltable()->find(vptr, before_symid);
-      }
-      if (vptr &&((ComValue*) vptr)->class_symid() == AttributeList::class_symid()) {
-	al = (AttributeList*) ((ComValue*) vptr)->obj_val();
-      } else {
-	al = new AttributeList();
-	ComValue* comval = new ComValue(AttributeList::class_symid(), (void*)al);
-	if (!global)
-	  comterp()->localtable()->insert(before_symid, comval);
-	else
-	  comterp()->globaltable()->insert(before_symid, comval);
+	if (!global) {
+	  comterp()->localtable()->find(vptr, before_symid);
+	  if (!vptr) comterp()->globaltable()->find(vptr, before_symid);
+	} else {
+	  comterp()->globaltable()->find(vptr, before_symid);
+	}
+	if (vptr &&((ComValue*) vptr)->class_symid() == AttributeList::class_symid()) {
+	  al = (AttributeList*) ((ComValue*) vptr)->obj_val();
+	} else {
+	  al = new AttributeList();
+	  ComValue* comval = new ComValue(AttributeList::class_symid(), (void*)al);
+	  if (!global)
+	    comterp()->localtable()->insert(before_symid, comval);
+	  else
+	    comterp()->globaltable()->insert(before_symid, comval);
+	}
       }
     } else if (!before_part.is_attributelist()) {
       if (((Attribute*)before_part.obj_val())->Value()->is_attributelist())

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,9 +1,9 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 55/68 (81%)
+// coverage: 56/68 (82%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
-//          dot(func-local-scope-isolation) -(empty-rhs)
+//          -(empty-rhs)
 //
 // Tests the dot (.) compound variable / attribute list access operator,
 // list(:attr) attribute list construction, and the attrlist() command
@@ -357,6 +357,46 @@ v43=(:setit func(nope=nope+1; nope))
 r43=v43.setit(:nope 5)
 ok=ok&&(r43==6 && v43.nope==6)
 print("43 v43=(:setit func(nope=nope+1; nope)); v43.setit(:nope 5) (expect 6, v43.nope=6 -- new field, written, sticks): %v %v\n\n" r43 v43.nope)
+prev_ok=check_fail(:ok ok)
+
+// --- test 44: dot read on a keyword-bound attrlist sourced from a
+// command-call return value, not a direct variable reference -- #292
+// regression.  Before the fix, DotFunc's before-variable lookup skipped
+// _alist (func scope) entirely and went straight to local/global tables;
+// a keyword-bound :al param lives only in _alist, so this always read
+// back nil. ---
+k44=func(al.n)
+v44=k44(:al attrlist(:n 5))
+ok=ok&&(v44==5)
+print("44 k44=func(al.n); k44(:al attrlist(:n 5)) reads keyword-bound attrlist (expect 5): %v\n\n" v44)
+prev_ok=check_fail(:ok ok)
+
+// --- test 45: func-local scope isolation -- a keyword-bound :al param
+// must resolve to the value actually passed in, not to a same-named
+// outer variable.  This is the masking gap that let #292 slip past test
+// 13 undetected: pre-fix, the buggy lookup auto-vivified a *new*
+// attrlist under the "al" name in local/global scope (since _alist was
+// never consulted), so a write immediately followed by a read of the
+// same name looked self-consistent even though neither one ever touched
+// the real keyword-bound object.  Giving the outer scope a *pre-existing*
+// same-named al with different content exposes that: pre-fix this read
+// the outer al's stale value instead of the one just passed in. ---
+al=attrlist(:n 999)
+k45=func(al.n)
+v45=k45(:al attrlist(:n 5))
+ok=ok&&(v45==5)
+print("45 outer al pre-existing with different value, keyword-bound al still wins (expect 5): %v\n\n" v45)
+prev_ok=check_fail(:ok ok)
+
+// --- test 46: write-isolation companion to test 45 -- a func-local :al
+// write must land on the object actually passed in, not on a same-named
+// outer variable. ---
+al=attrlist(:n 999)
+myal46=attrlist(:n 1)
+k46=func(al.n=5)
+k46(:al myal46)
+ok=ok&&(al.n==999 && myal46.n==5)
+print("46 func-local :al write hits the passed-in object, not outer al (expect al.n=999, myal46.n=5): %v %v\n\n" al.n myal46.n)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "0fd46df2"
+#define PATCH_KEY "fbd2e3d5"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `DotFunc::execute_core()`'s bare-symbol lookup went straight to `localtable()`/`globaltable()`, skipping `_alist` (the func's own scope) entirely.
- `ComTerp::lookup_symval` — the general-purpose lookup used everywhere else (assignment, boolean ops, `is_funcobj`, etc.) — checks `_alist` first, for exactly this reason: a func-local variable should shadow a same-named outer one.
- Concretely: `f=func(al.x); f(:al someexpr())` binds `al` only into `_alist` (a keyword-arg binding), never into `localtable()`. Dot access on `al` inside the func body missed it and silently fell through to the auto-vivify branch, producing `nil` instead of the real value.
- Confirmed the bug is general (not `global()`-specific as originally reported) — any command-call return value passed as a keyword arg triggers it, including a direct variable reference to a *different-named* outer variable. The one case that looked like it worked (`al=...; f=func(al.x); f(:al al)`) only worked because the outer variable happened to share the func param's name, so the (buggy) local/global-only lookup found the outer `al` by coincidence.

Fixes #292.

## Test plan
- [x] `run("./run_all.comt")` from `src/comterp_/tests` — all pass, no FAIL lines
- [x] Reproduced all three #292 repro cases (`global()`, direct user-func call, direct builtin call) against the fix — all now correctly return the bound value instead of `nil`
- [x] Confirmed the previously-"working" same-name case only worked by name-shadowing accident, and now works correctly for the right reason (tested with a differently-named outer variable)