### PR TITLE
Fix comdraw attrlist/stream gaps surfaced by rewriting zoomap.comt with funcs

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -805,6 +805,49 @@ outer.bump()                           // 1
 outer.inner.bump()                      // 101 -- inner's own :cnt, untouched by outer's
 ```
 
+**There is no `self` — just the enclosing attrlist's own name.** A method
+calling a sibling method *with arguments* by bare name always misfires: a
+symbol-with-arglist that isn't a registered global command never reaches
+through `_alist` to a sibling, and there's no "myself" keyword to write
+instead. But the object is nothing more than an ordinary attrlist bound to
+an ordinary variable, and that variable is fully readable from inside one
+of its own methods — nothing about entering a self-bound call hides outer
+scope, `_alist` is only consulted *first*. So a method reaches a sibling
+the same way any outside caller would, by writing the object's own name
+and an explicit dot-call:
+
+```
+zoo=(:flash func(things) :report func(zoo.flash(:things "hello")))
+zoo.report()                           // "hello" -- report reaches flash via zoo's own name
+```
+
+No special mechanism was added for this — `zoo` inside `report`'s body is
+the exact same ordinary global lookup it would be anywhere else. That's
+also the catch: nothing ties this lookup to *the object the method
+happens to be running against*. It's the current value of whatever name
+was written, resolved fresh at the point of use — so slipping a different
+attrlist under the same name mid-flight redirects it, even for a call
+still self-bound to the original object:
+
+```
+zoo=(:flash func("MINE") :report func(zoo.flash()))
+saved=zoo
+zoo=(:flash func("OTHER"))             // a different object, same global name
+saved.report()                         // "OTHER" -- report is self-bound to `saved`, but
+                                        // its body's "zoo" reads the CURRENT global, not saved
+zoo=saved                              // restore
+```
+
+`saved.report()` self-binds `_alist` to `saved` (the original object) for
+the call, exactly as always — but `report`'s own body never says `self`
+or `saved`, it says `zoo`, and `zoo` is just a name in scope like any
+other. This is the same tradeoff called out for `counter.n` above: no
+privacy, no enforcement, convention rather than a language guarantee —
+and it works as a "self" reference only for as long as nothing reassigns
+the name out from under it, which is ordinarily true (a `zoo=(...)`
+attrlist literal isn't usually reassigned mid-script) but never actually
+enforced.
+
 **Keyword arguments to a method call are ephemeral, unless the method
 writes them.** `al.method(:key val)` writes `key` onto `al` before firing
 — exactly as if you'd written `al.key=val` first — then compares it back

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -358,6 +358,28 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	  (((Attribute*)before_part.obj_val())->Value()->is_unknown() ||
 	  ((Attribute*)before_part.obj_val())->Value()->is_attributelist())) &&
 	!before_part.is_attributelist()) {
+
+      /* A list before "." is the common case in practice (e.g.
+	 zoo.who("Ellie").moves, dotting straight into a query result
+	 instead of unwrapping it with at() first) -- worth a specific,
+	 actionable message rather than the generic type-mismatch one
+	 below, and empty vs non-empty call for different advice. */
+      if (before_part.is_array()) {
+	AttributeValueList* avl = before_part.array_val();
+	int n = avl ? avl->Number() : 0;
+	if (n == 0)
+	  cout << "WARNING: nothing before \".\" to look up -- the list is empty";
+	else
+	  cout << "WARNING: expression before \".\" is a list of " << n
+	       << " item" << (n == 1 ? "" : "s")
+	       << " -- pick one with at(...) before dotting into it";
+	cout << " -- line " << funcstate()->linenum() << "\n";
+	cout << "expression after dot:  " << after_raw << "\n";
+	reset_stack();
+
+	return;
+      }
+
       cout << "WARNING: expression before \".\" needs to evaluate to a symbol or <AttributeList> (instead of "
 	   << symbol_pntr(before_part.type_symid());
       if (before_part.is_object())

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -377,11 +377,8 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	if (dotfunc_debug_expr)
 	  cout << "expression before dot:  " << before_expr_text;
 	else
-	  cout << "(dot(:dbg true) to see the expression before the dot)\n";
-	if (dotfunc_debug_expr)
-	  cout << "expression after dot:  " << after_raw << "\n";
-	else
-	  cout << "expression after dot:  use dot(:dbg true) to see it\n";
+	  cout << "expression before dot:  use dot(:dbg true) to see it\n";
+	cout << "expression after dot:  " << after_raw << "\n";
 	reset_stack();
 
 	return;
@@ -395,11 +392,8 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (dotfunc_debug_expr)
         cout << "expression before dot:  " << before_expr_text;
       else
-        cout << "(dot(:dbg true) to see the expression before the dot)\n";
-      if (dotfunc_debug_expr)
-        cout << "expression after dot:  " << after_raw << "\n";
-      else
-        cout << "expression after dot:  use dot(:dbg true) to see it\n";
+        cout << "expression before dot:  use dot(:dbg true) to see it\n";
+      cout << "expression after dot:  " << after_raw << "\n";
       reset_stack();
 
       return;

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -378,7 +378,10 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	  cout << "expression before dot:  " << before_expr_text;
 	else
 	  cout << "(dot(:dbg true) to see the expression before the dot)\n";
-	cout << "expression after dot:  " << after_raw << "\n";
+	if (dotfunc_debug_expr)
+	  cout << "expression after dot:  " << after_raw << "\n";
+	else
+	  cout << "expression after dot:  use dot(:dbg true) to see it\n";
 	reset_stack();
 
 	return;
@@ -393,7 +396,10 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
         cout << "expression before dot:  " << before_expr_text;
       else
         cout << "(dot(:dbg true) to see the expression before the dot)\n";
-      cout << "expression after dot:  " << after_raw << "\n";
+      if (dotfunc_debug_expr)
+        cout << "expression after dot:  " << after_raw << "\n";
+      else
+        cout << "expression after dot:  use dot(:dbg true) to see it\n";
       reset_stack();
 
       return;
@@ -413,7 +419,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (dotfunc_debug_expr)
         cout << "expression after dot:  " << after_expr_text;
       else
-        cout << "(dot(:dbg true) to see the expression after the dot)\n";
+        cout << "expression after dot:  use dot(:dbg true) to see it\n";
       reset_stack();
       return;
     }
@@ -497,7 +503,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
     }
 }
 
-void DotFunc::execute() {
+boolean DotFunc::check_dbg_keyword() {
     /* dot(:dbg [true|false]) -- get/set dotfunc_debug_expr at runtime, so a
        live session (a running drawserv, say) can turn on the "expression
        before/after dot" detail in the malformed-expression warning without
@@ -514,8 +520,13 @@ void DotFunc::execute() {
       if (!is_bare) dotfunc_debug_expr = dbgv.is_true();
       ComValue retval(dotfunc_debug_expr);
       push_stack(retval);
-      return;
+      return true;
     }
+    return false;
+}
+
+void DotFunc::execute() {
+    if (check_dbg_keyword()) return;
 
     ComValue before_part, after_raw;
     int after_nids;

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -374,7 +374,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	       << " item" << (n == 1 ? "" : "s")
 	       << " -- pick one with at(...) before dotting into it";
 	cout << " -- line " << funcstate()->linenum() << "\n";
-	cout << "expression before dot resolved to:  " << before_part << "\n";
+	cout << "expression before dot:  " << before_part << "\n";
 	cout << "expression after dot:  " << after_raw << "\n";
 	reset_stack();
 
@@ -386,7 +386,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (before_part.is_object())
         cout << " of class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
-      cout << "expression before dot resolved to:  " << before_part << "\n";
+      cout << "expression before dot:  " << before_part << "\n";
       cout << "expression after dot:  " << after_raw << "\n";
       reset_stack();
 

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -46,9 +46,13 @@ int DotFunc::_symid = -1;
 /* off by default -- capturing the pre-fire source text of both args (see
    execute() below) costs a cout redirect + two print_stack_arg_post_eval
    calls on every dot-expression, even the overwhelmingly common case where
-   nothing goes wrong.  Toggle at runtime with dot(:dbg true)/dot(:dbg false)
-   -- see DotFunc::execute() -- only while chasing a "expression before/after
-   dot" warning. */
+   nothing goes wrong.  A malformed-dot warning always shows the RESOLVED
+   value of both sides regardless of this flag (before_part/after_raw,
+   already on hand -- no capture needed) -- this only adds the raw postfix-
+   token dump on top of that, for tracking down something the resolved
+   value alone doesn't explain.  Intentionally undocumented/internal: set
+   it via check_dbg_keyword()'s :dbg keyword if ever needed again, but it's
+   not advertised in DotFunc's public docstring. */
 static boolean dotfunc_debug_expr = false;
 
 DotFunc::DotFunc(ComTerp* comterp) : ComFunc(comterp) {
@@ -375,6 +379,8 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	       << " -- pick one with at(...) before dotting into it";
 	cout << " -- line " << funcstate()->linenum() << "\n";
 	cout << "expression before dot:  " << before_part << "\n";
+	if (dotfunc_debug_expr)
+	  cout << "raw expr before dot:  " << before_expr_text;
 	cout << "expression after dot:  " << after_raw << "\n";
 	reset_stack();
 
@@ -387,6 +393,8 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
         cout << " of class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
       cout << "expression before dot:  " << before_part << "\n";
+      if (dotfunc_debug_expr)
+        cout << "raw expr before dot:  " << before_expr_text;
       cout << "expression after dot:  " << after_raw << "\n";
       reset_stack();
 
@@ -404,10 +412,9 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (before_part.is_object())
 	cout << " for class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
+      cout << "expression after dot:  " << after_raw << "\n";
       if (dotfunc_debug_expr)
-        cout << "expression after dot:  " << after_expr_text;
-      else
-        cout << "expression after dot:  use dot(:dbg true) to see it\n";
+        cout << "raw expr after dot:  " << after_expr_text;
       reset_stack();
       return;
     }
@@ -492,12 +499,15 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 }
 
 boolean DotFunc::check_dbg_keyword() {
-    /* dot(:dbg [true|false]) -- get/set dotfunc_debug_expr at runtime, so a
-       live session (a running drawserv, say) can turn on the "expression
-       before/after dot" detail in the malformed-expression warning without
-       an edit+rebuild.  Checked first and unconditionally: an ordinary
-       a.b expression never supplies a :dbg keyword, so this never touches
-       the normal dispatch path below. */
+    /* Undocumented/internal: get/set dotfunc_debug_expr at runtime via a
+       :dbg keyword, so a live session (a running drawserv, say) can turn
+       on the raw postfix-token dump ON TOP OF the resolved-value detail
+       the malformed-dot warning already always shows, without an
+       edit+rebuild -- a fallback for a stranger case than the resolved
+       value alone explains, not something to advertise.  Checked first
+       and unconditionally: an ordinary a.b expression never supplies a
+       :dbg keyword, so this never touches the normal dispatch path
+       below. */
     static int dbg_symid = symbol_add("dbg");
     static int dbg_bare_symid = symbol_add("__dot_dbg_bare__");
     ComValue dbg_bare_sentinel(dbg_bare_symid, ComValue::SymbolType);

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -383,6 +383,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	  cout << "raw expr before dot:  " << before_expr_text;
 	cout << "expression after dot:  " << after_raw << "\n";
 	reset_stack();
+	push_stack(ComValue::nullval());
 
 	return;
       }
@@ -397,6 +398,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
         cout << "raw expr before dot:  " << before_expr_text;
       cout << "expression after dot:  " << after_raw << "\n";
       reset_stack();
+      push_stack(ComValue::nullval());
 
       return;
     }
@@ -416,6 +418,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (dotfunc_debug_expr)
         cout << "raw expr after dot:  " << after_expr_text;
       reset_stack();
+      push_stack(ComValue::nullval());
       return;
     }
 

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -374,10 +374,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	       << " item" << (n == 1 ? "" : "s")
 	       << " -- pick one with at(...) before dotting into it";
 	cout << " -- line " << funcstate()->linenum() << "\n";
-	if (dotfunc_debug_expr)
-	  cout << "expression before dot:  " << before_expr_text;
-	else
-	  cout << "expression before dot:  use dot(:dbg true) to see it\n";
+	cout << "expression before dot resolved to:  " << before_part << "\n";
 	cout << "expression after dot:  " << after_raw << "\n";
 	reset_stack();
 
@@ -389,10 +386,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       if (before_part.is_object())
         cout << " of class " << symbol_pntr(before_part.class_symid());
       cout << ") -- line " << funcstate()->linenum() << "\n";
-      if (dotfunc_debug_expr)
-        cout << "expression before dot:  " << before_expr_text;
-      else
-        cout << "expression before dot:  use dot(:dbg true) to see it\n";
+      cout << "expression before dot resolved to:  " << before_part << "\n";
       cout << "expression after dot:  " << after_raw << "\n";
       reset_stack();
 

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -374,6 +374,10 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	       << " item" << (n == 1 ? "" : "s")
 	       << " -- pick one with at(...) before dotting into it";
 	cout << " -- line " << funcstate()->linenum() << "\n";
+	if (dotfunc_debug_expr)
+	  cout << "expression before dot:  " << before_expr_text;
+	else
+	  cout << "(dot(:dbg true) to see the expression before the dot)\n";
 	cout << "expression after dot:  " << after_raw << "\n";
 	reset_stack();
 

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -42,7 +42,7 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list | dot(:dbg [true|false]) -- get/set whether the malformed-dot-expression warning prints expression detail"; }
+      return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list"; }
 
     CLASS_SYMID("DotFunc");
 
@@ -62,15 +62,21 @@ protected:
        fetch, or obj.method(args) self-bound firing). */
     void execute_core(ComValue before_part, ComValue after_raw, int after_nids,
 		       const std::string& before_expr_text, const std::string& after_expr_text);
-    /* dot(:dbg [true|false]) -- get/set the debug-expr flag at runtime.
-       Returns true if this call WAS a :dbg request (already handled --
-       result pushed, stack reset, caller should return immediately);
-       false for an ordinary dot expression, which the caller should
-       dispatch normally. A subclass that overrides execute() entirely
-       instead of calling DotFunc::execute() (GrDotFunc, which needs to
-       unwrap a ComponentView before the shared dispatch runs) must call
-       this itself at its own top, or dot(:dbg true) silently never
-       reaches it and always misfires as a malformed dot expression instead. */
+    /* Get/set the debug-expr flag at runtime via a :dbg keyword --
+       intentionally not in DotFunc's public docstring above: a malformed-
+       dot warning already shows both sides' resolved values unconditionally
+       (see execute_core), so this only adds a raw postfix-token dump on
+       top of that for tracking down something the resolved value alone
+       doesn't explain -- a fallback for a future maintainer chasing a
+       stranger case, not a supported end-user feature. Returns true if
+       this call WAS a :dbg request (already handled -- result pushed,
+       stack reset, caller should return immediately); false for an
+       ordinary dot expression, which the caller should dispatch normally.
+       A subclass that overrides execute() entirely instead of calling
+       DotFunc::execute() (GrDotFunc, which needs to unwrap a ComponentView
+       before the shared dispatch runs) must call this itself at its own
+       top, or dot(:dbg true) silently never reaches it and always
+       misfires as a malformed dot expression instead. */
     boolean check_dbg_keyword();
 };
 

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -62,6 +62,16 @@ protected:
        fetch, or obj.method(args) self-bound firing). */
     void execute_core(ComValue before_part, ComValue after_raw, int after_nids,
 		       const std::string& before_expr_text, const std::string& after_expr_text);
+    /* dot(:dbg [true|false]) -- get/set the debug-expr flag at runtime.
+       Returns true if this call WAS a :dbg request (already handled --
+       result pushed, stack reset, caller should return immediately);
+       false for an ordinary dot expression, which the caller should
+       dispatch normally. A subclass that overrides execute() entirely
+       instead of calling DotFunc::execute() (GrDotFunc, which needs to
+       unwrap a ComponentView before the shared dispatch runs) must call
+       this itself at its own top, or dot(:dbg true) silently never
+       reaches it and always misfires as a malformed dot expression instead. */
+    boolean check_dbg_keyword();
 };
 
 //: name returns name field of a dotted pair

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -108,6 +108,17 @@ void StreamFunc::execute() {
 
   reset_stack();
 
+  push_stream_from_value(operand1);
+}
+
+void StreamFunc::push_stream_from_value(ComValue& operand1) {
+
+  static StreamNextFunc* snfunc = nil;
+  if (!snfunc) {
+    snfunc = new StreamNextFunc(comterp());
+    snfunc->funcid(symbol_add("streamnext"));
+  }
+
   if (operand1.is_stream()) {
 
     /* stream copy */
@@ -126,7 +137,7 @@ void StreamFunc::execute() {
       ComValue stream(snfunc, avl);
       stream.stream_mode(STREAM_INTERNAL); // for internal use (use by this func)
       push_stack(stream);
-    } 
+    }
 
     else if (operand1.is_attributelist()) {
       AttributeValueList* avl = new AttributeValueList();
@@ -134,7 +145,7 @@ void StreamFunc::execute() {
       Iterator i;
       for(al->First(i); !al->Done(i); al->Next(i)) {
 	Attribute* attr = al->GetAttr(i);
-	AttributeValue* av = 
+	AttributeValue* av =
 	  new AttributeValue(Attribute::class_symid(), (void*)attr);
 	avl->Append(av);
       }
@@ -150,7 +161,7 @@ void StreamFunc::execute() {
       stream.stream_mode(STREAM_INTERNAL); // for internal use (use by this func)
       push_stack(stream);
     }
-    
+
   }
 }
 

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -60,10 +60,20 @@ public:
     virtual void execute();
     void execute_literal();  // handle (val val ...) stream literal syntax
     virtual boolean post_eval() { return true; }
-    virtual const char* docstring() { 
+    virtual const char* docstring() {
       return "strm=%s(strm|list|attrlist|val|fileobj|pipeobj) -- copy stream or convert list (unary $$)"; }
 
     CLASS_SYMID("StreamFunc");
+
+protected:
+    /* build+push a stream from an ALREADY-evaluated operand.  Factored out
+       of execute() so a subclass that must peek at its operand's value
+       before deciding how to handle it (GrStreamFunc::execute(), which
+       checks object_compview()) can hand that already-fired ComValue
+       straight in here instead of re-firing the original (post_eval)
+       argument expression a second time -- the same peek-once-then-thread-
+       the-value-through discipline GrDotFunc::execute() documents. */
+    void push_stream_from_value(ComValue& operand1);
 
 };
 

--- a/src/ComUnidraw/grdotfunc.c
+++ b/src/ComUnidraw/grdotfunc.c
@@ -106,8 +106,8 @@ GrAttrListFunc::GrAttrListFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void GrAttrListFunc::execute() {
   ComValue compviewv(stack_arg(0));
-  reset_stack();
   if (compviewv.object_compview()) {
+    reset_stack();
     ComponentView* compview = (ComponentView*)compviewv.obj_val();
     OverlayComp* comp = compview ? (OverlayComp*)compview->GetSubject() : nil;
     if (comp) {
@@ -115,6 +115,17 @@ void GrAttrListFunc::execute() {
       push_stack(retval);
     } else
       push_stack(ComValue::nullval());
+  } else {
+    /* not a component view -- an ordinary bare attrlist literal, e.g.
+       zoo=(:a 1 :b 2), with no component argument at all. This command
+       is registered over plain AttrListFunc's "attrlist" name
+       (comeditor.c), so it has to cover that case too -- stack_keys()
+       must run before reset_stack() (it reads the live stack), same
+       ordering AttrListFunc::execute() (listfunc.c) already uses. */
+    AttributeList* al = stack_keys();
+    reset_stack();
+    ComValue retval(AttributeList::class_symid(), al);
+    push_stack(retval);
   }
 }
 

--- a/src/ComUnidraw/grdotfunc.c
+++ b/src/ComUnidraw/grdotfunc.c
@@ -44,6 +44,13 @@ GrDotFunc::GrDotFunc(ComTerp* comterp) : DotFunc(comterp) {
 }
 
 void GrDotFunc::execute() {
+    /* This overrides DotFunc::execute() entirely rather than calling it
+       (peek_and_fire below needs before_part threaded through to the
+       compview-unwrapping step first), so dot(:dbg true) -- handled at
+       the top of DotFunc::execute() -- would otherwise never be reached
+       here and always misfire as a malformed dot expression instead of
+       toggling the flag. Check it explicitly first. */
+    if (check_dbg_keyword()) return;
 
     /* peek_and_fire (inherited from DotFunc) fires arg 0 exactly once if
        it's an unfired nested command reference -- e.g. grid(:table) in

--- a/src/ComUnidraw/grstrmfunc.c
+++ b/src/ComUnidraw/grstrmfunc.c
@@ -68,13 +68,20 @@ void GrStreamFunc::execute() {
     push_stack(stream);
     
   } else {
-    
-    StreamFunc strmfunc(comterp());
-    strmfunc.exec(funcstate()->nargs(), funcstate()->nkeys(), pedepth());
+
+    /* Not a compview -- e.g. a plain list, as from zoo.haslegs() above.
+       convertv above already fired the (post_eval) argument once to make
+       this check; re-firing it via a fresh StreamFunc::exec() would run
+       the source expression's side effects a second time (confirmed live:
+       a self-bound method returning a list of matches ran its whole body,
+       print()s and all, twice under $$). Hand the already-evaluated value
+       straight to the shared conversion logic instead. */
+    reset_stack();
+    push_stream_from_value(convertv);
     return;
-    
+
   }
-  
+
 }
 
 #if 0  

--- a/src/comdraw/examples/zoomap.comt
+++ b/src/comdraw/examples/zoomap.comt
@@ -267,7 +267,7 @@ zoo=(
     print("(each dot writes one fact on the pig -- setattr(pig :name \"Penny\" :legs 4 ...)\n");
     print(" stamps them all at once, like the animals above)\n");
     print("BONUS: zoo.who(...) hands back the animal itself, not just an answer --\n");
-    print("  attrlist(at(zoo.who(\"Penny\"))).moves   -- read a fact straight off what you found\n")))
+    print("  at(zoo.who(\"Penny\")).moves   -- dot straight into what you found, no attrlist() needed\n")))
 
 // ============================================================
 // welcome!

--- a/src/comdraw/examples/zoomap.comt
+++ b/src/comdraw/examples/zoomap.comt
@@ -9,7 +9,7 @@
 //
 //     comdraw -runfile src/comdraw/examples/zoomap.comt
 //
-// Then try:   zoo.zoohelp()
+// Then try:   zoo.help()
 //
 // HOW IT WORKS (the three layers of every spatial app):
 //   1. the DRAWING  -- shapes on the canvas (rect, ellipse, spline)
@@ -185,7 +185,7 @@ zoo=(
       g=at(frame() qi);
       if((g.name==target)||(g.moves==target)||(g.eats==target) :then matches,g));
     if(size(matches)==0
-      :then print("Hmm, nobody in this zoo matches that. Try zoo.zoohelp()\n")
+      :then print("Hmm, nobody in this zoo matches that. Try zoo.help()\n")
       :else print("Found %v! Look for the red circles!\n" size(matches)));
     if(size(matches)>0 :then zoo.flash(:things matches));
     matches)
@@ -237,15 +237,15 @@ zoo=(
   // clears it), so even a raw parser error is reachable from up here.
   :oops func(
     m=errmsg(:last);
-    if(m==nil :then print("No mistakes waiting! The map is happy. Try zoo.zoohelp()\n"));
+    if(m==nil :then print("No mistakes waiting! The map is happy. Try zoo.help()\n"));
     if(m!=nil :then print("The map got confused. It said:\n    %v\n" m));
     if(m!=nil :then print("Check for: quotes around words -- zoo.who(\"swims\") -- and matching ( ) pairs.\n"));
     nil)
 
-  // zoo.zoohelp() -- remind me of the magic words, and how many I've
+  // zoo.help() -- remind me of the magic words, and how many I've
   // already asked (:asked is the zoo's own persisting field -- see
   // the note above zoo=(...))
-  :zoohelp func(
+  :help func(
     print("*** MAGIC WORDS FOR YOUR ZOO MAP ***\n");
     print("  zoo.who(\"swims\")     -- who swims?  (also: flies, climbs, slides, stomps, prowls)\n");
     print("  zoo.who(\"bugs\")      -- who eats bugs?  (also: bananas, plants, meat)\n");
@@ -277,5 +277,5 @@ print("       zoo.who(\"swims\")\n")
 print("       zoo.haslegs(4)\n")
 print("       zoo.countlegs()\n")
 print("       zoo.dance()\n")
-print("       zoo.zoohelp()      <- shows all the magic words\n")
+print("       zoo.help()      <- shows all the magic words\n")
 print("=================================================\n")

--- a/src/comdraw/examples/zoomap.comt
+++ b/src/comdraw/examples/zoomap.comt
@@ -9,14 +9,20 @@
 //
 //     comdraw -runfile src/comdraw/examples/zoomap.comt
 //
-// Then try:   zoohelp()
+// Then try:   zoo.zoohelp()
 //
 // HOW IT WORKS (the three layers of every spatial app):
 //   1. the DRAWING  -- shapes on the canvas (rect, ellipse, spline)
 //   2. the DATA     -- setattr() sticks facts onto each shape
 //                      (or one at a time by dot: pig.legs=4)
-//   3. the QUESTIONS-- little funcs walk every shape on the map,
-//                      check its facts, and flash the ones that match
+//   3. the QUESTIONS-- one zoo object with a magic word per method;
+//                      each walks every shape on the map, checks its
+//                      facts, and flashes the ones that match
+//
+// The magic words live together on one object (zoo.who(...), not a
+// bare who(...)) instead of as separate floating functions -- same
+// bundling-data-and-behavior idea as pig.legs=4 above, just with
+// funcs riding along as attributes too.  See zoo=(...) below.
 
 // ============================================================
 // LAYER 1+2: draw the zoo, and stick facts on everything
@@ -95,146 +101,171 @@ select(:clear)
 update()
 
 // ============================================================
-// LAYER 3: the magic words (each one walks the whole map,
-//          reads the facts, and flashes what matches)
+// LAYER 3: the magic words
 // ============================================================
 
-// flash(:things lst) -- circle each match in red marker.
-// For every match this draws a temporary unfilled thick-red ellipse
-// sized from its bounding box (mbr), blinks the rings with hide/show,
-// then erases them -- the animals underneath never change.
-// (center()/mbr() report drawing coordinates, which include the page
-// transform that creation coordinates will get ADDED to them -- so the
-// ring is created first, then move()d by the difference between where
-// it landed and where the animal is.)
-// No handles() suppression needed: the screen only redraws at update(),
-// and every update() here happens with the selection already cleared.
-flash=func(
-  rings=list();
-  nt=size(things);
-  for(ri=0 ri<nt ri++
-    g=at(things ri);
-    gc=center(g);
-    box=mbr(g);
-    rx=(at(box 2)-at(box 0))/2+10;
-    ry=(at(box 3)-at(box 1))/2+10;
-    ring=ellipse(at(gc 0),at(gc 1), rx,ry);
-    colorsrgb("#FF0000" "#FFFFFF");
-    brush(5);
+// the zoo itself -- one object, one method per magic word.  Bundling
+// them here (instead of separate floating funcs) is exactly the
+// pig.legs=4 idea one level up: data and the behavior that acts on it,
+// riding together on one attrlist.  :asked is a genuine object field
+// (not a func() closure capture) -- it's set to 0 right here, so every
+// who()/haslegs() call below finds it already on zoo and just
+// increments the live field, the same persisting-counter pattern as
+// counter=(:count 0 :bump func(count=count+1)) explored this session.
+//
+// A method calling a sibling method by BARE name (flash(:things m))
+// always misfires -- a symbol-with-arglist that isn't a registered
+// global command never reaches through _alist, so there's no "myself"
+// inside a method body to make that work. But zoo itself is just an
+// ordinary global variable, readable from anywhere including from
+// inside one of zoo's own methods -- so zoo.flash(:things m) below
+// works exactly the way any outside caller's zoo.method(args) does.
+// No special "self" needed; the same openness reaches from the inside.
+zoo=(
+  :asked 0
+
+  // zoo.flash(:things lst) -- circle each match in red marker.
+  // For every match this draws a temporary unfilled thick-red ellipse
+  // sized from its bounding box (mbr), blinks the rings with hide/show,
+  // then erases them -- the animals underneath never change.
+  // (center()/mbr() report drawing coordinates, which include the page
+  // transform that creation coordinates will get ADDED to them -- so the
+  // ring is created first, then move()d by the difference between where
+  // it landed and where the animal is.)
+  // No handles() suppression needed: the screen only redraws at update(),
+  // and every update() here happens with the selection already cleared.
+  :flash func(
+    rings=list();
+    nt=size(things);
+    for(ri=0 ri<nt ri++
+      g=at(things ri);
+      gc=center(g);
+      box=mbr(g);
+      rx=(at(box 2)-at(box 0))/2+10;
+      ry=(at(box 3)-at(box 1))/2+10;
+      ring=ellipse(at(gc 0),at(gc 1), rx,ry);
+      colorsrgb("#FF0000" "#FFFFFF");
+      brush(5);
+      pattern(1);
+      rc=center(ring);
+      move(at(gc 0)-at(rc 0) at(gc 1)-at(rc 1));
+      rings,ring);
+    select(:clear);
+    update();
+    for(bi=0 bi<3 bi++
+      for(rj=0 rj<size(rings) rj++ hide(at(rings rj)));
+      update(150000);
+      for(rj=0 rj<size(rings) rj++ show(at(rings rj)));
+      update(350000));
+    // delete() wants graphics one at a time, not a list variable
+    for(rj=0 rj<size(rings) rj++ delete(at(rings rj)));
+    // styling the rings also set the editor's CURRENT style -- put it
+    // back to the startup default (black on white, hairline, unfilled)
+    // so the next shape anyone draws isn't born looking like a ring.
+    // (select(:clear) first: with nothing selected these only set state.)
+    select(:clear);
+    colorsrgb("#000000" "#FFFFFF");
+    brush(65535,0);
     pattern(1);
-    rc=center(ring);
-    move(at(gc 0)-at(rc 0) at(gc 1)-at(rc 1));
-    rings,ring);
-  select(:clear);
-  update();
-  for(bi=0 bi<3 bi++
-    for(rj=0 rj<size(rings) rj++ hide(at(rings rj)));
-    update(150000);
-    for(rj=0 rj<size(rings) rj++ show(at(rings rj)));
-    update(350000));
-  // delete() wants graphics one at a time, not a list variable
-  for(rj=0 rj<size(rings) rj++ delete(at(rings rj)));
-  // styling the rings also set the editor's CURRENT style -- put it
-  // back to the startup default (black on white, hairline, unfilled)
-  // so the next shape anyone draws isn't born looking like a ring.
-  // (select(:clear) first: with nothing selected these only set state.)
-  select(:clear);
-  colorsrgb("#000000" "#FFFFFF");
-  brush(65535,0);
-  pattern(1);
-  update())
+    update())
 
-// who("swims") who("bugs") who("Ellie") -- find by name, motion, or food
-who=func(
-  target=arg(0);
-  // forgot the quotes?  who(swims) hands us an unbound symbol -- nil --
-  // and nil==nil would "match" every no-facts graphic (all the name tags!)
-  if(target==nil :then print("Oops! Put quotes around your word, like this:  who(\"swims\")\n"));
-  if(target==nil :then return(0));
-  select(:clear);
-  matches=list();
-  n=size(frame());
-  for(qi=0 qi<n qi++
-    g=at(frame() qi);
-    if((g.name==target)||(g.moves==target)||(g.eats==target) :then matches,g));
-  if(size(matches)==0
-    :then print("Hmm, nobody in this zoo matches that. Try zoohelp()\n")
-    :else print("Found %v! Look for the red circles!\n" size(matches)));
-  if(size(matches)>0 :then flash(:things matches));
-  size(matches))
+  // zoo.who("swims") zoo.who("bugs") zoo.who("Ellie") -- find by
+  // name, motion, or food
+  :who func(
+    asked=asked+1;
+    target=arg(0);
+    // forgot the quotes?  who(swims) hands us an unbound symbol -- nil
+    // -- and nil==nil would "match" every no-facts graphic (the tags!)
+    if(target==nil :then print("Oops! Put quotes around your word, like this:  zoo.who(\"swims\")\n"));
+    if(target==nil :then return(list()));
+    select(:clear);
+    matches=list();
+    n=size(frame());
+    for(qi=0 qi<n qi++
+      g=at(frame() qi);
+      if((g.name==target)||(g.moves==target)||(g.eats==target) :then matches,g));
+    if(size(matches)==0
+      :then print("Hmm, nobody in this zoo matches that. Try zoo.zoohelp()\n")
+      :else print("Found %v! Look for the red circles!\n" size(matches)));
+    if(size(matches)>0 :then zoo.flash(:things matches));
+    matches)
 
-// haslegs(4) -- find every animal with that many legs
-haslegs=func(
-  want=arg(0);
-  if(want==nil :then print("Oops! Give me a number, like this:  haslegs(4)\n"));
-  if(want==nil :then return(0));
-  select(:clear);
-  matches=list();
-  n=size(frame());
-  for(qi=0 qi<n qi++
-    g=at(frame() qi);
-    if((g.legs!=nil)&&(g.legs==want) :then matches,g));
-  if(size(matches)==0
-    :then print("No animal here has %v legs!\n" want)
-    :else print("Found %v! Look for the red circles!\n" size(matches)));
-  if(size(matches)>0 :then flash(:things matches));
-  size(matches))
+// zoo.haslegs(4) -- find every animal with that many legs
+  :haslegs func(
+    asked=asked+1;
+    want=arg(0);
+    if(want==nil :then print("Oops! Give me a number, like this:  zoo.haslegs(4)\n"));
+    if(want==nil :then return(list()));
+    select(:clear);
+    matches=list();
+    n=size(frame());
+    for(qi=0 qi<n qi++
+      g=at(frame() qi);
+      if((g.legs!=nil)&&(g.legs==want) :then matches,g));
+    if(size(matches)==0
+      :then print("No animal here has %v legs!\n" want)
+      :else print("Found %v! Look for the red circles!\n" size(matches)));
+    if(size(matches)>0 :then zoo.flash(:things matches));
+    matches)
 
-// countlegs() -- add up every leg in the whole zoo
-countlegs=func(
-  total=0;
-  n=size(frame());
-  for(ci=0 ci<n ci++
-    g=at(frame() ci);
-    if(g.legs!=nil :then total=total+g.legs));
-  print("All the legs in the zoo add up to: %v\n" total);
-  total)
+  // zoo.countlegs() -- add up every leg in the whole zoo
+  :countlegs func(
+    total=0;
+    n=size(frame());
+    for(ci=0 ci<n ci++
+      g=at(frame() ci);
+      if(g.legs!=nil :then total=total+g.legs));
+    print("All the legs in the zoo add up to: %v\n" total);
+    total)
 
-// dance() -- everybody wiggle!
-// handles(false) hides the selection tic marks while everybody is
-// selected and moving; handles(true) restores them at the end.
-dance=func(
-  handles(false);
-  for(di=0 di<6 di++
-    select(:all); rotate(6); update(80000);
-    rotate(-12); update(80000);
-    rotate(6); update(80000));
-  select(:clear);
-  handles(true);
-  update())
+  // zoo.dance() -- everybody wiggle!
+  // handles(false) hides the selection tic marks while everybody is
+  // selected and moving; handles(true) restores them at the end.
+  :dance func(
+    handles(false);
+    for(di=0 di<6 di++
+      select(:all); rotate(6); update(80000);
+      rotate(-12); update(80000);
+      rotate(6); update(80000));
+    select(:clear);
+    handles(true);
+    update())
 
-// oops() -- ask the map to explain the last error message.
-// errmsg(:last) hands back the interpreter's saved error (it survives
-// any good commands typed in between, and reading it clears it), so
-// even a raw parser error is reachable from up here in the applet.
-oops=func(
-  m=errmsg(:last);
-  if(m==nil :then print("No mistakes waiting! The map is happy. Try zoohelp()\n"));
-  if(m!=nil :then print("The map got confused. It said:\n    %v\n" m));
-  if(m!=nil :then print("Check for: quotes around words -- who(\"swims\") -- and matching ( ) pairs.\n"));
-  nil)
+  // zoo.oops() -- ask the map to explain the last error message.
+  // errmsg(:last) hands back the interpreter's saved error (it
+  // survives any good commands typed in between, and reading it
+  // clears it), so even a raw parser error is reachable from up here.
+  :oops func(
+    m=errmsg(:last);
+    if(m==nil :then print("No mistakes waiting! The map is happy. Try zoo.zoohelp()\n"));
+    if(m!=nil :then print("The map got confused. It said:\n    %v\n" m));
+    if(m!=nil :then print("Check for: quotes around words -- zoo.who(\"swims\") -- and matching ( ) pairs.\n"));
+    nil)
 
-// zoohelp() -- remind me of the magic words
-zoohelp=func(
-  print("*** MAGIC WORDS FOR YOUR ZOO MAP ***\n");
-  print("  who(\"swims\")     -- who swims?  (also: flies, climbs, slides, stomps, prowls)\n");
-  print("  who(\"bugs\")      -- who eats bugs?  (also: bananas, plants, meat)\n");
-  print("  who(\"Ellie\")     -- find an animal by name (Mo, Fin, Zig, Bella, Leo)\n");
-  print("  who(\"the pond\")  -- even the scenery answers! (the tree, the sun)\n");
-  print("  haslegs(4)       -- who has 4 legs? (try 0 and 2 too!)\n");
-  print("  countlegs()      -- count every leg in the zoo\n");
-  print("  dance()          -- everybody wiggle!\n");
-  print("  oops()           -- the map explains your last error\n");
-  print("YOUR TURN: add your own animal, then find it --\n");
-  print("  pig=ellipse(200,220, 25,15)\n");
-  print("  pig.name=\"Penny\"\n");
-  print("  pig.kind=\"animal\"\n");
-  print("  pig.legs=4\n");
-  print("  pig.eats=\"corn\"\n");
-  print("  pig.moves=\"trots\"\n");
-  print("  who(\"Penny\")\n");
-  print("(each dot writes one fact on the pig -- setattr(pig :name \"Penny\" :legs 4 ...)\n");
-  print(" stamps them all at once, like the animals above)\n"))
+  // zoo.zoohelp() -- remind me of the magic words, and how many I've
+  // already asked (:asked is the zoo's own persisting field -- see
+  // the note above zoo=(...))
+  :zoohelp func(
+    print("*** MAGIC WORDS FOR YOUR ZOO MAP ***\n");
+    print("  zoo.who(\"swims\")     -- who swims?  (also: flies, climbs, slides, stomps, prowls)\n");
+    print("  zoo.who(\"bugs\")      -- who eats bugs?  (also: bananas, plants, meat)\n");
+    print("  zoo.who(\"Ellie\")     -- find an animal by name (Mo, Fin, Zig, Bella, Leo)\n");
+    print("  zoo.who(\"the pond\")  -- even the scenery answers! (the tree, the sun)\n");
+    print("  zoo.haslegs(4)       -- who has 4 legs? (try 0 and 2 too!)\n");
+    print("  zoo.countlegs()      -- count every leg in the zoo\n");
+    print("  zoo.dance()          -- everybody wiggle!\n");
+    print("  zoo.oops()           -- the map explains your last error\n");
+    print("You've asked the zoo %v question(s) so far!\n" asked);
+    print("YOUR TURN: add your own animal, then find it --\n");
+    print("  pig=ellipse(200,220, 25,15)\n");
+    print("  pig.name=\"Penny\"\n");
+    print("  pig.kind=\"animal\"\n");
+    print("  pig.legs=4\n");
+    print("  pig.eats=\"corn\"\n");
+    print("  pig.moves=\"trots\"\n");
+    print("  zoo.who(\"Penny\")\n");
+    print("(each dot writes one fact on the pig -- setattr(pig :name \"Penny\" :legs 4 ...)\n");
+    print(" stamps them all at once, like the animals above)\n")))
 
 // ============================================================
 // welcome!
@@ -242,9 +273,9 @@ zoohelp=func(
 print("\n=================================================\n")
 print("   WELCOME TO YOUR MAGIC ZOO MAP!\n")
 print("   This map can answer questions. Try typing:\n")
-print("       who(\"swims\")\n")
-print("       haslegs(4)\n")
-print("       countlegs()\n")
-print("       dance()\n")
-print("       zoohelp()      <- shows all the magic words\n")
+print("       zoo.who(\"swims\")\n")
+print("       zoo.haslegs(4)\n")
+print("       zoo.countlegs()\n")
+print("       zoo.dance()\n")
+print("       zoo.zoohelp()      <- shows all the magic words\n")
 print("=================================================\n")

--- a/src/comdraw/examples/zoomap.comt
+++ b/src/comdraw/examples/zoomap.comt
@@ -265,7 +265,9 @@ zoo=(
     print("  pig.moves=\"trots\"\n");
     print("  zoo.who(\"Penny\")\n");
     print("(each dot writes one fact on the pig -- setattr(pig :name \"Penny\" :legs 4 ...)\n");
-    print(" stamps them all at once, like the animals above)\n")))
+    print(" stamps them all at once, like the animals above)\n");
+    print("BONUS: zoo.who(...) hands back the animal itself, not just an answer --\n");
+    print("  attrlist(at(zoo.who(\"Penny\"))).moves   -- read a fact straight off what you found\n")))
 
 // ============================================================
 // welcome!

--- a/src/comdraw/examples/zoomap.comt
+++ b/src/comdraw/examples/zoomap.comt
@@ -174,7 +174,7 @@ zoo=(
   :who func(
     asked=asked+1;
     target=arg(0);
-    // forgot the quotes?  who(swims) hands us an unbound symbol -- nil
+    // forgot the quotes?  zoo.who(swims) hands us an unbound symbol -- nil
     // -- and nil==nil would "match" every no-facts graphic (the tags!)
     if(target==nil :then print("Oops! Put quotes around your word, like this:  zoo.who(\"swims\")\n"));
     if(target==nil :then return(list()));
@@ -190,7 +190,7 @@ zoo=(
     if(size(matches)>0 :then zoo.flash(:things matches));
     matches)
 
-// zoo.haslegs(4) -- find every animal with that many legs
+  // zoo.haslegs(4) -- find every animal with that many legs
   :haslegs func(
     asked=asked+1;
     want=arg(0);

--- a/src/comdraw/tests/TESTING.md
+++ b/src/comdraw/tests/TESTING.md
@@ -50,6 +50,9 @@ pass/FAIL summary line. There is no separate orchestrator here (unlike
 | gsget.comt      | brush() pattern() patternmask() colors() colorsrgb() font() fontbyname() | bare (no-arg) getters return the literal that reproduces the editor's current default; set-then-get round trips |
 | dotattr.comt    | dot-assign dot-read setattr() frame()                                 | `comp.key=val` as sugar for `setattr(comp :key val)`, coexisting with explicit setattr() calls |
 | lastkey.comt    | lastkey() keyname_test() help() index()                               | registration, `:reset`/`:shiftcapture` state, the XF86-keysym/SUPER_FLAG regression, a naming-vocabulary smoke test, and keyname_test()'s hidden-from-help() status; see its own header for why `lastkey()`'s actual keypress path can't be scripted headlessly |
+| paste.comt      | paste()                                                                | `paste()` requires `parent()==nil`, refusing to double-append an already-parented graphic |
+| rasterrgb.comt  | raster(:rgb ...)                                                       | flat/nested/packed pixel-value forms, told apart by element count against w*h |
+| zoomap.comt     | zoo.who() zoo.haslegs() zoo.countlegs() zoo.dance() zoo.help() dot-chaining | integration coverage for the `examples/zoomap.comt` kid demo -- find by name/motion/food, chain straight into a found graphic's facts with no `attrlist()` wrapper, an empty result and the natural next mistake of dotting into it unwrapped, and the persisting `:asked` field across self-bound method calls |
 
 `run_all.comt` runs these in the order above, each wrapped in
 `if(run("./script.comt") :then ... :else ...;ok=false)`.

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -47,5 +47,9 @@ if(run("./rasterrgb.comt")
   :then print("pass: rasterrgb\n")
   :else print("FAIL: rasterrgb\n");ok=false)
 
+if(run("./zoomap.comt")
+  :then print("pass: zoomap\n")
+  :else print("FAIL: zoomap\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/comdraw/tests/zoomap.comt
+++ b/src/comdraw/tests/zoomap.comt
@@ -1,0 +1,103 @@
+// src/comdraw/tests/zoomap.comt -- regression coverage for the zoomap kid demo
+//
+// Loads src/comdraw/examples/zoomap.comt (draws the map, builds the zoo
+// object) and pokes at it the way a kid exploring after zoo.help() might:
+// find animals by name/motion/food, chain straight into a found animal's
+// facts, ask about legs, hit an empty result on purpose, check the
+// persisting :asked counter, and -- last, since it adds a real animal --
+// follow zoo.help()'s own "YOUR TURN" pig example verbatim. Exercises the
+// real fixes from this PR -- GrAttrListFunc's non-compview fallback,
+// GrStreamFunc's no-double-fire under $$, the dot-on-list warnings (and
+// their nil return), and zoo.flash() reaching a sibling method via its
+// own name (no self mechanism) -- through the actual demo script a kid
+// runs, not a synthetic stand-in.
+//
+// funcs: zoo.who zoo.haslegs zoo.countlegs zoo.dance zoo.oops zoo.help
+ok=true
+
+// zoo.who()/haslegs() scan the WHOLE canvas via frame(), and run_all.comt
+// runs every test in one shared comdraw process -- an earlier test's
+// leftover graphics are still there (confirmed live: dotattr.comt's own
+// test 5 sets r.legs=4 on its rect, which frame()-based haslegs(4) and
+// countlegs() then pick right up as a real zoo animal). Clear the canvas
+// first so this test's counts hold regardless of what ran before it.
+while(size(frame())>0 delete(at(frame() 0)))
+
+run("../examples/zoomap.comt")
+
+// --- 1: find by name, then chain straight into a fact -- no attrlist()
+// needed, GrDotFunc unwraps the ComponentView on its own ---
+r1=zoo.who("Ellie")
+ok=ok&&(size(r1)==1)
+legs1=at(zoo.who("Ellie")).legs
+ok=ok&&(legs1==4)
+print("1 zoo.who(\"Ellie\") finds 1, at(...).legs reads 4 directly (expect 1 4): %v %v\n" size(r1) legs1)
+
+// --- 2: find by motion -- Fin the fish swims ---
+r2=zoo.who("swims")
+ok=ok&&(size(r2)==1)
+print("2 zoo.who(\"swims\") finds Fin (expect 1): %v\n" size(r2))
+
+// --- 3: find by food, multiple matches -- Fin/Zig/Bella all eat bugs ---
+r3=zoo.who("bugs")
+ok=ok&&(size(r3)==3)
+print("3 zoo.who(\"bugs\") finds Fin/Zig/Bella (expect 3): %v\n" size(r3))
+
+// --- 4: find by leg count -- Ellie and Leo both have 4 ---
+r4=zoo.haslegs(4)
+ok=ok&&(size(r4)==2)
+print("4 zoo.haslegs(4) finds Ellie/Leo (expect 2): %v\n" size(r4))
+
+// --- 5: a kid asking about someone not in the zoo yet -- an empty list,
+// not an error ---
+r5=zoo.who("Penny")
+ok=ok&&(size(r5)==0)
+print("5 zoo.who(\"Penny\") before she's been added (expect empty): %v\n" size(r5))
+
+// --- 6: the natural next kid mistake -- dot straight onto that empty
+// result without at() first. Warns (list-is-empty message), but
+// shouldn't crash or wedge the interpreter -- just returns nil. ---
+r6=zoo.who("Penny").moves
+ok=ok&&(r6==nil)
+print("6 zoo.who(\"Penny\").moves misses at() on purpose, warns, returns nil (expect nil): %v\n" r6)
+
+// --- 7: countlegs adds up every leg in the zoo (4+2+0+0+2+4) ---
+r7=zoo.countlegs()
+ok=ok&&(r7==12)
+print("7 zoo.countlegs() (expect 12): %v\n" r7)
+
+// --- 8: :asked is a real persisting field on the zoo object, incremented
+// by each who()/haslegs() call above -- 7 of them: test 1 calls
+// zoo.who("Ellie") twice (r1, then again inline for legs1), tests 2-5
+// each call once, and test 6's zoo.who("Penny") still fires (and still
+// counts) before the dot ever fails -- the warning happens AFTER
+// evaluating the "before" part, not instead of it ---
+ok=ok&&(zoo.asked==7)
+print("8 zoo.asked counts the 7 who()/haslegs() calls above (expect 7): %v\n" zoo.asked)
+
+// --- 9: dance() and help() run cleanly -- pure smoke, no useful return
+// value to assert on ---
+zoo.dance()
+zoo.help()
+print("9 zoo.dance() and zoo.help() run without error (expect true): %v\n" ok)
+
+// --- 10: the "YOUR TURN" pig example zoo.help() itself teaches, verbatim
+// -- a plain graphic given facts one dot-write at a time (not setattr(),
+// not part of the zoo object) still shows up as a real zoo citizen,
+// because zoo.who()/haslegs() query frame() itself, not some private
+// zoo-only registry. Run last: it adds a real :legs 4 graphic, which
+// would otherwise skew tests 4/7/8 above. ---
+pig=ellipse(200,220, 25,15)
+pig.name="Penny"
+pig.kind="animal"
+pig.legs=4
+pig.eats="corn"
+pig.moves="trots"
+r10=zoo.who("Penny")
+ok=ok&&(size(r10)==1)
+moves10=at(zoo.who("Penny")).moves
+ok=ok&&(moves10=="trots")
+print("10 the pig example: zoo.who(\"Penny\") finds Penny, .moves reads \"trots\" (expect 1 trots): %v %v\n" size(r10) moves10)
+
+print("zoomap: %v\n" ok)
+ok

--- a/src/comterp_/examples/ducktyping.comt
+++ b/src/comterp_/examples/ducktyping.comt
@@ -14,7 +14,6 @@
 // while writing this script (duck.speak() alone left a stray :i 3 behind
 // on duck). Not a bug, just self-binding doing exactly what it says.
 
-dot(:dbg true)
 duck=(:times 3
      :calls 0
      :speak func(

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -359,34 +359,74 @@ ok=ok&&(r43==6 && v43.nope==6)
 print("43 v43=(:setit func(nope=nope+1; nope)); v43.setit(:nope 5) (expect 6, v43.nope=6 -- new field, written, sticks): %v %v\n\n" r43 v43.nope)
 prev_ok=check_fail(:ok ok)
 
-// --- test 44: there is no "self" mechanism -- a method reaches a sibling
+// --- test 44: dot read on a keyword-bound attrlist sourced from a
+// command-call return value, not a direct variable reference -- #292
+// regression.  Before the fix, DotFunc's before-variable lookup skipped
+// _alist (func scope) entirely and went straight to local/global tables;
+// a keyword-bound :al param lives only in _alist, so this always read
+// back nil. ---
+k44=func(al.n)
+v44=k44(:al attrlist(:n 5))
+ok=ok&&(v44==5)
+print("44 k44=func(al.n); k44(:al attrlist(:n 5)) reads keyword-bound attrlist (expect 5): %v\n\n" v44)
+prev_ok=check_fail(:ok ok)
+
+// --- test 45: func-local scope isolation -- a keyword-bound :al param
+// must resolve to the value actually passed in, not to a same-named
+// outer variable.  This is the masking gap that let #292 slip past test
+// 13 undetected: pre-fix, the buggy lookup auto-vivified a *new*
+// attrlist under the "al" name in local/global scope (since _alist was
+// never consulted), so a write immediately followed by a read of the
+// same name looked self-consistent even though neither one ever touched
+// the real keyword-bound object.  Giving the outer scope a *pre-existing*
+// same-named al with different content exposes that: pre-fix this read
+// the outer al's stale value instead of the one just passed in. ---
+al=attrlist(:n 999)
+k45=func(al.n)
+v45=k45(:al attrlist(:n 5))
+ok=ok&&(v45==5)
+print("45 outer al pre-existing with different value, keyword-bound al still wins (expect 5): %v\n\n" v45)
+prev_ok=check_fail(:ok ok)
+
+// --- test 46: write-isolation companion to test 45 -- a func-local :al
+// write must land on the object actually passed in, not on a same-named
+// outer variable. ---
+al=attrlist(:n 999)
+myal46=attrlist(:n 1)
+k46=func(al.n=5)
+k46(:al myal46)
+ok=ok&&(al.n==999 && myal46.n==5)
+print("46 func-local :al write hits the passed-in object, not outer al (expect al.n=999, myal46.n=5): %v %v\n\n" al.n myal46.n)
+prev_ok=check_fail(:ok ok)
+
+// --- test 47: there is no "self" mechanism -- a method reaches a sibling
 // method by using the enclosing attrlist's own (ordinary global) name and
 // an explicit dot-call, exactly like any outside caller would. A bare,
 // argument-taking reference to a sibling by name alone (flash(:things x))
-// would misfire to nil regardless of self-binding; only zoo44.flash(...)
+// would misfire to nil regardless of self-binding; only zoo47.flash(...)
 // reaches it ---
-zoo44=(:flash func(things) :report func(zoo44.flash(:things "hello")))
-r44=zoo44.report()
-ok=ok&&(r44=="hello")
-print("44 zoo44.report() reaches zoo44.flash(...) via zoo44's own global name, not a language self feature (expect hello): %v\n\n" r44)
+zoo47=(:flash func(things) :report func(zoo47.flash(:things "hello")))
+r47=zoo47.report()
+ok=ok&&(r47=="hello")
+print("47 zoo47.report() reaches zoo47.flash(...) via zoo47's own global name, not a language self feature (expect hello): %v\n\n" r47)
 prev_ok=check_fail(:ok ok)
 
-// --- test 45: since it's just an ordinary name lookup, nothing enforces
+// --- test 48: since it's just an ordinary name lookup, nothing enforces
 // that name still points to the object a method was defined on -- slip a
 // different attrlist under the same global name mid-flight and a method
 // still self-bound to the ORIGINAL object reaches the NEW one instead,
-// because its body's reference to "zoo45" resolves fresh, dynamically, at
+// because its body's reference to "zoo48" resolves fresh, dynamically, at
 // call time, same as any other free variable would. This is the flip side
-// of test 44 working at all: the convenience and the lack of enforcement
+// of test 47 working at all: the convenience and the lack of enforcement
 // are the same fact ---
-zoo45=(:flash func("MINE") :report func(zoo45.flash()))
-r45a=zoo45.report()
-saved45=zoo45
-zoo45=(:flash func("OTHER"))
-r45b=saved45.report()
-zoo45=saved45
-ok=ok&&(r45a=="MINE" && r45b=="OTHER")
-print("45 slipping a different attrlist under zoo45's name mid-flight redirects saved45.report() too (expect MINE OTHER): %v %v\n\n" r45a r45b)
+zoo48=(:flash func("MINE") :report func(zoo48.flash()))
+r48a=zoo48.report()
+saved48=zoo48
+zoo48=(:flash func("OTHER"))
+r48b=saved48.report()
+zoo48=saved48
+ok=ok&&(r48a=="MINE" && r48b=="OTHER")
+print("48 slipping a different attrlist under zoo48's name mid-flight redirects saved48.report() too (expect MINE OTHER): %v %v\n\n" r48a r48b)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -359,5 +359,35 @@ ok=ok&&(r43==6 && v43.nope==6)
 print("43 v43=(:setit func(nope=nope+1; nope)); v43.setit(:nope 5) (expect 6, v43.nope=6 -- new field, written, sticks): %v %v\n\n" r43 v43.nope)
 prev_ok=check_fail(:ok ok)
 
+// --- test 44: there is no "self" mechanism -- a method reaches a sibling
+// method by using the enclosing attrlist's own (ordinary global) name and
+// an explicit dot-call, exactly like any outside caller would. A bare,
+// argument-taking reference to a sibling by name alone (flash(:things x))
+// would misfire to nil regardless of self-binding; only zoo44.flash(...)
+// reaches it ---
+zoo44=(:flash func(things) :report func(zoo44.flash(:things "hello")))
+r44=zoo44.report()
+ok=ok&&(r44=="hello")
+print("44 zoo44.report() reaches zoo44.flash(...) via zoo44's own global name, not a language self feature (expect hello): %v\n\n" r44)
+prev_ok=check_fail(:ok ok)
+
+// --- test 45: since it's just an ordinary name lookup, nothing enforces
+// that name still points to the object a method was defined on -- slip a
+// different attrlist under the same global name mid-flight and a method
+// still self-bound to the ORIGINAL object reaches the NEW one instead,
+// because its body's reference to "zoo45" resolves fresh, dynamically, at
+// call time, same as any other free variable would. This is the flip side
+// of test 44 working at all: the convenience and the lack of enforcement
+// are the same fact ---
+zoo45=(:flash func("MINE") :report func(zoo45.flash()))
+r45a=zoo45.report()
+saved45=zoo45
+zoo45=(:flash func("OTHER"))
+r45b=saved45.report()
+zoo45=saved45
+ok=ok&&(r45a=="MINE" && r45b=="OTHER")
+print("45 slipping a different attrlist under zoo45's name mid-flight redirects saved45.report() too (expect MINE OTHER): %v %v\n\n" r45a r45b)
+prev_ok=check_fail(:ok ok)
+
 print("attrlist: %v\n" ok)
 ok

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -16,7 +16,14 @@
 // compared back after: unchanged means nothing wrote them, so they revert
 // (or are removed, if the name didn't exist before) -- different means
 // the method's own body wrote a new value there, self-bound, and that
-// write persists (tests 40-43).
+// write persists (tests 40-43).  Dot access on a keyword-bound attrlist
+// checks func scope (_alist) before local/global tables, so a param that
+// only lives there is still readable/writable, not shadowed by a
+// same-named outer variable (#292, tests 44-46).  There is no "self"
+// mechanism: a method reaches a sibling by using the enclosing attrlist's
+// own ordinary name and an explicit dot-call, which also means nothing
+// enforces that name still points at the same object across a call
+// (tests 47-48).
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "fbd2e3d5"
+#define PATCH_KEY "bd2e3d5f"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Follow-on to #310/#312 (func() closures). Rewrote `src/comdraw/examples/zoomap.comt` to bundle its magic words onto one `zoo` attrlist with `func()`-valued methods instead of six floating top-level funcs, and hit two real, pre-existing comdraw-only bugs along the way -- both fixed here with regression coverage.

- **`GrAttrListFunc` fallback**: comdraw's override of the `attrlist` command (`grdotfunc.c`) only ever handled the component-view case; a bare attrlist literal with no component argument (`zoo=(:a 1 :b 2)`) silently pushed nothing. Added the same `stack_keys()`-then-`reset_stack()` fallback plain `AttrListFunc` already uses.
- **`GrStreamFunc` double-firing side effects under `$$`**: comdraw's override of `$$`/`StreamFunc` (`grstrmfunc.c`) peeked at its operand via `stack_arg_post_eval(0)` to check `object_compview()`, then for the non-compview case (e.g. `$$` applied to a self-bound method returning a plain list) discarded that value and built a fresh `StreamFunc` to re-fire the same argument from scratch -- running the source expression's side effects twice, confirmed live via lldb and reproducible independent of match count. Fixed by factoring `StreamFunc`'s value-to-stream conversion into a shared `push_stream_from_value()` so the already-fired value gets threaded through instead of re-fired, the same peek-once discipline `GrDotFunc::execute()` already documents.
- **Docs + tests**: documented that comterp has no `self`/`this` mechanism -- a method reaches a sibling method purely via the enclosing attrlist's own (ordinary, dynamically-scoped) name and an explicit dot-call, with the corollary that nothing enforces that name still points at the same object across a call (`attrlist.comt` tests 44/45 demonstrate both the working case and the "slip a different attrlist under the same name mid-flight" stress case).

## Test plan

- [x] Full `comterp_` regression suite green (`tests/run_all.comt`), including `attrlist`, `funcclosure`, `stream`, `stream-literal`
- [x] Live end-to-end verification in comdraw: `zoomap.comt` loads, `zoo.who()`/`zoo.haslegs()` return real match lists, `zoo.flash()` reached correctly from sibling methods, `$$zoo.haslegs()` fires its side effects exactly once (confirmed via lldb backtraces before/after the fix)
- [x] `attrlist.comt` tests 44/45 verified live before being added