### PR TITLE
Give char()/int()/float()/double() sane defaults when called with no arg

### DIFF
--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -46,7 +46,7 @@
 #include <strstream>
 using namespace std;
 
-ComValue ComValue::_nullval;
+ComValue ComValue::_nullval(ComValue::UnknownType);
 ComValue ComValue::_trueval(1, ComValue::BooleanType);
 ComValue ComValue::_falseval(0, ComValue::BooleanType);
 ComValue ComValue::_blankval(ComValue::BlankType);
@@ -55,6 +55,7 @@ ComValue ComValue::_oneval(1, ComValue::IntType);
 ComValue ComValue::_zeroval(0, ComValue::IntType);
 ComValue ComValue::_minusoneval(-1, ComValue::IntType);
 ComValue ComValue::_twoval(2, ComValue::IntType);
+ComValue ComValue::_acharval('a', ComValue::CharType);
 
 /*****************************************************************************/
 
@@ -382,50 +383,54 @@ const char* ComValue::String() {
 }
 
 
-
 ComValue& ComValue::nullval() { 
-  *&_nullval = ComValue();
+  //*&_nullval = ComValue();
   return _nullval; 
 }
 
 ComValue& ComValue::trueval() { 
-  *&_trueval = ComValue(1, ComValue::BooleanType);
+  //*&_trueval = ComValue(1, ComValue::BooleanType);
   return _trueval; 
 }
 
 ComValue& ComValue::falseval() { 
-  *&_falseval = ComValue(0, ComValue::BooleanType);
+  //*&_falseval = ComValue(0, ComValue::BooleanType);
   return _falseval; 
 }
 
 ComValue& ComValue::blankval() { 
-  *&_blankval = ComValue(ComValue::BlankType);
+  //*&_blankval = ComValue(ComValue::BlankType);
   return _blankval;
 }
 
 ComValue& ComValue::unkval() { 
-  *&_unkval = ComValue(ComValue::UnknownType);
+  //*&_unkval = ComValue(ComValue::UnknownType);
   return _unkval;
 }
 
 ComValue& ComValue::oneval() { 
-  *&_oneval = ComValue(1, ComValue::IntType);
+  //*&_oneval = ComValue(1, ComValue::IntType);
   return _oneval;
 }
 
 ComValue& ComValue::zeroval() { 
-  *&_zeroval = ComValue(0, ComValue::IntType);
+  //*&_zeroval = ComValue(0, ComValue::IntType);
   return _zeroval;
 }
 
 ComValue& ComValue::minusoneval() { 
-  *&_minusoneval = ComValue(-1, ComValue::IntType);
+  //*&_minusoneval = ComValue(-1, ComValue::IntType);
   return _minusoneval;
 }
 
 ComValue& ComValue::twoval() { 
-  *&_twoval = ComValue(2, ComValue::IntType);
+  //*&_twoval = ComValue(2, ComValue::IntType);
   return _twoval;
+}
+
+ComValue& ComValue::acharval() { 
+  //*&_achar = ComValue('a', ComValue::CharType);
+  return _acharval;
 }
 
 boolean ComValue::is_comfunc(int func_classid) {

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -176,6 +176,8 @@ public:
     // returns reference to IntType ComValue with value of -1.
     static ComValue& twoval();
     // returns reference to IntType ComValue with value of 2.
+    static ComValue& acharval();
+    // returns reference to CharType ComValue with value of 'a'.
 
     unsigned linenum() const { return _linenum; }
     // Get line number of command in script file.
@@ -213,6 +215,7 @@ protected:
     static ComValue _zeroval;
     static ComValue _minusoneval;
     static ComValue _twoval;
+    static ComValue _acharval;
 };
 
 #endif /* !defined(_comvalue_h) */

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1092,7 +1092,7 @@ void LongFunc::execute() {
 FloatFunc::FloatFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
 void FloatFunc::execute() {
-    static ComValue float_zero = ComValue(ComValue::FloatType, (float)0.0);
+    static ComValue float_zero = ComValue((float)0.0);
     ComValue operand(stack_arg(0, false, float_zero));
     reset_stack();
     if (operand.is_string()) {
@@ -1110,7 +1110,7 @@ void FloatFunc::execute() {
 DoubleFunc::DoubleFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
 void DoubleFunc::execute() {
-    static ComValue double_zero = ComValue(ComValue::DoubleType, (double)0.0);
+    static ComValue double_zero = ComValue((double)0.0);
     ComValue operand(stack_arg(0, false, double_zero));
     reset_stack();
     if (operand.is_string()) {

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1008,7 +1008,7 @@ void AbsFunc::execute() {
 CharFunc::CharFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
 void CharFunc::execute() {
-    ComValue operand(stack_arg(0));
+    ComValue operand(stack_arg(0, false, ComValue::acharval()));
     static int u_symid = symbol_add("u");
     int uval_flag = stack_key(u_symid).is_true(); 
     reset_stack();
@@ -1050,7 +1050,7 @@ void ShortFunc::execute() {
 IntFunc::IntFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
 void IntFunc::execute() {
-    ComValue operand(stack_arg(0));
+    ComValue operand(stack_arg(0, false, ComValue::zeroval()));
     static int u_symid = symbol_add("u");
     int uval_flag = stack_key(u_symid).is_true(); 
     reset_stack();
@@ -1092,7 +1092,8 @@ void LongFunc::execute() {
 FloatFunc::FloatFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
 void FloatFunc::execute() {
-    ComValue operand(stack_arg(0));
+    static ComValue float_zero = ComValue(ComValue::FloatType, (float)0.0);
+    ComValue operand(stack_arg(0, false, float_zero));
     reset_stack();
     if (operand.is_string()) {
       const char* numstr = operand.symbol_ptr();
@@ -1109,7 +1110,8 @@ void FloatFunc::execute() {
 DoubleFunc::DoubleFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
 void DoubleFunc::execute() {
-    ComValue operand(stack_arg(0));
+    static ComValue double_zero = ComValue(ComValue::DoubleType, (double)0.0);
+    ComValue operand(stack_arg(0, false, double_zero));
     reset_stack();
     if (operand.is_string()) {
       const char* numstr = operand.symbol_ptr();

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "fbd2e3d5"
+#define PATCH_KEY "68c5ae2d"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

- Called bare (no positional arg), `char()`/`int()`/`float()`/`double()` read whatever `stack_arg(0)` produced on a missing arg rather than a defined value. Give each a sane default via `stack_arg(n, symbol, dflt)`: `char()` -> `'a'`, `int()` -> `0`, `float()`/`double()` -> `0.0`.
- Adds `ComValue::acharval()` alongside the existing `zeroval()`/`oneval()`/etc. singleton family, plus static per-type zero constants for `float`/`double` where no singleton existed yet.
- Also stops reconstructing the canonical singletons (`nullval()`, `trueval()`, `zeroval()`, etc.) on every accessor call -- they're never mutated, so the reset was dead work on every lookup.

Unrelated to the closures/self-binding work in #314 -- split out into its own PR so each tells one story.

## Test plan

- [x] `libComTerp` builds clean
- [x] Full `comterp_` regression suite green (`tests/run_all.comt`), including `char`
- [x] Live-verified: `char()`/`int()`/`float()`/`double()` called bare now return `'a'`/`0`/`0`/`0` instead of an undefined value