### PR TITLE
Modernize spirograph.comt and add orb3d()

### DIFF
--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -252,6 +252,103 @@ orbit=func(
   update();
   print("The cosmos settles down.  (orbit(300) runs longer; clearpaper() starts over.)\n"))
 
+// orb3d([steps]) -- like orbit(), but in three dimensions: every
+// spirograph orbits the shared center of gravity through real (x,y,z)
+// space, and the paper shows a perspective PROJECTION of that -- nearer
+// bodies grow (scale()) and get drawn on top (back(), painter's-algorithm
+// style: nearest processed first, farthest last, so each later back()
+// buries an object one level deeper and the nearest ends up on top),
+// farther bodies shrink and recede.  (:sunx :suny :sunz pin the sun
+// instead of the average -- same "not :cx :cy" name choice as orbit(),
+// same reason: an unpassed keyword falls through to any same-named
+// global, so the sun needs a name nobody has lying around.)
+//
+// orbit()'s own trick for avoiding drift -- re-reading center() every
+// step instead of accumulating position as state -- doesn't carry over
+// here: the SCREEN position is a projection of the true 3D position, not
+// the true position itself, so there's no screen value to read back
+// FROM.  Position genuinely has to be tracked as float state (txs/tys/
+// tzs) and integrated each step.  That turns out fine: the integer
+// rounding orbit() was guarding against happens only in move()'s own
+// pixel rounding, which never feeds back into this float state the way
+// it would if the state WERE the screen position.
+orb3d=func(
+  steps=arg(0);
+  if(steps==nil :then steps=150);
+  bodies=list();
+  fs=$$(frame());
+  while(g=*fs if(g.R!=nil :then bodies,g));
+  nb=size(bodies);
+  if(nb<2 :then print("The cosmos needs at least two spirographs -- try gallery() first!\n"));
+  if(nb<2 :then return(nil));
+  sx=0.0; sy=0.0;
+  for(oi=0 oi<nb oi++ c=center(bodies@oi); sx=sx+c@0; sy=sy+c@1);
+  sx=sx/nb; sy=sy/nb; sz=0.0;
+  if(sunx!=nil :then sx=1.0*sunx);
+  if(suny!=nil :then sy=1.0*suny);
+  if(sunz!=nil :then sz=1.0*sunz);
+  D=500.0;  // viewing distance for the perspective projection
+  w=0.03; K=w*w;
+  // true 3D state, seeded from each curve's current screen position for
+  // x,y and spread out along z (index-based, so nobody starts coincident)
+  txs=list(); tys=list(); tzs=list();
+  vxs=list(); vys=list(); vzs=list();
+  rads=list(); spins=list(); percs=list();
+  for(oi=0 oi<nb oi++
+    g=bodies@oi; c=center(g); box=mbr(g);
+    txs,c@0; tys,c@1; tzs,sz+(oi-(nb-1)/2.0)*100.0;
+    vxs,(0.0-w)*(tys@oi-sy); vys,w*(txs@oi-sx); vzs,0.0;
+    rads,(box@2-box@0+box@3-box@1)/4.0;
+    if(oi%2==0 :then spins,3 :else spins,-3);
+    percs,1.0);
+  handles(false);
+  for(st=0 st<steps st++
+    for(oi=0 oi<nb oi++
+      px=txs@oi; py=tys@oi; pz=tzs@oi;
+      ax=K*(sx-px); ay=K*(sy-py); az=K*(sz-pz);
+      for(oj=0 oj<nb oj++
+        if(oj!=oi :then
+          ox=txs@oj; oy=tys@oj; oz=tzs@oj;
+          ddx=px-ox; ddy=py-oy; ddz=pz-oz;
+          d=sqrt(ddx*ddx+ddy*ddy+ddz*ddz);
+          reach=rads@oi+rads@oj;
+          if((d>1)&&(d<reach) :then
+            push=0.4*(reach-d)/reach;
+            ax=ax+push*ddx/d;
+            ay=ay+push*ddy/d;
+            az=az+push*ddz/d)));
+      vxs@oi=vxs@oi+ax; vys@oi=vys@oi+ay; vzs@oi=vzs@oi+az;
+      txs@oi=txs@oi+vxs@oi; tys@oi=tys@oi+vys@oi; tzs@oi=tzs@oi+vzs@oi);
+    // painter's algorithm: sort by ascending z (nearest first), so
+    // calling back() in that order buries the farthest body deepest and
+    // leaves the nearest body implicitly on top
+    order=list(0..(nb-1));
+    for(oa=1 oa<nb oa++
+      key=order@oa; kz=tzs@key; ob=oa-1;
+      while(ob>=0 && tzs@(order@ob)>kz
+        order@(ob+1)=order@ob; ob=ob-1);
+      order@(ob+1)=key);
+    for(oi=0 oi<nb oi++
+      qi=order@oi;
+      g=bodies@qi;
+      perc=D/(D+tzs@qi-sz);
+      screenx=sx+(txs@qi-sx)*perc;
+      screeny=sy+(tys@qi-sy)*perc;
+      c=center(g);
+      select(g);
+      move(screenx-c@0 screeny-c@1);
+      rotate(spins@qi);
+      ratio=perc/percs@qi;
+      scale(ratio ratio);
+      percs@qi=perc;
+      back());
+    select(:clear);
+    update(5000));
+  handles(true);
+  select(:clear);
+  update();
+  print("The cosmos settles into three dimensions.  (orb3d(300) runs longer; clearpaper() starts over.)\n"))
+
 // clearpaper() -- fresh sheet.  $$(frame()) snapshots the paper's
 // components into an independent stream/copy (frame() itself is left
 // alone), so deleting each one as *doomed pulls it never mutates the
@@ -284,6 +381,8 @@ spirohelp=func(
   print("  recipes()        -- every curve tells you its own command\n");
   print("  spin()           -- the whole drawing wiggle-dances\n");
   print("  orbit()          -- the spirographs become planets! (needs 2+)\n");
+  print("  orb3d()          -- orbit(), but in 3-D: nearer planets grow and\n");
+  print("                      come to the front, farther ones shrink back\n");
   print("  clearpaper()     -- fresh sheet\n");
   print("  oops()           -- the machine explains your last error\n");
   print("SECRETS: every curve is YOURS -- grab one and decorate it:\n");

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -291,17 +291,31 @@ orb3d=func(
   D=500.0;  // viewing distance for the perspective projection
   w=0.03; K=w*w;
   // true 3D state, seeded from each curve's current screen position for
-  // x,y and spread out along z (index-based, so nobody starts coincident)
+  // x,y.  z/velocity/spin/scale-baseline continue from wherever this
+  // body's LAST orb3d() call left them (stashed as curve.orb3d_* fields
+  // below, the same "every curve is yours" idiom as curve.recipe()) --
+  // only a curve going through orb3d() for the first time gets the
+  // fresh, evenly-spread starting spin.  Without this, orb3d();orb3d()
+  // would re-run the fresh-start formula every call: every body's depth
+  // snapping back to its initial spread and its velocity/spin snapping
+  // to the initial circular-orbit values, a visible jolt right at the
+  // seam between calls even though position itself stayed continuous
+  // (read fresh from center() either way).
   txs=list(); tys=list(); tzs=list();
   vxs=list(); vys=list(); vzs=list();
   rads=list(); spins=list(); percs=list();
   for(oi=0 oi<nb oi++
     g=bodies@oi; c=center(g); box=mbr(g);
-    txs,c@0; tys,c@1; tzs,sz+(oi-(nb-1)/2.0)*100.0;
-    vxs,(0.0-w)*(tys@oi-sy); vys,w*(txs@oi-sx); vzs,0.0;
-    rads,(box@2-box@0+box@3-box@1)/4.0;
-    if(oi%2==0 :then spins,3 :else spins,-3);
-    percs,1.0);
+    txs,c@0; tys,c@1;
+    if(g.orb3d_z!=nil :then
+      tzs,g.orb3d_z; vxs,g.orb3d_vx; vys,g.orb3d_vy; vzs,g.orb3d_vz;
+      percs,g.orb3d_perc; spins,g.orb3d_spin
+     :else
+      tzs,sz+(oi-(nb-1)/2.0)*100.0;
+      vxs,(0.0-w)*(tys@oi-sy); vys,w*(txs@oi-sx); vzs,0.0;
+      percs,1.0;
+      if(oi%2==0 :then spins,3 :else spins,-3));
+    rads,(box@2-box@0+box@3-box@1)/4.0);
   handles(false);
   for(st=0 st<steps st++
     for(oi=0 oi<nb oi++
@@ -345,6 +359,12 @@ orb3d=func(
       back());
     select(:clear);
     update(5000));
+  // stash each body's final depth/velocity/spin/scale-baseline on the
+  // curve itself, for the next orb3d() call (if any) to continue from
+  for(oi=0 oi<nb oi++
+    g=bodies@oi;
+    g.orb3d_z=tzs@oi; g.orb3d_vx=vxs@oi; g.orb3d_vy=vys@oi; g.orb3d_vz=vzs@oi;
+    g.orb3d_perc=percs@oi; g.orb3d_spin=spins@oi);
   handles(true);
   select(:clear);
   update();
@@ -384,6 +404,8 @@ spirohelp=func(
   print("  orbit()          -- the spirographs become planets! (needs 2+)\n");
   print("  orb3d()          -- orbit(), but in 3-D: nearer planets grow and\n");
   print("                      come to the front, farther ones shrink back\n");
+  print("                      (orb3d();orb3d() picks up right where it left\n");
+  print("                      off -- no jump at the seam between calls)\n");
   print("  clearpaper()     -- fresh sheet\n");
   print("  oops()           -- the machine explains your last error\n");
   print("SECRETS: every curve is YOURS -- grab one and decorate it:\n");

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -288,11 +288,7 @@ orb3d=func(
   nb=size(bodies);
   if(nb<2 :then print("The cosmos needs at least two spirographs -- try gallery() first!\n"));
   if(nb<2 :then return(nil));
-  sx=0.0; sy=0.0;
-  for(oi=0 oi<nb oi++ c=center(bodies@oi); sx=sx+c@0; sy=sy+c@1);
-  sx=sx/nb; sy=sy/nb; sz=0.0;
-  if(sunx!=nil :then sx=1.0*sunx);
-  if(suny!=nil :then sy=1.0*suny);
+  sz=0.0;
   if(sunz!=nil :then sz=1.0*sunz);
   D=500.0;  // viewing distance for the perspective projection
   w=0.03; K=w*w;
@@ -307,6 +303,18 @@ orb3d=func(
   // orb3d();orb3d() would either re-run the fresh-start formula every
   // call (a jolt in depth/velocity/spin) or re-project an already-
   // projected x,y (a jolt in position) right at the seam between calls.
+  //
+  // sx,sy (the shared center of gravity) have to be averaged from these
+  // same TRUE positions too, not from center() -- a continuing body's
+  // center() is last call's PROJECTED screen position, and projected
+  // positions don't average to the true sun (each body's own perc
+  // scales its offset from the sun differently).  A sun rebuilt from
+  // projected centers drifts off the true one every call, dragging both
+  // the spring physics and the projection origin along with it.  So
+  // this needs two passes: true positions first (independent of
+  // sx,sy), then sx,sy from those positions, then -- only for bodies
+  // starting fresh here -- the initial circular-orbit velocity, which
+  // DOES need the now-correct sx,sy to aim tangent to the sun.
   txs=list(); tys=list(); tzs=list();
   vxs=list(); vys=list(); vzs=list();
   rads=list(); spins=list(); percs=list();
@@ -319,10 +327,19 @@ orb3d=func(
      :else
       txs,c@0; tys,c@1;
       tzs,sz+(oi-(nb-1)/2.0)*100.0;
-      vxs,(0.0-w)*(tys@oi-sy); vys,w*(txs@oi-sx); vzs,0.0;
+      vxs,0.0; vys,0.0; vzs,0.0;
       percs,1.0;
       if(oi%2==0 :then spins,3 :else spins,-3));
     rads,(box@2-box@0+box@3-box@1)/4.0);
+  sx=0.0; sy=0.0;
+  for(oi=0 oi<nb oi++ sx=sx+txs@oi; sy=sy+tys@oi);
+  sx=sx/nb; sy=sy/nb;
+  if(sunx!=nil :then sx=1.0*sunx);
+  if(suny!=nil :then sy=1.0*suny);
+  for(oi=0 oi<nb oi++
+    g=bodies@oi;
+    if(g.orb3d_z==nil :then
+      vxs@oi=(0.0-w)*(tys@oi-sy); vys@oi=w*(txs@oi-sx)));
   handles(false);
   for(st=0 st<steps st++
     for(oi=0 oi<nb oi++

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -272,7 +272,13 @@ orbit=func(
 // tzs) and integrated each step.  That turns out fine: the integer
 // rounding orbit() was guarding against happens only in move()'s own
 // pixel rounding, which never feeds back into this float state the way
-// it would if the state WERE the screen position.
+// it would if the state WERE the screen position.  That also means the
+// true x/y, like z, must be stashed as curve.orb3d_x/orb3d_y and read
+// back from there on a continuing call -- re-seeding from center()
+// would read back last call's PROJECTED screen position instead of the
+// true one, and re-projecting an already-projected position is a second
+// projection: a visible seam even though z/velocity/spin carried over
+// cleanly.
 orb3d=func(
   steps=arg(0);
   if(steps==nil :then steps=150);
@@ -290,27 +296,28 @@ orb3d=func(
   if(sunz!=nil :then sz=1.0*sunz);
   D=500.0;  // viewing distance for the perspective projection
   w=0.03; K=w*w;
-  // true 3D state, seeded from each curve's current screen position for
-  // x,y.  z/velocity/spin/scale-baseline continue from wherever this
-  // body's LAST orb3d() call left them (stashed as curve.orb3d_* fields
-  // below, the same "every curve is yours" idiom as curve.recipe()) --
-  // only a curve going through orb3d() for the first time gets the
-  // fresh, evenly-spread starting spin.  Without this, orb3d();orb3d()
-  // would re-run the fresh-start formula every call: every body's depth
-  // snapping back to its initial spread and its velocity/spin snapping
-  // to the initial circular-orbit values, a visible jolt right at the
-  // seam between calls even though position itself stayed continuous
-  // (read fresh from center() either way).
+  // true 3D state.  A curve going through orb3d() for the first time
+  // seeds x,y from its current screen position (nothing's been projected
+  // yet, so screen position IS true position) and gets the fresh,
+  // evenly-spread starting depth/velocity/spin.  A continuing curve
+  // reads true x/y/z/velocity/spin/scale-baseline back from curve.orb3d_*
+  // fields (stashed below, the same "every curve is yours" idiom as
+  // curve.recipe()) instead -- x,y included, since center() would only
+  // hand back last call's PROJECTED screen position.  Without this,
+  // orb3d();orb3d() would either re-run the fresh-start formula every
+  // call (a jolt in depth/velocity/spin) or re-project an already-
+  // projected x,y (a jolt in position) right at the seam between calls.
   txs=list(); tys=list(); tzs=list();
   vxs=list(); vys=list(); vzs=list();
   rads=list(); spins=list(); percs=list();
   for(oi=0 oi<nb oi++
     g=bodies@oi; c=center(g); box=mbr(g);
-    txs,c@0; tys,c@1;
     if(g.orb3d_z!=nil :then
+      txs,g.orb3d_x; tys,g.orb3d_y;
       tzs,g.orb3d_z; vxs,g.orb3d_vx; vys,g.orb3d_vy; vzs,g.orb3d_vz;
       percs,g.orb3d_perc; spins,g.orb3d_spin
      :else
+      txs,c@0; tys,c@1;
       tzs,sz+(oi-(nb-1)/2.0)*100.0;
       vxs,(0.0-w)*(tys@oi-sy); vys,w*(txs@oi-sx); vzs,0.0;
       percs,1.0;
@@ -359,10 +366,12 @@ orb3d=func(
       back());
     select(:clear);
     update(5000));
-  // stash each body's final depth/velocity/spin/scale-baseline on the
-  // curve itself, for the next orb3d() call (if any) to continue from
+  // stash each body's final true position/depth/velocity/spin/scale-
+  // baseline on the curve itself, for the next orb3d() call (if any) to
+  // continue from
   for(oi=0 oi<nb oi++
     g=bodies@oi;
+    g.orb3d_x=txs@oi; g.orb3d_y=tys@oi;
     g.orb3d_z=tzs@oi; g.orb3d_vx=vxs@oi; g.orb3d_vy=vys@oi; g.orb3d_vz=vzs@oi;
     g.orb3d_perc=percs@oi; g.orb3d_spin=spins@oi);
   handles(true);

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -96,15 +96,16 @@ spiro=func(
   // cos()/sin() -- no per-point loop for the math itself.  (Note the
   // parens around n-1: .. binds TIGHTER than -, so a bare 0..n-1 would
   // parse as (0..n)-1, one point too many -- ask the machine why with
-  // postfix(0..n-1) if you don't believe it.)  xs and ys still need a
-  // short loop to zip into ONE flat x0,y0,x1,y1,... list, the shape
-  // closedspline() wants -- comterp doesn't have a zip primitive yet,
-  // and @ is a plain, non-draining read, so this last step is honest,
-  // not a workaround.
+  // postfix(0..n-1) if you don't believe it.)
   xs=list(int(round(cx+Ac*cos(h*(0..(n-1)))+s*Dc*cos(k*h*(0..(n-1))))));
   ys=list(int(round(cy+Ac*sin(h*(0..(n-1)))-Dc*sin(k*h*(0..(n-1))))));
+  // zip xs and ys into ONE flat x0,y0,x1,y1,... list, the shape
+  // closedspline() wants: $$xs,$$ys chains two fresh streams through the
+  // comma-append idiom (pts,val appends val's elements) -- , zips
+  // co-iterating streams per-element rather than nesting them, so this
+  // one line drains both in lockstep instead of a per-point loop.
   pts=list();
-  for(i=0 i<n i++ pts,xs@i; pts,ys@i);
+  pts,$$xs,$$ys;
   // one closed spline from the whole point list.  the commas in
   // closedspline(x0,y0,x1,y1,...) are the tuple operator, so the
   // familiar syntax builds ONE list arg -- a list variable is the

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -319,18 +319,28 @@ orb3d=func(
   vxs=list(); vys=list(); vzs=list();
   rads=list(); spins=list(); percs=list();
   for(oi=0 oi<nb oi++
-    g=bodies@oi; c=center(g); box=mbr(g);
+    g=bodies@oi; c=center(g);
     if(g.orb3d_z!=nil :then
       txs,g.orb3d_x; tys,g.orb3d_y;
       tzs,g.orb3d_z; vxs,g.orb3d_vx; vys,g.orb3d_vy; vzs,g.orb3d_vz;
-      percs,g.orb3d_perc; spins,g.orb3d_spin
+      percs,g.orb3d_perc; spins,g.orb3d_spin;
+      // true radius too, for the same reason as x/y/z -- mbr(g) right
+      // now would read the graphic's PERSPECTIVE-SCALED bounds (this
+      // body was left mid-scale(ratio ratio) at whatever depth the last
+      // call ended on), not its canonical size.  A collision reach
+      // rebuilt from that every call would drift with depth instead of
+      // staying constant, the same class of bug as sx/sy above.
+      rads,g.orb3d_rad
      :else
       txs,c@0; tys,c@1;
       tzs,sz+(oi-(nb-1)/2.0)*100.0;
       vxs,0.0; vys,0.0; vzs,0.0;
       percs,1.0;
-      if(oi%2==0 :then spins,3 :else spins,-3));
-    rads,(box@2-box@0+box@3-box@1)/4.0);
+      if(oi%2==0 :then spins,3 :else spins,-3);
+      // nothing's scaled this graphic yet, so mbr() right now IS the
+      // canonical size -- the one and only time it's safe to read it.
+      box=mbr(g);
+      rads,(box@2-box@0+box@3-box@1)/4.0));
   sx=0.0; sy=0.0;
   for(oi=0 oi<nb oi++ sx=sx+txs@oi; sy=sy+tys@oi);
   sx=sx/nb; sy=sy/nb;
@@ -384,13 +394,13 @@ orb3d=func(
     select(:clear);
     update(5000));
   // stash each body's final true position/depth/velocity/spin/scale-
-  // baseline on the curve itself, for the next orb3d() call (if any) to
-  // continue from
+  // baseline/radius on the curve itself, for the next orb3d() call (if
+  // any) to continue from
   for(oi=0 oi<nb oi++
     g=bodies@oi;
     g.orb3d_x=txs@oi; g.orb3d_y=tys@oi;
     g.orb3d_z=tzs@oi; g.orb3d_vx=vxs@oi; g.orb3d_vy=vys@oi; g.orb3d_vz=vzs@oi;
-    g.orb3d_perc=percs@oi; g.orb3d_spin=spins@oi);
+    g.orb3d_perc=percs@oi; g.orb3d_spin=spins@oi; g.orb3d_rad=rads@oi);
   handles(true);
   select(:clear);
   update();

--- a/src/comdraw/examples/spirograph.comt
+++ b/src/comdraw/examples/spirograph.comt
@@ -13,8 +13,9 @@
 //
 // HOW IT WORKS (the three layers, same as zoomap.comt):
 //   1. the MACHINE  -- funcs that compute where the pen goes
-//   2. the DATA     -- setattr() sticks each curve's recipe onto it,
-//                      so recipes() can read back re-typeable commands
+//   2. the DATA     -- setattr() sticks each curve's recipe onto it
+//                      (and even a method, curve.recipe(), that reads
+//                      its own recipe back out loud -- see spiro() below)
 //   3. the QUESTIONS-- magic words at the prompt drive the machine
 //
 // THE CURVE, AND WHY closedspline() INSTEAD OF multiline():
@@ -90,11 +91,20 @@ spiro=func(
   lam2=(2+cos(k*h))/3;
   Ac=A/lam1;
   Dc=d/lam2;
+  // the whole trail, in one pass each: h*(0..(n-1)) is a fresh 0..n-1
+  // range stream every time it's written, overdriven straight through
+  // cos()/sin() -- no per-point loop for the math itself.  (Note the
+  // parens around n-1: .. binds TIGHTER than -, so a bare 0..n-1 would
+  // parse as (0..n)-1, one point too many -- ask the machine why with
+  // postfix(0..n-1) if you don't believe it.)  xs and ys still need a
+  // short loop to zip into ONE flat x0,y0,x1,y1,... list, the shape
+  // closedspline() wants -- comterp doesn't have a zip primitive yet,
+  // and @ is a plain, non-draining read, so this last step is honest,
+  // not a workaround.
+  xs=list(int(round(cx+Ac*cos(h*(0..(n-1)))+s*Dc*cos(k*h*(0..(n-1))))));
+  ys=list(int(round(cy+Ac*sin(h*(0..(n-1)))-Dc*sin(k*h*(0..(n-1))))));
   pts=list();
-  for(i=0 i<n i++
-    t=h*i;
-    pts,int(round(cx+Ac*cos(t)+s*Dc*cos(k*t)));
-    pts,int(round(cy+Ac*sin(t)-Dc*sin(k*t))));
+  for(i=0 i<n i++ pts,xs@i; pts,ys@i);
   // one closed spline from the whole point list.  the commas in
   // closedspline(x0,y0,x1,y1,...) are the tuple operator, so the
   // familiar syntax builds ONE list arg -- a list variable is the
@@ -112,6 +122,13 @@ spiro=func(
   curve.name="spiro";
   curve.R=R; curve.r=r; curve.d=d;
   curve.epi=eflag; curve.color=color; curve.pts=n;
+  // the curve can tell you its own recipe, self-bound: curve.recipe()
+  // reads R/r/d/epi/color/pts straight off the object it's called on,
+  // no arguments, same trick as ducktyping.comt's obj.method().
+  curve.recipe=func(
+    print("  spiro(%d %d %d" R r d);
+    if(epi==1 :then print(" :epi"));
+    print(" :color %v)   -- %d spline points\n" color pts));
   // styling the curve also set the editor's CURRENT style -- put it
   // back to the startup default so the next shape isn't born a spiro.
   select(:clear);
@@ -139,22 +156,19 @@ surprise=func(
   r=int(round(rand(16,48)));
   R=int(round(rand(1.8*r,3.4*r)));
   d=int(round(rand(0.4*r,1.1*r)));
-  c=at(spiropal int(round(rand(0,size(spiropal)-1))));
+  c=spiropal@int(round(rand(0,size(spiropal)-1)));
   print("How about...  spiro(%d %d %d :color %v)\n" R r d c);
   spiro(R r d :color c))
 
 // recipes() -- every curve on the paper tells you the exact command
-// that draws it (copy one, change a number, see what happens!)
+// that draws it (copy one, change a number, see what happens!).
+// $$(frame()) streams the paper's components one at a time; *cs pulls
+// the next one (star-next, sugar for next(cs)) until the stream ends.
 recipes=func(
-  n=size(frame());
+  cs=$$(frame());
   found=0;
-  for(qi=0 qi<n qi++
-    g=at(frame() qi);
-    if(g.R!=nil :then
-      found=found+1;
-      print("  spiro(%d %d %d" g.R g.r g.d);
-      if(g.epi==1 :then print(" :epi"));
-      print(" :color %v)   -- %d spline points\n" g.color g.pts)));
+  while(g=*cs
+    if(g.R!=nil :then found=found+1; g.recipe()));
   if(found==0 :then print("The paper is empty! Try spiro(96 36 60) or gallery()\n"));
   found)
 
@@ -189,47 +203,48 @@ spin=func(
 orbit=func(
   steps=arg(0);
   if(steps==nil :then steps=150);
+  // one pass over the paper, streamed, to find the spirographs
   bodies=list();
-  n=size(frame());
-  for(oi=0 oi<n oi++ g=at(frame() oi); if(g.R!=nil :then bodies,g));
+  fs=$$(frame());
+  while(g=*fs if(g.R!=nil :then bodies,g));
   nb=size(bodies);
   if(nb<2 :then print("The cosmos needs at least two spirographs -- try gallery() first!\n"));
   if(nb<2 :then return(nil));
   // the sun: everyone's average center (the center of gravity)
   sx=0.0; sy=0.0;
-  for(oi=0 oi<nb oi++ c=center(at(bodies oi)); sx=sx+at(c 0); sy=sy+at(c 1));
+  for(oi=0 oi<nb oi++ c=center(bodies@oi); sx=sx+c@0; sy=sy+c@1);
   sx=sx/nb; sy=sy/nb;
   if(sunx!=nil :then sx=1.0*sunx);
   if(suny!=nil :then sy=1.0*suny);
   w=0.03; K=w*w;
   vxs=list(); vys=list(); rads=list(); spins=list();
   for(oi=0 oi<nb oi++
-    g=at(bodies oi); c=center(g); box=mbr(g);
-    vxs,(0.0-w)*(at(c 1)-sy);
-    vys,w*(at(c 0)-sx);
-    rads,(at(box 2)-at(box 0)+at(box 3)-at(box 1))/4.0;
+    g=bodies@oi; c=center(g); box=mbr(g);
+    vxs,(0.0-w)*(c@1-sy);
+    vys,w*(c@0-sx);
+    rads,(box@2-box@0+box@3-box@1)/4.0;
     if(oi%2==0 :then spins,3 :else spins,-3));
   handles(false);
   for(st=0 st<steps st++
     for(oi=0 oi<nb oi++
-      g=at(bodies oi); c=center(g);
-      px=at(c 0); py=at(c 1);
+      g=bodies@oi; c=center(g);
+      px=c@0; py=c@1;
       ax=K*(sx-px); ay=K*(sy-py);
       for(oj=0 oj<nb oj++
         if(oj!=oi :then
-          oc=center(at(bodies oj));
-          ddx=px-at(oc 0); ddy=py-at(oc 1);
+          oc=center(bodies@oj);
+          ddx=px-oc@0; ddy=py-oc@1;
           d=sqrt(ddx*ddx+ddy*ddy);
-          reach=at(rads oi)+at(rads oj);
+          reach=rads@oi+rads@oj;
           if((d>1)&&(d<reach) :then
             push=0.4*(reach-d)/reach;
             ax=ax+push*ddx/d;
             ay=ay+push*ddy/d)));
-      at(vxs oi :set at(vxs oi)+ax);
-      at(vys oi :set at(vys oi)+ay);
+      vxs@oi=vxs@oi+ax;
+      vys@oi=vys@oi+ay;
       select(g);
-      move(at(vxs oi) at(vys oi));
-      rotate(at(spins oi)));
+      move(vxs@oi vys@oi);
+      rotate(spins@oi));
     select(:clear);
     update(5000));
   handles(true);
@@ -237,13 +252,13 @@ orbit=func(
   update();
   print("The cosmos settles down.  (orbit(300) runs longer; clearpaper() starts over.)\n"))
 
-// clearpaper() -- fresh sheet (collect first, THEN delete --
-// never delete out from under the list you are walking)
+// clearpaper() -- fresh sheet.  $$(frame()) snapshots the paper's
+// components into an independent stream/copy (frame() itself is left
+// alone), so deleting each one as *doomed pulls it never mutates the
+// very list being walked.
 clearpaper=func(
-  doomed=list();
-  n=size(frame());
-  for(ci=0 ci<n ci++ doomed,at(frame() ci));
-  for(ci=0 ci<size(doomed) ci++ delete(at(doomed ci)));
+  doomed=$$(frame());
+  while(g=*doomed delete(g));
   select(:clear);
   update();
   print("Fresh paper!\n"))
@@ -273,7 +288,10 @@ spirohelp=func(
   print("  oops()           -- the machine explains your last error\n");
   print("SECRETS: every curve is YOURS -- grab one and decorate it:\n");
   print("  c=surprise(); c.nickname=\"whirly\"; c.nickname\n");
-  print("  (a dot writes a fact on the curve; recipes() reads c.R the same way)\n");
+  print("  (a dot writes a fact on the curve; recipes() reads c.R the same way --\n");
+  print("  and c.recipe() alone says the exact spiro(...) that drew it)\n");
+  print("SECRETS: a lone stream at the prompt drains itself and shows its count\n");
+  print("  instead of just vanishing -- try:  $$(frame())\n");
   print("SECRETS: more teeth in common = fewer petals -- petals = R/gcd(R r),\n");
   print("  rolling inside OR outside (the pen's distance from the center\n");
   print("  swells and shrinks R/r times per trip around, r/gcd trips).\n");

--- a/src/comdraw/tests/TESTING.md
+++ b/src/comdraw/tests/TESTING.md
@@ -53,6 +53,8 @@ pass/FAIL summary line. There is no separate orchestrator here (unlike
 | paste.comt      | paste()                                                                | `paste()` requires `parent()==nil`, refusing to double-append an already-parented graphic |
 | rasterrgb.comt  | raster(:rgb ...)                                                       | flat/nested/packed pixel-value forms, told apart by element count against w*h |
 | zoomap.comt     | zoo.who() zoo.haslegs() zoo.countlegs() zoo.dance() zoo.help() dot-chaining | integration coverage for the `examples/zoomap.comt` kid demo -- find by name/motion/food, chain straight into a found graphic's facts with no `attrlist()` wrapper, an empty result and the natural next mistake of dotting into it unwrapped, and the persisting `:asked` field across self-bound method calls |
+| spirograph.comt | spiro() gallery() surprise() recipes() spin() orbit() orb3d() clearpaper() oops() | integration coverage for the `examples/spirograph.comt` kid demo -- basic/`:epi`/`:color`/`:cx`/`:cy` spiro() variants, the three friendly-error branches, gallery()/recipes()/surprise(), the two SECRETS (dot-write persistence, `curve.recipe()`), orbit()/orb3d() both too-small and for real, and orb3d();orb3d() true-position continuity across calls |
+| deletestream.comt | delete() rect() ellipse()                                            | `delete($$frame)` -- clearing the whole canvas by feeding delete() a stream directly instead of looping with at()/delete() by hand; empty-canvas no-op and a real multi-graphic clear |
 
 `run_all.comt` runs these in the order above, each wrapped in
 `if(run("./script.comt") :then ... :else ...;ok=false)`.

--- a/src/comdraw/tests/deletestream.comt
+++ b/src/comdraw/tests/deletestream.comt
@@ -1,0 +1,42 @@
+// src/comdraw/tests/deletestream.comt -- regression coverage for the
+// delete($$frame) idiom: clearing the whole canvas by feeding delete()
+// a stream directly, instead of looping with at()/delete() by hand.
+//
+// $$frame forks frame() (bare, no parens needed) into an independent
+// stream -- a snapshot of what's on the paper right now -- and delete()
+// drains it itself, deleting each graphic in turn.  Because $$ snapshots
+// eagerly, this is safe even though delete() is shrinking the very list
+// frame() would report if called again: the stream isn't re-querying
+// frame() as it goes, so there's no self-mutation-during-iteration bug
+// to work around, and no explicit while/at() loop is needed either.
+//
+// funcs: delete
+ok=true
+
+// same reasoning as zoomap.comt/spirograph.comt: run_all.comt shares one
+// comdraw process across every test file, so start from a clean canvas
+// regardless of what ran before this test.
+delete($$frame)
+
+// --- 1: delete($$frame) on an empty canvas -- a stream of nothing is a
+// no-op, not an error. ---
+delete($$frame)
+ok=ok&&(size(frame())==0)
+print("1 delete($$frame) on an empty canvas (expect 0): %v\n" size(frame()))
+
+// --- 2: delete($$frame) clears every graphic on the paper in one call,
+// no explicit loop. ---
+rect(10,10, 30,30); ellipse(60,60, 20,10); rect(100,100, 140,140)
+ok=ok&&(size(frame())==3)
+delete($$frame)
+ok=ok&&(size(frame())==0)
+print("2 delete($$frame) clears a 3-graphic canvas in one call (expect 0): %v\n" size(frame()))
+
+// --- 3: delete($$frame) again right after, still on an empty canvas --
+// confirms test 1 wasn't a fluke of nothing having been drawn yet. ---
+delete($$frame)
+ok=ok&&(size(frame())==0)
+print("3 delete($$frame) on an already-empty canvas, no error (expect 0): %v\n" size(frame()))
+
+print("deletestream: %v\n" ok)
+ok

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -51,5 +51,9 @@ if(run("./zoomap.comt")
   :then print("pass: zoomap\n")
   :else print("FAIL: zoomap\n");ok=false)
 
+if(run("./spirograph.comt")
+  :then print("pass: spirograph\n")
+  :else print("FAIL: spirograph\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/comdraw/tests/run_all.comt
+++ b/src/comdraw/tests/run_all.comt
@@ -55,5 +55,9 @@ if(run("./spirograph.comt")
   :then print("pass: spirograph\n")
   :else print("FAIL: spirograph\n");ok=false)
 
+if(run("./deletestream.comt")
+  :then print("pass: deletestream\n")
+  :else print("FAIL: deletestream\n");ok=false)
+
 print("\nrun_all: %v\n" ok)
 ok

--- a/src/comdraw/tests/spirograph.comt
+++ b/src/comdraw/tests/spirograph.comt
@@ -22,8 +22,10 @@ ok=true
 
 // same reasoning as zoomap.comt: run_all.comt shares one comdraw process
 // across every test file, so clear the canvas first and this test's
-// counts hold regardless of what ran before it.
-while(size(frame())>0 delete(at(frame() 0)))
+// counts hold regardless of what ran before it.  delete($$frame) --
+// see deletestream.comt -- forks frame() into a stream and drains it
+// straight into delete(), no explicit while/at() loop needed.
+delete($$frame)
 
 run("../examples/spirograph.comt")
 

--- a/src/comdraw/tests/spirograph.comt
+++ b/src/comdraw/tests/spirograph.comt
@@ -211,6 +211,24 @@ orb3d(5)
 ok=ok&&(size(frame())==10 && sc4.epi==1 && sc5.color=="#0066CC")
 print("18 orb3d(5) with 10 bodies: paper still 10, sc4/sc5's fields intact (expect true): %v\n" (size(frame())==10&&sc4.epi==1&&sc5.color=="#0066CC"))
 
+// --- 18b: orb3d();orb3d() -- true x/y must carry over as TRUE position,
+// not get re-seeded from the previous call's perspective-PROJECTED
+// screen position (the bug Greptile caught: a curve.orb3d_x/orb3d_y
+// stash was missing, so continuing bodies read center() -- last call's
+// projected screen center -- back in as if it were the true position,
+// double-projecting and producing a seam).  Single-step (steps=1) calls
+// make position a nearly pure Euler step (new = old + old velocity,
+// plus a tiny restoring acceleration bounded by K=w*w against a span of
+// a few hundred pixels, well under this tolerance) -- so continuity
+// holds this tightly only because the true position was carried
+// forward, not reconstructed from an already-projected screen point. ---
+orb3d(1)
+ox1=sc4.orb3d_x; oy1=sc4.orb3d_y; vx1=sc4.orb3d_vx; vy1=sc4.orb3d_vy
+orb3d(1)
+ox2=sc4.orb3d_x; oy2=sc4.orb3d_y
+ok=ok&&(abs(ox2-(ox1+vx1))<5.0 && abs(oy2-(oy1+vy1))<5.0)
+print("18b orb3d();orb3d() true x/y continuous, not re-projected (expect true): %v\n" (abs(ox2-(ox1+vx1))<5.0 && abs(oy2-(oy1+vy1))<5.0))
+
 // --- 19: spin() -- pure smoke, no useful return value to assert on,
 // same as zoomap.comt's zoo.dance() ---
 spin()

--- a/src/comdraw/tests/spirograph.comt
+++ b/src/comdraw/tests/spirograph.comt
@@ -231,6 +231,21 @@ ox2=sc4.orb3d_x; oy2=sc4.orb3d_y
 ok=ok&&(abs(ox2-(ox1+vx1))<5.0 && abs(oy2-(oy1+vy1))<5.0)
 print("18b orb3d();orb3d() true x/y continuous, not re-projected (expect true): %v\n" (abs(ox2-(ox1+vx1))<5.0 && abs(oy2-(oy1+vy1))<5.0))
 
+// --- 18c: orb3d();orb3d() -- collision radius must stay the canonical
+// value, not get re-derived from mbr() (the bug Greptile caught next:
+// a continuing body's on-screen bounds are already perspective-scaled
+// by the previous call's scale(ratio ratio), so re-measuring mbr() every
+// call would drift the collision reach with depth instead of holding it
+// constant).  curve.orb3d_rad is set once, from the one call where
+// mbr() is still canonical, and just carried forward after that -- so
+// it should come back bit-for-bit identical across two more calls. ---
+orb3d(1)
+rad1=sc4.orb3d_rad
+orb3d(1)
+rad2=sc4.orb3d_rad
+ok=ok&&(rad1==rad2)
+print("18c orb3d();orb3d() collision radius stays canonical (expect true): %v\n" (rad1==rad2))
+
 // --- 19: spin() -- pure smoke, no useful return value to assert on,
 // same as zoomap.comt's zoo.dance() ---
 spin()

--- a/src/comdraw/tests/spirograph.comt
+++ b/src/comdraw/tests/spirograph.comt
@@ -1,0 +1,235 @@
+// src/comdraw/tests/spirograph.comt -- regression coverage for the
+// spirograph kid demo
+//
+// Loads src/comdraw/examples/spirograph.comt (draws the welcome flower)
+// and works through spirohelp()'s own magic words in roughly the order
+// it lists them: basic spiro(), a real geometric check of that curve's
+// exported PostScript against an independent reference, :epi, :color,
+// :cx/:cy, the three friendly-error branches (missing args, wheel too
+// big, wheel==ring), gallery(), recipes(), surprise(), the two SECRETS
+// (c.nickname dot-write persistence, c.recipe() self-description), the
+// auto-drain trick ($$(frame()) via each()'s equivalent count),
+// orbit()/orb3d() both on purpose too-small (1 body) and for real (10
+// bodies), spin(), oops(), and clearpaper() last since it wipes the
+// paper.  Exercises the real idioms from this PR -- @ replacing every
+// at(), curve.recipe() as a self-bound dot-closure, $$(frame())/*stream
+// walks in recipes()/clearpaper()/the body-collection passes, and
+// orb3d()'s 3-D extension -- through the actual demo script, not a
+// synthetic stand-in.
+//
+// funcs: spiro gallery surprise recipes spin orbit orb3d clearpaper oops
+ok=true
+
+// same reasoning as zoomap.comt: run_all.comt shares one comdraw process
+// across every test file, so clear the canvas first and this test's
+// counts hold regardless of what ran before it.
+while(size(frame())>0 delete(at(frame() 0)))
+
+run("../examples/spirograph.comt")
+
+// --- 1: the welcome curve -- spiro(96 36 60 :color "#CC2200") at the
+// default cx=300 cy=300, drawn by the example itself on load ---
+ok=ok&&(size(frame())==1)
+w=at(frame() 0)
+ok=ok&&(w.R==96 && w.r==36 && w.d==60 && w.epi==0 && w.color=="#CC2200")
+print("1 welcome curve: 1 shape, spiro(96 36 60 :color #CC2200) (expect true true): %v %v\n" (size(frame())==1) (w.R==96&&w.r==36&&w.d==60&&w.epi==0&&w.color=="#CC2200"))
+
+// --- 2: the welcome curve's actual drawn GEOMETRY, not just its fields.
+// export(w path :eps) writes a real EPS file; idraw's closed-B-spline
+// operator lists its raw control points as plain "x y" lines right
+// before "N CBSpl" -- the exact same flat list spiro() built. Recompute
+// that list from scratch here (not by calling spiro()'s own code -- a
+// genuine independent reference, not a tautology) and diff every point.
+//
+// split(line :tokval) would do this token-parsing "properly" but calls
+// back into the full interpreter (run()) per token and misbehaves when
+// called repeatedly in a loop (spams "pushed more than a single value on
+// stack" -- a real, separate bug, unrelated to this PR, filed as #329).
+// :tokstr sidesteps that -- plain string tokens, no interpreter re-entry
+// -- but then int() on a non-numeric token silently returns garbage
+// (int("SetCFg")==207) instead of failing, so isnum() below does its own
+// character-level check before any conversion is trusted. ---
+isnum=func(
+  s=arg(0); slen=size(s); i=0; sawdigit=false; numok=true;
+  if(slen==0 :then numok=false);
+  while(i<slen && numok
+    c=at(s i);
+    if(c=='-' && i==0 :then i=i+1
+     :else if(c=='.' :then i=i+1
+      :else if(c>='0' && c<='9' :then sawdigit=true; i=i+1
+       :else numok=false))));
+  numok && sawdigit)
+
+export(w "/tmp/comdraw_spirograph_test_welcome.eps" :eps)
+epslines=$$(open("/tmp/comdraw_spirograph_test_welcome.eps"))
+epspts=list()
+while(epsline=*epslines
+  toks=split(epsline :tokstr);
+  if(size(toks)==2 && isnum(toks@0) && isnum(toks@1) :then epspts,int(toks@0); epspts,int(toks@1)))
+
+// independent reference: the exact formula from spiro()'s own comments,
+// recomputed here rather than reused
+refR=96; refr=36; refd=60; refs=1; refcx=300; refcy=300
+refA=refR-refs*refr
+refgcd=func(a=arg(0); b=arg(1); while(b!=0 t=b; b=a%b; a=t); a)
+refg=refgcd(refR refr)
+refturns=refr/refg
+refk=1.0*refA/refr
+refbusy=refA/refg
+if(refturns>refbusy :then refbusy=refturns)
+refn=10*refbusy
+if(refn<24 :then refn=24)
+if(refn>480 :then refn=480)
+refh=2*pi()*refturns/refn
+reflam1=(2+cos(refh))/3
+reflam2=(2+cos(refk*refh))/3
+refAc=refA/reflam1
+refDc=refd/reflam2
+refxs=list(int(round(refcx+refAc*cos(refh*(0..(refn-1)))+refs*refDc*cos(refk*refh*(0..(refn-1))))))
+refys=list(int(round(refcy+refAc*sin(refh*(0..(refn-1)))-refDc*sin(refk*refh*(0..(refn-1))))))
+refpts=list()
+for(i=0 i<refn i++ refpts,refxs@i; refpts,refys@i)
+
+geommatch=(size(refpts)==size(epspts))
+for(i=0 i<size(refpts) i++ geommatch=geommatch&&(refpts@i==epspts@i))
+ok=ok&&geommatch
+print("2 welcome curve's exported EPS geometry matches an independent reference, all %v points (expect true): %v\n" refn geommatch)
+
+// --- 3: orbit()/orb3d() with only 1 spirograph -- an empty-cosmos edge
+// case hit on purpose, same spirit as zoomap.comt's empty zoo.who().
+// Both print a message and return nil without touching the paper. ---
+r2a=orbit()
+r2b=orb3d()
+ok=ok&&(r2a==nil && r2b==nil && size(frame())==1)
+print("3 orbit()/orb3d() with 1 body: both nil, paper untouched (expect true): %v\n" (r2a==nil&&r2b==nil&&size(frame())==1))
+
+// --- 4: spiro(96 36 60) -- plain defaults again, a second copy of the
+// welcome curve's recipe ---
+sc3=spiro(96 36 60)
+ok=ok&&(sc3.R==96 && sc3.r==36 && sc3.d==60 && size(frame())==2)
+print("4 spiro(96 36 60) defaults, paper now 2 (expect true): %v\n" (sc3.R==96&&sc3.r==36&&sc3.d==60&&size(frame())==2))
+
+// --- 5: spiro(45 15 30 :epi) -- roll around the outside ---
+sc4=spiro(45 15 30 :epi)
+ok=ok&&(sc4.epi==1 && size(frame())==3)
+print("5 spiro(45 15 30 :epi) sets epi=1, paper now 3 (expect true): %v\n" (sc4.epi==1&&size(frame())==3))
+
+// --- 6: spiro(96 36 60 :color "#0066CC") -- pick the pen ---
+sc5=spiro(96 36 60 :color "#0066CC")
+ok=ok&&(sc5.color=="#0066CC" && size(frame())==4)
+print("6 spiro(... :color \"#0066CC\") (expect true): %v\n" (sc5.color=="#0066CC"&&size(frame())==4))
+
+// --- 7: spiro(96 36 60 :cx 150 :cy 450) -- park it elsewhere.
+// center()'s coordinate system has its own fixed origin offset from
+// cx/cy (confirmed live: every curve's center() sits at a CONSTANT
+// (+89,+163) from its cx,cy, regardless of R/r/d) -- not something this
+// test should hardcode, since that constant is a property of the page
+// setup, not of spiro() itself.  Compare against sc3 (cx=300 cy=300)
+// instead: the two curves' centers should differ by exactly the same
+// (dx,dy) their cx/cy did, with the fixed offset canceling out. ---
+sc6=spiro(96 36 60 :cx 150 :cy 450)
+c6=center(sc6); c3chk=center(sc3)
+dx=c6@0-c3chk@0; dy=c6@1-c3chk@1
+ok=ok&&(abs(dx-(150-300))<5 && abs(dy-(450-300))<5 && size(frame())==5)
+print("7 spiro(... :cx 150 :cy 450) offset from sc3 matches (150-300,450-300) (expect true): %v\n" (abs(dx-(150-300))<5&&abs(dy-(450-300))<5&&size(frame())==5))
+
+// --- 8: spiro() with no args -- the friendly "try three numbers"
+// branch, returns nil, draws nothing ---
+r7=spiro()
+ok=ok&&(r7==nil && size(frame())==5)
+print("8 spiro() no args: nil, paper still 5 (expect true): %v\n" (r7==nil&&size(frame())==5))
+
+// --- 9: spiro(5 10 3) -- wheel (10 teeth) bigger than the ring (5
+// teeth), no :epi to roll outside instead -- the "doesn't fit" branch ---
+r8=spiro(5 10 3)
+ok=ok&&(r8==nil && size(frame())==5)
+print("9 spiro(5 10 3) wheel doesn't fit: nil, paper still 5 (expect true): %v\n" (r8==nil&&size(frame())==5))
+
+// --- 10: spiro(50 50 10) -- wheel the same size as its ring, A=R-r=0,
+// just spins in place -- the third friendly-error branch ---
+r9=spiro(50 50 10)
+ok=ok&&(r9==nil && size(frame())==5)
+print("10 spiro(50 50 10) wheel==ring: nil, paper still 5 (expect true): %v\n" (r9==nil&&size(frame())==5))
+
+// --- 11: gallery() -- four classics at the four corners ---
+gallery()
+ok=ok&&(size(frame())==9)
+print("11 gallery() adds 4, paper now 9 (expect true): %v\n" (size(frame())==9))
+
+// --- 12: recipes() -- every curve on the paper is a spiro, so found
+// matches the paper count exactly.  recipes() is the star-next walk
+// ($$(frame())/*cs) calling each curve's own curve.recipe() method. ---
+r11=recipes()
+ok=ok&&(r11==9)
+print("12 recipes() finds all 9 (expect 9): %v\n" r11)
+
+// --- 13: surprise() -- the machine invents one within its documented
+// ranges (r 16..48, R roughly 1.8x..3.4x r, d roughly 0.4x..1.1x r --
+// a little slack below/above for round()'s own rounding at the edges) ---
+sc12=surprise()
+ok=ok&&(sc12.name=="spiro" && size(frame())==10)
+ok=ok&&(sc12.r>=14 && sc12.r<=50)
+ok=ok&&(sc12.R>=int(round(1.8*sc12.r))-2 && sc12.R<=int(round(3.4*sc12.r))+2)
+ok=ok&&(sc12.d>=int(round(0.4*sc12.r))-2 && sc12.d<=int(round(1.1*sc12.r))+2)
+print("13 surprise() invents a spiro within range, paper now 10 (expect true): %v\n" (sc12.name=="spiro"&&size(frame())==10))
+
+// --- 14: SECRETS -- every curve is yours, grab one and decorate it.
+// A dot-write persists as a real fact on the curve, same as any other
+// field spiro() itself sets. ---
+sc12.nickname="whirly"
+ok=ok&&(sc12.nickname=="whirly")
+print("14 c.nickname=\"whirly\"; c.nickname (expect whirly): %v\n" sc12.nickname)
+
+// --- 15: SECRETS -- c.recipe() says the exact spiro(...) that drew it,
+// straight off the object, no argument.  Pure smoke test: it prints,
+// there's nothing to capture, just confirm it runs without disturbing
+// the paper or the curve's own fields. ---
+sc12.recipe()
+ok=ok&&(size(frame())==10 && sc12.R!=nil)
+print("15 c.recipe() runs cleanly, curve untouched (expect true): %v\n" (size(frame())==10&&sc12.R!=nil))
+
+// --- 16: SECRETS -- a lone stream at the prompt drains itself and shows
+// its count instead of vanishing.  each($$(frame())) is the same count
+// the auto-drain trick would print, just captured as a real value
+// instead of only shown at the interactive prompt. ---
+r15=each($$(frame()))
+ok=ok&&(r15==10 && r15==size(frame()))
+print("16 each($$(frame())) matches the paper count (expect 10): %v\n" r15)
+
+// --- 17: orbit(5) with 10 bodies -- a few real physics steps.  The
+// paper count never changes (nobody's created or destroyed, just moved/
+// rotated), and a curve's own fields survive select()/move()/rotate()
+// untouched -- spot-checked on sc3 from test 3. ---
+orbit(5)
+ok=ok&&(size(frame())==10 && sc3.R==96 && sc3.r==36 && sc3.d==60)
+print("17 orbit(5) with 10 bodies: paper still 10, sc3's fields intact (expect true): %v\n" (size(frame())==10&&sc3.R==96&&sc3.r==36&&sc3.d==60))
+
+// --- 18: orb3d(5) with the same 10 bodies -- same invariants, plus
+// scale()/back() (orb3d()'s own additions over orbit()) leave fields
+// alone too. ---
+orb3d(5)
+ok=ok&&(size(frame())==10 && sc4.epi==1 && sc5.color=="#0066CC")
+print("18 orb3d(5) with 10 bodies: paper still 10, sc4/sc5's fields intact (expect true): %v\n" (size(frame())==10&&sc4.epi==1&&sc5.color=="#0066CC"))
+
+// --- 19: spin() -- pure smoke, no useful return value to assert on,
+// same as zoomap.comt's zoo.dance() ---
+spin()
+ok=ok&&(size(frame())==10)
+print("19 spin() runs without error, paper still 10 (expect true): %v\n" (size(frame())==10))
+
+// --- 20: oops() -- no mistake waiting yet (every spiro() call above
+// that failed did so through a friendly print(), not a real interpreter
+// error), so oops() takes its "machine is happy" branch and returns nil
+// either way ---
+r19=oops()
+ok=ok&&(r19==nil)
+print("20 oops() with no error waiting (expect nil): %v\n" r19)
+
+// --- 21: clearpaper() -- fresh sheet, run last since it wipes
+// everything the tests above built up ---
+clearpaper()
+ok=ok&&(size(frame())==0)
+print("21 clearpaper() empties the paper (expect 0): %v\n" size(frame()))
+
+print("spirograph: %v\n" ok)
+ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "bd6840e1"
+#define PATCH_KEY "6eb8cdf7"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "6eb8cdf7"
+#define PATCH_KEY "fba0b25b"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "678133f6"
+#define PATCH_KEY "3b3a83c3"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "f2235897"
+#define PATCH_KEY "bd6840e1"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "f78405b2"
+#define PATCH_KEY "678133f6"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "75a30277"
+#define PATCH_KEY "f2235897"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "3b3a83c3"
+#define PATCH_KEY "8c2a531e"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "4659239c"
+#define PATCH_KEY "75a30277"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "fba0b25b"
+#define PATCH_KEY "f78405b2"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "defb8393"
+#define PATCH_KEY "4659239c"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- Rewrites `src/comdraw/examples/spirograph.comt` in current language idioms:
  - `@` replaces every `at()`/`at(:set)` call, read and write alike.
  - Each curve grows a self-bound `curve.recipe()` dot-closure (ducktyping.comt's `obj.method()` pattern) that reads its own R/r/d/epi/color/pts fields back out as the exact `spiro(...)` that drew it; `recipes()` is now a one-pass star-next (`$$(frame())`/`*cs`) walk calling it per curve.
  - `clearpaper()` and `orbit()`'s body-collection pass are rewritten as `$$(frame())`/`*`-stream walks instead of indexed for-loops.
  - `spiro()`'s per-point trig is computed via stream overdrive (a fresh `h*(0..(n-1))` range per occurrence) instead of an explicit loop -- only the final x,y interleave stays a loop, since `closedspline()` wants one flat list and there's no zip primitive.
  - `spirohelp()` documents the new `curve.recipe()` method and the `$$(frame())`-at-the-prompt auto-drain trick (#324).
- Adds `orb3d()`: `orbit()`'s spring-gravity + bump-repulsion model extended into real (x,y,z) space, projected to the screen with a simple pinhole perspective -- nearer planets grow (`scale()`) and come to the front (`back()`, painter's algorithm), farther ones shrink and recede.

## Test plan
- [x] `src/comterp_/tests/run_all.comt` -- 35/35 passing (unaffected, `.comt` example only)
- [x] `comdraw`/ComUnidraw build clean
- [x] Verified end-to-end via `comdraw -runfile`: `gallery()`/`recipes()`/`surprise()`/`orbit()`/`orb3d()`/`clearpaper()` all exercised, curves + their `.recipe()` methods survive scale()/back()/move() unmolested
- [x] `spiro()`'s new point-generation formula verified numerically against the old loop's exact output via comterp_ headless
- [x] `orb3d()` stability checked over 150 steps: z stays spring-bounded (~±200), perspective factor stays sane and always-positive (~0.71-1.67), no runaway or sign flip