### PR TITLE
An orphaned top-level stream auto-drains and shows its element count

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1393,6 +1393,21 @@ void ComTerp::quitflag(boolean flag) {
     _quitflag = flag;
 }
 
+ComValue ComTerp::orphan_stream_count(ComValue& streamv) {
+  ComValue sv(streamv);
+  int cnt = 0;
+  boolean done = false;
+  while (!done) {
+    NextFunc::execute_impl(this, sv, false);
+    ComValue popval(pop_stack());
+    if (popval.is_unknown() || StrmFunc::is_delimiter(popval))
+      done = true;
+    else
+      cnt++;
+  }
+  return ComValue(cnt, ComValue::IntType);
+}
+
 int ComTerp::run(boolean one_expr, boolean nested) {
   int old_runflag = running();
   running(true);
@@ -1456,16 +1471,51 @@ int ComTerp::run(boolean one_expr, boolean nested) {
 		#endif
 	      }
 	    } while (stack_top().is_known());
-	  } else {
+	  } else if (stack_top().is_stream() && stack_top().stream_list() &&
+		     stack_top().stream_list()->refcount_==1) {
+	    /* An orphaned stream -- the final result of a stand-alone
+	       expression, never assigned to anything, never streamed
+	       further -- would otherwise print as an uninformative "[]"
+	       (whatever's left of it once it falls out of scope
+	       unconsumed).  Drain it instead (orphan_stream_count(), same
+	       traversal EachFunc uses) and show the count: strictly more
+	       informative, and the stream was headed for the same fate
+	       either way.  Gated on refcount_==1 (nothing else holds a
+	       reference to the underlying AttributeValueList*, confirmed
+	       live: an orphaned `$$(1,2,3)` sits at 1, `x=$$(1,2,3)` sits
+	       at 2 -- one for the stack, one for x's binding) so this can
+	       never drain a stream a variable still needs: x=$$(1,2,3)
+	       at an interactive prompt must leave x fully intact for a
+	       later next(x), not silently exhaust it while "just printing
+	       the result". */
+	    ComValue streamv(stack_top());
+	    pop_stack();
+	    ComValue countv(orphan_stream_count(streamv));
+	    push_stack(countv);
 	    #ifdef USE_FDSTREAMS
 	    print_stack_top(out);
-	    out << "\n"; 
+	    out << "\n";
 	    out.flush();
 	    #else
 	    std::streambuf* strmbuf = new std::strstreambuf();
 	    ostream out(strmbuf);
 	    print_stack_top(out);
-	    out << "\n"; 
+	    out << "\n";
+	    out << '\0';
+	    const char *str = ((std::strstreambuf*)strmbuf)->str();
+	    fprintf(fp, "%s", str);
+	    fflush(fp);
+	    #endif
+	  } else {
+	    #ifdef USE_FDSTREAMS
+	    print_stack_top(out);
+	    out << "\n";
+	    out.flush();
+	    #else
+	    std::streambuf* strmbuf = new std::strstreambuf();
+	    ostream out(strmbuf);
+	    print_stack_top(out);
+	    out << "\n";
 	    out << '\0';
 	    const char *str = ((std::strstreambuf*)strmbuf)->str();
 	    fprintf(fp, "%s", str);

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1823,7 +1823,17 @@ int ComTerp::runfile(const char* filename, boolean popen_flag) {
 	        retval = new ComValue(pop_stack());
 	        break;
 	    } else {
-	        /* save last thing on stack */
+	        /* save last thing on stack -- if the PREVIOUS statement's
+	           retval is an orphaned stream (refcount_==1: nothing else
+	           holds it) about to be overwritten/discarded here, drain
+	           it first so its computation doesn't go to waste (same
+	           treatment SeqFunc gives a discarded ";" operand,
+	           postfunc.c -- this loop is runfile()'s own equivalent
+	           discard point for separate top-level statements/lines,
+	           which never go through SeqFunc/";" at all). */
+	        if (retval && retval->is_stream() && retval->stream_list() &&
+	            retval->stream_list()->refcount_==1)
+	          orphan_stream_count(*retval);
 	        retval = new ComValue(pop_stack());
 	    }
 	}

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1809,6 +1809,30 @@ int ComTerp::runfile(const char* filename, boolean popen_flag) {
     int status = 0;
     while( fptr && !feof(fptr)) {
 	if (read_expr()) {
+	    /* Drain a leftover orphaned stream from the PREVIOUS statement
+	       now that read_expr() confirms a genuine next statement
+	       exists (checking any earlier, e.g. unconditionally at the
+	       top of the loop, would incorrectly drain the truly LAST
+	       statement's retval too, on whatever trailing pass finds
+	       nothing left to read and the while() condition was
+	       nonetheless still true for). Before this iteration's own
+	       eval_expr() runs, not after: draining can have visible side
+	       effects of its own (e.g. a print() overdrive stream defers
+	       each repetition's actual print() call until that element is
+	       pulled -- draining fires all of them at once), and checking
+	       this any later (e.g. the "save last thing on stack" spot
+	       below, which used to have this check) would run it AFTER
+	       the next statement's own eval_expr() already produced its
+	       output, interleaving the two out of script order -- see the
+	       identical fix and full explanation in ComTerpServ::runfile(),
+	       comterpserv.c, the override actually exercised by
+	       `comterp run <file>`. */
+	    if (retval && retval->is_stream() && retval->stream_list() &&
+	        retval->stream_list()->refcount_==1) {
+	      orphan_stream_count(*retval);
+	      delete retval;
+	      retval = nil;
+	    }
 	    if (eval_expr(true)) {
 	        this->err_print( stderr, "comterp" );
 		FILEBUF(obuf, stdout, ios_base::out);
@@ -1823,17 +1847,7 @@ int ComTerp::runfile(const char* filename, boolean popen_flag) {
 	        retval = new ComValue(pop_stack());
 	        break;
 	    } else {
-	        /* save last thing on stack -- if the PREVIOUS statement's
-	           retval is an orphaned stream (refcount_==1: nothing else
-	           holds it) about to be overwritten/discarded here, drain
-	           it first so its computation doesn't go to waste (same
-	           treatment SeqFunc gives a discarded ";" operand,
-	           postfunc.c -- this loop is runfile()'s own equivalent
-	           discard point for separate top-level statements/lines,
-	           which never go through SeqFunc/";" at all). */
-	        if (retval && retval->is_stream() && retval->stream_list() &&
-	            retval->stream_list()->refcount_==1)
-	          orphan_stream_count(*retval);
+	        /* save last thing on stack */
 	        retval = new ComValue(pop_stack());
 	    }
 	}

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -190,11 +190,19 @@ public:
     // call _exit().
 
     virtual int run(boolean one_expr=false, boolean nested=false);
-    // run interpreter until end-of-file or quit command, unless 
+    // run interpreter until end-of-file or quit command, unless
     // 'one_expr' is true.  Leave 'one_expr' false when using a ComTerpServ.
-    // Return Value:  -1 if eof, 0 if normal operation, 1 if 
-    // partial expression parsed, 2 if no result computed, 3 if error in parsing.  
+    // Return Value:  -1 if eof, 0 if normal operation, 1 if
+    // partial expression parsed, 2 if no result computed, 3 if error in parsing.
     // 'nested' indicates contents of stack should be preserved.
+
+    ComValue orphan_stream_count(ComValue& streamv);
+    // drain a stream (same traversal EachFunc uses) and return the count
+    // of elements pulled from it.  Used wherever a "final result of a
+    // stand-alone expression" gets shown to the user and that result is
+    // an orphaned stream -- never assigned to anything, never streamed
+    // further -- so the more informative element count gets shown
+    // instead of an uninformative, still-unconsumed-looking print.
 
     virtual int runfile(const char* filename, boolean popen_flag=0);
     // run interpreter on contents of 'filename'.

--- a/src/ComTerp/comterpserv.c
+++ b/src/ComTerp/comterpserv.c
@@ -343,6 +343,28 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
 
  	if (feof(ifptr) && !*inbuf)  // deal with last line without new-line
 	  break;
+        /* Drain a leftover orphaned stream from the PREVIOUS statement
+           now that a genuine next line/statement is confirmed to exist
+           (the loop's own while(!feof()) can be true here even though
+           this turns out to be the trailing EOF-probe pass above with
+           nothing left to read -- checking any earlier than this, e.g.
+           at the very top of the loop, would incorrectly drain the
+           truly last statement's retval too, since that probe pass
+           also enters the loop body).  Draining before this iteration's
+           own line runs, not after: it can have visible side effects of
+           its own (e.g. a print() overdrive stream defers each
+           repetition's actual print() call until that element is
+           pulled -- draining fires all of them at once), and checking
+           this any later (e.g. the matching spot below, which used to
+           have this check) would run it AFTER the next statement's own
+           eval_expr() already produced its output, interleaving the two
+           out of script order. */
+        if (retval && retval->is_stream() && retval->stream_list() &&
+            retval->stream_list()->refcount_==1) {
+          orphan_stream_count(*retval);
+          delete retval;
+          retval = nil;
+        }
         if (_linenum==0 && !*inbuf) { // run a dummy space in to initialize parser
             inbuf[0]=' ';
             inbuf[1]='\0';
@@ -406,17 +428,10 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
 		  } while (stack_top().is_known());
 		  pop_stack();
 		} else {
-		  /* save last thing on stack -- if the PREVIOUS statement's
-		     retval is an orphaned stream (refcount_==1: nothing else
-		     holds it) about to be discarded here, drain it first so
-		     its computation doesn't go to waste (same treatment
-		     SeqFunc gives a discarded ";" operand, postfunc.c -- this
-		     loop is this class's own equivalent discard point for
-		     separate top-level statements/lines, which never go
-		     through SeqFunc/";" at all). */
-		  if (retval && retval->is_stream() && retval->stream_list() &&
-		      retval->stream_list()->refcount_==1)
-		    orphan_stream_count(*retval);
+		  /* save last thing on stack -- the PREVIOUS statement's
+		     orphaned-stream drain (if any) already happened at the
+		     top of this iteration, before this line even ran; see
+		     that check for why it can't happen here instead. */
 		  if(retval) delete retval;
 		  retval = new ComValue(pop_stack());
 		}

--- a/src/ComTerp/comterpserv.c
+++ b/src/ComTerp/comterpserv.c
@@ -406,7 +406,17 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
 		  } while (stack_top().is_known());
 		  pop_stack();
 		} else {
-		  /* save last thing on stack */  
+		  /* save last thing on stack -- if the PREVIOUS statement's
+		     retval is an orphaned stream (refcount_==1: nothing else
+		     holds it) about to be discarded here, drain it first so
+		     its computation doesn't go to waste (same treatment
+		     SeqFunc gives a discarded ";" operand, postfunc.c -- this
+		     loop is this class's own equivalent discard point for
+		     separate top-level statements/lines, which never go
+		     through SeqFunc/";" at all). */
+		  if (retval && retval->is_stream() && retval->stream_list() &&
+		      retval->stream_list()->refcount_==1)
+		    orphan_stream_count(*retval);
 		  if(retval) delete retval;
 		  retval = new ComValue(pop_stack());
 		}

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -255,28 +255,31 @@ void SeqFunc::execute() {
       push_stack(arg1);
     }
     else {
+      /* Drain arg1 (the statement before this ";") BEFORE evaluating
+	 arg2, not after -- if it's an orphaned stream (refcount_==1: no
+	 variable binding or anything else still holds it), draining it
+	 can have visible side effects of its own (e.g. a print()
+	 overdrive stream defers each repetition's actual print() call
+	 until that element is pulled -- draining fires all of them at
+	 once), and evaluating arg2 first would run arg2's own output
+	 before arg1's deferred output, out of script order.  Mirrors
+	 ComTerp::orphan_stream_count()'s use at the top level for the
+	 very last statement, and ComTerpServ::runfile()'s equivalent
+	 discard point for separate top-level lines (comterpserv.c) --
+	 together they cover every freestanding stream in a script, not
+	 just the final one.
+	 Assumes arg2 won't turn out blank -- the one case where arg1
+	 would have been kept as the ";" expression's own result rather
+	 than discarded, and draining it first would return it already
+	 exhausted.  Accepted: arg2 is blank only when there's no real
+	 second operand at all (a bare trailing ";"), vanishingly rare in
+	 combination with arg1 additionally being an undrained stream --
+	 getting the common case's output order right matters more. */
+      if (arg1.is_stream() && arg1.stream_list() && arg1.stream_list()->refcount_==1)
+	comterp()->orphan_stream_count(arg1);
       ComValue arg2(stack_arg_post_eval(1, true));
       reset_stack();
-      if (!arg2.is_blank()) {
-	/* arg1 (the statement before this ";") is being discarded in
-	   favor of arg2 -- if it's an orphaned stream (refcount_==1: no
-	   variable binding or anything else still holds it), drain it so
-	   its computation actually runs instead of being silently
-	   dropped unevaluated.  Doesn't print anything -- an intermediate
-	   statement's result was never shown to begin with; this is
-	   about not wasting the work, not about console output.  Mirrors
-	   ComTerp::orphan_stream_count()'s use at the top level for the
-	   very last statement (comterp.c) -- the two together cover every
-	   freestanding stream in a script, not just the final one. A
-	   non-final statement's fate (assigned or not) is already fully
-	   decided by the time it reaches here, unlike the last statement,
-	   whose fate isn't knowable until the top level asks whether
-	   anything still references it. */
-	if (arg1.is_stream() && arg1.stream_list() && arg1.stream_list()->refcount_==1)
-	  comterp()->orphan_stream_count(arg1);
-	push_stack(arg2);
-      } else
-	push_stack(arg1);
+      push_stack(arg2.is_blank() ? arg1 : arg2);
     }
 }
 

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -252,12 +252,31 @@ void SeqFunc::execute() {
     ComValue arg1(stack_arg_post_eval(0, true));
     if (SeqFunc::continueflag() || SeqFunc::breakflag() || comterp()->returnflag() || comterp()->quitflag()) {
       reset_stack();
-      push_stack(arg1);       
+      push_stack(arg1);
     }
     else {
       ComValue arg2(stack_arg_post_eval(1, true));
       reset_stack();
-      push_stack(arg2.is_blank() ? arg1 : arg2);
+      if (!arg2.is_blank()) {
+	/* arg1 (the statement before this ";") is being discarded in
+	   favor of arg2 -- if it's an orphaned stream (refcount_==1: no
+	   variable binding or anything else still holds it), drain it so
+	   its computation actually runs instead of being silently
+	   dropped unevaluated.  Doesn't print anything -- an intermediate
+	   statement's result was never shown to begin with; this is
+	   about not wasting the work, not about console output.  Mirrors
+	   ComTerp::orphan_stream_count()'s use at the top level for the
+	   very last statement (comterp.c) -- the two together cover every
+	   freestanding stream in a script, not just the final one. A
+	   non-final statement's fate (assigned or not) is already fully
+	   decided by the time it reaches here, unlike the last statement,
+	   whose fate isn't knowable until the top level asks whether
+	   anything still references it. */
+	if (arg1.is_stream() && arg1.stream_list() && arg1.stream_list()->refcount_==1)
+	  comterp()->orphan_stream_count(arg1);
+	push_stack(arg2);
+      } else
+	push_stack(arg1);
     }
 }
 

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -50,6 +50,7 @@ static const char *const SERVER_HOST = ACE_DEFAULT_SERVER_HOST;
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/comvalue.h>
 #include <ComTerp/ctrlfunc.h>
+#include <Attribute/attrlist.h>
 
 #include <execinfo.h>
 
@@ -368,7 +369,27 @@ int main(int argc, char *argv[]) {
 	// ComTerp::runfile()), it just never prints it on its own.
 	terp->brief(1);
 	ComValue::comterp(terp);
-	cout << terp->stack_top() << '\n';
+	{
+	  ComValue topval(terp->stack_top());
+	  // an orphaned stream (never assigned, never streamed further)
+	  // prints as an uninformative, still-unconsumed "[]" -- drain it
+	  // and show the element count instead (same treatment the
+	  // interactive/nested run() loop gives this case, comterp.c).
+	  // Gated on refcount_ -- if anything else (a variable binding)
+	  // still holds this same stream, leave it alone; draining it here
+	  // would silently exhaust that binding too.  Threshold is <=2, not
+	  // ==1, specifically for this call site: runfile() (comterp.c)
+	  // pops each statement's result into its own `retval` ComValue and
+	  // re-pushes a copy of it at the end (see runfile()'s tail), which
+	  // adds one baseline ref beyond the plain interactive run() loop's
+	  // -- confirmed live: an orphaned stream sits at 2 here (vs. 1
+	  // there), an assigned one at 3 (vs. 2).
+	  if (topval.is_stream() && topval.stream_list() &&
+	      topval.stream_list()->refcount_<=2)
+	    cout << terp->orphan_stream_count(topval) << '\n';
+	  else
+	    cout << topval << '\n';
+	}
 	cout.flush();
 	return 0;
       }
@@ -377,7 +398,12 @@ int main(int argc, char *argv[]) {
 	terp->brief(1);
 	ComValue::comterp(terp);
         ComValue comval(terp->run(argv[1]));
-        cout << comval << '\n';
+        // see the runfile() branch above for the refcount_==1 gate's purpose
+        if (comval.is_stream() && comval.stream_list() &&
+            comval.stream_list()->refcount_==1)
+          cout << terp->orphan_stream_count(comval) << '\n';
+        else
+          cout << comval << '\n';
         return 0;
       } else {
 	

--- a/src/comterp_/tests/atop.comt
+++ b/src/comterp_/tests/atop.comt
@@ -28,9 +28,13 @@ ok=ok&&(lst@3==40)
 print("1 lst@0, lst@3 (expect 10, 40): %v %v\n" lst@0 lst@3)
 // proto assert() shape (#322, not yet functional -- for scale, this is
 // what the two ok=ok&&(...) lines above plus the (expect 10, 40) in the
-// print() call might collapse into, once assert() exists):
+// print() call might collapse into, once assert() exists).  Simple form
+// -- the comma (first one not inside parens) is what ends the expression
+// and starts the trailing docstring, no quotes needed:
+// lst@0==10, lst@0 should be 10
+// lst@3==40, lst@3 should be 40
+// Doubleton form, for anything the simple form can't say plainly:
 // (:assert lst@0==10 :msg "lst@0 should be 10, got %v")
-// (:assert lst@3==40 :msg "lst@3 should be 40, got %v")
 
 // --- test 2: lst@N=val writes through a plain list in place ---
 lst@2=999

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -333,6 +333,35 @@ ok=ok&&(r2==(4,10,18))
 print("39 var*var and var*lit overdrive (expect {4,10,18} both): %v %v\n" r1 r2)
 prev_ok=check_fail(:ok ok)
 
+// --- test 40: a freestanding (orphaned) stream statement -- never
+// assigned, never streamed further -- gets auto-drained rather than
+// silently discarded unevaluated (ComTerpServ::runfile()/ComTerp::run(),
+// comterp.c/comterpserv.c; SeqFunc, postfunc.c, for an explicit ";"
+// sequence).  Not directly observable in-script (the drain doesn't print
+// or bind anything -- that's the point, an orphaned value has nowhere to
+// go); this just confirms it doesn't crash or hang the script around it,
+// and a following statement still runs normally. ---
+$$(1,2,3)
+ok=ok&&true
+print("40 freestanding $$(1,2,3) mid-script doesn't disrupt what follows: %v\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 41: the safety property that matters most -- a stream that IS
+// bound to a variable must stay fully intact even though a LATER
+// statement's own (unrelated) result gets discarded right after it, the
+// same discard point an orphaned stream would be drained at.  Only an
+// orphaned stream (nothing else referencing it) gets drained; a live
+// variable binding keeps the underlying stream's reference count above
+// the orphaned threshold, so it's left alone. ---
+s41=$$(1,2,3)
+unrelated41=42
+v41a=next(s41)
+v41b=next(s41)
+v41c=next(s41)
+ok=ok&&(v41a==1 && v41b==2 && v41c==3)
+print("41 s41=$$(1,2,3); unrelated41=42 (discards unrelated41's result at the same point); s41 still fully intact (expect 1,2,3): %v %v %v\n" v41a v41b v41c)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "82f61994"
+#define PATCH_KEY "5d8a5714"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "acba0253"
+#define PATCH_KEY "82f61994"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "5d8a5714"
+#define PATCH_KEY "5775227b"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Follows on from #321 (merged) — everything below was committed to the same `at-operator-318` branch after that PR merged, so this is a new PR for the remaining commits.

- **The core feature**: the final result of a stand-alone expression — never assigned, never streamed further — used to print as an uninformative `[]` (whatever's left of a lazy, unconsumed stream once it falls out of scope). It's now auto-drained and shown as its element count instead, since the stream was headed to be silently discarded either way. New `ComTerp::orphan_stream_count()`, shared across all three places this actually happens: the interactive/nested read-eval loop, `comterp run <file>` (`ComTerpServ::runfile()`, not the `ComTerp::runfile()` it overrides), and `comterp '<expr>'`.
- Extended to **every** freestanding stream statement in a script, not just the last one — via `SeqFunc` (explicit `;` sequences) and `runfile()`'s own per-line discard point (the far more common case for an ordinary multi-line `.comt` script).
- **Critical safety property**: a stream still bound to a variable must never be touched. Gated on the stream's `Resource` refcount (a public field) rather than assumed — confirmed empirically that the threshold differs per call site (`runfile()`'s own retval-juggling adds a baseline ref beyond the plain read-eval loop) and documented why at each site.
- **A real regression found and fixed along the way**: `print()`'s scalar overdrive turned out to be lazily deferred (each repetition's actual `print()` call only fires when that stream element is pulled). The first cut of the drain checks ran one statement too late, so an orphaned overdrive-print statement's deferred output surfaced interleaved *after* the following statement's own output instead of before it. Fixed by moving each check to fire before the *current* statement runs, which then exposed a second bug (draining the file's genuinely last statement one iteration early, on `runfile()`'s own trailing EOF-probe pass) — fixed by only checking once a real next statement is confirmed. Verified byte-for-byte (`od -c`) against the exact reproduction case.
- Also fixes a stale `#318`-era code comment (`ListEltFunc`/`elt()`) left over from an earlier, abandoned design in this same branch's history, and a small `atop.comt` doc tweak showing the `// expr, docstring` proto-assert form (#322) alongside the doubleton form.

## Test plan

- [x] Full `run_all.comt` suite green (35/35) at every step, including after the ordering-bug fix.
- [x] `comdraw`/ComUnidraw build clean throughout.
- [x] Verified live at every call site (not assumed) with a temporary debug print before locking in each refcount threshold.
- [x] Critical safety property re-verified after every change: a variable-bound stream survives an unrelated same-point discard, both interactively and via `runfile()`.
- [x] Byte-exact (`od -c`) verification of the exact reported interleaving bug, both broken and fixed.
- [x] `PATCH_KEY` bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)