### PR TITLE
Add unary prefix * operator as shorthand for next()

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -412,6 +412,7 @@ associativity. Run `optable()` inside comterp to see the live table.
 | 75       | `,,`     | concat        | LtoR  | BINARY          |
 | 70       | `/`      | div           | LtoR  | BINARY          |
 | 70       | `*`      | mpy           | LtoR  | BINARY          |
+| 70       | `*`      | next          | RtoL  | UNARY PREFIX    |
 | 70       | `%`      | mod           | LtoR  | BINARY          |
 | 60       | `-`      | sub           | LtoR  | BINARY          |
 | 60       | `+`      | add           | LtoR  | BINARY          |
@@ -447,6 +448,12 @@ A few things worth noting:
 - `=` is right-associative and below `,` — `a=b=1` chains correctly
 - `;` binds lowest of all — everything to its left and right is a complete expression
 - `$$` and `$` are unary prefix RtoL so `$$lst` and `$strm` parse without parens
+- `*` plays two roles at once: binary `*` (`mpy`, LtoR) and unary prefix `*`
+  (`next`, RtoL) are two separate table entries sharing one operator string, at
+  the same priority — the same double-duty pattern `-` already uses for
+  `minus`/`sub`. `*s` means `next(s)`; parenthesize when mixing the two roles
+  (`2*(*s)`), and watch for `**` — already the stream-repeat operator at a
+  higher priority — swallowing an unspaced `2**s` before it ever reaches `*s`
 
 ### Streaming operators
 
@@ -459,6 +466,33 @@ A few things worth noting:
 | `..` | iterate / range |
 | `**` | repeat |
 | `~~` | spread a collection into a call's arguments (see *The spread operator*) |
+| `*` (unary prefix) | shorthand for `next()` — advance a stream one element |
+
+Unary prefix `*` is plain sugar for `next()`:
+
+```
+s=$$(10 20 30)
+*s               // 10 -- same as next(s)
+*s               // 20
+*s               // 30
+*s               // nil -- exhausted, same as next() always reports
+```
+
+It composes with binary `*` (multiplication) as long as the two roles are
+kept unambiguous — `2*(*s)` doubles the next value pulled off `s`. Without
+parens, watch the lexer: `**` is already the stream-repeat operator at a
+higher priority (80 vs. 70), so an unspaced `2**s` reads as `2 ** s`
+(repeat), never as `2 * (*s)` — separate them with a space or parens.
+
+This operator adds no new C++ machinery: it is a single line in
+`ComUtil/optable.c`'s `DefaultOperatorTable[]` mapping the string `*`,
+unary-prefix, RtoL, priority 70, to the existing `next` command — nothing
+`next()` didn't already do. `optable()` is a live view onto that same table
+at runtime, and `optable(:insert)`/`optable(:delete)` can add or remove
+operators exactly this way from a running script — see
+`src/comterp_/tests/starnext.comt`, which round-trips this very operator
+through `optable(:delete)`/`optable(:insert)` to prove it isn't special
+cased. Any script can bind its own symbol to any command this same way.
 
 ### Dot operator
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -410,9 +410,9 @@ associativity. Run `optable()` inside comterp to see the live table.
 | 90       | `..`     | iterate       | LtoR  | BINARY          |
 | 80       | `**`     | repeat        | LtoR  | BINARY          |
 | 75       | `,,`     | concat        | LtoR  | BINARY          |
+| 71       | `*`      | next          | RtoL  | UNARY PREFIX    |
 | 70       | `/`      | div           | LtoR  | BINARY          |
 | 70       | `*`      | mpy           | LtoR  | BINARY          |
-| 70       | `*`      | next          | RtoL  | UNARY PREFIX    |
 | 70       | `%`      | mod           | LtoR  | BINARY          |
 | 60       | `-`      | sub           | LtoR  | BINARY          |
 | 60       | `+`      | add           | LtoR  | BINARY          |
@@ -448,12 +448,18 @@ A few things worth noting:
 - `=` is right-associative and below `,` — `a=b=1` chains correctly
 - `;` binds lowest of all — everything to its left and right is a complete expression
 - `$$` and `$` are unary prefix RtoL so `$$lst` and `$strm` parse without parens
-- `*` plays two roles at once: binary `*` (`mpy`, LtoR) and unary prefix `*`
-  (`next`, RtoL) are two separate table entries sharing one operator string, at
-  the same priority — the same double-duty pattern `-` already uses for
-  `minus`/`sub`. `*s` means `next(s)`; parenthesize when mixing the two roles
-  (`2*(*s)`), and watch for `**` — already the stream-repeat operator at a
-  higher priority — swallowing an unspaced `2**s` before it ever reaches `*s`
+- `*` plays two roles at once: binary `*` (`mpy`, LtoR, 70) and unary prefix
+  `*` (`next`, RtoL, 71) are two separate table entries sharing one operator
+  string — the same double-duty pattern `-` already uses for `minus`/`sub`.
+  `*s` means `next(s)`, and it composes with binary `*` even without parens
+  (`2 * *s` doubles the next value pulled off `s`) — but the two roles need
+  a real priority gap, not just different associativity, to resolve cleanly:
+  at an exact tie the parser can't settle which role a bare `*` token plays
+  before both are on the stack, and silently mis-emits the binary op before
+  its right operand is even read. One point of separation (71 vs 70) is
+  enough. The one remaining caveat is lexical, not a priority matter: `**`
+  is already the stream-repeat operator, so an unspaced `2**s` reads as
+  `2 ** s` (repeat) before it ever reaches `*s` — a space or parens avoid it
 
 ### Streaming operators
 
@@ -478,20 +484,25 @@ s=$$(10 20 30)
 *s               // nil -- exhausted, same as next() always reports
 ```
 
-It composes with binary `*` (multiplication) as long as the two roles are
-kept unambiguous — `2*(*s)` doubles the next value pulled off `s`. Without
-parens, watch the lexer: `**` is already the stream-repeat operator at a
-higher priority (80 vs. 70), so an unspaced `2**s` reads as `2 ** s`
-(repeat), never as `2 * (*s)` — separate them with a space or parens.
+It composes with binary `*` (multiplication) even without parens — `2 * *s`
+doubles the next value pulled off `s`, same as `2*(*s)`. The one thing to
+watch is lexical, not grammatical: `**` is already the stream-repeat
+operator at a higher priority (80 vs. 71), so an *unspaced* `2**s` reads as
+`2 ** s` (repeat), never as `2 * (*s)` — a space or parens separate them.
 
-This operator adds no new C++ machinery: it is a single line in
+This operator adds almost no new C++ machinery: it is one line in
 `ComUtil/optable.c`'s `DefaultOperatorTable[]` mapping the string `*`,
-unary-prefix, RtoL, priority 70, to the existing `next` command — nothing
-`next()` didn't already do. `optable()` is a live view onto that same table
-at runtime, and `optable(:insert)`/`optable(:delete)` can add or remove
-operators exactly this way from a running script — see
-`src/comterp_/tests/starnext.comt`, which round-trips this very operator
-through `optable(:delete)`/`optable(:insert)` to prove it isn't special
+unary-prefix, RtoL, to the existing `next` command — nothing `next()`
+didn't already do. Its priority (71) sits one above binary `*`'s (70)
+rather than matching it exactly: at an exact tie the parser can't decide
+which role a bare `*` token plays before both are on the operator stack,
+and silently mis-emits the binary op before its right operand is even
+parsed. One point of separation is enough for the unary role to declare
+itself. `optable()` is a live view onto that same table at runtime, and
+`optable(:insert)`/`optable(:delete)` can add or remove operators exactly
+this way from a running script — see `src/comterp_/tests/starnext.comt`,
+which round-trips this very operator through `optable(:delete)`/
+`optable(:insert)` to prove it isn't special
 cased. Any script can bind its own symbol to any command this same way.
 
 ### Dot operator

--- a/src/ComTerp/numfunc.h
+++ b/src/ComTerp/numfunc.h
@@ -88,8 +88,8 @@ public:
     MpyFunc(ComTerp*);
 
     virtual void execute();
-    virtual const char* docstring() { 
-      return "* is the multiply operator for numerics and matrices"; }
+    virtual const char* docstring() {
+      return "* is the multiply operator for numerics and matrices, and the unary prefix operator for next"; }
 
     AttributeValueList* matrix_mpy(AttributeValueList*, AttributeValueList*);
 

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -231,7 +231,7 @@ public:
 
 };
 
-//: next command from stream for ComTerp
+//: next command from stream for ComTerp; also * (unary prefix next) operator.
 class NextFunc : public StrmFunc {
 public:
     NextFunc(ComTerp*);
@@ -239,8 +239,14 @@ public:
     virtual void execute();
     static  void execute_impl(ComTerp*, ComValue& strmv, boolean skim);
     virtual boolean post_eval() { return true; }
-    virtual const char* docstring() { 
-      return "val=%s(stream :skim) -- return next value from stream, don't recurse if :skim"; }
+    virtual const char* docstring() {
+      /* %1$s (not plain %s) reused twice: the caller (helpfunc.c) passes
+	 exactly one substitution argument (this command's own name), and a
+	 second bare %s here would read past it -- an uninitialized-argument
+	 format-string bug.  POSIX/BSD printf's positional specifier lets
+	 one supplied argument fill both slots safely. */
+      return "val=%1$s(stream :skim) -- return next value from stream, don't recurse if :skim.\n\
+*s is unary-prefix sugar for %1$s(s)"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":skim      do not recurse into nested streams",

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -817,8 +817,26 @@ int status;
 	 if( expecting == OPTYPE_BINARY &&
 	     optype == OPTYPE_UNARY_PREFIX ) {
 	    if( UNEXPECTED_NEW_EXPRESSION ) {
-	       COMERR_SET2( ERR_UNEXPECTED_OPERATOR, *linenum, token );
-	       goto error_return;
+
+	      /* stream literal: slip in stream_symid when an operator-led
+		 expression (*s, -s, !x, etc.) arrives as the first element
+		 (narg==0, comm_id==-1).  Mirrors the scalar/identifier
+		 slip-in in the literal and identifier cases below -- a
+		 unary-prefix operator token is just as valid a way to lead
+		 a stream literal's element as a literal or identifier is,
+		 and without this a bare (*s *s) errors out the moment the
+		 *second* element is the one to first need the slip-in. */
+
+	       if( TopOfParenStack >= 0 &&
+	           LITERAL_DELIM( ParenStack[ TopOfParenStack ].paren_type ) &&
+	           ParenStack[ TopOfParenStack ].comm_id == -1 &&
+	           ParenStack[ TopOfParenStack ].narg == 0 ) {
+	         if(stream_symid==-1) stream_symid = symbol_add("stream");
+	         ParenStack[ TopOfParenStack ].comm_id = stream_symid;
+	         } else {
+	         COMERR_SET2( ERR_UNEXPECTED_OPERATOR, *linenum, token );
+	         goto error_return;
+	         }
 	       }
 
 	 /* End of an argument                     */

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -113,9 +113,16 @@ struct _opr_tbl_default_entry {
   {"**",         "repeat",             80,         FALSE,      OPTYPE_BINARY },
   {"%%",         "replay",             79,         FALSE,      OPTYPE_BINARY },
   {",,",         "concat",             75,         FALSE,      OPTYPE_BINARY },
+  // "next" sits one above "mpy" (71 vs 70), not level with it: when the
+  // parser resolves "2 * *s" (no parens) it must settle each * token's role
+  // -- binary vs unary-prefix -- before either can be pushed, and an exact
+  // priority tie between the two roles of the same operator string makes it
+  // misparse (the binary mpy gets emitted before its right operand is even
+  // read).  One point of separation is enough for the unary role to declare
+  // itself distinctly; see starnext.comt test 3b.
+  {"*",          "next",               71,         TRUE,       OPTYPE_UNARY_PREFIX },
   {"%",          "mod",                70,         FALSE,      OPTYPE_BINARY },
   {"*",          "mpy",                70,         FALSE,      OPTYPE_BINARY },
-  {"*",          "next",               70,         TRUE,       OPTYPE_UNARY_PREFIX },
   {"/",          "div",                70,         FALSE,      OPTYPE_BINARY },
   {"+",          "add",                60,         FALSE,      OPTYPE_BINARY },
   {"-",          "sub",                60,         FALSE,      OPTYPE_BINARY },

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -115,6 +115,7 @@ struct _opr_tbl_default_entry {
   {",,",         "concat",             75,         FALSE,      OPTYPE_BINARY },
   {"%",          "mod",                70,         FALSE,      OPTYPE_BINARY },
   {"*",          "mpy",                70,         FALSE,      OPTYPE_BINARY },
+  {"*",          "next",               70,         TRUE,       OPTYPE_UNARY_PREFIX },
   {"/",          "div",                70,         FALSE,      OPTYPE_BINARY },
   {"+",          "add",                60,         FALSE,      OPTYPE_BINARY },
   {"-",          "sub",                60,         FALSE,      OPTYPE_BINARY },

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -130,6 +130,10 @@ if(run("./optable.comt")
   :then print("pass: optable\n")
   :else print("FAIL: optable\n");topok=false)
 
+if(run("./starnext.comt")
+  :then print("pass: starnext\n")
+  :else print("FAIL: starnext\n");topok=false)
+
 if(run("./symboldrain.comt")
   :then print("pass: symboldrain\n")
   :else print("FAIL: symboldrain\n");topok=false)

--- a/src/comterp_/tests/starnext.comt
+++ b/src/comterp_/tests/starnext.comt
@@ -1,0 +1,94 @@
+// src/comterp_/tests/starnext.comt -- the unary prefix * operator, shorthand
+// for next() -- and a demonstration of adding a whole new operator to the
+// language with nothing but one line in the operator table.
+//
+// funcs: * (unary next) * (binary mpy) optable(:table) optable(:delete)
+//        optable(:insert) postfix errmsg
+// coverage: *s as next(s) (baked in), binary * unaffected, dual-role
+//           coexistence in optable(:table), the ** lexical collision when
+//           chained without a separator, and the optable(:delete)/
+//           optable(:insert) round-trip that shows this is not special --
+//           any script could have defined its own *s this same way.
+//
+// *s reads as "the next thing in s", the same dereference-an-iterator
+// intuition C-family languages use * for -- distinct from bare `s`, which
+// stays pure reference/inspection (see istype()), never advancing anything.
+
+ok=true
+
+// --- test 1: *s advances the stream one element at a time, same as
+// next(s) -- exhausted reads nil, same as next() always has ---
+s=$$(10 20 30)
+x=*s
+ok=ok&&(x==10)
+y=*s
+ok=ok&&(y==20)
+z=*s
+ok=ok&&(z==30)
+w=*s
+ok=ok&&(w==nil)
+print("1 *s walks a stream (expect 10 20 30 nil): %v %v %v %v\n" x y z w)
+
+// --- test 2: binary * (multiplication) is completely unaffected -- the
+// two roles coexist under the same operator string ---
+r=3*4
+ok=ok&&(r==12)
+print("2 3*4 binary multiplication unaffected (expect 12): %v\n" r)
+
+// --- test 3: they compose -- a unary *s inside a larger binary expression,
+// parenthesized to keep the two roles unambiguous ---
+s2=$$(5 6 7)
+r2=2*(*s2)
+ok=ok&&(r2==10)
+print("3 2*(*s2) -- binary * around a unary *s (expect 10): %v\n" r2)
+
+// --- test 4: optable(:table) shows both roles as genuinely separate
+// entries under the same operator string, not one overwriting the other ---
+t=optable(:table)
+n=size(t)
+found_binary=false
+found_prefix=false
+for(i=0 i<n i++
+  e=at(t i);
+  if((e.opr=="*")&&(e.cmd=="mpy") :then found_binary=true);
+  if((e.opr=="*")&&(e.cmd=="next") :then found_prefix=true))
+ok=ok&&(found_binary && found_prefix)
+print("4 optable(:table) lists both * roles separately (expect true): %v\n" (found_binary&&found_prefix))
+
+// --- test 5: the one real caveat -- ** is ALREADY the stream-repeat
+// operator (see matrixmult.comt/replay.comt), at a higher priority than
+// either * role, so two *s back to back with no separator lexes as **,
+// not as "binary * around a unary *s" -- parens or a space avoid it.
+// Checked via postfix(), not by evaluating and printing the result: **
+// expects an int count on its right, not a stream, so 2**s3 doesn't
+// evaluate to anything print()-safe to demonstrate directly. ---
+s3=$$(1 2 3)
+p5=postfix(2**s3)
+check5=(index(p5 "repeat")!=nil)&&(index(p5 "next")==nil)
+ok=ok&&check5
+print("5 postfix(2**s3) (no separator) compiles to ** (repeat), not next (expect true): %v\n" check5)
+
+// --- test 6: this is not special -- optable(:delete)/optable(:insert)
+// round-trip the unary role exactly like replay.comt does for %%, proving
+// any script could define its own *-as-next() (or any other symbol) the
+// same way. Only the unary-prefix role is touched; binary * (mpy) is a
+// separate table entry and is never affected by deleting the prefix one. ---
+optable("*" :delete :prefix)
+errmsg(:clear)
+postfix(*s3)
+e=errmsg()
+ok=ok&&(index(e "Unexpected")!=nil)
+print("6a optable(\"*\" :delete :prefix) -- *s3 is now a parse error (expect 'Unexpected'): %v\n" e)
+
+r4=5*6
+ok=ok&&(r4==30)
+print("6b binary * still works with the prefix role deleted (expect 30): %v\n" r4)
+
+optable("*" "next" :insert :prefix :rtol :pri 70)
+errmsg(:clear)
+p=postfix(*s3)
+ok=ok&&(index(p "next")!=nil)
+print("6c optable(:insert) re-adds it -- postfix(*s3) contains 'next' again: %v\n" p)
+
+print("starnext: %v\n" ok)
+ok

--- a/src/comterp_/tests/starnext.comt
+++ b/src/comterp_/tests/starnext.comt
@@ -42,6 +42,17 @@ r2=2*(*s2)
 ok=ok&&(r2==10)
 print("3 2*(*s2) -- binary * around a unary *s (expect 10): %v\n" r2)
 
+// --- test 3b: they also compose WITHOUT parens, as long as the two *
+// characters aren't lexically adjacent (see test 5) -- this is the case
+// the unary role's priority (71, one above binary mpy's 70) exists for:
+// at an exact tie, the parser can't settle which role a bare "*" token
+// plays before both are on the stack, and mis-emits the binary op before
+// its right operand is read. One point of separation is enough. ---
+s2b=$$(5 6 7)
+r2b=2 * *s2b
+ok=ok&&(r2b==10)
+print("3b 2 * *s2b -- same as test 3 but unparenthesized (expect 10): %v\n" r2b)
+
 // --- test 4: optable(:table) shows both roles as genuinely separate
 // entries under the same operator string, not one overwriting the other ---
 t=optable(:table)
@@ -84,7 +95,7 @@ r4=5*6
 ok=ok&&(r4==30)
 print("6b binary * still works with the prefix role deleted (expect 30): %v\n" r4)
 
-optable("*" "next" :insert :prefix :rtol :pri 70)
+optable("*" "next" :insert :prefix :rtol :pri 71)
 errmsg(:clear)
 p=postfix(*s3)
 ok=ok&&(index(p "next")!=nil)

--- a/src/comterp_/tests/stream-literal.comt
+++ b/src/comterp_/tests/stream-literal.comt
@@ -1,14 +1,15 @@
-// stream-literal.comt version 5
-print("stream-literal.comt version 5\n")
+// stream-literal.comt version 6
+print("stream-literal.comt version 6\n")
 
 // src/comterp_/tests/stream-literal.comt -- stream literal syntax tests
 //
-// coverage: 19 tests of stream literal feature
+// coverage: 22 tests of stream literal feature
 // funcs: postfix() errmsg() index() next() list() each() size() class() trace()
 // tests 1-8:   parser tests (postfix inspection)
 // tests 9-14:  stream literal runtime behavior
 // tests 15-18: stream-of-streams construction, zip behavior, mixed elements
 // test 19:     empty bracket literal []
+// tests 20-22: unary-prefix-operator-led elements (*x, -x, ...)
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/stream-literal.comt")
@@ -275,6 +276,85 @@ r19=next(s19)
 ok19=ok19&&(r19==nil)
 ok=ok&&ok19
 print("19 s=[]; next(s) -- empty stream literal (expect no error, StreamType, nil): %v %v\n" class(s19) r19)
+prev_ok=check_fail(:ok ok)
+
+// =========================================================
+// PART 5: unary-prefix-operator-led elements
+// =========================================================
+
+// --- test 20: unary-prefix operator (*) leading every element ---
+// (*s *s *s *s) -- BEFORE fix: "Unexpected operator (*)".  A bare paren
+// doesn't know it's a stream literal (as opposed to a plain grouping or
+// pending call) until the first element-boundary check fires, at which
+// point it "slips in" stream_symid as its comm_id.  That slip-in was
+// only implemented for literal- and identifier-led elements
+// (ComUtil/_parser.c's TOK_COMMAND/default cases), not for operator-led
+// ones (TOK_OPERATOR case) -- so whichever element is the first to need
+// that check, if it's operator-led, the paren never gets marked as a
+// stream literal, and the error fires right there.
+// AFTER fix: parses like any other stream literal; *s (next(s), see
+// starnext.comt) is evaluated once per element, in source order.
+errmsg(:clear)
+s20=(0 1 2 3 4 5 6 7)
+ss20=(*s20 *s20 *s20 *s20)
+e20=errmsg(:last)
+ok20=(e20==nil)
+r20a=next(ss20)
+ok20=ok20&&(r20a==0)
+r20b=next(ss20)
+ok20=ok20&&(r20b==1)
+r20c=next(ss20)
+ok20=ok20&&(r20c==2)
+r20d=next(ss20)
+ok20=ok20&&(r20d==3)
+r20e=next(ss20)
+ok20=ok20&&(r20e==nil)
+ok=ok&&ok20
+print("20 (*s *s *s *s) -- unary-prefix * leads every element (expect no error, 0 1 2 3 nil): %v %v %v %v %v\n" r20a r20b r20c r20d r20e)
+prev_ok=check_fail(:ok ok)
+
+// --- test 21: unary minus (-) leading every element -- same fix, a
+// different, much older operator, confirming this isn't specific to *.
+errmsg(:clear)
+n21=42
+ss21=(-n21 -n21 -n21)
+e21=errmsg(:last)
+ok21=(e21==nil)
+r21a=next(ss21)
+ok21=ok21&&(r21a==-42)
+r21b=next(ss21)
+ok21=ok21&&(r21b==-42)
+r21c=next(ss21)
+ok21=ok21&&(r21c==-42)
+r21d=next(ss21)
+ok21=ok21&&(r21d==nil)
+ok=ok&&ok21
+print("21 (-n -n -n) -- unary minus leads every element (expect no error, -42 -42 -42 nil): %v %v %v %v\n" r21a r21b r21c r21d)
+prev_ok=check_fail(:ok ok)
+
+// --- test 22: mixed leading token kinds in one literal -- a plain
+// literal, a plain identifier, an operator-led element, and another
+// operator-led element (a different operator) all in source order,
+// confirming they interoperate regardless of which one happens to be
+// first to trip the stream-literal auto-detection.
+errmsg(:clear)
+m22=9
+s22b=(100 200)
+ss22=(1 m22 -m22 *s22b)
+e22=errmsg(:last)
+ok22=(e22==nil)
+r22a=next(ss22)
+ok22=ok22&&(r22a==1)
+r22b=next(ss22)
+ok22=ok22&&(r22b==9)
+r22c=next(ss22)
+ok22=ok22&&(r22c==-9)
+r22d=next(ss22)
+ok22=ok22&&(r22d==100)
+r22e=next(ss22)
+ok22=ok22&&(r22e==nil)
+ok=ok&&ok22
+print("22 (1 m -m *s2) -- literal, identifier, and two different operator-led elements in one literal (expect no error, 1 9 -9 100 nil): %v %v %v %v %v\n" r22a r22b r22c r22d r22e)
 prev_ok=check_fail(:ok ok)
 
 print("stream-literal: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "cd7955d5"
+#define PATCH_KEY "8e81210b"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -124,6 +124,7 @@ Print a usage summary of all the invocation modes above and exit.
     **         repeat         90          L-to-R      binary
     ..         iterate        80          L-to-R      binary
     %%         replay         79          L-to-R      binary
+    *          next           71          R-to-L      unary-prefix
     %          mod            70          L-to-R      binary
     *          mpy            70          L-to-R      binary
     /          div            70          L-to-R      binary
@@ -240,6 +241,7 @@ Print a usage summary of all the invocation modes above and exit.
  strm=stream(strm|lst|attrlst|val|fileobj|pipeobj) -- copy stream or convert list (unary $)
 
  val=next(stream :skim) -- return next value from stream, don't recurse if :skim
+   (unary prefix *: *strm is next(strm))
 
  cnt=each(strm) -- traverse stream returning its length
 


### PR DESCRIPTION
## Summary

Adds unary prefix `*` as sugar for `next()`, permanently, in every comterp
binary (comterp_, comdraw, drawserv, etc.) -- `*s` now means `next(s)`.

The entire implementation is one line in `ComUtil/optable.c`'s
`DefaultOperatorTable[]`: `"*"` mapped to the existing `next` command,
unary-prefix, RtoL, priority 70 -- the same priority level as binary `*`
(`mpy`), and the same dual-role pattern the table already uses for unary
`-` (`minus`) vs. binary `-` (`sub`). No new C++ machinery; `next()` and
the operator table already did all the work.

This also doubles as a demonstration of the operator table's live
reprogrammability as a real language feature -- see the round-trip test
below and the writeup in `doc/LANGUAGE.md`.

## Details

- `src/ComUtil/optable.c`: new `DefaultOperatorTable[]` entry for unary
  prefix `*` -> `next`, priority 70, alongside the existing binary `*`.
- `doc/LANGUAGE.md`: documents the new operator in the precedence table,
  the streaming-operators table, and a worked example (including the
  lexical caveat below).
- `src/comterp_/tests/starnext.comt` (new): `*s` walks a stream the same
  as repeated `next(s)` calls, including exhaustion to `nil`; binary `*`
  is unaffected; the two roles compose (`2*(*s)`); `optable(:table)`
  lists both roles as separate entries; the one real lexical caveat --
  `**` is already the higher-priority stream-repeat operator, so an
  unspaced `2**s` lexes as `2 ** s` (repeat), not `2 * (*s)`; and an
  `optable(:delete)`/`optable(:insert)` round-trip proving this operator
  isn't special-cased -- any script could bind its own symbol to any
  command the same way.
- `src/comterp_/tests/run_all.comt`: registers `starnext.comt` in the
  suite.
- `src/include/ivstd/patch.h`: bumped `PATCH_KEY` per convention.

## Test plan

- [x] Rebuilt ComUtil -> ComTerp -> comterp_, confirmed `*s` works as a
      permanent built-in with no `optable(:insert)` needed
- [x] `src/comterp_/tests/starnext.comt` passes standalone (all 6
      sub-checks, `starnext: true`)
- [x] Full `src/comterp_/tests/run_all.comt` suite passes with the new
      test registered, no regressions