### PR TITLE
Remove next()'s :skim keyword entirely (issue #45)

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -309,7 +309,7 @@ void ComTerp::eval_expr_internals(int pedepth) {
           int npos = 0, nkey = 0;
           boolean done = false;
           while (!done) {
-            NextFunc::execute_impl(this, v, false);
+            NextFunc::execute_impl(this, v);
             if (stack_top().is_unknown()) { pop_stack(); done = true; }
             else if (stack_top().is_object(Attribute::class_symid())) {
               /* an Attribute element (from an attrlist) becomes a real
@@ -1398,7 +1398,7 @@ ComValue ComTerp::orphan_stream_count(ComValue& streamv) {
   int cnt = 0;
   boolean done = false;
   while (!done) {
-    NextFunc::execute_impl(this, sv, false);
+    NextFunc::execute_impl(this, sv);
     ComValue popval(pop_stack());
     if (popval.is_unknown() || StrmFunc::is_delimiter(popval))
       done = true;
@@ -1454,7 +1454,7 @@ int ComTerp::run(boolean one_expr, boolean nested) {
 	    ComValue streamv(stack_top());
 	    do {
 	      pop_stack();
-	      NextFunc::execute_impl(this, streamv, false);
+	      NextFunc::execute_impl(this, streamv);
 	      if (stack_top().is_known()) {
 		#ifdef USE_FDSTREAMS
 		print_stack_top(out);

--- a/src/ComTerp/comterpserv.c
+++ b/src/ComTerp/comterpserv.c
@@ -424,7 +424,7 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
 		  ComValue streamv(stack_top());
 		  do {
 		    pop_stack();
-		    NextFunc::execute_impl(this, streamv, false);
+		    NextFunc::execute_impl(this, streamv);
 		  } while (stack_top().is_known());
 		  pop_stack();
 		} else {

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -73,7 +73,7 @@ void ListFunc::execute() {
 	/* stream to list conversion */
 	boolean done = false;
 	while (!done) {
-	  NextFunc::execute_impl(comterp(), listv, false);
+	  NextFunc::execute_impl(comterp(), listv);
 	  ComValue topval(comterp()->pop_stack());
 	  if (topval.is_unknown() || StrmFunc::is_delimiter(topval)) {
 	    done = true;

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -506,7 +506,7 @@ void ConcatNextFunc::execute() {
     if (oneval->is_known()) {
       if (oneval->is_stream()) {
 	ComValue valone(*oneval);
-	NextFunc::execute_impl(comterp(), valone, false);
+	NextFunc::execute_impl(comterp(), valone);
 	if (comterp()->stack_top().is_unknown()) {
 	  *oneval = ComValue::nullval();
 	  comterp()->pop_stack();
@@ -523,7 +523,7 @@ void ConcatNextFunc::execute() {
     if (twoval->is_known() && !done) {
       if (twoval->is_stream()) {
 	ComValue valtwo(*twoval);
-	NextFunc::execute_impl(comterp(), valtwo, false);
+	NextFunc::execute_impl(comterp(), valtwo);
 	if (comterp()->stack_top().is_unknown())
 	  *twoval = ComValue::nullval();
       } else {
@@ -663,7 +663,7 @@ void ReplayNextFunc::execute() {
 	}
 	/* pull the next element from the current copy */
 	ComValue curcopy(*curval);
-	NextFunc::execute_impl(comterp(), curcopy, false);
+	NextFunc::execute_impl(comterp(), curcopy);
 	if (comterp()->stack_top().is_unknown()) {
 	  comterp()->pop_stack();                      // this pass exhausted
 	  *curval = ComValue::nullval();               // force a fresh copy next time
@@ -741,14 +741,12 @@ NextFunc::NextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 
 void NextFunc::execute() {
     ComValue streamv(stack_arg_post_eval(0));
-    static int skim_symid = symbol_add("skim");
-    ComValue skimflag(stack_key(skim_symid));
     reset_stack();
 
-    execute_impl(comterp(), streamv, skimflag.is_true());
+    execute_impl(comterp(), streamv);
 }
 
-void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
+void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv) {
 
     _next_depth++;
 
@@ -763,7 +761,7 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
        restarted by calling execute_impl(streamv) again, which re-entered
        the C++ call stack once per element and could exhaust it given a
        sufficiently long run (flagged in #288 review). */
-    if (!skim) {
+    {
       AttributeValueList* avl = streamv.stream_list();
       for (;;) {
 	Iterator i;
@@ -776,7 +774,7 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
 	if (!(val->is_stream() && val->stream_mode_raw()&STREAM_NESTED)) break;
 	// fprintf(stderr, "NextFunc: Handling nested stream\n");
 	ComValue cval(*val);
-	NextFunc::execute_impl(comterp, cval, false);
+	NextFunc::execute_impl(comterp, cval);
 	if (!comterp->stack_top().is_null()) {
 	  return;
 	}
@@ -852,7 +850,7 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
               // fprintf(stdout, "Stack before NextFunc::execute_impl\n");
               // comterp->print_stack();
 
-	      NextFunc::execute_impl(comterp, cval, false);
+	      NextFunc::execute_impl(comterp, cval);
               // fprintf(stderr, "after:  strm arg 0x%lx, stack_top %d\n", val, comterp->stack_height());
 
 	      if (comterp->stack_top().is_stream()) {
@@ -895,9 +893,9 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv, boolean skim) {
 	funcptr->exec(narg, nkey);
 
 	// recurse until not a stream
-	while (comterp->stack_top().is_stream() && !skim) {
+	while (comterp->stack_top().is_stream()) {
 	  ComValue *newstream = new ComValue(comterp->pop_stack());
-	  execute_impl(comterp, *newstream, false);
+	  execute_impl(comterp, *newstream);
 
   	  // insert this stream at the front of the parent stream, to be recognized and dealt with by NextFunc
 	  newstream->stream_mode(newstream->stream_mode()|STREAM_NESTED);
@@ -926,8 +924,6 @@ EachFunc::EachFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void EachFunc::execute() {
   ComValue strmv(stack_arg_post_eval(0));
-  static int skim_symid = symbol_add("skim");
-  ComValue skimflag(stack_key(skim_symid));
 
   if (strmv.is_stream()) {
     /* explicit stream argument -- traverse normally */
@@ -935,7 +931,7 @@ void EachFunc::execute() {
     int cnt = 0;
     boolean done = false;
     while (!done) {
-      NextFunc::execute_impl(comterp(), strmv, skimflag.is_true());
+      NextFunc::execute_impl(comterp(), strmv);
       ComValue popval(comterp()->pop_stack());
       if (popval.is_unknown() || StrmFunc::is_delimiter(popval))
 	done = true;
@@ -1030,7 +1026,7 @@ void FilterNextFunc::execute() {
 	boolean done = false;
 	while(!done) {
 	  ComValue strm2filt(*strmval);
-	  NextFunc::execute_impl(comterp(), strm2filt, false);
+	  NextFunc::execute_impl(comterp(), strm2filt);
 	  if (comterp()->stack_top().is_unknown()) {
 	    *strmval = ComValue::nullval();
 	    push_stack(*strmval);

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -237,7 +237,7 @@ public:
     NextFunc(ComTerp*);
 
     virtual void execute();
-    static  void execute_impl(ComTerp*, ComValue& strmv, boolean skim);
+    static  void execute_impl(ComTerp*, ComValue& strmv);
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
       /* %1$s (not plain %s) reused twice: the caller (helpfunc.c) passes
@@ -245,15 +245,8 @@ public:
 	 second bare %s here would read past it -- an uninitialized-argument
 	 format-string bug.  POSIX/BSD printf's positional specifier lets
 	 one supplied argument fill both slots safely. */
-      return "val=%1$s(stream :skim) -- return next value from stream, don't recurse if :skim.\n\
+      return "val=%1$s(stream) -- return next value from stream\n\
 *s is unary-prefix sugar for %1$s(s)"; }
-    virtual const char** dockeys() {
-      static const char* keys[] = {
-	":skim      do not recurse into nested streams",
-	nil
-      };
-      return keys;
-    }
 
     static int next_depth() { return _next_depth; }
 protected:

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -5,11 +5,11 @@
 // missing: str()->(stream) -- str() not stream-aware (test 33 deferred)
 //          $(attrlist) size(attrlist,compview)
 //          !,,(empty-stream -- bug #46)
-//          !next(:skim -- bug #45)
 //
 // slot 10 keyword compatibility groups:
-//   next(:skim) -- single keyword, no combinations; excluded due to bug #45
-//   all other funcs have no keywords
+//   all funcs have no keywords -- next()'s :skim was removed (issue #45):
+//   feed() now does the (deliberately 1-level-only, no 2-level expansion)
+//   nested-stream job :skim was a broken attempt at
 //
 // Tests: $$ $ ,, next() each() .. ** and their interactions.
 // Also tests streams overdriving scalar operators (implicit vectorization),
@@ -90,8 +90,7 @@ ok=ok&&(size(result)==3)
 print("8 size($($$(tuples))) (expect 3): %v\n" size(result))
 prev_ok=check_fail(:ok ok)
 
-// --- test 9: next(:skim) -- deferred ---
-print("9 ERROR: next(:skim) bug to investigate - ivtools issue #45\n")
+// (test 9's slot retired: it was next(:skim), removed entirely -- see #45)
 
 // --- test 10: total=0; while((v=next($$(1,2,3,4,5)))!=nil total=total+v) ---
 total=0

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "defb8393"
+#define PATCH_KEY "78210c37"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -242,7 +242,7 @@ Print a usage summary of all the invocation modes above and exit.
  
  strm=stream(strm|lst|attrlst|val|fileobj|pipeobj) -- copy stream or convert list (unary $)
 
- val=next(stream :skim) -- return next value from stream, don't recurse if :skim
+ val=next(stream) -- return next value from stream
    (unary prefix *: *strm is next(strm))
 
  cnt=each(strm) -- traverse stream returning its length


### PR DESCRIPTION
## Summary
- `:skim` was a broken attempt at controlling nested-stream recursion depth in `next()` (issue #45, closed without the dead code ever being removed).
- `feed()`'s `STREAM_NESTED` tagging convention now does that job properly -- deliberately 1-level expansion, 2-level ruled out -- so `:skim` has nothing left to do.
- Removes the `skim` parameter from `NextFunc::execute_impl` and every call site, the keyword read in `NextFunc::execute()`, and the (never-documented) keyword read in `EachFunc::execute()` that was silently accepting `each(strm :skim)` too.
- Updates `next()`'s docstring/dockeys, the man page, and retires `stream.comt` test 9's dead placeholder slot.

## Test plan
- [x] `src/comterp_/tests/run_all.comt` -- 35/35 passing
- [x] `comdraw`/ComUnidraw build clean
- [x] `help(next)`/`*s`/`next(s)` verified live, no `:skim` mention