### PR TITLE
DotFunc: lhs of a list and rhs of a numeric invokes at() (#318)

### DIFF
--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -55,9 +55,22 @@ void AssignFunc::execute() {
     
     if (operand1.type() != ComValue::SymbolType) {
         // if lhs is a global() or local() call, set lhs_assign flag on its
-        // ComValue so the scope command can distinguish lhs from rhs context
+        // ComValue so the scope command can distinguish lhs from rhs context.
+        // Same for a dot expression (lst.N=val, #318) -- DotFunc checks its
+        // own lhs_assign() (confirmed live: startval here is CommandType
+        // funcname=dot for any X.Y=val shape) to tell "l.0" apart from an
+        // ordinary read, and -- for a plain-list before-part with a numeric
+        // rhs specifically -- hands back a [list, idx] pair instead of
+        // performing a read, so this function can perform the write
+        // itself below (see that branch for why a pair, not a spare
+        // ComValue field).  Harmless no-op for every other dot shape
+        // (al.b=val already works via the Attribute branch below and
+        // never consults this flag; al.N=val is deliberately excluded by
+        // DotFunc too --
+        // a numeric attrlist walk is read-only reflection, not an address).
         static int global_symid = symbol_add("global");
         static int local_symid = symbol_add("local");
+        static int dot_symid = symbol_add("dot");
         ComValue argoff(comterp()->stack_top());
         int offtop = argoff.int_val() - comterp()->pfnum();
         int arg0top = offtop;
@@ -67,7 +80,8 @@ void AssignFunc::execute() {
         ComValue& startval = comterp()->pfcomvals()[startidx];
         if (startval.is_type(ComValue::CommandType)) {
             ComFunc* func = (ComFunc*)startval.obj_val();
-            if (func->funcid() == global_symid || func->funcid() == local_symid)
+            if (func->funcid() == global_symid || func->funcid() == local_symid ||
+                func->funcid() == dot_symid)
                 startval.lhs_assign(1);
         }
         operand1 = stack_arg_post_eval(0, true /* no symbol or attribute lookup */);
@@ -125,6 +139,36 @@ void AssignFunc::execute() {
     } else if (operand1.is_object(Attribute::class_symid())) {
       Attribute* attr = (Attribute*)operand1.obj_val();
       attr->Value(operand2);
+    } else if (operand1.is_array() && operand1.lhs_assign()) {
+      /* #318 write: lst.N=val.  DotFunc, seeing its own lhs_assign() flag
+	 set (above) and a plain-list before-part with a numeric rhs,
+	 doesn't perform a read -- it hands back a tiny 2-element
+	 [list, idx] ArrayValueList (lhs_assign() still set, so this
+	 branch can tell it apart from an ordinary array-valued read
+	 reaching here some other way) instead of stashing the index in a
+	 spare ComValue field -- nids() was tried first and confirmed live
+	 NOT to survive the round trip for an ArrayType value. A plain
+	 list has no per-element Attribute the way a named attrlist key
+	 does (the branch just above), so there's nothing to write through
+	 directly.
+
+	 Mutating via AttributeValueList::Set() directly -- the exact call
+	 ListAtFunc's own :set branch makes internally (listfunc.c) --
+	 rather than driving ListAtFunc's exec() with a manually-built
+	 :set keyword pair from here: confirmed live that a keyword pushed
+	 the normal way (value, then its KeywordType marker on top, two
+	 physical stack slots) doesn't round-trip cleanly through a
+	 manually-invoked exec() -- ListAtFunc's own reset_stack() decrements
+	 by nargs()+nkeys() as a plain *count* (2+1=3), one short of the 4
+	 slots actually pushed, leaving a stray value that corrupted the
+	 stack for every statement after.  Calling the same underlying
+	 mutation directly sidesteps that keyword-accounting mismatch
+	 entirely -- same effect, no exec() stack-balance risk. */
+      AttributeValueList* pair = operand1.array_val();
+      AttributeValueList* avl = pair->Get(0)->array_val();
+      int idx = pair->Get(1)->int_val();
+      AttributeValue* oldv = avl->Set(idx, new AttributeValue(*operand2));
+      delete oldv;
     } else {
         cout << "WARNING:  assignment to something other than a symbol or attribute (" <<
           symbol_pntr(operand1.type_symid()) << ") ignored -- line " << funcstate()->linenum() << "\n";

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -34,6 +34,11 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
+#include <cstdio>
 
 #define TITLE "DotFunc"
 
@@ -321,6 +326,142 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
   self->push_stack(result);
 }
 
+/* #318: resolve before_part (a symbol, Attribute, or already-resolved
+   value) to the array/attrlist it names, read-only -- the same lookup
+   the integer-index path and the split-decimal-index path below both
+   need, factored out so neither has to duplicate it.  Never vivifies:
+   a bare-symbol lookup here uses AttributeList::find()/table find(),
+   not the insert-a-fresh-attrlist path plain dot-assignment falls back
+   to for a non-list value (dotfunc.c's execute_core, further down). */
+static boolean resolve_dotted_list(ComTerp* comterp, ComValue& before_part, ComValue& listv) {
+  if (before_part.is_array() || before_part.is_attributelist()) {
+    listv = before_part;
+    return true;
+  } else if (before_part.is_attribute()) {
+    AttributeValue* av = ((Attribute*)before_part.obj_val())->Value();
+    if (av->is_array() || av->is_attributelist()) {
+      listv = *av;
+      return true;
+    }
+  } else if (before_part.is_symbol()) {
+    int before_symid = before_part.symbol_val();
+    boolean global = before_part.global_flag();
+    AttributeList* funcscope = !global ? comterp->get_attributes() : nil;
+    AttributeValue* curval = funcscope ? funcscope->find(before_symid) : nil;
+    if (!curval) {
+      void* vptr = nil;
+      if (!global) {
+	comterp->localtable()->find(vptr, before_symid);
+	if (!vptr) comterp->globaltable()->find(vptr, before_symid);
+      } else {
+	comterp->globaltable()->find(vptr, before_symid);
+      }
+      if (vptr) curval = (ComValue*) vptr;
+    }
+    if (curval && (curval->is_array() || curval->is_attributelist())) {
+      listv = *curval;
+      return true;
+    }
+  }
+  return false;
+}
+
+/* #318: one level of read-only lst.N / al.N indexing -- for a plain
+   list, the same at() call the ordinary integer-rhs path below makes;
+   for an attrlist, the same detached-singleton construction (never the
+   live internal Attribute*, see the ordinary path's own comment on why:
+   a numeric position is reflection, not a stable write address).
+   Shared so the split-decimal-index path below can apply it twice
+   without duplicating either case. */
+static ComValue read_list_index_once(ComTerp* comterp, ComValue& listv, int idx) {
+  if (listv.is_array()) {
+    ComValue listcopy(listv);
+    ComValue idxv(idx, ComValue::IntType);
+    comterp->push_stack(listcopy);
+    comterp->push_stack(idxv);
+    ListAtFunc atf(comterp);
+    atf.exec(2, 0);
+    return comterp->pop_stack();
+  } else if (listv.is_attributelist()) {
+    AttributeList* al = (AttributeList*) listv.obj_val();
+    if (al && idx < al->Number()) {
+      int count = 0;
+      Iterator it;
+      for (al->First(it); !al->Done(it); al->Next(it)) {
+	if (count==idx) {
+	  Attribute* found = al->GetAttr(it);
+	  AttributeList* singleton = new AttributeList();
+	  singleton->add_attr(found->SymbolId(), *found->Value());
+	  return ComValue(AttributeList::class_symid(), (void*) singleton);
+	}
+	count++;
+      }
+    }
+  }
+  return ComValue::blankval();
+}
+
+/* #318: lst.0.1 and lst.0.1.2 tokenize with "0.1" merged into a single
+   DOUBLE token (ComUtil/_lexscan.c: a decimal point encountered while
+   already scanning digits always continues the token into a float --
+   there is no way to tell "0.1" apart from "0" DOT "1" at the lexer,
+   and postfix_token only ever stores the parsed value, never the
+   source text, so there's nothing to recover downstream either).
+
+   Formats with %.9f (always fixed notation, never scientific, always
+   has a decimal point) rather than %g: %g's shortest-round-trip
+   behavior collapses a whole-valued double like 1.0 to the bare text
+   "1" -- no decimal point at all -- which would wrongly reject
+   lst.1.0.2 (a real 3-deep chain: index 1, then index 0, then index
+   2) as not looking like int.frac in the first place. Trailing zeros
+   are stripped back off (keeping at least one digit) after formatting
+   to recover "1" from "1.000000000", "34" from "0.340000000", etc.
+
+   Requires a nonzero fractional part. This is a real, deliberate
+   restriction, not just a simplification: 1e0 and 1.0 are the exact
+   same double once parsed (scientific notation is a source-text
+   distinction lost before this ever runs, same loss as the
+   digit-count one below), so there is no way to accept "lst.1.0" as
+   a legitimate 0-index chain step while also rejecting "lst.1e0" as
+   requested -- they are literally the same bits. Requiring frac!=0
+   resolves that the only way available: any whole-valued double,
+   however it was written, is rejected outright rather than guessed
+   at. lst.1.0.2 as a chain needs a different spelling (e.g. explicit
+   at() calls) as a result -- a known, accepted trade-off, not an
+   oversight.
+
+   Beyond that: a fractional part that isn't clearly two short digit
+   groups (scientific notation; negative; anything that doesn't
+   reconstruct to the original value) is rejected outright rather than
+   guessed at -- this recovers the common "chained single-digit
+   indices" case, not a general float-as-index feature, and it can't
+   be more than that: how many digits followed the decimal point is
+   information already lost by the time this runs (0.1 and 0.10 are
+   the identical double), so index 10 can never be reliably
+   distinguished from index 1 this way -- out of scope, same as at()'s
+   own integer-only contract. */
+static boolean split_decimal_index(double v, int& intpart, int& fracpart) {
+  if (v < 0) return false;
+  if (v >= 1e9) return false;
+  char buf[64];
+  snprintf(buf, sizeof(buf), "%.9f", v);
+  char* dot = strchr(buf, '.');
+  if (!dot) return false;
+  *dot = '\0';
+  const char* intstr = buf;
+  char* fracstr = dot + 1;
+  int fraclen = (int)strlen(fracstr);
+  while (fraclen > 1 && fracstr[fraclen-1] == '0') fracstr[--fraclen] = '\0';
+  if (!*intstr || !*fracstr) return false;
+  for (const char* p = intstr; *p; p++) if (!isdigit((unsigned char)*p)) return false;
+  for (const char* p = fracstr; *p; p++) if (!isdigit((unsigned char)*p)) return false;
+  intpart = atoi(intstr);
+  fracpart = atoi(fracstr);
+  if (fracpart == 0) return false;
+  double recon = intpart + fracpart / pow(10.0, (double)strlen(fracstr));
+  return fabs(recon - v) < 1e-6;
+}
+
 void DotFunc::peek_and_fire(ComValue& before_part, ComValue& after_raw, int& after_nids,
 			     std::string& before_expr_text, std::string& after_expr_text) {
     /* Grab the raw, unfired source text of both args for the warnings
@@ -393,39 +534,18 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
        always unary minus applied to 1, so after_raw arrives as an
        unevaluated CommandType reference to "minus", not IntType) --
        this check is belt-and-suspenders against that changing, not
-       covering a case observed in practice. */
-    if (after_raw.is_num() && after_raw.int_val()>=0) {
+       covering a case observed in practice.
+
+       is_integer(), not is_num(): a floating-point rhs is never a
+       valid single index (only positive integers are) -- handled
+       separately below via split_decimal_index() instead, since
+       lst.0.1 tokenizes with "0.1" merged into one DOUBLE token (see
+       that function's own comment) and silently truncating it here
+       (int_val() on 0.1 would give 0) would be wrong, not just
+       imprecise. */
+    if (after_raw.is_integer() && after_raw.int_val()>=0) {
       ComValue listv;
-      boolean have_list = false;
-      if (before_part.is_array() || before_part.is_attributelist()) {
-	listv = before_part;
-	have_list = true;
-      } else if (before_part.is_attribute()) {
-	AttributeValue* av = ((Attribute*)before_part.obj_val())->Value();
-	if (av->is_array() || av->is_attributelist()) {
-	  listv = *av;
-	  have_list = true;
-	}
-      } else if (before_part.is_symbol()) {
-	int before_symid = before_part.symbol_val();
-	boolean global = before_part.global_flag();
-	AttributeList* funcscope = !global ? comterp()->get_attributes() : nil;
-	AttributeValue* curval = funcscope ? funcscope->find(before_symid) : nil;
-	if (!curval) {
-	  void* vptr = nil;
-	  if (!global) {
-	    comterp()->localtable()->find(vptr, before_symid);
-	    if (!vptr) comterp()->globaltable()->find(vptr, before_symid);
-	  } else {
-	    comterp()->globaltable()->find(vptr, before_symid);
-	  }
-	  if (vptr) curval = (ComValue*) vptr;
-	}
-	if (curval && (curval->is_array() || curval->is_attributelist())) {
-	  listv = *curval;
-	  have_list = true;
-	}
-      }
+      boolean have_list = resolve_dotted_list(comterp(), before_part, listv);
       if (have_list && listv.is_array()) {
 	/* lhs_assign() is set by AssignFunc (assignfunc.c) on this dot
 	   command's own token whenever it starts a "something.something"
@@ -513,6 +633,47 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	  push_stack(ComValue::blankval());
 	return;
       }
+    } else if (after_raw.is_floatingpoint()) {
+      /* lst.0.1 / lst.0.1.2 -- see split_decimal_index()'s own comment
+	 for why this is needed at all.  Read-only, like the plain
+	 AttributeList case above: no lhs_assign() handling here, so
+	 lst.0.1=val falls through to the ordinary "not a symbol or
+	 attribute" warning rather than attempting a chained write --
+	 out of scope for this recovery, which exists for indexing, not
+	 assignment.
+
+	 Rejection (1e0; a value that doesn't reconstruct cleanly) is
+	 handled explicitly here rather than by falling through to the
+	 generic checks further down -- confirmed live that falling
+	 through hits the exact same pre-existing trap the integer path
+	 above was already written to avoid (its own "is_integer(), not
+	 is_num()" comment): a bare numeric rhs has nids==0, not the -1
+	 the malformed-rhs check below is gated on, so it silently skips
+	 that check and reaches fire_attrlist_method instead, producing
+	 a nonsense "\"<garbage>\" is not a func-valued attribute"
+	 warning -- and, worse, left stack residue that corrupted every
+	 statement after it in the same script (confirmed live: a
+	 correctly-working lst.1 on the very next line printed blank
+	 until this was fixed). */
+      int intpart, fracpart;
+      ComValue listv;
+      if (split_decimal_index(after_raw.double_val(), intpart, fracpart) &&
+	  resolve_dotted_list(comterp(), before_part, listv)) {
+	ComValue mid = read_list_index_once(comterp(), listv, intpart);
+	ComValue result = (mid.is_array() || mid.is_attributelist())
+	  ? read_list_index_once(comterp(), mid, fracpart)
+	  : ComValue::blankval();
+	reset_stack();
+	push_stack(result);
+	return;
+      }
+      cout << "WARNING: expression after \".\" is not a valid list index ("
+	   << after_raw.double_val() << ") -- only positive integers, or "
+	      "chained ones merged by a decimal point (lst.0.1), are -- line "
+	   << funcstate()->linenum() << "\n";
+      reset_stack();
+      push_stack(ComValue::nullval());
+      return;
     }
 
     if (!before_part.is_symbol() &&

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -426,12 +426,91 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	  have_list = true;
 	}
       }
-      if (have_list) {
+      if (have_list && listv.is_array()) {
+	/* lhs_assign() is set by AssignFunc (assignfunc.c) on this dot
+	   command's own token whenever it starts a "something.something"
+	   assignment lhs -- checked the same way GlobalFunc/LocalFunc
+	   already do (symbolfunc.c) -- before this evaluation's own
+	   reset_stack().  For lst.N=val on a plain list, don't read at
+	   all: hand back the list plus the target index so AssignFunc can
+	   build and fire at(list idx :set val) itself -- a plain list has
+	   no per-element Attribute the way a named attrlist key does, so
+	   there's nothing here to return that the existing
+	   Attribute-write-through path could use directly (#318).
+
+	   Offset is nkeys()+1, not nargs()+nkeys() the way symbolfunc.c's
+	   GlobalFunc/LocalFunc check it -- confirmed live (dumping
+	   stack_top(0..5) for lst.N=val): that formula only coincidentally
+	   matches nkeys()+1 for a 1-positional-arg command; dot has 2
+	   (before, after), and its own flagged token sits at stack_top(1)
+	   regardless, not stack_top(nargs()+nkeys())=stack_top(2).
+
+	   The list+index pair travels as a tiny 2-element ArrayValueList
+	   [list, idx], not stashed in a spare ComValue field (nids() was
+	   tried first: confirmed live that it does NOT survive the round
+	   trip -- something along the push/copy path recomputes it for an
+	   ArrayType value, so AssignFunc saw a stale/unrelated number, not
+	   the index this pushed). Reusing AttributeValueList's own,
+	   already-safe element storage avoids that -- no custom field
+	   semantics to fight, and no ownership hazard either: aliasing the
+	   array's own internal AttributeValue* (e.g. via avl->Get(idx),
+	   wrapped in a throwaway Attribute for the existing write-through
+	   branch to use) was the other option considered and rejected --
+	   Attribute owns and deletes its Value() on destruction, and so
+	   does the array itself, a double-free waiting to happen. */
+	boolean assign_lhs = comterp()->stack_top(nkeys()+1).lhs_assign();
+	if (assign_lhs) {
+	  reset_stack();
+	  AttributeValueList* pair = new AttributeValueList();
+	  pair->Append(new AttributeValue(listv));
+	  pair->Append(new AttributeValue(after_raw.int_val(), AttributeValue::IntType));
+	  ComValue retval(pair);
+	  retval.lhs_assign(1);
+	  push_stack(retval);
+	  return;
+	}
 	reset_stack();
 	push_stack(listv);
 	push_stack(after_raw);
 	ListAtFunc atf(comterp());
 	atf.exec(2, 0);
+	return;
+      } else if (have_list) {
+	/* AttributeList: a numeric position is reflection/inspection only
+	   -- "the indexed tour of an attrlist will be by attrlist
+	   singletons" -- never a stable write address, so this always
+	   returns a fresh, detached one-entry AttributeList copy rather
+	   than ListAtFunc's own live Attribute* reference into the
+	   original (which -- confirmed live -- would otherwise let
+	   al.1=val silently overwrite whatever attribute happens to sit
+	   at position 1 today, e.g. :b, purely by position; positions
+	   shift as attributes are added/removed, so that's not an
+	   address worth honoring as an lvalue). Same outcome whether or
+	   not lhs_assign() is set: al.1=val falls through to the
+	   ordinary "not a symbol or attribute" warning, same as any
+	   other non-writable rhs. */
+	AttributeList* al = (AttributeList*) listv.obj_val();
+	int nvv = after_raw.int_val();
+	AttributeList* singleton = nil;
+	if (al && nvv < al->Number()) {
+	  int count = 0;
+	  Iterator it;
+	  for (al->First(it); !al->Done(it); al->Next(it)) {
+	    if (count==nvv) {
+	      Attribute* found = al->GetAttr(it);
+	      singleton = new AttributeList();
+	      singleton->add_attr(found->SymbolId(), *found->Value());
+	      break;
+	    }
+	    count++;
+	  }
+	}
+	reset_stack();
+	if (singleton) {
+	  ComValue retval(AttributeList::class_symid(), (void*) singleton);
+	  push_stack(retval);
+	} else
+	  push_stack(ComValue::blankval());
 	return;
       }
     }

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -28,6 +28,7 @@
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/postfunc.h>
 #include <ComTerp/boolfunc.h>
+#include <ComTerp/listfunc.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attribute.h>
 #include <iostream>
@@ -357,6 +358,84 @@ void DotFunc::peek_and_fire(ComValue& before_part, ComValue& after_raw, int& aft
 
 void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_nids,
 			    const std::string& before_expr_text, const std::string& after_expr_text) {
+    /* #318: lst.N / al.N -- a numeric rhs on a list or attrlist is sugar
+       for at(lst N), read-only.  Checked first, ahead of both the ordinary
+       validation below (which would otherwise reject a numeric rhs
+       outright -- see the "needs to be a symbol" warning further down)
+       and the symbol/attribute lookup that follows it, which -- for a
+       bare symbol or attribute currently holding a plain list rather than
+       an AttributeList -- destructively replaces that value with a fresh
+       empty AttributeList (the existing auto-vivify behavior dot-
+       assignment relies on, e.g. `x.foo=1` on an unset `x`; wrong here,
+       since `lst.3` must read `lst`'s existing list, not blow it away).
+       Peeking at a symbol's or attribute's current value this way is
+       read-only (AttributeList::find, not insert), so nothing is created
+       or mutated when this doesn't match and falls through to the
+       existing logic below.
+
+       Deliberately not gated on after_nids==-1 the way the malformed-rhs
+       check further down is: nids defaults to 0 (zero_vals()) for a bare
+       numeric literal rather than the -1 a plain symbol token carries, so
+       that guard would silently exclude every numeric rhs and fall
+       through into the arglist-attached path below with a numeric token
+       standing in for a method name -- confirmed live, produced
+       nonsense "\"<garbage>\" is not a func-valued attribute" warnings.
+       A numeric literal can never have an arglist attached in valid
+       syntax regardless of what nids happens to hold, so is_num() alone
+       is the correct and sufficient guard here.
+
+       Positive/zero only, matching at()'s own limit (ListAtFunc::execute,
+       listfunc.c, requires nv.int_val()>=0 for the ArrayType case) --
+       negative indexing isn't a thing this sugar adds on top of at(),
+       just what at() itself already supports.  In practice a literal
+       negative rhs (lst.-1) never reaches here as a single numeric
+       token anyway (the lexer has no negative-literal token; "-1" is
+       always unary minus applied to 1, so after_raw arrives as an
+       unevaluated CommandType reference to "minus", not IntType) --
+       this check is belt-and-suspenders against that changing, not
+       covering a case observed in practice. */
+    if (after_raw.is_num() && after_raw.int_val()>=0) {
+      ComValue listv;
+      boolean have_list = false;
+      if (before_part.is_array() || before_part.is_attributelist()) {
+	listv = before_part;
+	have_list = true;
+      } else if (before_part.is_attribute()) {
+	AttributeValue* av = ((Attribute*)before_part.obj_val())->Value();
+	if (av->is_array() || av->is_attributelist()) {
+	  listv = *av;
+	  have_list = true;
+	}
+      } else if (before_part.is_symbol()) {
+	int before_symid = before_part.symbol_val();
+	boolean global = before_part.global_flag();
+	AttributeList* funcscope = !global ? comterp()->get_attributes() : nil;
+	AttributeValue* curval = funcscope ? funcscope->find(before_symid) : nil;
+	if (!curval) {
+	  void* vptr = nil;
+	  if (!global) {
+	    comterp()->localtable()->find(vptr, before_symid);
+	    if (!vptr) comterp()->globaltable()->find(vptr, before_symid);
+	  } else {
+	    comterp()->globaltable()->find(vptr, before_symid);
+	  }
+	  if (vptr) curval = (ComValue*) vptr;
+	}
+	if (curval && (curval->is_array() || curval->is_attributelist())) {
+	  listv = *curval;
+	  have_list = true;
+	}
+      }
+      if (have_list) {
+	reset_stack();
+	push_stack(listv);
+	push_stack(after_raw);
+	ListAtFunc atf(comterp());
+	atf.exec(2, 0);
+	return;
+      }
+    }
+
     if (!before_part.is_symbol() &&
 	!(before_part.is_attribute() &&
 	  (((Attribute*)before_part.obj_val())->Value()->is_unknown() ||

--- a/src/ComUtil/_lexscan.c
+++ b/src/ComUtil/_lexscan.c
@@ -797,10 +797,20 @@ token_return:
 /* Append null-byte to finish the token */
    TOKEN_ADD( '\0' );
 
-/* Check to make sure a constant is not butted up against another */
+/* Check to make sure a constant is not butted up against another.  The
+   dot case mirrors the start-of-token float-vs-operator check above
+   (~line 445-446): '.' immediately followed by a digit only reads as
+   the start of a float constant (".5") when it's NOT itself immediately
+   preceded by an identifier character -- when it is (lst.3), '.' is
+   unambiguously the dot operator, not glued to a second constant, so
+   flagging it here was overly conservative (#318: blocked lst.3/al.0 as
+   list-indexing sugar for at(lst 3), forcing a workaround space before
+   every numeric dot rhs even though the operator-vs-float scan just
+   above already resolves the identical ambiguity correctly). */
    if ( token_state != TOK_OPERATOR )
       if ( CURR_CHAR  == '"' ||  CURR_CHAR  == '\'' || isdigit( CURR_CHAR ) ||
-	 ( CURR_CHAR == '.' && isdigit( NEXT_CHAR )))
+	 ( CURR_CHAR == '.' && isdigit( NEXT_CHAR ) &&
+	   !isalpha( PREV_CHAR ) && !isdigit( PREV_CHAR )))
 	 return ERR_CONSTSEP;
 
    switch( token_state ) {   

--- a/src/comterp_/tests/dotindex.comt
+++ b/src/comterp_/tests/dotindex.comt
@@ -3,16 +3,16 @@
 // to a plain list (AttributeList stays read-only -- reflection, not an
 // address, see test 3).
 //
-// funcs: at() list() class() type() next() errmsg()
+// funcs: at() list() class() next() errmsg()
 // coverage: lst.N on a plain list, al.N as a positional walk of an
 //           attrlist, out-of-range, nested chains, existing symbolic
 //           dot access unaffected, non-numeric rhs left to existing
 //           (unrelated, pre-#318) behavior, lst.N=val write support,
-//           al.N=val confirmed to never mutate, and lst.symbolname=val
-//           on a plain list confirmed to auto-vivify it into an
-//           AttributeList (pre-existing dot-assignment behavior,
-//           unrelated to #318, locked in by test rather than left
-//           undocumented -- see #304's comment thread).
+//           and al.N=val confirmed to never mutate.  (lst.symbolname=
+//           val's auto-vivify-to-AttributeList behavior was tried as
+//           a test here and reverted -- not portable across DotFunc
+//           vs GrDotFunc, see the comment near the end of this file
+//           and #320.)
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/dotindex.comt")
@@ -129,28 +129,20 @@ ok=ok&&ok8
 print("8 al.1=999 -- must not mutate (expect al.y still 20): %v\n" al2.y)
 prev_ok=check_fail(:ok ok)
 
-// --- test 9: lst.symbolname=val on a plain list auto-vivifies the list
-// into an AttributeList -- pre-existing dot-assignment behavior (the
-// same convenience x.foo=1 relies on to turn an unset x into an
-// attrlist), unrelated to and unfixed by #318/#319, but worth locking
-// in explicitly here: it's what a plain list falls through to whenever
-// the rhs isn't numeric, so it's the concrete, tested answer to "what
-// happens if I write lst.foo=val instead of lst.3=val" -- the list's
-// original contents are gone, replaced by a fresh one-attribute
-// AttributeList.  Also confirms the rhs symbol is used as a literal
-// key, never dereferenced as a variable, even when a same-named
-// variable happens to hold a value (b=2 here has no bearing on what
-// "b" means as .b's rhs) -- see #304's comment thread for the live
-// transcript (lst.n after lst=(10,11,12,13)) that surfaced this. ---
-lst4=0,1,2,3
-ok9=(type(lst4)==`ListType)
-b=2
-lst4.b=20
-ok9=ok9&&(type(lst4)==`ObjectType)
-ok9=ok9&&(class(lst4)==`AttributeList)
-ok=ok&&ok9
-print("9 lst.b=20 (b a var holding 2, list before) -- auto-vivifies to AttributeList, b used as literal key (expect ListType->ObjectType/AttributeList): %v\n" ok9)
-prev_ok=check_fail(:ok ok)
+// Deliberately no runnable test for lst.symbolname=val's auto-vivify
+// behavior on a plain list (converts it to an AttributeList,
+// discarding the original contents -- confirmed live, matching the
+// same pre-existing convenience x.foo=1 relies on for an unset x):
+// tried as test 9, reverted (#319) once CI showed it isn't a portable
+// guarantee -- it holds for plain DotFunc (dotfunc.c, ComTerp) but
+// not for GrDotFunc (grdotfunc.c, ComUnidraw, used by comdraw/
+// drawserv), which eagerly calls lookup_symval() on a symbol
+// before-part before execute_core() ever runs, so before_part is
+// already resolved to the array value by the time the auto-vivify
+// path would normally trigger, landing on the "list of N items"
+// warning instead. Pre-existing DotFunc/GrDotFunc divergence,
+// unrelated to and unfixed by #318/#319 -- see #320 (which already
+// proposes replacing this whole mechanism) for the write-up.
 
 // Deliberately no runnable test for a literal negative rhs (lst.-1):
 // out of scope for #318, matching at()'s own limit (ListAtFunc::execute,

--- a/src/comterp_/tests/dotindex.comt
+++ b/src/comterp_/tests/dotindex.comt
@@ -3,12 +3,16 @@
 // to a plain list (AttributeList stays read-only -- reflection, not an
 // address, see test 3).
 //
-// funcs: at() list() class() next() errmsg()
+// funcs: at() list() class() type() next() errmsg()
 // coverage: lst.N on a plain list, al.N as a positional walk of an
 //           attrlist, out-of-range, nested chains, existing symbolic
 //           dot access unaffected, non-numeric rhs left to existing
 //           (unrelated, pre-#318) behavior, lst.N=val write support,
-//           and al.N=val confirmed to never mutate.
+//           al.N=val confirmed to never mutate, and lst.symbolname=val
+//           on a plain list confirmed to auto-vivify it into an
+//           AttributeList (pre-existing dot-assignment behavior,
+//           unrelated to #318, locked in by test rather than left
+//           undocumented -- see #304's comment thread).
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/dotindex.comt")
@@ -123,6 +127,29 @@ al2.1=999
 ok8=(al2.y==20)
 ok=ok&&ok8
 print("8 al.1=999 -- must not mutate (expect al.y still 20): %v\n" al2.y)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: lst.symbolname=val on a plain list auto-vivifies the list
+// into an AttributeList -- pre-existing dot-assignment behavior (the
+// same convenience x.foo=1 relies on to turn an unset x into an
+// attrlist), unrelated to and unfixed by #318/#319, but worth locking
+// in explicitly here: it's what a plain list falls through to whenever
+// the rhs isn't numeric, so it's the concrete, tested answer to "what
+// happens if I write lst.foo=val instead of lst.3=val" -- the list's
+// original contents are gone, replaced by a fresh one-attribute
+// AttributeList.  Also confirms the rhs symbol is used as a literal
+// key, never dereferenced as a variable, even when a same-named
+// variable happens to hold a value (b=2 here has no bearing on what
+// "b" means as .b's rhs) -- see #304's comment thread for the live
+// transcript (lst.n after lst=(10,11,12,13)) that surfaced this. ---
+lst4=0,1,2,3
+ok9=(type(lst4)==`ListType)
+b=2
+lst4.b=20
+ok9=ok9&&(type(lst4)==`ObjectType)
+ok9=ok9&&(class(lst4)==`AttributeList)
+ok=ok&&ok9
+print("9 lst.b=20 (b a var holding 2, list before) -- auto-vivifies to AttributeList, b used as literal key (expect ListType->ObjectType/AttributeList): %v\n" ok9)
 prev_ok=check_fail(:ok ok)
 
 // Deliberately no runnable test for a literal negative rhs (lst.-1):

--- a/src/comterp_/tests/dotindex.comt
+++ b/src/comterp_/tests/dotindex.comt
@@ -1,0 +1,99 @@
+// src/comterp_/tests/dotindex.comt -- #318: dot access with a numeric rhs
+// on a list or attrlist is sugar for at(), read-only.
+//
+// funcs: at() list() class() next() errmsg()
+// coverage: lst.N on a plain list, al.N as a positional walk of an
+//           attrlist, out-of-range, nested chains, existing symbolic
+//           dot access unaffected, and non-numeric/negative rhs left to
+//           existing (unrelated, pre-#318) behavior.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/dotindex.comt")
+
+errmsg(:clear)
+run("./testlib.comt")
+ok=true
+
+// --- test 1: lst.N reads the Nth element of a plain list, 0-indexed,
+// same as at(lst N) -- and the tight form (no space before the digit)
+// parses at all, which needed a scanner fix (ComUtil/_lexscan.c): the
+// dot-immediately-followed-by-digit ambiguity check ("Insufficient
+// separation from trailing constant", meant to catch a bare float like
+// ".5" glued onto a preceding token) now also consults whether that
+// preceding token ends in an identifier character -- if it does (lst),
+// "." is unambiguously the dot operator, not the start of a float. ---
+lst=list(10,20,30,40,50)
+r1=lst.0
+ok=ok&&(r1==10)
+r2=lst.3
+ok=ok&&(r2==40)
+r3=lst.4
+ok=ok&&(r3==50)
+print("1 lst.0 lst.3 lst.4 on list(10,20,30,40,50) (expect 10 40 50): %v %v %v\n" r1 r2 r3)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: out of range reads back blank, same as at()'s own
+// out-of-range behavior -- not an error. ---
+errmsg(:clear)
+r4=lst.9
+e2=errmsg(:last)
+ok2=(e2==nil)
+ok=ok&&ok2
+print("2 lst.9 out of range (expect no error): %v\n" e2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: al.N is a positional walk of an attrlist, same shape
+// at() already returns for AttributeList -- an Attribute-wrapped
+// dotted pair, the identical shape al.name (existing, symbolic dot
+// access) already returns, so both print and compare the same way. ---
+al=(:a 1 :b 2 :c 3)
+byname=al.b
+byindex=al.1
+ok3=(byname==byindex)
+ok=ok&&ok3
+print("3 al.b == al.1 -- attrlist positional walk matches symbolic access (expect true): %v (byname=%v byindex=%v)\n" ok3 byname byindex)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: existing symbolic dot access on an attrlist is completely
+// unaffected -- al.b still works exactly as before. ---
+r5=al.b
+ok=ok&&(r5==2)
+print("4 al.b unaffected by #318 (expect 2): %v\n" r5)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: nested dot chains compose -- obj.mylist.2 reads mylist's
+// index 2, the same as (obj.mylist).2 with explicit parens. ---
+obj=(:mylist list(7,8,9))
+r6=obj.mylist.2
+ok=ok&&(r6==9)
+print("5 obj.mylist.2 -- nested dot-chain composition (expect 9): %v\n" r6)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: a non-numeric rhs on a plain list is untouched by #318 --
+// still the pre-existing "expression before '.' is a list of N items"
+// warning path (is_num() is false for a bare symbol, so this new sugar
+// never engages; #318 only ever adds behavior for a numeric rhs, never
+// removes the existing warning for anything else). ---
+errmsg(:clear)
+lst2=list(1,2,3)
+r7=lst2.foo
+e6=errmsg(:last)
+print("6 lst.foo (non-numeric rhs, pre-#318 behavior unaffected): %v\n" r7)
+prev_ok=check_fail(:ok ok)
+
+// Deliberately no runnable test for a literal negative rhs (lst.-1):
+// out of scope for #318, matching at()'s own limit (ListAtFunc::execute,
+// listfunc.c, requires a non-negative index for the ArrayType case) --
+// this sugar doesn't add negative indexing on top of at(), just what
+// at() already supports. Exercising it live prints "not a func-valued
+// attribute"/"assignment to something other than a symbol" warnings
+// (confirmed: lst.-1 never reaches this sugar's at() call at all --
+// "-1" is unary minus applied to 1, two tokens, not a single negative
+// literal, so after_raw arrives as an unevaluated CommandType
+// reference to "minus", not IntType) -- harmless standalone, but those
+// warnings trip run()'s own nested pass/fail detection when this file
+// runs under run_all.comt, so it stays undocumented-by-test rather than
+// asserted here.
+
+print("dotindex: %v\n" ok)
+ok

--- a/src/comterp_/tests/dotindex.comt
+++ b/src/comterp_/tests/dotindex.comt
@@ -8,7 +8,11 @@
 //           attrlist, out-of-range, nested chains, existing symbolic
 //           dot access unaffected, non-numeric rhs left to existing
 //           (unrelated, pre-#318) behavior, lst.N=val write support,
-//           and al.N=val confirmed to never mutate.  (lst.symbolname=
+//           al.N=val confirmed to never mutate, lst.0.1 / lst.0.1.2
+//           (a chained integer index merged into one DOUBLE token by
+//           the scanner) recovered as 2/3-deep chained indexing, and
+//           lst.1e0 / lst.1.0 (the same double once parsed -- 1.0)
+//           rejected outright, only positive integers.  (lst.symbolname=
 //           val's auto-vivify-to-AttributeList behavior was tried as
 //           a test here and reverted -- not portable across DotFunc
 //           vs GrDotFunc, see the comment near the end of this file
@@ -157,6 +161,70 @@ prev_ok=check_fail(:ok ok)
 // warnings trip run()'s own nested pass/fail detection when this file
 // runs under run_all.comt, so it stays undocumented-by-test rather than
 // asserted here.
+
+// --- test 9: lst.0.1.2 -- a chained integer index the scanner merges
+// into one DOUBLE token (ComUtil/_lexscan.c: a decimal point mid-scan
+// always continues the current token into a float -- "0.1" and "0"
+// DOT "1" are lexically identical, and postfix_token only ever stores
+// the parsed value, never the source text, so there's nothing to
+// recover from downstream either).  DotFunc's split_decimal_index()
+// recovers this: when the double's fixed-notation text round-trips as
+// int.frac with a nonzero fractional part, it's treated as those two
+// digit groups chained, same as if "lst.0.1" had tokenized as two
+// separate dots.  Built bottom-up with single-level (integer) writes,
+// since list() flattens a list-valued positional argument instead of
+// nesting it (list(list(1,2,3),4) is {1,2,3,4}, not {{1,2,3},4} --
+// unrelated to #318, a pre-existing list() quirk worked around here
+// rather than exercised as its own test) and the split-decimal path
+// is deliberately read-only (see test 10). ---
+level9b=list(999,999,777)
+level9a=list(999,999,999)
+level9a.1=level9b
+lst9=list(999,20,30)
+lst9.0=level9a
+r9a=lst9.0.1.2
+ok9=(r9a==777)
+r9b=lst9.0.1
+ok9=ok9&&(r9b==level9b)
+ok=ok&&ok9
+print("9 lst.0.1.2 / lst.0.1 -- decimal-merged chained index (expect 777, then level9b): %v %v\n" r9a r9b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: lst.1e0 and lst.1.0 -- both parse to the identical
+// double 1.0 (scientific notation is a source-text distinction lost
+// before DotFunc ever sees the value), so split_decimal_index()
+// requires a nonzero fractional part specifically so both are rejected
+// the same way, rather than accepting "1.0" as index-1-then-index-0
+// while (unable to) rejecting "1e0" -- see that function's own
+// comment for why this is the only workable rule. Only positive
+// integers, or decimal-merged chains of them, are valid -- everything
+// else is explicitly rejected (a real warning, not silently truncated
+// the way a plain is_num() gate would have truncated 1.0/1e0 to index
+// 1) and, confirmed live, does not leave stack residue behind for
+// later statements in the same script (test 11 immediately follows,
+// unaffected). ---
+errmsg(:clear)
+r10a=lst9.1e0
+ok10=(r10a==nil)
+r10b=lst9.1.0
+ok10=ok10&&(r10b==nil)
+ok=ok&&ok10
+print("10 lst.1e0 / lst.1.0 -- both reject (expect nil nil): %v %v\n" r10a r10b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: an ordinary single-level integer read immediately after
+// test 10's rejections is unaffected -- confirms test 10's explicit
+// rejection path (dotfunc.c) properly resets the stack on every exit,
+// rather than relying on falling through to the generic malformed-dot
+// checks further down execute_core(), which -- confirmed live during
+// development -- mishandle a bare numeric rhs (nids==0, not the -1
+// the malformed-rhs check is gated on) by reaching
+// fire_attrlist_method instead, corrupting the stack for every
+// statement after. ---
+r11=lst9.1
+ok=ok&&(r11==20)
+print("11 lst.1 right after test 10's rejections -- no residue (expect 20): %v\n" r11)
+prev_ok=check_fail(:ok ok)
 
 print("dotindex: %v\n" ok)
 ok

--- a/src/comterp_/tests/dotindex.comt
+++ b/src/comterp_/tests/dotindex.comt
@@ -1,11 +1,14 @@
 // src/comterp_/tests/dotindex.comt -- #318: dot access with a numeric rhs
-// on a list or attrlist is sugar for at(), read-only.
+// on a list or attrlist is sugar for at(); lst.N=val also writes through
+// to a plain list (AttributeList stays read-only -- reflection, not an
+// address, see test 3).
 //
 // funcs: at() list() class() next() errmsg()
 // coverage: lst.N on a plain list, al.N as a positional walk of an
 //           attrlist, out-of-range, nested chains, existing symbolic
-//           dot access unaffected, and non-numeric/negative rhs left to
-//           existing (unrelated, pre-#318) behavior.
+//           dot access unaffected, non-numeric rhs left to existing
+//           (unrelated, pre-#318) behavior, lst.N=val write support,
+//           and al.N=val confirmed to never mutate.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/dotindex.comt")
@@ -42,16 +45,20 @@ ok=ok&&ok2
 print("2 lst.9 out of range (expect no error): %v\n" e2)
 prev_ok=check_fail(:ok ok)
 
-// --- test 3: al.N is a positional walk of an attrlist, same shape
-// at() already returns for AttributeList -- an Attribute-wrapped
-// dotted pair, the identical shape al.name (existing, symbolic dot
-// access) already returns, so both print and compare the same way. ---
+// --- test 3: al.N is a positional walk of an attrlist -- reflection
+// only, per design discussion: "the indexed tour of an attrlist will
+// be by attrlist singletons".  Returns a fresh, detached one-entry
+// AttributeList copy (:b 2), NOT the live internal Attribute* al.b
+// (symbolic access) returns -- so it reads the same key/value but is
+// never a write address (see the write-support tests below: al.N=val
+// must not silently overwrite whatever attribute happens to sit at
+// position N today, purely by position). ---
 al=(:a 1 :b 2 :c 3)
-byname=al.b
 byindex=al.1
-ok3=(byname==byindex)
+ok3=(class(byindex)==`AttributeList)
+ok3=ok3&&(byindex.b==2)
 ok=ok&&ok3
-print("3 al.b == al.1 -- attrlist positional walk matches symbolic access (expect true): %v (byname=%v byindex=%v)\n" ok3 byname byindex)
+print("3 al.1 -- detached singleton (:b 2), same key/value as al.b (expect true): %v (byindex=%v)\n" ok3 byindex)
 prev_ok=check_fail(:ok ok)
 
 // --- test 4: existing symbolic dot access on an attrlist is completely
@@ -79,6 +86,43 @@ lst2=list(1,2,3)
 r7=lst2.foo
 e6=errmsg(:last)
 print("6 lst.foo (non-numeric rhs, pre-#318 behavior unaffected): %v\n" r7)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: lst.N=val writes through to a plain list -- AssignFunc
+// (assignfunc.c), not DotFunc, performs the actual mutation: DotFunc
+// only resolves which list and index are in play (its existing
+// expertise, reused unchanged from the read path) and, seeing its own
+// lhs_assign() flag set, hands both back instead of reading; a plain
+// list has no per-element Attribute the way a named attrlist key does,
+// so there's nothing to write through the way al.b=val already does --
+// AssignFunc calls the same AttributeValueList::Set() at()'s own :set
+// keyword uses internally (listfunc.c), directly. ---
+lst3=list(10,20,30,40,50)
+r9=lst3.0=100
+ok7=(r9==100)
+ok7=ok7&&(lst3.0==100)
+ok7=ok7&&(lst3.3==40)
+ok=ok&&ok7
+print("7 lst.0=100 -- write support (expect 100, list[0]==100, list[3] untouched==40): %v %v %v\n" r9 lst3.0 lst3.3)
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: al.N=val is confirmed to never mutate -- position isn't
+// a stable write address for an attrlist (test 3's premise): writing
+// by position could silently clobber whichever key happens to sit
+// there today, which shifts as attributes are added/removed.  Checked
+// via a copy so a failure here doesn't corrupt state for later tests;
+// the attempt itself does print a warning (harmless, matches the
+// existing "not a symbol or attribute" path any other non-writable
+// dot rhs already hits) -- confirmed separately not to trip run()'s
+// nested pass/fail detection the way test 7's now-removed negative-rhs
+// probe did (that one hit a different, dot-parsing-level warning
+// before ever reaching AssignFunc; this one is the ordinary, already
+// print-safe assignment-target warning). ---
+al2=(:x 10 :y 20 :z 30)
+al2.1=999
+ok8=(al2.y==20)
+ok=ok&&ok8
+print("8 al.1=999 -- must not mutate (expect al.y still 20): %v\n" al2.y)
 prev_ok=check_fail(:ok ok)
 
 // Deliberately no runnable test for a literal negative rhs (lst.-1):

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -138,5 +138,9 @@ if(run("./bracket-brace-parity.comt")
   :then print("pass: bracket-brace-parity\n")
   :else print("FAIL: bracket-brace-parity\n");topok=false)
 
+if(run("./dotindex.comt")
+  :then print("pass: dotindex\n")
+  :else print("FAIL: dotindex\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "cd7955d5"
+#define PATCH_KEY "7a4a5028"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Closes #318.

## Summary

`lst.3` reads `at(lst 3)`; `al.1` walks an `AttributeList` positionally,
returning a fresh, detached one-entry `AttributeList` singleton (e.g.
`(:b 2)`) -- never the live internal `Attribute*` a named key returns,
since a numeric position isn't a stable address (it shifts as
attributes are added/removed; see "Write scope" below). The existing
warning at `dotfunc.c`'s `execute_core` -- `expression before "." is a
list of N items -- pick one with at(...) before dotting into it` --
had already named the read-side fix.

`lst.3=100` now also writes through to a plain list, mutating it in
place.

## Details

- `src/ComTerp/dotfunc.c`: new early check in `execute_core`, ahead of
  the ordinary dot validation/lookup -- both of which would otherwise
  misfire on a numeric rhs (the malformed-rhs check rejects anything
  that isn't a symbol/string; the symbol/attribute lookup destructively
  replaces a non-attrlist value with a fresh empty `AttributeList`, the
  existing auto-vivify behavior dot-assignment relies on, wrong here
  since `lst.3` must read `lst`'s existing list, not blow it away).
  Peeking a symbol's/attribute's current value is read-only, so nothing
  is created when this doesn't match and it falls through unchanged.
  For a write (`lhs_assign()` set by `AssignFunc`, see below), skips
  the read and hands back a `[list, idx]` pair instead.
- `src/ComTerp/assignfunc.c`: extends the existing `lhs_assign()`
  lvalue protocol (already used for `global()`/`local()`,
  `symbolfunc.c`) to also flag a dot expression's own command token.
  New branch performs the write via `AttributeValueList::Set()`
  directly -- the same call `at()`'s own `:set` keyword makes
  internally (`listfunc.c`) -- rather than driving `ListAtFunc`'s
  `exec()` with a manually-built keyword pair from C++ (tried first;
  confirmed live that doesn't round-trip cleanly through a manually-
  invoked `exec()`, corrupting the stack).
- `src/ComUtil/_lexscan.c`: companion scanner fix. The tight form
  (`lst.3`, no space) hit `"Insufficient separation from trailing
  constant"` -- a guard meant to catch a bare float like `.5` glued
  onto a preceding token, applied unconditionally to any
  `.`-then-digit sequence. The start-of-token scan just above it
  already resolves this exact ambiguity correctly (float only when
  *not* preceded by an identifier character); the trailing-separation
  check just never consulted that same signal. Mirrored it in.
- `src/comterp_/tests/dotindex.comt` (new): plain-list indexing,
  out-of-range, attrlist positional walk (detached singleton, not the
  live reference), nested dot-chain composition (`obj.mylist.2`),
  non-numeric rhs left untouched, `lst.N=val` write support, and
  `al.N=val` confirmed to never mutate.
- `src/comterp_/tests/run_all.comt`: registers `dotindex.comt`.
- `src/include/ivstd/patch.h`: bumped `PATCH_KEY` per convention.

## Write scope

`lst.N=val` writes to a plain list. `al.N=val` (an `AttributeList`
numeric position) is explicitly excluded -- confirmed live that
without this exclusion it silently succeeds via `ListAtFunc`'s own
live `Attribute*` reference, overwriting whatever key happens to sit
at that position today. A numeric attrlist walk is reflection/
inspection, not a stable write address; a named key (`al.b=val`,
already worked before this PR) is.

Negative indices are out of scope, matching `at()`'s own limit
(`ListAtFunc::execute` requires a non-negative index for the
`ArrayType` case) -- this sugar doesn't add negative indexing on top
of `at()`, just what `at()` already supports.

Lifting this over a `StreamType` before-part is a separate, already-
open concern -- see #304 (commented there with the connection).

## Test plan

- [x] `src/comterp_/tests/dotindex.comt` passes standalone and nested
      under `run_all.comt`
- [x] Full `run_all.comt` suite passes, no regressions
- [x] `comdraw` relinks clean against the updated `ComUtil`/`ComTerp`