### PR TITLE
NilFunc dynamic gate (#328) + :posteval lazy FuncObj arguments

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1176,13 +1176,21 @@ commands name the outer scopes explicitly, as both lvalue and rvalue:
 
 ```
 count=0
-bump=func(local(count)=count+1)   // reads outer count, writes it back
+bump=func(local(count)=local(count)+1)   // reads outer count, writes it back
 bump(); bump()
 count                  // 2 -- the func published through local()
 
 f=func(count=99; count,local(count))
 f()                    // {99,2} -- frame shadow vs explicit outer read
 ```
+
+Note the RHS is `local(count)`, not bare `count` — `local()` on the lvalue
+side alone does not exempt a bare rvalue mention of the same name from
+declaration-time capture (see *Closures* above): a bare, never-locally-
+written `count` here would still count as a genuine free-variable read,
+captured once when `bump` is declared, so every call would recompute
+`0+1` instead of reading the live outer value. Wrapping both sides in
+`local()` keeps the read genuinely live on every call.
 
 In a single-interpreter session `local()` and `global()` differ only in
 which table they touch; in a multi-session server they are session

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1122,24 +1122,42 @@ g=func(c=arg(0); if(c :then arg(1) :else -1))
 g(false print("runs anyway\n"))   // prints "runs anyway" first, then -1
 ```
 
-**Pulled once, not once per read.** Whichever value gets pulled — by
-`arg(n)` or by a keyword — is memoized in place: the first read evaluates
-it, every later read of the same arg/keyword returns that same result
-without re-running it:
+**`arg(n)` re-fires on every call; a keyword is pulled once.** These two
+are timed differently on purpose. `arg(n)` has no lvalue form — there's no
+`arg(0)=...` — so there's nothing to protect by caching it, and re-running
+the pending expression on every call is what lets a `while` loop inside
+the body see a live, current value each iteration, the same way any
+post_eval command's own operand (`while`'s condition, for instance) is
+genuinely re-evaluated every pass:
+
+```
+hits=list()
+counter=func(hits,1; size(hits))
+loopf=func(n=0; while(arg(0)<4 n=n+1) n :posteval)
+loopf(counter())   // 3 -- 4 condition checks (hits reaches 1,2,3,4), 3 loop bodies
+size(hits)         // 4
+```
+
+A keyword, by contrast, is lazy but otherwise timed exactly like a plain
+`func()`'s own eager keyword: evaluated once, on its first
+read-before-write, then memoized — a later read (or write) sees that same
+value, it does not re-fire, even from inside a loop:
 
 ```
 side=list()
 bump=func(side,1; size(side))
-h=func(a=arg(0); b=arg(0); a+b :posteval)
-h(bump())    // 2 -- a and b both get the SAME pulled value; bump() itself only ran once
-size(side)   // 1
+h=func(y+y :posteval)
+h(:y bump())   // 2 -- y is read twice, but bump() only ran once
+size(side)     // 1
 ```
 
-Same for keywords: a keyword's *first* read-before-write pulls it;
-assigning to it before ever reading it, or never reading it at all, means
-its argument expression never runs — the same write-before-read rule
-captures already use above, applied to arguments instead of free
-variables.
+Assigning to a keyword before ever reading it, or never reading it at
+all, means its argument expression never runs at all — the same
+write-before-read rule captures already use above, applied to a keyword
+argument instead of a free variable. The idiom for caching a
+repeatedly-read `arg(n)` inside a loop is the same one non-func code
+already uses for any post_eval command's operand: assign it to a local
+once, then read that local from then on.
 
 **Composes with any existing control command, no special-casing needed.**
 `if`/`while`/`switch` already selectively evaluate their own operands via

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1170,12 +1170,26 @@ laziness of the control command and the laziness of the call compose for
 free, all the way back through a chain of `:posteval` calls, without
 either side needing to know the other exists.
 
-**The gate is dynamic, not frozen at parse time.** Whether a call is
-lazy depends on the *current* value of the name being called, checked at
-the moment it actually fires — the same discipline the dynamic
-NilFunc gate uses for forward references to a not-yet-defined name — so
-reassigning a name to a differently-flagged func between its definition
-and a later call is honored, not decided once and cached.
+**The gate is dynamic within the limits of one static classification
+pass.** A whole `;`-joined statement chain is tokenized and classified
+once, before any of it runs — the same fact issue #328 is built around.
+Two cases correctly stay dynamic across that: an *undefined* name (the
+original #328 forward-reference shape) and a name that's *already*
+`:posteval` at that single classification pass — both get pedepth-marked
+so the real dispatch-time gate re-checks the *current* value right when
+the call fires, honoring a reassignment that happened earlier in the same
+chain (or on an earlier line entirely — the ordinary case: define on one
+line, call on a later one). What does *not* stay dynamic: a name that
+resolves to an already-*eager* `FuncObj` at that same classification
+pass never gets pedepth-marked at all, so its arguments are evaluated
+immediately by the ordinary eager path — before a same-chain reassignment
+to `:posteval` earlier in that chain has even run. By the time the
+reassignment takes effect, the arguments are already gone; there's no
+token span left for any dispatch-time recheck to defer. Closing this gap
+fully would mean pedepth-deferring every call-shaped symbol reference
+unconditionally, not just undefined or already-`:posteval` ones, so the
+dynamic gate is consulted for literally every func call in the language —
+a much larger change than this feature makes on its own.
 
 ### Escaping the func scope: local() and global()
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1096,6 +1096,69 @@ do not escape to the caller's scope. This includes dot-notation
 attributes: a dot namespace rooted at a local symbol is local to the
 call.
 
+### Lazy arguments: `:posteval`
+
+An ordinary `func()` call is eager: every positional and keyword argument
+is fully evaluated once, before the body runs, whether or not the body
+ever reads it (see `arg()`/`narg()` above). `func(body :posteval)` makes
+the call lazy instead: none of its arguments are evaluated at call time.
+They stay unevaluated — the same "wait until pulled" contract any
+post_eval command's own pending args already have — resolved only the
+moment something inside the body actually asks for them: `arg(n)` on its
+first read, a keyword on its own first read-before-write. An argument the
+body never reads is never evaluated at all, side effects included:
+
+```
+f=func(c=arg(0); if(c :then arg(1) :else -1) :posteval)
+f(false print("never runs\n"))   // -1 -- arg(1)'s expression is never touched
+f(true print("runs\n"))          // prints "runs", then true
+```
+
+Compare the same body without `:posteval` — the caller's argument is
+evaluated up front regardless of what the body's own `if` ever reads:
+
+```
+g=func(c=arg(0); if(c :then arg(1) :else -1))
+g(false print("runs anyway\n"))   // prints "runs anyway" first, then -1
+```
+
+**Pulled once, not once per read.** Whichever value gets pulled — by
+`arg(n)` or by a keyword — is memoized in place: the first read evaluates
+it, every later read of the same arg/keyword returns that same result
+without re-running it:
+
+```
+side=list()
+bump=func(side,1; size(side))
+h=func(a=arg(0); b=arg(0); a+b :posteval)
+h(bump())    // 2 -- a and b both get the SAME pulled value; bump() itself only ran once
+size(side)   // 1
+```
+
+Same for keywords: a keyword's *first* read-before-write pulls it;
+assigning to it before ever reading it, or never reading it at all, means
+its argument expression never runs — the same write-before-read rule
+captures already use above, applied to arguments instead of free
+variables.
+
+**Composes with any existing control command, no special-casing needed.**
+`if`/`while`/`switch` already selectively evaluate their own operands via
+the same on-demand mechanism (resolving one token-span bookmark at a
+time) that `arg()`/a keyword read now use to reach back into the
+*caller's* still-pending arguments. So a control command inside a
+`:posteval` body that skips a branch transparently skips whatever
+caller-side expression that branch's `arg(n)` would have pulled — the
+laziness of the control command and the laziness of the call compose for
+free, all the way back through a chain of `:posteval` calls, without
+either side needing to know the other exists.
+
+**The gate is dynamic, not frozen at parse time.** Whether a call is
+lazy depends on the *current* value of the name being called, checked at
+the moment it actually fires — the same discipline the dynamic
+NilFunc gate uses for forward references to a not-yet-defined name — so
+reassigning a name to a differently-flagged func between its definition
+and a later call is honored, not decided once and cached.
+
 ### Escaping the func scope: local() and global()
 
 When a func genuinely needs to write outside its own frame, two

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -25,6 +25,7 @@
 #include <ComTerp/comfunc.h>
 #include <ComTerp/comterp.h>
 #include <ComTerp/comvalue.h>
+#include <ComTerp/postfunc.h>
 #include <ComUtil/comutil.h>
 #include <Attribute/attrlist.h>
 #include <string.h>
@@ -295,6 +296,58 @@ AttributeList* ComFunc::stack_keys_post_eval(boolean symbol, ComValue& dflt) {
       al->add_attr(key_symid, val);
     } else {
       al->add_attr(key_symid, dflt);
+    }
+  }
+  return al;
+}
+
+ComValue* ComFunc::bookmark_stack_arg_post_eval_nargsfixed() {
+  ComValue argoff(comterp()->stack_top());
+  int offtop = argoff.int_val()-comterp()->_pfnum;
+  int argcnt;
+  for (int i=0; i<nkeys(); i++) {
+    argcnt = 0;
+    skip_key_in_expr(offtop, argcnt);
+  }
+
+  int n = nargsfixed();
+  ComValue* markers = n>0 ? new ComValue[n] : nil;
+  for (int j=n; j>0; j--) {
+    argcnt = 0;
+    skip_arg_in_expr(offtop, argcnt);
+    FuncObjPendingArg* marker = new FuncObjPendingArg(offtop, argcnt, pedepth()+1);
+    markers[j-1] = ComValue(FuncObjPendingArg::class_symid(), (void*)marker);
+  }
+  return markers;
+}
+
+AttributeList* ComFunc::bookmark_stack_keys_post_eval() {
+  AttributeList* al = new AttributeList();
+  if (nkeys() == 0) return al;
+
+  ComValue argoff(comterp()->stack_top());
+  int offtop = argoff.int_val()-comterp()->_pfnum;
+  if (offtop > 0 || comterp()->_pfnum + offtop < 1) {
+    fprintf(stderr, "comterp: bookmark_stack_keys_post_eval: offtop out of range "
+            "(offtop=%d nkeys=%d argoff=%d _pfnum=%d) -- argoff anchor missing "
+            "or corrupt; upstream command likely failed to push its bookmark\n",
+            offtop, nkeys(), argoff.int_val(), (int)comterp()->_pfnum);
+    return al;
+  }
+  int count = 0;
+  while (count < nkeys()) {
+    ComValue& curr = comterp()->expr_top(offtop);
+    if (!curr.is_type(ComValue::KeywordType)) break;
+    int key_symid = curr.symbol_val();
+    count++;
+    int argcnt = 0;
+    skip_key_in_expr(offtop, argcnt);
+    if (argcnt) {
+      FuncObjPendingArg* marker = new FuncObjPendingArg(offtop, argcnt, pedepth()+1);
+      ComValue markerval(FuncObjPendingArg::class_symid(), (void*)marker);
+      al->add_attr(key_symid, markerval);
+    } else {
+      al->add_attr(key_symid, ComValue::trueval());  /* bare :flag -- nothing to defer */
     }
   }
   return al;

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -262,6 +262,44 @@ ComValue** ComFunc::stack_arg_post_eval_nargsfixed(boolean symbol, ComValue& dfl
   return vals;
 }
 
+AttributeList* ComFunc::stack_keys_post_eval(boolean symbol, ComValue& dflt) {
+  AttributeList* al = new AttributeList();
+  /* same nkeys()==0 short-circuit as stack_key_post_eval -- nothing to
+     enumerate, and no reason to read a possibly-stale operand-stack
+     anchor for it (see that function's fuller comment). */
+  if (nkeys() == 0) return al;
+
+  ComValue argoff(comterp()->stack_top());
+  int offtop = argoff.int_val()-comterp()->_pfnum;
+  if (offtop > 0 || comterp()->_pfnum + offtop < 1) {
+    fprintf(stderr, "comterp: stack_keys_post_eval: offtop out of range "
+            "(offtop=%d nkeys=%d argoff=%d _pfnum=%d) -- argoff anchor missing "
+            "or corrupt; upstream command likely failed to push its bookmark\n",
+            offtop, nkeys(), argoff.int_val(), (int)comterp()->_pfnum);
+    return al;
+  }
+  /* same walk as stack_key_post_eval's search loop, generalized: instead
+     of stopping at the first keyword matching a sought id, evaluate and
+     collect every one. */
+  int count = 0;
+  while (count < nkeys()) {
+    ComValue& curr = comterp()->expr_top(offtop);
+    if (!curr.is_type(ComValue::KeywordType)) break;
+    int key_symid = curr.symbol_val();
+    count++;
+    int argcnt = 0;
+    skip_key_in_expr(offtop, argcnt);
+    if (argcnt) {
+      comterp()->post_eval_expr(argcnt, offtop, pedepth()+1);
+      ComValue val(comterp()->pop_stack(!symbol));
+      al->add_attr(key_symid, val);
+    } else {
+      al->add_attr(key_symid, dflt);
+    }
+  }
+  return al;
+}
+
 ComValue ComFunc::stack_key_post_eval
 (int id, boolean symbol, ComValue& dflt) {
   /* No keyword tokens for this command -> the sought keyword is definitively

--- a/src/ComTerp/comfunc.h
+++ b/src/ComTerp/comfunc.h
@@ -186,6 +186,20 @@ public:
     // of them, the same relationship stack_arg_post_eval_nargsfixed() has
     // to a per-index stack_arg_post_eval() loop.
 
+    ComValue* bookmark_stack_arg_post_eval_nargsfixed();
+    // same token-span walk as stack_arg_post_eval_nargsfixed(), but never
+    // evaluates anything -- each fixed positional's span becomes a
+    // FuncObjPendingArg marker (postfunc.h) in the returned array instead
+    // of a real value.  Used by NilFunc's dynamic gate (#328) when its
+    // resolved target is :posteval, so the args stay unevaluated exactly
+    // the way FuncObj::posteval() promises.
+
+    AttributeList* bookmark_stack_keys_post_eval();
+    // same, for keywords: each keyword with a value span becomes a
+    // FuncObjPendingArg marker; a bare :flag (no value token to defer)
+    // still gets ComValue::trueval() directly, same as the eager path,
+    // since there's nothing to defer.
+
     void funcid(int id) { _funcid = id; }
     // set symbol id of name for func
     int funcid() const { return _funcid; }

--- a/src/ComTerp/comfunc.h
+++ b/src/ComTerp/comfunc.h
@@ -170,10 +170,21 @@ public:
     // to the invocation of this ComFunc.  'dflt' is used whenever a 
     // keyword has no matching argument.
 
-    ComValue** stack_arg_post_eval_nargsfixed(boolean symbol=false, 
+    ComValue** stack_arg_post_eval_nargsfixed(boolean symbol=false,
                                               ComValue& dflt=ComValue::nullval());
     // evaluate all nargsfixed arguments for this post-evaluating ComFunc,
     // and return in newly allocated array of newly allocated pointers.
+
+    AttributeList* stack_keys_post_eval(boolean symbol=false,
+                                         ComValue& dflt=ComValue::trueval());
+    // post-eval counterpart of stack_keys(): evaluate every keyword's
+    // value for this post-evaluating ComFunc (a bare keyword flag gets
+    // 'dflt') and return them all as a newly-constructed AttributeList
+    // (needs referencing), one pass over the keyword run rather than one
+    // stack_key_post_eval() call per known id -- the walk stack_key_post_eval
+    // already does internally to find ONE id, generalized to collect all
+    // of them, the same relationship stack_arg_post_eval_nargsfixed() has
+    // to a per-index stack_arg_post_eval() loop.
 
     void funcid(int id) { _funcid = id; }
     // set symbol id of name for func

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -273,7 +273,7 @@ int ComTerp::eval_expr(ComValue* pfvals, int npfvals) {
   return FUNCOK;
 }
 
-void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys) {
+void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* lazy_posvals) {
   EvalFunc ef(this);
   /* keywords still build the body's locals (the _alist); the fixed
      positionals become the func's eager actual args, captured here so
@@ -285,7 +285,9 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys) {
      minus the keyword values actually consumed -- not narg-nkey.  (When
      extra_keys is supplied, narg() is already positional-only -- the
      caller's keywords never touched the shared stack -- so no post-
-     keyword deduction applies there; see below.) */
+     keyword deduction applies there; see below.  When lazy_posvals is
+     supplied, val.narg() is exactly its length -- nothing to deduct,
+     nothing was pushed for the args at all.) */
   int npos = val.narg();
   AttributeList* al = new AttributeList();
   /* #310: seed al from this funcobj's own declaration-time captures
@@ -303,19 +305,21 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys) {
     }
   }
   if (extra_keys) {
-    /* caller already evaluated its own keywords (ComFunc::stack_keys_post_eval
-       -- it can't leave them on the shared stack in the ordinary popped
-       shape the branch below expects, so it hands them in pre-built
-       instead).  Same add_attr call as the ordinary loop below, just
-       sourced from extra_keys instead of the stack -- still lands after
-       captures, so an explicit :x val keyword still overrides a capture
-       for free. */
+    /* caller already built the call's keyword AttributeList some other way
+       instead of leaving marker+value pairs on the shared stack --
+       NilFunc's dynamic re-check (ComFunc::stack_keys_post_eval) for an
+       eager target, or (a :posteval target) FuncObjPendingArg markers
+       instead of real values.  Either way fire_funcobj just copies the
+       entries into al -- it doesn't care whether they're real or pending,
+       only funcobj_arg()/the bare-read fallthrough do.  Same add_attr call
+       as the ordinary loop below, still lands after captures, so an
+       explicit :x val keyword still overrides a capture for free. */
     ALIterator ekit;
     for (extra_keys->First(ekit); !extra_keys->Done(ekit); extra_keys->Next(ekit)) {
       Attribute* ekattr = extra_keys->GetAttr(ekit);
       al->add_attr(ekattr->SymbolId(), *ekattr->Value());
     }
-  } else {
+  } else if (!lazy_posvals) {
     for(int i=0; i<val.nkey(); i++) {
       ComValue keyv(pop_stack());
       int knarg = keyv.keynarg_val();
@@ -338,8 +342,16 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys) {
     }
   }
   if (npos<0) npos = 0;
-  ComValue* posvals = npos>0 ? new ComValue[npos] : nil;
-  for(int i=npos-1; i>=0; i--) posvals[i] = pop_stack();
+  ComValue* posvals;
+  if (lazy_posvals) {
+    /* nothing to pop -- lazy_posvals' entries are ordinarily
+       FuncObjPendingArg markers, pulled and memoized in place by
+       funcobj_arg() the first time (if ever) arg(n) actually reads one. */
+    posvals = lazy_posvals;
+  } else {
+    posvals = npos>0 ? new ComValue[npos] : nil;
+    for(int i=npos-1; i>=0; i--) posvals[i] = pop_stack();
+  }
   ComValue* saved_argvals = _funcobj_argvals;
   int saved_nargs = _funcobj_nargs;
   boolean saved_active = _funcobj_active;
@@ -646,7 +658,17 @@ void ComTerp::eval_expr_internals(int pedepth) {
       if (_alist) {
 	// cerr << "looking up " << sv.symbol_ptr() << " (" << _alist << ")\n";
 	int id = sv.symbol_val();
-	AttributeValue* val = _alist->find(id);
+	/* a :posteval keyword arg that hasn't been read yet sits here as a
+	   FuncObjPendingArg marker (postfunc.h) instead of a real value --
+	   pull_alist_pending() pulls it on this, its first read-before-write,
+	   and memoizes the real result back under the same id, so every later
+	   read (here or through lookup_symval(), the path an ordinary
+	   operand -- not a standalone reference -- resolves through) takes
+	   the ordinary fast path below.  A keyword the body only ever
+	   writes, or never reads at all, never reaches here with a write
+	   first (AssignFunc writes directly, it doesn't read through this
+	   path) -- true laziness, not just "resolved late". */
+	AttributeValue* val = pull_alist_pending(_alist, id, _alist->find(id));
 	/* a func-local FuncObj falls through to the same fire-check below as
 	   every other symbol reference, instead of returning early -- a
 	   standalone variable is a niladic call site regardless of whether
@@ -1146,8 +1168,22 @@ void ComTerp::token_to_comvalue(postfix_token* token, ComValue* sv) {
       command_symid = sv->symbol_val();
     }
 
-    /* handle case where symbol has arguments/keywords, but is not defined */
-    else if (!vptr && (sv->narg() || sv->nkey())) {
+    /* handle case where symbol has arguments/keywords, but is not defined --
+       or (posteval FuncObj) already resolves to one, at this point, whose
+       :posteval flag is set.  Either way, route through the same NilFunc
+       substitution: NilFunc is post_eval, so the pre-pass below marks this
+       call's whole operand span pedepth'd and the forward push loop never
+       eagerly evaluates it -- exactly the "sit in the postfix buffer until
+       pulled" contract a posteval func's args need.  A symbol that's simply
+       undefined still resolves to NilFunc's real "not found" behavior at
+       dispatch time (comterp.c's dynamic gate, #328); one that resolves to a
+       posteval FuncObj here is re-checked there too, so a later reassignment
+       within the same statement chain is never trusted from this static
+       snapshot -- only used to decide whether to defer at all. */
+    else if ((sv->narg() || sv->nkey()) &&
+	     (!vptr ||
+	      (((ComValue*)vptr)->is_object(FuncObj::class_symid()) &&
+	       ((FuncObj*)((ComValue*)vptr)->obj_val())->posteval()))) {
       static int nil_symid = symbol_add("nil");
       localtable()->find(vptr, nil_symid);
     }
@@ -1264,7 +1300,7 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 
 	if (_alist) {
 	  int id = comval.symbol_val();
-	  AttributeValue* aval = _alist->find(id);  
+	  AttributeValue* aval = pull_alist_pending(_alist, id, _alist->find(id));
 	  if (aval) {
 	    ComValue newval(*aval);
 	    *&comval = newval;
@@ -1304,7 +1340,7 @@ AttributeValue* ComTerp::lookup_symval(ComValue* comval) {
 	   by their scope flags directly.) */
 	if (!comval->global_flag() && _alist) {
 	  int id = comval->symbol_val();
-	  AttributeValue* aval = _alist->find(id);
+	  AttributeValue* aval = pull_alist_pending(_alist, id, _alist->find(id));
 	  if (aval) return aval;
 	}
 	if (!comval->global_flag() && localtable()->find(vptr, comval->symbol_val())) {
@@ -2248,7 +2284,54 @@ int ComTerp::narg_str() {
 ComValue& ComTerp::funcobj_arg(int n) {
   if (!_funcobj_argvals || n<0 || n>=_funcobj_nargs)
     return ComValue::nullval();
+  if (_funcobj_argvals[n].is_object(FuncObjPendingArg::class_symid())) {
+    FuncObjPendingArg* marker = (FuncObjPendingArg*)_funcobj_argvals[n].obj_val();
+    _funcobj_argvals[n] = pull_funcobj_pending(marker);  /* memoize in place */
+  }
   return _funcobj_argvals[n];
+}
+
+ComValue ComTerp::pull_funcobj_pending(FuncObjPendingArg* marker) {
+  /* reach back into the caller's still-parked buffer -- push_servstate()
+     already stashed it on _ctsstack the moment this invocation's body
+     started running, purely as ordinary nested-call bookkeeping, so there's
+     nothing new to allocate here: borrow its pfbuf/pfcomvals/pfoff for the
+     one post_eval_expr() call, then put this invocation's own buffer back. */
+  ComTerpState* caller = top_servstate();
+  if (!caller) return ComValue::nullval();
+
+  postfix_token* save_pfbuf = _pfbuf;
+  int save_pfsiz = _pfsiz;
+  int save_pfnum = _pfnum;
+  int save_pfoff = _pfoff;
+  ComValue* save_pfcomvals = _pfcomvals;
+
+  _pfbuf = caller->pfbuf();
+  _pfsiz = caller->pfsiz();
+  _pfnum = caller->pfnum();
+  _pfoff = caller->pfoff();
+  _pfcomvals = caller->pfcomvals();
+
+  post_eval_expr(marker->tokcnt(), marker->offtop(), marker->pedepth());
+  ComValue val(pop_stack());
+
+  _pfbuf = save_pfbuf;
+  _pfsiz = save_pfsiz;
+  _pfnum = save_pfnum;
+  _pfoff = save_pfoff;
+  _pfcomvals = save_pfcomvals;
+
+  return val;
+}
+
+AttributeValue* ComTerp::pull_alist_pending(AttributeList* al, int id, AttributeValue* found) {
+  if (!found || !found->is_object(FuncObjPendingArg::class_symid()))
+    return found;
+  FuncObjPendingArg* marker = (FuncObjPendingArg*)found->obj_val();
+  ComValue pulled(pull_funcobj_pending(marker));
+  al->add_attr(id, pulled);  /* replaces the marker -- every later lookup
+                                of this id finds the real value directly */
+  return al->find(id);
 }
 
 void ComTerp::set_args(int argc, char** argv) {

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -273,7 +273,7 @@ int ComTerp::eval_expr(ComValue* pfvals, int npfvals) {
   return FUNCOK;
 }
 
-void ComTerp::fire_funcobj(ComValue& val) {
+void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys) {
   EvalFunc ef(this);
   /* keywords still build the body's locals (the _alist); the fixed
      positionals become the func's eager actual args, captured here so
@@ -282,7 +282,10 @@ void ComTerp::fire_funcobj(ComValue& val) {
      after keywords), so pop them first.  narg() counts non-keyword args
      *including* values that follow keywords, and each keyword carries its
      own keynarg (0 for a bare flag), so the fixed-positional count is narg
-     minus the keyword values actually consumed -- not narg-nkey. */
+     minus the keyword values actually consumed -- not narg-nkey.  (When
+     extra_keys is supplied, narg() is already positional-only -- the
+     caller's keywords never touched the shared stack -- so no post-
+     keyword deduction applies there; see below.) */
   int npos = val.narg();
   AttributeList* al = new AttributeList();
   /* #310: seed al from this funcobj's own declaration-time captures
@@ -299,23 +302,38 @@ void ComTerp::fire_funcobj(ComValue& val) {
       al->add_attr(capattr->SymbolId(), *capattr->Value());
     }
   }
-  for(int i=0; i<val.nkey(); i++) {
-    ComValue keyv(pop_stack());
-    int knarg = keyv.keynarg_val();
-    if (knarg==0) {
-      al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
-    } else {
-      /* knarg is 0 or 1 by construction: the parser emits every keyword
-	 token with narg 0 (bare flag) or 1 (keyword+value) -- the
-	 TOK_KEYWORD PFOUT sites in ComUtil/_parser.c -- and keynarg is set
-	 from token->narg (comterp.c:927).  So knarg>1 is unreachable; this
-	 loop is written generally only.  Even if it ran, add_attr dedups by
-	 symid (replaces, never appends), binding a single value, and every
-	 value is popped so the positional count (npos) stays correct. */
-      for(int j=0; j<knarg; j++) {
-	ComValue valv(pop_stack());
-	al->add_attr(keyv.keyid_val(), valv);
-	npos--;   /* a post-keyword value, not a fixed positional */
+  if (extra_keys) {
+    /* caller already evaluated its own keywords (ComFunc::stack_keys_post_eval
+       -- it can't leave them on the shared stack in the ordinary popped
+       shape the branch below expects, so it hands them in pre-built
+       instead).  Same add_attr call as the ordinary loop below, just
+       sourced from extra_keys instead of the stack -- still lands after
+       captures, so an explicit :x val keyword still overrides a capture
+       for free. */
+    ALIterator ekit;
+    for (extra_keys->First(ekit); !extra_keys->Done(ekit); extra_keys->Next(ekit)) {
+      Attribute* ekattr = extra_keys->GetAttr(ekit);
+      al->add_attr(ekattr->SymbolId(), *ekattr->Value());
+    }
+  } else {
+    for(int i=0; i<val.nkey(); i++) {
+      ComValue keyv(pop_stack());
+      int knarg = keyv.keynarg_val();
+      if (knarg==0) {
+	al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
+      } else {
+	/* knarg is 0 or 1 by construction: the parser emits every keyword
+	   token with narg 0 (bare flag) or 1 (keyword+value) -- the
+	   TOK_KEYWORD PFOUT sites in ComUtil/_parser.c -- and keynarg is set
+	   from token->narg (comterp.c:927).  So knarg>1 is unreachable; this
+	   loop is written generally only.  Even if it ran, add_attr dedups by
+	   symid (replaces, never appends), binding a single value, and every
+	   value is popped so the positional count (npos) stays correct. */
+	for(int j=0; j<knarg; j++) {
+	  ComValue valv(pop_stack());
+	  al->add_attr(keyv.keyid_val(), valv);
+	  npos--;   /* a post-keyword value, not a fixed positional */
+	}
       }
     }
   }

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -661,13 +661,15 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	/* a :posteval keyword arg that hasn't been read yet sits here as a
 	   FuncObjPendingArg marker (postfunc.h) instead of a real value --
 	   pull_alist_pending() pulls it on this, its first read-before-write,
-	   and memoizes the real result back under the same id, so every later
-	   read (here or through lookup_symval(), the path an ordinary
-	   operand -- not a standalone reference -- resolves through) takes
-	   the ordinary fast path below.  A keyword the body only ever
-	   writes, or never reads at all, never reaches here with a write
-	   first (AssignFunc writes directly, it doesn't read through this
-	   path) -- true laziness, not just "resolved late". */
+	   and memoizes the real result back under the same id (matching
+	   plain func()'s own eager-keyword timing, just deferred to first
+	   access instead of call time -- see comterp.h's own note on this),
+	   so every later read (here or through lookup_symval(), the path an
+	   ordinary operand -- not a standalone reference -- resolves
+	   through) takes the ordinary fast path below.  A keyword the body
+	   only ever writes, or never reads at all, never reaches here with a
+	   write first (AssignFunc writes directly, it doesn't read through
+	   this path) -- true laziness, not just "resolved late". */
 	AttributeValue* val = pull_alist_pending(_alist, id, _alist->find(id));
 	/* a func-local FuncObj falls through to the same fire-check below as
 	   every other symbol reference, instead of returning early -- a
@@ -2281,12 +2283,12 @@ int ComTerp::narg_str() {
   return _narg_strs;
 }
 
-ComValue& ComTerp::funcobj_arg(int n) {
+ComValue ComTerp::funcobj_arg(int n) {
   if (!_funcobj_argvals || n<0 || n>=_funcobj_nargs)
     return ComValue::nullval();
   if (_funcobj_argvals[n].is_object(FuncObjPendingArg::class_symid())) {
     FuncObjPendingArg* marker = (FuncObjPendingArg*)_funcobj_argvals[n].obj_val();
-    _funcobj_argvals[n] = pull_funcobj_pending(marker);  /* memoize in place */
+    return pull_funcobj_pending(marker);  /* re-fires every call, never memoized */
   }
   return _funcobj_argvals[n];
 }

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -368,6 +368,27 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* l
   _funcobj_argvals = saved_argvals;
   _funcobj_nargs = saved_nargs;
   _funcobj_active = saved_active;
+  /* free any FuncObjPendingArg markers still standing at invocation end --
+     AttributeValue::unref_as_needed() (Attribute/attrvalue.c) only knows
+     how to clean up ArrayType/StreamType/StringType and (for ObjectType)
+     AttributeList/Attribute specifically, nothing generic for an arbitrary
+     ObjectType payload, so a marker nobody explicitly deletes just leaks.
+     A positional's marker is always still here regardless of whether
+     arg(n) ever pulled it (arg(n) never overwrites its own slot, see
+     funcobj_arg()); a keyword's marker only survives to here if it was
+     never read at all -- one that was gets replaced by
+     pull_alist_pending()'s own add_attr call, which deletes the old
+     marker there instead, right as it's overwritten. */
+  for (int i=0; i<npos; i++) {
+    if (posvals[i].is_object(FuncObjPendingArg::class_symid()))
+      delete (FuncObjPendingArg*)posvals[i].obj_val();
+  }
+  ALIterator alit;
+  for (al->First(alit); !al->Done(alit); al->Next(alit)) {
+    AttributeValue* attrval = al->GetAttr(alit)->Value();
+    if (attrval->is_object(FuncObjPendingArg::class_symid()))
+      delete (FuncObjPendingArg*)attrval->obj_val();
+  }
   delete [] posvals;
 }
 
@@ -2333,6 +2354,10 @@ AttributeValue* ComTerp::pull_alist_pending(AttributeList* al, int id, Attribute
   ComValue pulled(pull_funcobj_pending(marker));
   al->add_attr(id, pulled);  /* replaces the marker -- every later lookup
                                 of this id finds the real value directly */
+  delete marker;  /* add_attr() overwrote the slot that held it above --
+                      nothing else knows this is a FuncObjPendingArg and
+                      would otherwise free it (see fire_funcobj()'s own
+                      cleanup pass for a marker that's never read at all) */
   return al->find(id);
 }
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -273,6 +273,74 @@ int ComTerp::eval_expr(ComValue* pfvals, int npfvals) {
   return FUNCOK;
 }
 
+void ComTerp::fire_funcobj(ComValue& val) {
+  EvalFunc ef(this);
+  /* keywords still build the body's locals (the _alist); the fixed
+     positionals become the func's eager actual args, captured here so
+     arg(n)/narg() can serve them inside the body (see funcobj_arg).
+     The keywords sit above the positionals on the stack (no positionals
+     after keywords), so pop them first.  narg() counts non-keyword args
+     *including* values that follow keywords, and each keyword carries its
+     own keynarg (0 for a bare flag), so the fixed-positional count is narg
+     minus the keyword values actually consumed -- not narg-nkey. */
+  int npos = val.narg();
+  AttributeList* al = new AttributeList();
+  /* #310: seed al from this funcobj's own declaration-time captures
+     (read-only/read-before-write free variables, funcobjscan.h)
+     before keyword args land on top -- add_attr's replace-by-symid
+     below then makes an explicit :x val keyword override a capture
+     for free, no special-case needed. */
+  FuncObj* callee_fo = (FuncObj*)val.obj_val();
+  if (callee_fo->captures().is_object(AttributeList::class_symid())) {
+    AttributeList* caps = (AttributeList*)callee_fo->captures().obj_val();
+    ALIterator capit;
+    for (caps->First(capit); !caps->Done(capit); caps->Next(capit)) {
+      Attribute* capattr = caps->GetAttr(capit);
+      al->add_attr(capattr->SymbolId(), *capattr->Value());
+    }
+  }
+  for(int i=0; i<val.nkey(); i++) {
+    ComValue keyv(pop_stack());
+    int knarg = keyv.keynarg_val();
+    if (knarg==0) {
+      al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
+    } else {
+      /* knarg is 0 or 1 by construction: the parser emits every keyword
+	 token with narg 0 (bare flag) or 1 (keyword+value) -- the
+	 TOK_KEYWORD PFOUT sites in ComUtil/_parser.c -- and keynarg is set
+	 from token->narg (comterp.c:927).  So knarg>1 is unreachable; this
+	 loop is written generally only.  Even if it ran, add_attr dedups by
+	 symid (replaces, never appends), binding a single value, and every
+	 value is popped so the positional count (npos) stays correct. */
+      for(int j=0; j<knarg; j++) {
+	ComValue valv(pop_stack());
+	al->add_attr(keyv.keyid_val(), valv);
+	npos--;   /* a post-keyword value, not a fixed positional */
+      }
+    }
+  }
+  if (npos<0) npos = 0;
+  ComValue* posvals = npos>0 ? new ComValue[npos] : nil;
+  for(int i=npos-1; i>=0; i--) posvals[i] = pop_stack();
+  ComValue* saved_argvals = _funcobj_argvals;
+  int saved_nargs = _funcobj_nargs;
+  boolean saved_active = _funcobj_active;
+  _funcobj_argvals = posvals;
+  _funcobj_nargs = npos;
+  _funcobj_active = true;
+  push_stack(val);
+  ComValue alv(AttributeList::class_symid(), al);
+  push_stack(alv);
+  static int alist_symid = symbol_add("alist");
+  ComValue alkeyv(alist_symid, 1);
+  push_stack(alkeyv);
+  ef.exec(2, 1);
+  _funcobj_argvals = saved_argvals;
+  _funcobj_nargs = saved_nargs;
+  _funcobj_active = saved_active;
+  delete [] posvals;
+}
+
 void ComTerp::eval_expr_internals(int pedepth) {
   static int step_symid = symbol_add("step");
   ComValue sv = pop_stack(false);
@@ -436,7 +504,14 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	else
 	  func_for_next_expr_post_eval = 1;
       }
-      func->push_funcstate(nargs, nkeys, pedepth, func->funcid(), sv.linenum());
+      /* sv.command_symid(), not func->funcid(): for the ordinary case
+	 they're the same symbol (sv resolved to exactly the command it
+	 named), but token_to_comvalue's nil-substitution fallback dispatches
+	 an unresolved call-shaped symbol to the single shared NilFunc
+	 instance while still recording the ORIGINAL requested name in
+	 sv.command_symid() -- func->funcid() would always read "nil" there,
+	 losing the name NilFunc needs to dynamically re-check (issue #328). */
+      func->push_funcstate(nargs, nkeys, pedepth, sv.command_symid(), sv.linenum());
     }
 
     /* output execution trace */
@@ -572,71 +647,7 @@ void ComTerp::eval_expr_internals(int pedepth) {
       const char* funcname = sv.symbol_ptr();
       ComValue val = lookup_symval(sv);
       if(val.is_object(FuncObj::class_symid())) {
-	EvalFunc ef(this);
-	/* keywords still build the body's locals (the _alist); the fixed
-	   positionals become the func's eager actual args, captured here so
-	   arg(n)/narg() can serve them inside the body (see funcobj_arg).
-	   The keywords sit above the positionals on the stack (no positionals
-	   after keywords), so pop them first.  narg() counts non-keyword args
-	   *including* values that follow keywords, and each keyword carries its
-	   own keynarg (0 for a bare flag), so the fixed-positional count is narg
-	   minus the keyword values actually consumed -- not narg-nkey. */
-	int npos = val.narg();
-	AttributeList* al = new AttributeList();
-	/* #310: seed al from this funcobj's own declaration-time captures
-	   (read-only/read-before-write free variables, funcobjscan.h)
-	   before keyword args land on top -- add_attr's replace-by-symid
-	   below then makes an explicit :x val keyword override a capture
-	   for free, no special-case needed. */
-	FuncObj* callee_fo = (FuncObj*)val.obj_val();
-	if (callee_fo->captures().is_object(AttributeList::class_symid())) {
-	  AttributeList* caps = (AttributeList*)callee_fo->captures().obj_val();
-	  ALIterator capit;
-	  for (caps->First(capit); !caps->Done(capit); caps->Next(capit)) {
-	    Attribute* capattr = caps->GetAttr(capit);
-	    al->add_attr(capattr->SymbolId(), *capattr->Value());
-	  }
-	}
-	for(int i=0; i<val.nkey(); i++) {
-	  ComValue keyv(pop_stack());
-	  int knarg = keyv.keynarg_val();
-	  if (knarg==0) {
-	    al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
-	  } else {
-	    /* knarg is 0 or 1 by construction: the parser emits every keyword
-	       token with narg 0 (bare flag) or 1 (keyword+value) -- the
-	       TOK_KEYWORD PFOUT sites in ComUtil/_parser.c -- and keynarg is set
-	       from token->narg (comterp.c:927).  So knarg>1 is unreachable; this
-	       loop is written generally only.  Even if it ran, add_attr dedups by
-	       symid (replaces, never appends), binding a single value, and every
-	       value is popped so the positional count (npos) stays correct. */
-	    for(int j=0; j<knarg; j++) {
-	      ComValue valv(pop_stack());
-	      al->add_attr(keyv.keyid_val(), valv);
-	      npos--;   /* a post-keyword value, not a fixed positional */
-	    }
-	  }
-	}
-	if (npos<0) npos = 0;
-	ComValue* posvals = npos>0 ? new ComValue[npos] : nil;
-	for(int i=npos-1; i>=0; i--) posvals[i] = pop_stack();
-	ComValue* saved_argvals = _funcobj_argvals;
-	int saved_nargs = _funcobj_nargs;
-	boolean saved_active = _funcobj_active;
-	_funcobj_argvals = posvals;
-	_funcobj_nargs = npos;
-	_funcobj_active = true;
-	push_stack(val);
-	ComValue alv(AttributeList::class_symid(), al);
-	push_stack(alv);
-	static int alist_symid = symbol_add("alist");
-	ComValue alkeyv(alist_symid, 1);
-	push_stack(alkeyv);
-	ef.exec(2, 1);
-	_funcobj_argvals = saved_argvals;
-	_funcobj_nargs = saved_nargs;
-	_funcobj_active = saved_active;
-	delete [] posvals;
+	fire_funcobj(val);
       } else {
 	/* sv carried a pending arglist (same-line adjacency to a following
 	   paren group always means "this is a call attempt"), but val --

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -204,16 +204,26 @@ public:
     // further -- so the more informative element count gets shown
     // instead of an uninformative, still-unconsumed-looking print.
 
-    void fire_funcobj(ComValue& val);
-    // val must be a FuncObj-holding ComValue whose narg()/nkey() worth of
-    // already-evaluated arguments are sitting on the stack, ready to pop
-    // (the ordinary calling convention: keywords topmost, positionals
-    // below).  Builds the call's AttributeList (declaration-time captures
-    // seeded first, #310), sets up funcobj_arg()'s eager-positional view,
-    // and fires it via EvalFunc.  Factored out of eval_expr_internals'
-    // ordinary SymbolType/FuncObj dispatch so NilFunc can reuse it once it
-    // dynamically re-resolves to a real FuncObj (issue #328) instead of
-    // duplicating this stack-unpacking logic.
+    void fire_funcobj(ComValue& val, AttributeList* extra_keys=nil);
+    // val must be a FuncObj-holding ComValue whose val.narg() worth of
+    // already-evaluated positional arguments are sitting on the stack,
+    // ready to pop (topmost = last positional).  Builds the call's
+    // AttributeList (declaration-time captures seeded first, #310), sets
+    // up funcobj_arg()'s eager-positional view, and fires it via EvalFunc.
+    // Factored out of eval_expr_internals' ordinary SymbolType/FuncObj
+    // dispatch so NilFunc can reuse it once it dynamically re-resolves to
+    // a real FuncObj (issue #328) instead of duplicating this stack-
+    // unpacking logic.
+    //
+    // extra_keys nil (the ordinary-dispatch case): keyword marker+value
+    // pairs are popped off the SAME shared stack as the positionals,
+    // val.nkey() of them, topmost first -- the original calling
+    // convention, unchanged.
+    // extra_keys non-nil (NilFunc's dynamic re-check): the caller has
+    // already evaluated its keywords some other way (it can't leave them
+    // on the shared stack in the expected shape -- see
+    // ComFunc::stack_keys_post_eval) and hands them in pre-built instead;
+    // val.nkey() is not consulted and nothing extra is popped for them.
 
     virtual int runfile(const char* filename, boolean popen_flag=0);
     // run interpreter on contents of 'filename'.

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -204,7 +204,8 @@ public:
     // further -- so the more informative element count gets shown
     // instead of an uninformative, still-unconsumed-looking print.
 
-    void fire_funcobj(ComValue& val, AttributeList* extra_keys=nil);
+    void fire_funcobj(ComValue& val, AttributeList* extra_keys=nil,
+		       ComValue* lazy_posvals=nil);
     // val must be a FuncObj-holding ComValue whose val.narg() worth of
     // already-evaluated positional arguments are sitting on the stack,
     // ready to pop (topmost = last positional).  Builds the call's
@@ -219,11 +220,22 @@ public:
     // pairs are popped off the SAME shared stack as the positionals,
     // val.nkey() of them, topmost first -- the original calling
     // convention, unchanged.
-    // extra_keys non-nil (NilFunc's dynamic re-check): the caller has
-    // already evaluated its keywords some other way (it can't leave them
-    // on the shared stack in the expected shape -- see
-    // ComFunc::stack_keys_post_eval) and hands them in pre-built instead;
-    // val.nkey() is not consulted and nothing extra is popped for them.
+    // extra_keys non-nil: the caller has already built the call's keyword
+    // AttributeList some other way instead of leaving marker+value pairs on
+    // the shared stack (NilFunc's dynamic re-check, ComFunc::stack_keys_-
+    // post_eval; or a :posteval target, whose entries are
+    // FuncObjPendingArg markers instead of real values -- fire_funcobj
+    // doesn't care, it just copies them into al either way); val.nkey() is
+    // not consulted and nothing extra is popped for them.
+    //
+    // lazy_posvals non-nil (val's FuncObj is :posteval): used directly as
+    // this invocation's funcobj_argvals() array instead of popping val.-
+    // narg() values off the stack -- nothing was pushed for them in the
+    // first place (the pedepth pre-pass left their whole span un-evaluated
+    // in the caller's buffer).  Its entries are ordinarily FuncObjPendingArg
+    // markers (postfunc.h), pulled on demand and memoized in place by
+    // funcobj_arg() the same array slot every other invocation already uses
+    // -- no separate lazy-argument channel or save/restore needed.
 
     virtual int runfile(const char* filename, boolean popen_flag=0);
     // run interpreter on contents of 'filename'.
@@ -381,6 +393,31 @@ public:
     // same bracketing set_attributes()/get_attributes() use around an
     // _alist swap (see DotFunc, which needs both at once to self-bind an
     // attrlist method call and still serve its positional args).
+
+    ComValue pull_funcobj_pending(class FuncObjPendingArg* marker);
+    // resolve one :posteval arg/keyword's still-pending token span --
+    // reaches back into the caller's parked postfix buffer via
+    // top_servstate() (the same frame push_servstate() already stashed
+    // there for ordinary nested-call bookkeeping, nothing new to allocate)
+    // and runs post_eval_expr() against it.  Shared by funcobj_arg(), which
+    // pulls-and-memoizes a FuncObjPendingArg sitting in funcobj_argvals(),
+    // and (via pull_alist_pending() below) by every _alist lookup path.
+
+    AttributeValue* pull_alist_pending(AttributeList* al, int id, AttributeValue* found);
+    // if 'found' (already the result of al->find(id)) is a still-pending
+    // FuncObjPendingArg marker, pull it via pull_funcobj_pending(), memoize
+    // the real value back into al under the same id, and return a pointer
+    // to that now-real entry; otherwise return 'found' unchanged.  A
+    // keyword arg is only ever reached through _alist -- there's no
+    // separate funcobj_argvals()-style channel for it the way a positional
+    // has -- so every one of _alist's several lookup call sites (the
+    // bare-variable-read fallthrough in eval_expr_internals, and both
+    // lookup_symval() overloads, which ComFunc::stack_arg/stack_key and
+    // ordinary operand resolution all route through for a symbol used as
+    // an operand rather than read standalone) needs this same check --
+    // that's the case a plain "y+y" exercises: y is never dispatched
+    // through eval_expr_internals's own SymbolType branch at all, it's
+    // just an operand add() resolves via lookup_symval.
 
     void set_args(int argc, char** argv);
     // set command line arguments

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -204,6 +204,17 @@ public:
     // further -- so the more informative element count gets shown
     // instead of an uninformative, still-unconsumed-looking print.
 
+    void fire_funcobj(ComValue& val);
+    // val must be a FuncObj-holding ComValue whose narg()/nkey() worth of
+    // already-evaluated arguments are sitting on the stack, ready to pop
+    // (the ordinary calling convention: keywords topmost, positionals
+    // below).  Builds the call's AttributeList (declaration-time captures
+    // seeded first, #310), sets up funcobj_arg()'s eager-positional view,
+    // and fires it via EvalFunc.  Factored out of eval_expr_internals'
+    // ordinary SymbolType/FuncObj dispatch so NilFunc can reuse it once it
+    // dynamically re-resolves to a real FuncObj (issue #328) instead of
+    // duplicating this stack-unpacking logic.
+
     virtual int runfile(const char* filename, boolean popen_flag=0);
     // run interpreter on contents of 'filename'.
     void add_defaults();

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -380,8 +380,15 @@ public:
     // serve the func's positionals instead of the script argv.
     int funcobj_narg() { return _funcobj_nargs; }
     // number of positional args of the current FuncObj invocation.
-    ComValue& funcobj_arg(int n);
-    // nth positional arg (eager value) of the current FuncObj invocation.
+    ComValue funcobj_arg(int n);
+    // nth positional arg of the current FuncObj invocation -- an
+    // already-materialized eager value, or (:posteval) pulled fresh on
+    // *every* call, never memoized: arg(n) has no lvalue form (no
+    // "arg(0)=..."), so there's no write-before-read escape the way a
+    // keyword has, and no write-through caller ever needs a stable
+    // address for it either. The idiom for caching a repeatedly-read
+    // arg inside a loop is the same as for any post_eval command's own
+    // operand: assign it to a local once, then read that local.
     ComValue* funcobj_argvals() { return _funcobj_argvals; }
     // return the current positional-argument array itself (nil if inactive),
     // for a caller that needs to save it before installing its own.
@@ -399,25 +406,32 @@ public:
     // reaches back into the caller's parked postfix buffer via
     // top_servstate() (the same frame push_servstate() already stashed
     // there for ordinary nested-call bookkeeping, nothing new to allocate)
-    // and runs post_eval_expr() against it.  Shared by funcobj_arg(), which
-    // pulls-and-memoizes a FuncObjPendingArg sitting in funcobj_argvals(),
-    // and (via pull_alist_pending() below) by every _alist lookup path.
+    // and runs post_eval_expr() against it.  Doesn't memoize anything
+    // itself -- that's the caller's job (funcobj_arg() never does;
+    // pull_alist_pending() below always does), this just runs the
+    // pending expression once, fresh, whenever it's called.
 
     AttributeValue* pull_alist_pending(AttributeList* al, int id, AttributeValue* found);
     // if 'found' (already the result of al->find(id)) is a still-pending
-    // FuncObjPendingArg marker, pull it via pull_funcobj_pending(), memoize
-    // the real value back into al under the same id, and return a pointer
-    // to that now-real entry; otherwise return 'found' unchanged.  A
-    // keyword arg is only ever reached through _alist -- there's no
-    // separate funcobj_argvals()-style channel for it the way a positional
-    // has -- so every one of _alist's several lookup call sites (the
-    // bare-variable-read fallthrough in eval_expr_internals, and both
-    // lookup_symval() overloads, which ComFunc::stack_arg/stack_key and
-    // ordinary operand resolution all route through for a symbol used as
-    // an operand rather than read standalone) needs this same check --
-    // that's the case a plain "y+y" exercises: y is never dispatched
-    // through eval_expr_internals's own SymbolType branch at all, it's
-    // just an operand add() resolves via lookup_symval.
+    // FuncObjPendingArg marker, pull it via pull_funcobj_pending() and
+    // write the real value back into al under the same id, so this and
+    // every later lookup of the same keyword see the same, already-
+    // resolved value -- a :posteval keyword is lazy (never evaluated
+    // until the body's first genuine read of it) but otherwise timed
+    // exactly like an ordinary func()'s eager keyword: evaluated once,
+    // just deferred from call-time to first-access.  All three _alist
+    // lookup call sites share this -- the bare-variable-read fallthrough
+    // in eval_expr_internals, lookup_symval(ComValue&) (which
+    // ComFunc::stack_arg/stack_key and ordinary operand resolution route
+    // through for a symbol used as an operand rather than read
+    // standalone -- the case a plain "y+y" exercises, since y there is
+    // never dispatched through eval_expr_internals's own SymbolType
+    // branch at all), and lookup_symval(ComValue*) (compound-assign's
+    // path, "y+=1": read the old value, then write the new one through
+    // the same pointer, ModAssignFunc et al in assignfunc.c -- needs a
+    // real, addressable, already-memoized slot to mutate in place).
+    // arg(n) is the one exception to all this -- see funcobj_arg()'s own
+    // comment for why positionals re-fire on every access instead.
 
     void set_args(int argc, char** argv);
     // set command line arguments

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -112,7 +112,17 @@ ComValue::ComValue(postfix_token* token) {
     clear();
     void* v1 = &_v;
     void* v2 = &token->v;
-    memcpy(v1, v2, sizeof(_v));
+    /* sizeof(token->v), not sizeof(_v): token->v is postfix_token's own
+       8-byte data_value union (ComUtil/comterp.h), narrower than
+       ComValue's 16-byte attr_value union (Attribute/attrvalue.h) -- a
+       stray sizeof(_v) here read 8 bytes past token->v into its own
+       adjacent type/narg fields, reinterpreted as the tail of whichever
+       multi-field union member (symval, objval, streamval, ...) this
+       token's type selects.  clear() already zeroed the full _v above,
+       so bounding the copy to the source's true size is always safe --
+       data_value's own widest member is 8 bytes, so no real payload is
+       ever lost by not reading further. */
+    memcpy(v1, v2, sizeof(token->v));
     switch (token->type) {
     case TOK_STRING:  type(StringType); break;
     case TOK_CHAR:    type(CharType); break;

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -553,6 +553,24 @@ void NilFunc::execute() {
       ComValue namesym(comm_symid, ComValue::SymbolType);
       ComValue target(comterp()->lookup_symval(namesym));
       if (target.is_object(FuncObj::class_symid())) {
+	FuncObj* target_fo = (FuncObj*)target.obj_val();
+	int n = nargsfixed();
+	if (target_fo->posteval()) {
+	  /* :posteval target -- don't evaluate anything.  Bookmark each
+	     pending positional/keyword's still-unevaluated span instead
+	     (same walk as the eager branch below, just stops short of
+	     calling post_eval_expr on it) and hand fire_funcobj the marker
+	     arrays directly; arg()/a keyword's own first read pulls each
+	     one later, on demand, from inside the fired body. */
+	  ComValue* posvals = bookmark_stack_arg_post_eval_nargsfixed();
+	  AttributeList* keys = bookmark_stack_keys_post_eval();
+	  reset_stack();
+	  target.narg(n);
+	  target.nkey(0);
+	  comterp()->fire_funcobj(target, keys, posvals);
+	  delete keys;  /* copied into fire_funcobj's own AttributeList; we own it */
+	  return;
+	}
 	/* batch (stack_arg_post_eval_nargsfixed/stack_keys_post_eval), not
 	   per-i/per-id post-eval calls: each one re-reads stack_top() as its
 	   own anchor bookmark, which a push_stack() of a prior result would
@@ -560,7 +578,6 @@ void NilFunc::execute() {
 	   bookmarks up front, before evaluating anything, and neither
 	   disturbs the shared stack in a way the other depends on, so
 	   either order is safe -- positionals, then keywords, here. */
-	int n = nargsfixed();
 	ComValue** argvals = stack_arg_post_eval_nargsfixed();
 	AttributeList* keys = stack_keys_post_eval();
 	/* reset_stack() -- once, now that every arg is safely loaded into

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -534,12 +534,55 @@ NilFunc::NilFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void NilFunc::execute() {
-    reset_stack();
+    /* token_to_comvalue (comterp.c) routes any call-shaped symbol here
+       (parens/args, not [yet] a registered command) at CONVERSION time --
+       once, frozen forever into that token.  That's wrong when the name
+       is defined earlier in the same already-tokenized ";"-sequence: the
+       whole sequence converts before any of it executes, so the earlier
+       "name=func(...)" hasn't run yet when "name(args)"'s own token gets
+       converted (issue #328).  Re-check dynamically, by name, right now --
+       if the gate has since opened (the name really is a FuncObj by the
+       time this actually fires), evaluate the pending args for real and
+       dispatch to it, same as an ordinary call would.  If it's still
+       closed, fall through unchanged: never touch the args (the
+       deliberate plugin-hook gate idiom, symboldrain.comt) and return nil.
+
+       Scoped to positional-only calls (nkeys()==0): stack_arg_post_eval
+       only indexes fixed positionals, and there's no analogous "replay
+       this keyword's pending expression by id" enumerator to reconstruct
+       an arbitrary keyword set here -- a keyword call to a name still
+       undefined at conversion time keeps today's behavior, unchanged. */
     static int nil_symid = symbol_add("nil");
     int comm_symid = funcstate()->command_symid();
-    if (comm_symid && comm_symid!= nil_symid)
-      cerr << "unknown command \"" << symbol_pntr(comm_symid)
-	<< "\" returned nil\n";
+    if (comm_symid && comm_symid != nil_symid && nkeys()==0) {
+      ComValue namesym(comm_symid, ComValue::SymbolType);
+      ComValue target(comterp()->lookup_symval(namesym));
+      if (target.is_object(FuncObj::class_symid())) {
+	/* _nargsfixed (batch), not a per-i stack_arg_post_eval loop: each
+	   call re-reads stack_top() as its own anchor bookmark, which a
+	   push_stack() of a prior arg's result would have already
+	   clobbered.  This variant resolves every arg's token-span bookmark
+	   up front, before evaluating any of them. */
+	int n = nargsfixed();
+	ComValue** argvals = stack_arg_post_eval_nargsfixed();
+	/* reset_stack() -- once, now that every arg is safely loaded into
+	   argvals[] (local copies) -- clears whatever pre-call stack state
+	   (the argoff anchor bookmark, etc.) is still sitting there; skipping
+	   it left a leftover entry behind (real regression, caught live: "nil
+	   pushed more than a single value on stack"). */
+	reset_stack();
+	for (int i=0; i<n; i++) {
+	  push_stack(*argvals[i]);
+	  delete argvals[i];
+	}
+	delete [] argvals;
+	target.narg(n);
+	target.nkey(0);
+	comterp()->fire_funcobj(target);
+	return;
+      }
+    }
+    reset_stack();
     push_stack(ComValue::nullval());
 }
 

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -542,34 +542,32 @@ void NilFunc::execute() {
        "name=func(...)" hasn't run yet when "name(args)"'s own token gets
        converted (issue #328).  Re-check dynamically, by name, right now --
        if the gate has since opened (the name really is a FuncObj by the
-       time this actually fires), evaluate the pending args for real and
-       dispatch to it, same as an ordinary call would.  If it's still
-       closed, fall through unchanged: never touch the args (the
-       deliberate plugin-hook gate idiom, symboldrain.comt) and return nil.
-
-       Scoped to positional-only calls (nkeys()==0): stack_arg_post_eval
-       only indexes fixed positionals, and there's no analogous "replay
-       this keyword's pending expression by id" enumerator to reconstruct
-       an arbitrary keyword set here -- a keyword call to a name still
-       undefined at conversion time keeps today's behavior, unchanged. */
+       time this actually fires), evaluate the pending args -- positional
+       and keyword alike -- for real and dispatch to it, same as an
+       ordinary call would.  If it's still closed, fall through unchanged:
+       never touch the args (the deliberate plugin-hook gate idiom,
+       symboldrain.comt) and return nil. */
     static int nil_symid = symbol_add("nil");
     int comm_symid = funcstate()->command_symid();
-    if (comm_symid && comm_symid != nil_symid && nkeys()==0) {
+    if (comm_symid && comm_symid != nil_symid) {
       ComValue namesym(comm_symid, ComValue::SymbolType);
       ComValue target(comterp()->lookup_symval(namesym));
       if (target.is_object(FuncObj::class_symid())) {
-	/* _nargsfixed (batch), not a per-i stack_arg_post_eval loop: each
-	   call re-reads stack_top() as its own anchor bookmark, which a
-	   push_stack() of a prior arg's result would have already
-	   clobbered.  This variant resolves every arg's token-span bookmark
-	   up front, before evaluating any of them. */
+	/* batch (stack_arg_post_eval_nargsfixed/stack_keys_post_eval), not
+	   per-i/per-id post-eval calls: each one re-reads stack_top() as its
+	   own anchor bookmark, which a push_stack() of a prior result would
+	   already have clobbered.  Both resolve their own token-span
+	   bookmarks up front, before evaluating anything, and neither
+	   disturbs the shared stack in a way the other depends on, so
+	   either order is safe -- positionals, then keywords, here. */
 	int n = nargsfixed();
 	ComValue** argvals = stack_arg_post_eval_nargsfixed();
+	AttributeList* keys = stack_keys_post_eval();
 	/* reset_stack() -- once, now that every arg is safely loaded into
-	   argvals[] (local copies) -- clears whatever pre-call stack state
-	   (the argoff anchor bookmark, etc.) is still sitting there; skipping
-	   it left a leftover entry behind (real regression, caught live: "nil
-	   pushed more than a single value on stack"). */
+	   argvals[]/keys (local copies) -- clears whatever pre-call stack
+	   state (the argoff anchor bookmark, etc.) is still sitting there;
+	   skipping it left a leftover entry behind (real regression, caught
+	   live: "nil pushed more than a single value on stack"). */
 	reset_stack();
 	for (int i=0; i<n; i++) {
 	  push_stack(*argvals[i]);
@@ -578,7 +576,8 @@ void NilFunc::execute() {
 	delete [] argvals;
 	target.narg(n);
 	target.nkey(0);
-	comterp()->fire_funcobj(target);
+	comterp()->fire_funcobj(target, keys);
+	delete keys;  /* copied into fire_funcobj's own AttributeList; we own it */
 	return;
       }
     }

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -609,8 +609,8 @@ void GetArgFunc::execute() {
   int n = numv.int_val();
   if (comterp()->funcobj_active()) {
     /* inside a FuncObj body: nth positional -- an already-materialized
-       eager value, or (:posteval) pulled on demand and memoized in place
-       by funcobj_arg() itself, transparently either way. */
+       eager value, or (:posteval) pulled fresh on every call, transparently
+       either way (see ComTerp::funcobj_arg()'s own comment). */
     ComValue retval(comterp()->funcobj_arg(n));
     push_stack(retval);
     return;

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -608,7 +608,9 @@ void GetArgFunc::execute() {
   reset_stack();
   int n = numv.int_val();
   if (comterp()->funcobj_active()) {
-    /* inside a FuncObj body: nth eager positional (a real value) */
+    /* inside a FuncObj body: nth positional -- an already-materialized
+       eager value, or (:posteval) pulled on demand and memoized in place
+       by funcobj_arg() itself, transparently either way. */
     ComValue retval(comterp()->funcobj_arg(n));
     push_stack(retval);
     return;

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -362,10 +362,12 @@ void SwitchFunc::execute() {
 
 /*****************************************************************************/
 int FuncObj::_symid = -1;
+int FuncObjPendingArg::_symid = -1;
 
 FuncObj::FuncObj(postfix_token* toks, int ntoks) {
   _toks = toks;
   _ntoks = ntoks;
+  _posteval = false;
 }
 
 FuncObj::~FuncObj() { 
@@ -383,6 +385,8 @@ void FuncObjFunc::execute() {
   postfix_token* tokbuf = copy_stack_arg_post_eval(0, toklen);
   static int echo_symid = symbol_add("echo");
   ComValue echov(stack_key_post_eval(echo_symid));
+  static int posteval_symid = symbol_add("posteval");
+  ComValue postevalv(stack_key_post_eval(posteval_symid));
   reset_stack();
   if (!tokbuf)
     push_stack(ComValue::nullval());
@@ -390,6 +394,7 @@ void FuncObjFunc::execute() {
     if (echov.is_true())
       comterp()->postfix_echo(tokbuf, toklen);
     FuncObj* tokbufobj = new FuncObj(tokbuf, toklen);
+    tokbufobj->posteval(postevalv.is_true());
 
     /* #310: capture this body's free variables (read-only or
        read-before-write, per #170's taxonomy -- see funcobjscan.h) at

--- a/src/ComTerp/postfunc.h
+++ b/src/ComTerp/postfunc.h
@@ -199,14 +199,54 @@ class FuncObj {
   // default) means no captures, the common case.
   ComValue& captures() { return _captures; }
 
+  // Lazy-argument flag (set by :posteval on the func() call that built this
+  // object).  An eager (default) call fully evaluates its positional and
+  // keyword arguments before the body ever runs -- arg()/keyword reads just
+  // index the already-materialized results.  A posteval call skips that
+  // step entirely: its arguments stay unevaluated, pedepth-marked tokens in
+  // the CALLING expression's own postfix buffer (the same "sit there until
+  // pulled" contract any other post_eval command's args already have), and
+  // are only resolved on demand -- arg(n) via stack_arg_post_eval, a
+  // keyword's first read-before-write via stack_key_post_eval -- reaching
+  // back into the caller's frame via top_servstate(), the same parked state
+  // every nested func call already leaves on the servstate stack for free.
+  boolean posteval() { return _posteval; }
+  void posteval(boolean p) { _posteval = p; }
+
   CLASS_SYMID("FuncObj");
 
  protected:
   postfix_token* _toks;
   int _ntoks;
   ComValue _captures;
+  boolean _posteval;
 };
-  
+
+//: marker for one still-unevaluated arg/keyword of a :posteval FuncObj call.
+// Sits directly in the SAME channel an eager call already uses for that
+// slot -- funcobj_argvals()[n] for a positional, _alist for a keyword --
+// so pulling and memoizing it in place (ComTerp::pull_funcobj_pending())
+// needs no separate storage or save/restore beyond what fire_funcobj()/
+// push_servstate() already do for those channels.  (offtop,tokcnt,pedepth)
+// locate the pending token span in the CALLING expression's own postfix
+// buffer, the same way any other post_eval command's own pending args do.
+class FuncObjPendingArg {
+ public:
+  FuncObjPendingArg(int offtop, int tokcnt, int pedepth)
+    : _offtop(offtop), _tokcnt(tokcnt), _pedepth(pedepth) {}
+
+  int offtop() { return _offtop; }
+  int tokcnt() { return _tokcnt; }
+  int pedepth() { return _pedepth; }
+
+  CLASS_SYMID("FuncObjPendingArg");
+
+ protected:
+  int _offtop;
+  int _tokcnt;
+  int _pedepth;
+};
+
 //: create token buffer object
 // funcobj=func(body) -- encapsulate a body of commands into an executable object
 class FuncObjFunc : public ComFunc {
@@ -215,11 +255,12 @@ public:
 
     virtual void execute();
     virtual boolean post_eval() { return true; }
-    virtual const char* docstring() { 
-      return "funcobj=%s(body :echo) -- encapsulate a body of commands into an executable object"; }
+    virtual const char* docstring() {
+      return "funcobj=%s(body :echo :posteval) -- encapsulate a body of commands into an executable object"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":echo      echo the postfix version of parsed body",
+	":posteval  lazy call -- arguments stay unevaluated until arg()/a keyword is read",
 	nil
       };
       return keys;

--- a/src/comterp_/tests/funcarg.comt
+++ b/src/comterp_/tests/funcarg.comt
@@ -10,7 +10,9 @@
 //
 // Note: positionals are eager, so re-reading arg(0) returns the SAME
 // already-computed value -- a side-effecting positional fires once, not
-// per read.  The re-firing form awaits a future :posteval keyword.
+// per read.  The lazy form is :posteval (see posteval.comt): a
+// :posteval func's args stay unevaluated until arg(n)/a keyword's own
+// first read pulls (and memoizes) it.
 //
 // Run from inside comterp, comdraw, or drawserv (cd to this dir first):
 //   run("./funcarg.comt")

--- a/src/comterp_/tests/funcarg.comt
+++ b/src/comterp_/tests/funcarg.comt
@@ -12,7 +12,8 @@
 // already-computed value -- a side-effecting positional fires once, not
 // per read.  The lazy form is :posteval (see posteval.comt): a
 // :posteval func's args stay unevaluated until arg(n)/a keyword's own
-// first read pulls (and memoizes) it.
+// first read pulls it -- and unlike this eager case, arg(n) then
+// re-fires on every later call too (a keyword still memoizes).
 //
 // Run from inside comterp, comdraw, or drawserv (cd to this dir first):
 //   run("./funcarg.comt")

--- a/src/comterp_/tests/posteval.comt
+++ b/src/comterp_/tests/posteval.comt
@@ -12,9 +12,21 @@
 // evaluated at call time.  They stay as unevaluated tokens in the CALLING
 // expression's own postfix buffer -- the same "sit there until pulled"
 // contract any other post_eval command's args already have -- and are only
-// resolved on demand: arg(n) on its first read, a keyword on its first
-// read-before-write.  Once pulled, the result is memoized in place, so a
-// second read of the same arg/keyword does not re-evaluate it.
+// resolved on demand.  arg(n) and keyword access differ in what happens
+// after that first pull, though:
+//   - arg(n) re-fires the pending expression on EVERY call, with no
+//     memoization at all -- there's no lvalue form ("arg(0)=...") the way a
+//     keyword has, so there's nothing to protect by caching it, and this is
+//     what makes arg(n) useful inside a :posteval body's own loop: each
+//     call reads the live, current value, the same way any post_eval
+//     command's own operand (e.g. while's condition) gets re-evaluated
+//     every iteration.  The idiom for caching a repeatedly-read arg is the
+//     same one non-func code already uses: assign it to a local once.
+//   - a keyword is lazy but otherwise timed like plain func()'s own eager
+//     keywords: evaluated once, on its first read-before-write, then
+//     memoized -- a later read (or a write) sees that same value, it does
+//     not re-fire.  (Read-vs-loop laziness for keywords is a further
+//     refinement still being worked out -- not implemented yet.)
 //
 // Side effects are counted via a list append (hits,1) rather than a
 // captured/reassigned scalar counter: a bare scalar read before any local
@@ -44,13 +56,14 @@ ok=ok&&(size(hits)==1)
 print("2 f1(true <side-effecting arg1>) does touch arg1 (expect size 1): %v\n\n" size(hits))
 check_fail(:ok ok)
 
-// --- test 3: arg(n) memoizes -- two reads, one evaluation ---
+// --- test 3: arg(n) re-fires on every call -- two reads, two evaluations,
+// unlike a keyword (test 6 below) or an ordinary eager arg (test 8) ---
 hits2=list()
 bump=func(hits2,1; size(hits2))
 f3=func(a=arg(0); b=arg(0); a+b :posteval)
 r3=f3(bump())
-ok=ok&&(r3==2)&&(size(hits2)==1)
-print("3 f3(a=arg(0);b=arg(0);a+b); f3(bump()) reads arg(0) twice, evals once (expect 2 1): %v %v\n\n" r3 size(hits2))
+ok=ok&&(r3==3)&&(size(hits2)==2)
+print("3 f3(a=arg(0);b=arg(0);a+b); f3(bump()) reads arg(0) twice, evals twice (expect 3 2): %v %v\n\n" r3 size(hits2))
 check_fail(:ok ok)
 
 // --- test 4: keyword laziness -- unread keyword never evaluated ---
@@ -67,7 +80,10 @@ ok=ok&&(size(hits3)==1)
 print("5 g4(true :y <side-effecting>) does touch y (expect size 1): %v\n\n" size(hits3))
 check_fail(:ok ok)
 
-// --- test 6: keyword memoization -- two reads, one evaluation ---
+// --- test 6: keyword memoization -- two reads, one evaluation.  Unlike
+// arg(n) (test 3/9 above), a keyword stays memoized after its first read,
+// even across further reads inside a loop -- timed like plain func()'s own
+// eager keywords, just deferred to first access instead of call time ---
 hits4=list()
 bump2=func(hits4,1; size(hits4))
 h6=func(y+y :posteval)
@@ -92,6 +108,18 @@ f8=func(arg(0))
 r8=f8(hits6,1)
 ok=ok&&(size(hits6)==1)
 print("8 f8=func(arg(0)) (no :posteval); f8(<side-effecting>) still eager (expect size 1): %v\n\n" size(hits6))
+check_fail(:ok ok)
+
+// --- test 9: the actual point of arg(n) re-firing -- a while loop inside
+// the body reads a live, changing value each iteration, not a snapshot
+// from its first read.  4 condition checks (hits7 reaches 1,2,3,4, the
+// last one failing the <4 test) but only 3 loop bodies (n stops at 3) ---
+hits7=list()
+counter=func(hits7,1; size(hits7))
+loopf=func(n=0; while(arg(0)<4 n=n+1) n :posteval)
+r9=loopf(counter())
+ok=ok&&(r9==3)&&(size(hits7)==4)
+print("9 loopf=func(while(arg(0)<4 n=n+1) n); loopf(counter()) sees a fresh arg(0) each check (expect 3 4): %v %v\n\n" r9 size(hits7))
 check_fail(:ok ok)
 
 print("posteval: %v\n" ok)

--- a/src/comterp_/tests/posteval.comt
+++ b/src/comterp_/tests/posteval.comt
@@ -1,0 +1,98 @@
+// src/comterp_/tests/posteval.comt -- test :posteval lazy FuncObj arguments
+//
+// funcs: func arg if
+//
+// funcarg.comt documents that an ordinary FuncObj call is EAGER: its
+// positional/keyword arguments are fully evaluated before the body ever
+// runs, and a re-read of arg(n)/a keyword just returns the same
+// already-computed value ("the re-firing form awaits a future :posteval
+// keyword" -- this file exercises that keyword).
+//
+// A :posteval FuncObj call is lazy instead: none of its arguments are
+// evaluated at call time.  They stay as unevaluated tokens in the CALLING
+// expression's own postfix buffer -- the same "sit there until pulled"
+// contract any other post_eval command's args already have -- and are only
+// resolved on demand: arg(n) on its first read, a keyword on its first
+// read-before-write.  Once pulled, the result is memoized in place, so a
+// second read of the same arg/keyword does not re-evaluate it.
+//
+// Side effects are counted via a list append (hits,1) rather than a
+// captured/reassigned scalar counter: a bare scalar read before any local
+// write inside a func body gets captured by #310 at declaration time,
+// shadowing the outer variable -- a list is a reference type, so mutating
+// it through a func body's capture is visible outside (see funcarg.comt's
+// own note on test 9/10 for the read-before-write capture rule this
+// exploits deliberately here, not works around).
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./posteval.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: an arg never read by the body is never evaluated at all ---
+hits=list()
+f1=func(c=arg(0); if(c :then arg(1) :else -1) :posteval)
+r1=f1(false hits,1)
+ok=ok&&(r1==-1)&&(size(hits)==0)
+print("1 f1(:posteval); f1(false <side-effecting arg1>) never touches arg1 (expect -1 0): %v %v\n\n" r1 size(hits))
+check_fail(:ok ok)
+
+// --- test 2: the same arg, actually read, IS evaluated ---
+r2=f1(true hits,1)
+ok=ok&&(size(hits)==1)
+print("2 f1(true <side-effecting arg1>) does touch arg1 (expect size 1): %v\n\n" size(hits))
+check_fail(:ok ok)
+
+// --- test 3: arg(n) memoizes -- two reads, one evaluation ---
+hits2=list()
+bump=func(hits2,1; size(hits2))
+f3=func(a=arg(0); b=arg(0); a+b :posteval)
+r3=f3(bump())
+ok=ok&&(r3==2)&&(size(hits2)==1)
+print("3 f3(a=arg(0);b=arg(0);a+b); f3(bump()) reads arg(0) twice, evals once (expect 2 1): %v %v\n\n" r3 size(hits2))
+check_fail(:ok ok)
+
+// --- test 4: keyword laziness -- unread keyword never evaluated ---
+hits3=list()
+g4=func(c=arg(0); if(c :then y :else -2) :posteval)
+r4=g4(false :y (hits3,1))
+ok=ok&&(r4==-2)&&(size(hits3)==0)
+print("4 g4(:posteval); g4(false :y <side-effecting>) never touches y (expect -2 0): %v %v\n\n" r4 size(hits3))
+check_fail(:ok ok)
+
+// --- test 5: the same keyword, actually read, IS evaluated ---
+r5=g4(true :y (hits3,1))
+ok=ok&&(size(hits3)==1)
+print("5 g4(true :y <side-effecting>) does touch y (expect size 1): %v\n\n" size(hits3))
+check_fail(:ok ok)
+
+// --- test 6: keyword memoization -- two reads, one evaluation ---
+hits4=list()
+bump2=func(hits4,1; size(hits4))
+h6=func(y+y :posteval)
+r6=h6(:y bump2())
+ok=ok&&(r6==2)&&(size(hits4)==1)
+print("6 h6(y+y); h6(:y bump2()) reads y twice, evals once (expect 2 1): %v %v\n\n" r6 size(hits4))
+check_fail(:ok ok)
+
+// --- test 7: same-chain forward reference -- NilFunc's dynamic gate (#328)
+// wraps a :posteval target's args as pending instead of eagerly resolving
+// them, same laziness as an already-defined call ---
+hits5=list()
+fwd=func(c=arg(0); if(c :then arg(1) :else -3) :posteval); r7=fwd(false hits5,1)
+ok=ok&&(r7==-3)&&(size(hits5)==0)
+print("7 fwd=func(:posteval)(same chain); fwd(false <side-effecting arg1>) still lazy (expect -3 0): %v %v\n\n" r7 size(hits5))
+check_fail(:ok ok)
+
+// --- test 8: an ordinary (non-posteval) func is unaffected -- still eager,
+// still fires a positional's side effect exactly once up front ---
+hits6=list()
+f8=func(arg(0))
+r8=f8(hits6,1)
+ok=ok&&(size(hits6)==1)
+print("8 f8=func(arg(0)) (no :posteval); f8(<side-effecting>) still eager (expect size 1): %v\n\n" size(hits6))
+check_fail(:ok ok)
+
+print("posteval: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -97,6 +97,10 @@ if(run("./funcclosure.comt")
   :then print("pass: funcclosure\n")
   :else print("FAIL: funcclosure\n");topok=false)
 
+if(run("./posteval.comt")
+  :then print("pass: posteval\n")
+  :else print("FAIL: posteval\n");topok=false)
+
 // networking: remote() round-trip over a real socket to a `comterp server`
 // child (launches/tears down its own servers; needs comterp on PATH)
 if(run("./updown.comt")

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "f6a3a720"
+#define PATCH_KEY "b3171fee"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "fbe87556"
+#define PATCH_KEY "6f4a298c"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "98e0046a"
+#define PATCH_KEY "fbe87556"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b3171fee"
+#define PATCH_KEY "13e452f1"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "78210c37"
+#define PATCH_KEY "98e0046a"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "6f4a298c"
+#define PATCH_KEY "f6a3a720"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
Fixes #328: `name=func(...)` followed by a call `name(args)` in the same already-tokenized `;`-sequence (a trailing `;` on the definition, or everything on one line) used to return `nil` on that first call, even though `name` is genuinely defined by the time it executes.

Root cause: `token_to_comvalue` routes any call-shaped symbol that isn't yet a registered command to the shared `NilFunc` instance **once, at token-conversion time** -- permanently baked into that token. That's wrong when the whole `;`-sequence gets tokenized before any of it executes, so an earlier `name=func(...)` hasn't run yet when `name(args)`'s own token gets converted. A bare niladic reference was always exempt (skips the substitution) and an already-registered name was always exempt too -- only "defined earlier in this exact sequence" fell through the cracks.

Fix:
- `NilFunc::execute()` now re-resolves its original name fresh, at the moment it actually fires. If the name has since become a real `FuncObj`, it evaluates the pending positional **and keyword** args and dispatches to it for real. If the gate is still closed, behavior is byte-for-byte unchanged: never touch the args (the deliberate plugin-hook idiom -- `optionalHook(sideEffectyExpr)` must never evaluate `sideEffectyExpr` while `optionalHook` is undefined, locked in by `symboldrain.comt`) and return nil.
- Needed a companion fix: `push_funcstate` was passing `func->funcid()` (always `"nil"` for the single shared `NilFunc` instance) instead of `sv.command_symid()` (the name actually asked for) -- `funcstate()->command_symid()` was unusable for this without it.
- Extracted the existing FuncObj-firing logic (build the call's `AttributeList`, seed `#310` captures, dispatch via `EvalFunc`) out of `eval_expr_internals` into a new shared `ComTerp::fire_funcobj()`, so both the ordinary dispatch path and `NilFunc`'s dynamic re-check share one implementation instead of two.
- Added `ComFunc::stack_keys_post_eval()`, the post-eval counterpart to the existing `stack_keys()`: one pass over the keyword run collecting and evaluating every keyword (generalizing the walk `stack_key_post_eval` already does internally to find a single known id). `fire_funcobj()` gained an optional `extra_keys` parameter to accept these pre-evaluated pairs directly, since NilFunc can't leave them on the shared stack in the ordinary popped shape.
- Keyword calls are now fully supported, not just positional -- `NilFunc` evaluates both before dispatching. The plugin-hook gate stays exactly as strict either way: a keyword call to a name still genuinely undefined never evaluates its keyword value's expression.
- Drops the old "unknown command X returned nil" warning -- it fought against the plugin-hook use case (a hook legitimately not wired up yet would warn on every call).

## :posteval -- lazy FuncObj arguments (builds on the dynamic gate above)

An ordinary `func()` call is eager: every positional/keyword argument is fully evaluated before the body runs, whether or not it's ever read. `func(body :posteval)` makes a call lazy instead: none of its arguments are evaluated at call time. They stay unevaluated -- pedepth-marked tokens in the calling expression's own postfix buffer, the same "sit there until pulled" contract any other post_eval command's args already have -- and are only resolved on demand. An argument the body never reads is never evaluated at all, side effects included, and this composes for free with any existing control command (`if`/`while`/`switch`) that already selectively evaluates its own operands, since both sides are built on the same token-span-bookmark primitive.

`arg(n)` and a keyword differ in what happens after the first pull, on purpose:
- **`arg(n)` re-fires the pending expression on every call, never memoized.** There's no lvalue form (no `arg(0)=...`), so there's nothing to protect by caching it -- and this is what lets a `while` loop inside a `:posteval` body see a live, current value each iteration, the same way any post_eval command's own operand is genuinely re-evaluated every pass. The idiom for caching a repeatedly-read `arg(n)` is the same one non-func code already uses: assign it to a local once.
- **A keyword is lazy but otherwise timed like plain `func()`'s own eager keyword:** evaluated once, on its first read-before-write, then memoized -- a later read (even from inside a loop) sees that same value, it does not re-fire. (Whether keyword laziness should itself vary per loop iteration is a further refinement still being thought through, not implemented here.)

Mechanism:
- A still-pending arg/keyword is represented by a small `FuncObjPendingArg` marker (offtop/tokcnt/pedepth) sitting directly in the same channels an eager call already uses -- `funcobj_argvals()[n]` for a positional, `_alist` for a keyword -- so no parallel storage or save/restore is needed. Reading one pulls it via `post_eval_expr` against the caller's still-parked buffer (reached through `top_servstate()`, the same frame `push_servstate()` already stashes for every nested func call). `pull_funcobj_pending()` itself never memoizes -- `funcobj_arg()` (positionals) always uses the fresh result as-is; `pull_alist_pending()` (keywords) writes it back into `_alist` on first access.
- `token_to_comvalue` is extended so a call to an already-resolved `:posteval` `FuncObj` gets the same static pedepth-deferral treatment #328's `NilFunc` substitution already gives an undefined symbol -- covering the ordinary cross-statement case, not just same-chain forward references.
- `NilFunc`'s own dynamic gate checks the resolved target's `posteval()` flag: eager as before, or wraps its args as pending markers via two new `ComFunc::bookmark_stack_*` methods (the same walk `stack_arg_post_eval_nargsfixed`/`stack_keys_post_eval` already do internally, stopping one step short of evaluating).
- Fixed a real bug the arg(n)-vs-keyword split surfaced: a bare `y+y` was firing its pending keyword expression three times instead of once, because `has_streams`'s own internal peek and `stack_arg`'s operand resolution each independently touch the same keyword through two different `lookup_symval` overloads -- both now route through the same memoizing `pull_alist_pending()`, so a keyword used as an ordinary operand fires exactly once no matter how many internal passes touch it. `lookup_symval(ComValue*)` (compound-assign's write-through path, `y+=1`) already needed real addressable storage to mutate in place, so it was always on this path.
- Also fixed, unrelated but found via the same investigation: `ComValue::ComValue(postfix_token*)` was `memcpy`ing 16 bytes (`sizeof` its own value union) from an 8-byte source (`postfix_token`'s narrower union), reading 8 bytes past the token into its own adjacent fields -- harmless in practice (nothing reads those bytes for any token type in use) but a real out-of-bounds read, predating this branch by years.

`doc/LANGUAGE.md` gains a "Lazy arguments: `:posteval`" section with verified runnable examples, including the arg(n)-vs-keyword split. `src/comterp_/tests/posteval.comt` adds 9 regression tests (short-circuit laziness, positional re-firing including a live while-loop case, keyword memoization, same-chain forward reference, cross-statement, eager-func regression) and is wired into `run_all.comt`.

Issue #331 (`global(x)` inside a func body) was filed then closed as a misunderstanding on my part of `global()`'s own semantics (it reads/writes the process-wide table, a different table than plain bare assignment uses) -- not a real bug.

## Test plan
- [x] All original repro shapes work (trailing-`;` definition, all-one-line, a name never seen before in the process) -- positional AND keyword calls
- [x] A genuine typo still gracefully returns nil, no crash, for both positional and keyword calls
- [x] The plugin-hook gate stays exactly as strict as before -- `symboldrain.comt` (side-effecting args never evaluate while the target is undefined) passes unchanged, and verified live for the keyword case too (a side-effecting keyword value never runs while the target is undefined)
- [x] Declaration-time captures (#310) still thread through `fire_funcobj` correctly, keyword path included
- [x] `:posteval` -- unused positional/keyword args never evaluated (verified live via side-effect probes, not just return values); `arg(n)` re-fires on every call (verified live via a while loop reading a live counter); a keyword memoizes on first access even when read multiple times; same-chain forward reference through NilFunc's gate; cross-statement already-defined call; ordinary eager funcs unaffected
- [x] `src/comterp_/tests/run_all.comt` -- 36/36 passing
- [x] `src/comdraw/tests/run_all.comt` -- 9/9 passing (this branch predates #327's `spirograph.comt`)
- [x] `comdraw`/ComUnidraw build clean
