### PR TITLE
help(func): IO-contract signature + default-value rendering (#334 stage 1 + #336 detection, staged from #170)

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1096,6 +1096,90 @@ do not escape to the caller's scope. This includes dot-notation
 attributes: a dot namespace rooted at a local symbol is local to the
 call.
 
+### Introspecting a func's IO contract: `help(f)`
+
+Comterp already communicates several contracts textually rather than
+leaving them implicit: `postfix(help)` appends a trailing `*` to a
+post-eval command's name, and `help()` renders a registered command's
+docstring and keyword list on request. `help(f)`, where `f` is a bare,
+unfired FuncObj, extends the same idea to a func you wrote yourself —
+rendering its positional and keyword contract as one line of text,
+without running the body:
+
+```
+f=func(arg(0)+arg(1))
+help(f)              // "(arg0 arg1)"
+```
+
+`help()` already reads its arguments symbol-preserving (it's post_eval),
+so `f` reaches it completely unfired — the same non-firing read
+`isclass(x :sym)` relies on elsewhere. Positionals render as `arg0`,
+`arg1`, ... (from the highest literal `arg(n)` index referenced), or
+`...` when the count can't be pinned down statically (`narg()` usage, or
+a computed index). Keywords show only the ones a caller can meaningfully
+supply — read-only and read-before-write free variables — since
+write-before-read is local scratch a keyword would just be clobbering,
+not a genuine input. Escaping (`local()`/`global()`) variables are
+reported in a trailing annotation instead, since they're not part of the
+func's own frame:
+
+```
+f=func(local(w)=1)
+help(f)              // "()  -- escapes: w->local"
+```
+
+**Defaults are shown too, in both of the senses that turn out to
+matter.** A func using the `if(x==nil :then DEFAULT :else x)`
+optional-keyword idiom has its coded `DEFAULT` rendered inline, when
+`DEFAULT` is a single literal:
+
+```
+ini=func(if(x==nil :then 99 :else x))
+help(ini)             // "(:x [99])"
+```
+
+But the coded default is only the *written* fallback — closures
+(above) mean it isn't necessarily the *effective* one. If `x` already
+had a real value in scope the moment `func()` ran, declaration-time
+capture grabbed that value, not `nil` — the body's `x==nil` check will
+never be true for as long as that capture stands, so `99` is currently
+dead code:
+
+```
+x=7
+ini=func(if(x==nil :then 99 :else x))
+help(ini)             // "(:x [99, captured 7])"
+ini()                 // 7, not 99
+```
+
+The same capture applies even without a coded default idiom at all —
+declaration-time capture doesn't care whether the func author wrote
+optional-parameter logic for a variable or just read it plainly. From a
+caller's side, both look the same: call the func bare, get whatever was
+captured; supply the keyword explicitly, get that instead:
+
+```
+w=42
+f=func(w+1)
+help(f)               // "(:w [captured 42])"
+```
+
+This isn't a bug or a special case worth working around — it's the same
+fact the earlier closures section already establishes (a func's
+free-variable reads resolve to whatever was true *when `func()` ran*,
+not whatever's true when it's called), surfaced in text instead of
+staying implicit. A captured value is simple, stable, and constant once
+the func exists, which is exactly what makes it worth `help()` showing
+rather than leaving to be discovered by firing the func and being
+surprised.
+
+None of this is fully perfected — return-kind isn't derived yet, output
+is one line rather than column-aligned, and there's no way yet to feed a
+`help(f)` string back in to reconstruct the func the way `~~` round-trips
+a stream's own emitted representation. But the direction is the same one
+the rest of the language already leans on: make a contract legible as
+text first, and let round-tripping follow once the shape earns it.
+
 ### Lazy arguments: `:posteval`
 
 An ordinary `func()` call is eager: every positional and keyword argument

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1148,7 +1148,7 @@ dead code:
 ```
 x=7
 ini=func(if(x==nil :then 99 :else x))
-help(ini)             // "(:x [99, captured 7])"
+help(ini)             // "(:x [99, 7])"  -- coded default, then what got captured
 ini()                 // 7, not 99
 ```
 
@@ -1161,7 +1161,7 @@ captured; supply the keyword explicitly, get that instead:
 ```
 w=42
 f=func(w+1)
-help(f)               // "(:w [captured 42])"
+help(f)               // "(:w [42])"
 ```
 
 This isn't a bug or a special case worth working around — it's the same

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -362,7 +362,7 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
     append_bounded(buf, sizeof(buf), pos, "...");
     first = false;
   } else {
-    for (int i = 0; i < posinfo.count; i++) {
+    for (int i = 0; i < posinfo.count && pos < (int)sizeof(buf) - 1; i++) {
       append_bounded(buf, sizeof(buf), pos, first ? "arg%d" : " arg%d", i);
       first = false;
     }

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -362,8 +362,20 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
     append_bounded(buf, sizeof(buf), pos, "...");
     first = false;
   } else {
-    for (int i = 0; i < posinfo.count && pos < (int)sizeof(buf) - 1; i++) {
+    /* Reserve room for a " ... argMAX)" tail (worst case ~19 bytes for a
+       10-digit index) so a huge literal index like arg(2000000000) -- the
+       same repro as the DoS this loop's bound guards against, Greptile,
+       PR #337 -- renders as many arg%d entries as fit and then names the
+       true final index instead of just stopping mid-list with no
+       indication anything was cut off. */
+    const int tail_reserve = 32;
+    int i = 0;
+    for (; i < posinfo.count && pos < (int)sizeof(buf) - 1 - tail_reserve; i++) {
       append_bounded(buf, sizeof(buf), pos, first ? "arg%d" : " arg%d", i);
+      first = false;
+    }
+    if (i < posinfo.count) {
+      append_bounded(buf, sizeof(buf), pos, first ? "... arg%d" : " ... arg%d", posinfo.count - 1);
       first = false;
     }
   }

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -59,6 +59,7 @@
 #include <ComTerp/numfunc.h>
 #include <ComTerp/parsefunc.h>
 #include <ComTerp/postfunc.h>
+#include <ComTerp/funcobjscan.h>
 #include <ComTerp/randfunc.h>
 #include <ComTerp/soundfunc.h>
 #include <ComTerp/statfunc.h>
@@ -290,6 +291,67 @@ int ComTerp::eval_expr(ComValue* pfvals, int npfvals) {
   pop_servstate();
 
   return FUNCOK;
+}
+
+/* #334 (staged from #170 phase 1): the bare IO-contract signature for
+   help(f) where f is a bare, unfired FuncObj -- see the fuller comment on
+   ComTerp::describe_funcobj in comterp.h.  Positionals render as
+   arg0/arg1/... (the arg(n) indices themselves, since a positional has no
+   other name) or "..." when the count can't be pinned down statically (a
+   computed index, or narg() usage -- see FuncObjVarScan::scan_positionals).
+   Keywords are read-only union read-before-write only -- per #170's own
+   framing, write-before-read is local scratch a caller's keyword would
+   just be clobbering, not a real input, so it's omitted; escaping
+   (local()/global()) vars are reported in a trailing annotation instead
+   of the parens themselves, since they're not part of the func's own
+   frame at all. */
+ComValue ComTerp::describe_funcobj(FuncObj* fo) {
+  boolean* is_plain_var = FuncObjVarScan::build_is_plain_var(this, fo->toks(), fo->ntoks());
+  AttributeList* classification = FuncObjVarScan::classify(fo->toks(), fo->ntoks(), is_plain_var);
+  ComValue classification_owner(AttributeList::class_symid(), (void*)classification);
+  delete [] is_plain_var;
+
+  FuncObjVarScan::PositionalInfo posinfo = FuncObjVarScan::scan_positionals(fo->toks(), fo->ntoks());
+
+  char buf[2048];
+  int pos = snprintf(buf, sizeof(buf), "(");
+  boolean first = true;
+
+  if (posinfo.count < 0) {
+    pos += snprintf(buf+pos, sizeof(buf)-pos, "...");
+    first = false;
+  } else {
+    for (int i = 0; i < posinfo.count; i++) {
+      pos += snprintf(buf+pos, sizeof(buf)-pos, first ? "arg%d" : " arg%d", i);
+      first = false;
+    }
+  }
+
+  ALIterator cit;
+  for (classification->First(cit); !classification->Done(cit); classification->Next(cit)) {
+    Attribute* attr = classification->GetAttr(cit);
+    int kind = attr->Value()->int_val();
+    if (kind == FuncObjVarScan::ReadOnly || kind == FuncObjVarScan::ReadBeforeWrite) {
+      pos += snprintf(buf+pos, sizeof(buf)-pos, first ? ":%s" : " :%s",
+                       symbol_pntr(attr->SymbolId()));
+      first = false;
+    }
+  }
+  pos += snprintf(buf+pos, sizeof(buf)-pos, ")");
+
+  boolean any_escape = false;
+  for (classification->First(cit); !classification->Done(cit); classification->Next(cit)) {
+    Attribute* attr = classification->GetAttr(cit);
+    int kind = attr->Value()->int_val();
+    if (kind == FuncObjVarScan::EscapingLocal || kind == FuncObjVarScan::EscapingGlobal) {
+      pos += snprintf(buf+pos, sizeof(buf)-pos, any_escape ? ", %s->%s" : "  -- escapes: %s->%s",
+                       symbol_pntr(attr->SymbolId()),
+                       kind == FuncObjVarScan::EscapingGlobal ? "global" : "local");
+      any_escape = true;
+    }
+  }
+
+  return ComValue(buf);
 }
 
 void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* lazy_posvals) {

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -399,7 +399,7 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
           char capbuf[256];
           ComValue capv(*capval);
           render_comvalue(capv, capbuf, sizeof(capbuf));
-          append_bounded(buf, sizeof(buf), pos, first ? ":%s [%s, captured %s]" : " :%s [%s, captured %s]",
+          append_bounded(buf, sizeof(buf), pos, first ? ":%s [%s, %s]" : " :%s [%s, %s]",
                           symbol_pntr(attr->SymbolId()), defbuf, capbuf);
         } else {
           append_bounded(buf, sizeof(buf), pos, first ? ":%s [%s]" : " :%s [%s]",
@@ -413,7 +413,7 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
         char capbuf[256];
         ComValue capv(*capval);
         render_comvalue(capv, capbuf, sizeof(capbuf));
-        append_bounded(buf, sizeof(buf), pos, first ? ":%s [captured %s]" : " :%s [captured %s]",
+        append_bounded(buf, sizeof(buf), pos, first ? ":%s [%s]" : " :%s [%s]",
                         symbol_pntr(attr->SymbolId()), capbuf);
       } else {
         append_bounded(buf, sizeof(buf), pos, first ? ":%s" : " :%s",

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -315,6 +315,19 @@ static void append_bounded(char* buf, size_t bufsize, int& pos, const char* fmt,
   if ((size_t)pos > bufsize - 1) pos = (int)(bufsize - 1);  /* clamp for the next call */
 }
 
+/* renders a ComValue as text into a fixed buffer, for embedding into
+   append_bounded's printf-style calls above (which have no %v of their
+   own) -- same std::strstreambuf/ostream pattern already used elsewhere
+   in this file (e.g. the stack_top() print path). */
+static void render_comvalue(ComValue& v, char* out, size_t outsize) {
+  std::strstreambuf sbuf;
+  ostream os(&sbuf);
+  os << v;
+  os << '\0';
+  strncpy(out, sbuf.str(), outsize - 1);
+  out[outsize - 1] = '\0';
+}
+
 /* #334 (staged from #170 phase 1): the bare IO-contract signature for
    help(f) where f is a bare, unfired FuncObj -- see the fuller comment on
    ComTerp::describe_funcobj in comterp.h.  Positionals render as
@@ -331,6 +344,11 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
   boolean* is_plain_var = FuncObjVarScan::build_is_plain_var(this, fo->toks(), fo->ntoks());
   AttributeList* classification = FuncObjVarScan::classify(fo->toks(), fo->ntoks(), is_plain_var);
   ComValue classification_owner(AttributeList::class_symid(), (void*)classification);
+  /* #336 (staged from #170's "Future" section): recognizes only the
+     canonical if(x==nil :then DEFAULT :else x) idiom -- needs
+     is_plain_var too, so computed before it's freed below. */
+  AttributeList* defaults = FuncObjVarScan::scan_defaults(this, fo->toks(), fo->ntoks(), is_plain_var);
+  ComValue defaults_owner(AttributeList::class_symid(), (void*)defaults);
   delete [] is_plain_var;
 
   FuncObjVarScan::PositionalInfo posinfo = FuncObjVarScan::scan_positionals(fo->toks(), fo->ntoks());
@@ -355,8 +373,52 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
     Attribute* attr = classification->GetAttr(cit);
     int kind = attr->Value()->int_val();
     if (kind == FuncObjVarScan::ReadOnly || kind == FuncObjVarScan::ReadBeforeWrite) {
-      append_bounded(buf, sizeof(buf), pos, first ? ":%s" : " :%s",
-                      symbol_pntr(attr->SymbolId()));
+      AttributeValue* defval = defaults->find(attr->SymbolId());
+      /* #310's declaration-time capture can make the coded default
+	 above unreachable: if this name already had a real value in
+	 scope when func() ran, ReadOnly capture grabbed THAT value, not
+	 nil -- the x==nil check inside the body will never be true for
+	 as long as that capture stands, so the :then literal is
+	 currently dead code.  Surface this rather than let :help claim
+	 a default that the func will actually never produce. */
+      AttributeValue* capval = nil;
+      if (fo->captures().is_object(AttributeList::class_symid())) {
+        capval = ((AttributeList*)fo->captures().obj_val())->find(attr->SymbolId());
+      }
+      boolean cap_shadows = capval && !ComValue(*capval).is_unknown();
+      if (defval) {
+        /* #336: render the detected default inline, :name [value] --
+           comterp contracts are textually communicated wherever
+           possible (postfix(help)'s trailing * for post-eval commands,
+           help()'s own docstring/dockeys rendering); this is the same
+           idea applied to a func's own IO contract. */
+        char defbuf[256];
+        ComValue defv(*defval);
+        render_comvalue(defv, defbuf, sizeof(defbuf));
+        if (cap_shadows) {
+          char capbuf[256];
+          ComValue capv(*capval);
+          render_comvalue(capv, capbuf, sizeof(capbuf));
+          append_bounded(buf, sizeof(buf), pos, first ? ":%s [%s, captured %s]" : " :%s [%s, captured %s]",
+                          symbol_pntr(attr->SymbolId()), defbuf, capbuf);
+        } else {
+          append_bounded(buf, sizeof(buf), pos, first ? ":%s [%s]" : " :%s [%s]",
+                          symbol_pntr(attr->SymbolId()), defbuf);
+        }
+      } else if (cap_shadows) {
+        /* no coded default idiom at all, but this read-only keyword was
+           still captured as a real value at declaration time -- worth
+           showing too, same reasoning as above, just without a coded
+           literal to contrast it against. */
+        char capbuf[256];
+        ComValue capv(*capval);
+        render_comvalue(capv, capbuf, sizeof(capbuf));
+        append_bounded(buf, sizeof(buf), pos, first ? ":%s [captured %s]" : " :%s [captured %s]",
+                        symbol_pntr(attr->SymbolId()), capbuf);
+      } else {
+        append_bounded(buf, sizeof(buf), pos, first ? ":%s" : " :%s",
+                        symbol_pntr(attr->SymbolId()));
+      }
       first = false;
     }
   }

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -23,6 +23,7 @@
  * 
  */
 
+#include <cstdarg>
 #include <cstdio>
 #include <ctype.h>
 #include <iostream.h>
@@ -293,6 +294,27 @@ int ComTerp::eval_expr(ComValue* pfvals, int npfvals) {
   return FUNCOK;
 }
 
+/* Bounds-safe snprintf accumulation into a fixed buffer -- plain
+   'pos += snprintf(buf+pos, sizeof(buf)-pos, ...)' is unsafe to repeat:
+   once the buffer is full, snprintf returns the length it WOULD have
+   written (not what it actually wrote), so pos can end up past the
+   buffer's end.  The next call then computes buf+pos as an out-of-bounds
+   pointer and sizeof(buf)-pos as a size_t underflow (huge, since
+   sizeof() is unsigned) -- snprintf believes it has nearly unlimited
+   room and writes past the real allocation (Greptile, PR #337).  This
+   clamps pos to stay valid after every call, so a signature long enough
+   to fill the buffer truncates safely instead of overflowing it. */
+static void append_bounded(char* buf, size_t bufsize, int& pos, const char* fmt, ...) {
+  if (pos < 0 || (size_t)pos >= bufsize - 1) return;  /* already full/invalid -- skip */
+  va_list ap;
+  va_start(ap, fmt);
+  int n = vsnprintf(buf + pos, bufsize - (size_t)pos, fmt, ap);
+  va_end(ap);
+  if (n < 0) return;  /* encoding error -- leave pos alone */
+  pos += n;
+  if ((size_t)pos > bufsize - 1) pos = (int)(bufsize - 1);  /* clamp for the next call */
+}
+
 /* #334 (staged from #170 phase 1): the bare IO-contract signature for
    help(f) where f is a bare, unfired FuncObj -- see the fuller comment on
    ComTerp::describe_funcobj in comterp.h.  Positionals render as
@@ -314,15 +336,16 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
   FuncObjVarScan::PositionalInfo posinfo = FuncObjVarScan::scan_positionals(fo->toks(), fo->ntoks());
 
   char buf[2048];
-  int pos = snprintf(buf, sizeof(buf), "(");
+  int pos = 0;
+  append_bounded(buf, sizeof(buf), pos, "(");
   boolean first = true;
 
   if (posinfo.count < 0) {
-    pos += snprintf(buf+pos, sizeof(buf)-pos, "...");
+    append_bounded(buf, sizeof(buf), pos, "...");
     first = false;
   } else {
     for (int i = 0; i < posinfo.count; i++) {
-      pos += snprintf(buf+pos, sizeof(buf)-pos, first ? "arg%d" : " arg%d", i);
+      append_bounded(buf, sizeof(buf), pos, first ? "arg%d" : " arg%d", i);
       first = false;
     }
   }
@@ -332,21 +355,21 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
     Attribute* attr = classification->GetAttr(cit);
     int kind = attr->Value()->int_val();
     if (kind == FuncObjVarScan::ReadOnly || kind == FuncObjVarScan::ReadBeforeWrite) {
-      pos += snprintf(buf+pos, sizeof(buf)-pos, first ? ":%s" : " :%s",
-                       symbol_pntr(attr->SymbolId()));
+      append_bounded(buf, sizeof(buf), pos, first ? ":%s" : " :%s",
+                      symbol_pntr(attr->SymbolId()));
       first = false;
     }
   }
-  pos += snprintf(buf+pos, sizeof(buf)-pos, ")");
+  append_bounded(buf, sizeof(buf), pos, ")");
 
   boolean any_escape = false;
   for (classification->First(cit); !classification->Done(cit); classification->Next(cit)) {
     Attribute* attr = classification->GetAttr(cit);
     int kind = attr->Value()->int_val();
     if (kind == FuncObjVarScan::EscapingLocal || kind == FuncObjVarScan::EscapingGlobal) {
-      pos += snprintf(buf+pos, sizeof(buf)-pos, any_escape ? ", %s->%s" : "  -- escapes: %s->%s",
-                       symbol_pntr(attr->SymbolId()),
-                       kind == FuncObjVarScan::EscapingGlobal ? "global" : "local");
+      append_bounded(buf, sizeof(buf), pos, any_escape ? ", %s->%s" : "  -- escapes: %s->%s",
+                      symbol_pntr(attr->SymbolId()),
+                      kind == FuncObjVarScan::EscapingGlobal ? "global" : "local");
       any_escape = true;
     }
   }

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -375,7 +375,7 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
       first = false;
     }
     if (i < posinfo.count) {
-      append_bounded(buf, sizeof(buf), pos, first ? "... arg%d" : " ... arg%d", posinfo.count - 1);
+      append_bounded(buf, sizeof(buf), pos, first ? "... arg%ld" : " ... arg%ld", posinfo.count - 1);
       first = false;
     }
   }

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -46,6 +46,7 @@ class ComFunc;
 class ComFuncState;
 class ComTerpState;
 class ComValue;
+class FuncObj;
 #include <iosfwd>
 
 class ComterpHandler;
@@ -171,6 +172,20 @@ public:
     // time in load_sub_expr, by is_funcobj's own unchanged fast path.
     // ComFunc::stack_arg()/stack_key() are the callers, right after their
     // own real (non-pending) resolution.
+    ComValue describe_funcobj(FuncObj* fo);
+    // #334 (staged from #170 phase 1): the bare IO-contract signature for
+    // help(f) where f is a bare, unfired FuncObj -- help() reads its
+    // argument symbol-preserving (post_eval(), stack_arg(i, true)) so it
+    // never fires f itself; HelpFunc::execute() (helpfunc.c) resolves that
+    // symbol via lookup_symval, checks is_object(FuncObj::class_symid()),
+    // and calls this instead of falling through to its usual registered-
+    // command docstring lookup.  Returns a StringType ComValue rendering
+    // positionals (from FuncObjVarScan::scan_positionals) and read-only/
+    // read-before-write keywords (from FuncObjVarScan::classify) as
+    // "(arg0 arg1 :key1 :key2)", with any escaping (local()/global())
+    // variables reported in a trailing "  -- escapes: name->scope"
+    // annotation instead.  Never runs fo's body.
+
     AttributeValue* lookup_symval(ComValue*, boolean freeze=true);
     // look up a pointer to an AttributeValue associated with a symbol
     // (specified in the input ComValue) in the local or global symbol

--- a/src/ComTerp/funcobjscan.c
+++ b/src/ComTerp/funcobjscan.c
@@ -29,6 +29,8 @@
 #include <Attribute/attribute.h>
 #include <Attribute/attrvalue.h>
 
+#include <limits.h>
+
 /* Per-occurrence event, for the FIRST-mention/ever-written bookkeeping --
    distinct from the public Kind, which is the FINAL classification derived
    from these once the whole body has been walked. */
@@ -191,9 +193,21 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
 
     if (info.uses_narg || saw_nonliteral)
         info.count = -1;
-    else if (saw_arg)
-        info.count = maxidx + 1;
-    else
+    else if (saw_arg) {
+        /* maxidx+1 overflowing (maxidx == LONG_MAX) is signed-integer UB,
+           not just "unlikely" -- check before doing the addition rather
+           than let it wrap and rely on that wrapping to coincidentally
+           land back on the same -1 "can't be pinned down" sentinel
+           (Greptile, PR #337). This is unreachable through today's literal
+           parsing (values above INT_MAX don't currently survive intact --
+           a separate, pre-existing bug, #342), but the guard costs nothing
+           and removes the UB regardless of whether any path can trigger
+           it today. */
+        if (maxidx == LONG_MAX)
+            info.count = -1;
+        else
+            info.count = maxidx + 1;
+    } else
         info.count = 0;      /* no arg(n) calls at all -- a niladic body */
 
     return info;

--- a/src/ComTerp/funcobjscan.c
+++ b/src/ComTerp/funcobjscan.c
@@ -146,7 +146,10 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
     info.count = -1;
     info.uses_narg = false;
 
-    int maxidx = -1;            /* highest literal index seen: arg(0) -> 0 */
+    long maxidx = -1;           /* highest literal index seen: arg(0) -> 0 --
+                                    long (not int) so maxidx+1 below can't
+                                    overflow for a literal near INT_MAX
+                                    (Greptile, PR #337) */
     boolean saw_arg = false;
     boolean saw_nonliteral = false;
 
@@ -171,9 +174,9 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
             if (operand.count == 1 &&
                 (toks[operand.start].type == TOK_DFINT ||
                  toks[operand.start].type == TOK_LNINT)) {
-                int idx = toks[operand.start].type == TOK_DFINT
-                    ? toks[operand.start].v.dfintval
-                    : (int)toks[operand.start].v.lnintval;
+                long idx = toks[operand.start].type == TOK_DFINT
+                    ? (long)toks[operand.start].v.dfintval
+                    : toks[operand.start].v.lnintval;
                 if (idx > maxidx) maxidx = idx;
             } else {
                 /* a computed index (arg(i), arg(i+1), ...) -- resolving

--- a/src/ComTerp/funcobjscan.c
+++ b/src/ComTerp/funcobjscan.c
@@ -23,6 +23,8 @@
 
 #include <ComTerp/funcobjscan.h>
 #include <ComTerp/postfixspan.h>
+#include <ComTerp/comvalue.h>
+#include <ComTerp/comterp.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attribute.h>
 #include <Attribute/attrvalue.h>
@@ -115,6 +117,83 @@ static void add_to_set(int*& set, int& n, int& cap, int symid) {
    and simply produces no event). */
 static boolean span_is_plain_var(PostfixSpanWalk::Span span, boolean* is_plain_var) {
     return span.count == 1 && is_plain_var[span.start];
+}
+
+boolean* FuncObjVarScan::build_is_plain_var(ComTerp* comterp, postfix_token* toks, int ntoks) {
+    boolean* is_plain_var = new boolean[ntoks];
+    for (int i = 0; i < ntoks; i++) {
+        /* nids<0 (HACKING.md's "Dot Operator Rhs" section) marks a bare
+           identifier on the right of a dot -- an attribute-key literal
+           like the "v" in "obj.v", never promoted to CommandType
+           regardless of whether that name is also a registered command,
+           but not an ordinary variable reference either. */
+        if (toks[i].type == TOK_COMMAND && toks[i].nids >= 0) {
+            ComValue sv;
+            comterp->token_to_comvalue(&toks[i], &sv);
+            is_plain_var[i] = sv.type() == ComValue::SymbolType;
+        } else {
+            is_plain_var[i] = false;
+        }
+    }
+    return is_plain_var;
+}
+
+FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* toks, int ntoks) {
+    static int arg_symid = symbol_add("arg");
+    static int narg_symid = symbol_add("narg");
+
+    PositionalInfo info;
+    info.count = -1;
+    info.uses_narg = false;
+
+    int maxidx = -1;            /* highest literal index seen: arg(0) -> 0 */
+    boolean saw_arg = false;
+    boolean saw_nonliteral = false;
+
+    PostfixSpanWalk walk;
+    for (int i = 0; i < ntoks; i++) {
+        walk.step(toks, i);
+        if (toks[i].type != TOK_COMMAND) continue;
+        int symid = toks[i].v.symbolid;
+
+        if (symid == narg_symid) {
+            /* narg() anywhere in the body reads as "this loops over a
+               run of positionals bounded at call time," i.e. variadic --
+               not resolvable to one fixed count regardless of any
+               literal arg(n) indices also present. */
+            info.uses_narg = true;
+            continue;
+        }
+
+        if (symid == arg_symid && walk.consumed_count() == 1) {
+            saw_arg = true;
+            PostfixSpanWalk::Span operand = walk.consumed(0);
+            if (operand.count == 1 &&
+                (toks[operand.start].type == TOK_DFINT ||
+                 toks[operand.start].type == TOK_LNINT)) {
+                int idx = toks[operand.start].type == TOK_DFINT
+                    ? toks[operand.start].v.dfintval
+                    : (int)toks[operand.start].v.lnintval;
+                if (idx > maxidx) maxidx = idx;
+            } else {
+                /* a computed index (arg(i), arg(i+1), ...) -- resolving
+                   simple cases statically is future work (#170 phase 1
+                   point 2's "attempt, fall back to dynamic" allowance);
+                   this first pass gives up gracefully instead of
+                   guessing. */
+                saw_nonliteral = true;
+            }
+        }
+    }
+
+    if (info.uses_narg || saw_nonliteral)
+        info.count = -1;
+    else if (saw_arg)
+        info.count = maxidx + 1;
+    else
+        info.count = 0;      /* no arg(n) calls at all -- a niladic body */
+
+    return info;
 }
 
 AttributeList* FuncObjVarScan::classify(postfix_token* toks, int ntoks, boolean* is_plain_var) {

--- a/src/ComTerp/funcobjscan.c
+++ b/src/ComTerp/funcobjscan.c
@@ -328,3 +328,81 @@ AttributeList* FuncObjVarScan::classify(postfix_token* toks, int ntoks, boolean*
 
     return result;
 }
+
+AttributeList* FuncObjVarScan::scan_defaults(ComTerp* comterp, postfix_token* toks, int ntoks, boolean* is_plain_var) {
+    static int if_symid = symbol_add("if");
+    static int eq_symid = symbol_add("eq");
+    static int nil_symid = symbol_add("nil");
+    static int then_symid = symbol_add("then");
+    static int else_symid = symbol_add("else");
+
+    AttributeList* result = new AttributeList();
+
+    PostfixSpanWalk walk;
+    for (int i = 0; i < ntoks; i++) {
+        walk.step(toks, i);
+        if (toks[i].type != TOK_COMMAND || (unsigned)toks[i].v.symbolid != (unsigned)if_symid) continue;
+        /* only the plain 3-operand if(cond :then v :else v) shape --
+           :until/:nilchk or any other keyword on this if() means it
+           isn't this idiom at all */
+        if (walk.consumed_count() != 3) continue;
+
+        PostfixSpanWalk::Span condspan = walk.consumed(0);
+        PostfixSpanWalk::Span branch1 = walk.consumed(1);
+        PostfixSpanWalk::Span branch2 = walk.consumed(2);
+
+        /* condition must be exactly "K==nil" or "nil==K" -- 3 tokens,
+           last one eq, the other two bare single-token operands, one of
+           them the literal nil command and the other a plain variable
+           (the keyword this default belongs to) */
+        if (condspan.count != 3) continue;
+        int eqtok = condspan.start + 2;
+        if (toks[eqtok].type != TOK_COMMAND || (unsigned)toks[eqtok].v.symbolid != (unsigned)eq_symid) continue;
+        int t0 = condspan.start, t1 = condspan.start + 1;
+        boolean t0_nil = toks[t0].type == TOK_COMMAND && (unsigned)toks[t0].v.symbolid == (unsigned)nil_symid;
+        boolean t1_nil = toks[t1].type == TOK_COMMAND && (unsigned)toks[t1].v.symbolid == (unsigned)nil_symid;
+        int keysym;
+        if (t0_nil && is_plain_var[t1]) keysym = toks[t1].v.symbolid;
+        else if (t1_nil && is_plain_var[t0]) keysym = toks[t0].v.symbolid;
+        else continue;
+
+        /* branch1/branch2 (source order) must each end in a KEYWORD
+           token -- that's what identifies which is :then and which is
+           :else (see funcobjscan.h's spanwalk comment: a keyword-tagged
+           operand's span includes its trailing KEYWORD marker token) */
+        PostfixSpanWalk::Span then_span, else_span;
+        boolean have_then = false, have_else = false;
+        PostfixSpanWalk::Span branches[2];
+        branches[0] = branch1;
+        branches[1] = branch2;
+        for (int b = 0; b < 2; b++) {
+            PostfixSpanWalk::Span sp = branches[b];
+            if (sp.count < 1) continue;
+            int last = sp.start + sp.count - 1;
+            if (toks[last].type != TOK_KEYWORD) continue;
+            if ((unsigned)toks[last].v.symbolid == (unsigned)then_symid) { then_span = sp; have_then = true; }
+            else if ((unsigned)toks[last].v.symbolid == (unsigned)else_symid) { else_span = sp; have_else = true; }
+        }
+        if (!have_then || !have_else) continue;
+
+        /* :else's value portion (span minus its trailing keyword token)
+           must be exactly the bare keyword, unchanged -- confirms this
+           if() really is the "return x as-is" idiom for THIS keysym,
+           not some other, unrelated keyword-adjacent if() */
+        if (else_span.count != 2) continue;
+        if (!is_plain_var[else_span.start] || toks[else_span.start].v.symbolid != keysym) continue;
+
+        /* :then's value portion must be exactly one literal token --
+           give up gracefully (no default reported) on anything computed,
+           same restraint scan_positionals uses for a non-literal arg(n)
+           index */
+        if (then_span.count != 2) continue;
+        ComValue litval;
+        comterp->token_to_comvalue(&toks[then_span.start], &litval);
+        if (litval.is_type(AttributeValue::CommandType) || litval.is_type(AttributeValue::SymbolType)) continue;
+
+        result->add_attr(keysym, litval);
+    }
+
+    return result;
+}

--- a/src/ComTerp/funcobjscan.h
+++ b/src/ComTerp/funcobjscan.h
@@ -72,7 +72,10 @@ public:
     // that's keyword-symbol classification only, with no notion of arg(n)
     // at all.
     struct PositionalInfo {
-        int count;         // -1 means "count could not be pinned down statically"
+        long count;        // -1 means "count could not be pinned down statically";
+                            // long (not int) so a literal index near INT_MAX
+                            // doesn't overflow computing count = maxidx + 1
+                            // (Greptile, PR #337)
         boolean uses_narg; // true if narg() appears anywhere in the body --
                             // treated as a signal the body is variadic
                             // (loops over an arg(n) run bounded by narg()),

--- a/src/ComTerp/funcobjscan.h
+++ b/src/ComTerp/funcobjscan.h
@@ -87,6 +87,25 @@ public:
     // computed n, fall back to dynamic" allowance; this first pass only
     // resolves literal indices, computed-index resolution is future work.
     static PositionalInfo scan_positionals(postfix_token* toks, int ntoks);
+
+    // #336 (staged from #170's "Future" section, "Positional optionality"):
+    // recognizes the canonical "unsupplied keyword defaults to nil" idiom --
+    // if(x==nil :then DEFAULT :else x) -- and extracts DEFAULT where it's a
+    // single literal token. Only this one, well-known shape is matched
+    // (condition is exactly "x==nil"/"nil==x", the :else branch is exactly
+    // the bare keyword unchanged, the :then branch is exactly one literal
+    // token); anything more elaborate -- a computed default, extra
+    // keywords on the if(), a differently-shaped condition -- is silently
+    // skipped rather than guessed at, the same "attempt simple cases, give
+    // up gracefully" restraint scan_positionals uses for computed arg(n)
+    // indices. Needs ComTerp access (token_to_comvalue) to turn the
+    // literal token into a real ComValue, unlike classify()/
+    // scan_positionals() above.
+    //
+    // Returns an AttributeList mapping each keyword's symid (only those
+    // with a recognized default) to its default ComValue. Always non-nil,
+    // possibly empty. Caller owns the returned list.
+    static AttributeList* scan_defaults(ComTerp* comterp, postfix_token* toks, int ntoks, boolean* is_plain_var);
 };
 
 #endif /* !defined(_funcobjscan_h) */

--- a/src/ComTerp/funcobjscan.h
+++ b/src/ComTerp/funcobjscan.h
@@ -27,6 +27,7 @@
 #include <ComUtil/comterp.h>
 
 class AttributeList;
+class ComTerp;
 
 // FuncObjVarScan: classifies every distinct symbol referenced in a FuncObj
 // body's token span into #170's taxonomy -- read-only, read-before-write,
@@ -56,6 +57,36 @@ public:
     // attribute name) to its Kind (stored as an IntType AttributeValue).
     // Caller owns the returned list.
     static AttributeList* classify(postfix_token* toks, int ntoks, boolean* is_plain_var);
+
+    // Builds a fresh is_plain_var[] array for classify() above, resolving
+    // each token the same way ordinary evaluation would (token_to_comvalue
+    // is public specifically for this, see its own comment in comterp.h).
+    // Shared by #310's declaration-time capture (postfunc.c) and #170's
+    // :help fire-time analysis (comterp.c) so both go through one
+    // implementation of the nids<0 dot-rhs exclusion (HACKING.md's "Dot
+    // Operator Rhs" section) rather than two copies drifting apart. Caller
+    // owns the returned array (delete []).
+    static boolean* build_is_plain_var(ComTerp* comterp, postfix_token* toks, int ntoks);
+
+    // Positional arg(n) usage, derived separately from classify() above --
+    // that's keyword-symbol classification only, with no notion of arg(n)
+    // at all.
+    struct PositionalInfo {
+        int count;         // -1 means "count could not be pinned down statically"
+        boolean uses_narg; // true if narg() appears anywhere in the body --
+                            // treated as a signal the body is variadic
+                            // (loops over an arg(n) run bounded by narg()),
+                            // so count is forced to -1 regardless of any
+                            // literal arg(n) indices also found.
+    };
+
+    // Scans for arg(n) calls, deriving the positional count from the
+    // highest literal index referenced (max constant index + 1).  A
+    // non-literal index (e.g. arg(i)) makes the count unresolvable the same
+    // way narg() usage does -- see #170 phase 1 point 2's "attempt simple
+    // computed n, fall back to dynamic" allowance; this first pass only
+    // resolves literal indices, computed-index resolution is future work.
+    static PositionalInfo scan_positionals(postfix_token* toks, int ntoks);
 };
 
 #endif /* !defined(_funcobjscan_h) */

--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -27,6 +27,7 @@ vv * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
 #include <ComTerp/helpfunc.h>
 #include <ComTerp/comterp.h>
 #include <ComTerp/comvalue.h>
+#include <ComTerp/postfunc.h>
 
 #include <Attribute/attrlist.h>
 #include <Attribute/attrvalue.h>
@@ -72,7 +73,15 @@ void HelpFunc::execute() {
   int* command_ids = nil;
   boolean* str_flags;
   int nfuncs = 0;
-  
+
+  /* #334 (staged from #170 phase 1): help(f) where f is a bare, unfired
+     FuncObj -- parallel to comfuncs[]/command_ids[] above, populated only
+     in the ordinary (non-:all/:top) branch below, since a user FuncObj is
+     never a registered command and so can never appear via :all/:top's
+     enumeration of those.  Left nil there; the print loop below guards on
+     that. */
+  ComValue* funcobj_help = nil;
+
   /* build up table of command ids and flags to indicate if its an operator encased in quotes */
   if (allflag.is_false() && postevalflag.is_false() && topflag.is_false()) {
 
@@ -80,8 +89,13 @@ void HelpFunc::execute() {
     comfuncs = new ComFunc*[nfuncs];
     command_ids = new int[nfuncs];
     str_flags = new boolean[nfuncs];
+    funcobj_help = new ComValue[nfuncs];
 
     for (int i=0; i<nfuncs; i++) {
+      /* stack_arg(i, true) already reads symbol-preserving -- val stays a
+	 raw SymbolType reference, never resolved/fired -- so a bare FuncObj
+	 argument reaches the SymbolType branch below completely unfired,
+	 the same guarantee isclass(x :sym) relies on elsewhere. */
       ComValue val = stack_arg(i, true);
       if (val.is_type(AttributeValue::CommandType)) {
 	comfuncs[i] = (ComFunc*)val.obj_val();
@@ -99,9 +113,17 @@ void HelpFunc::execute() {
 	str_flags[i] = true;
       } else {
 	comfuncs[i] = nil;
-	if (val.is_type(AttributeValue::SymbolType))
+	if (val.is_type(AttributeValue::SymbolType)) {
 	  command_ids[i] = val.symbol_val();
-	else 
+	  /* lookup_symval is a pure symbol-table read, no firing involved
+	     (firing only ever happens via fire_if_funcobj/fire_funcobj,
+	     neither called here) -- safe to check what val actually names
+	     without running it. */
+	  ComValue resolved(comterp()->lookup_symval(val));
+	  if (resolved.is_object(FuncObj::class_symid()))
+	    funcobj_help[i] = comterp()->describe_funcobj((FuncObj*)resolved.obj_val());
+	}
+	else
 	  command_ids[i] = -1;
 	str_flags[i] = false;
       }
@@ -181,7 +203,15 @@ void HelpFunc::execute() {
     boolean first=true;
     for (int i=0; i<nfuncs; i++) {
       boolean printed = false;
-      if (comfuncs[i]) {
+      if (funcobj_help && funcobj_help[i].is_type(AttributeValue::StringType)) {
+	if (first)
+	  first = false;
+	else
+	  *out << '\n';
+	*out << funcobj_help[i].string_ptr();
+	printed = true;
+      }
+      if (!printed && comfuncs[i]) {
 	void *vptr = nil;
 	comterp()->localtable()->find(vptr, command_ids[i]);
 	if (vptr && ((ComValue*)vptr)->type() == ComValue::CommandType) {
@@ -274,6 +304,7 @@ void HelpFunc::execute() {
   delete command_ids;
   delete comfuncs;
   delete str_flags;
+  delete [] funcobj_help;
 
 }
 

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -401,24 +401,10 @@ void FuncObjFunc::execute() {
        declaration time, so a later fire sees the value that was live now,
        not whatever's live at call time.  is_plain_var[i] tells the
        classifier which tokens are ordinary variable references rather
-       than registered commands -- resolved here via the same
-       token_to_comvalue lookup an ordinary read already goes through, not
-       reimplemented. */
-    boolean* is_plain_var = new boolean[toklen];
-    for (int i = 0; i < toklen; i++) {
-      /* nids<0 (HACKING.md's "Dot Operator Rhs" section) marks a bare
-	 identifier on the right of a dot -- an attribute-key literal like
-	 the "v" in "obj.v", never promoted to CommandType regardless of
-	 whether that name is also a registered command, but not an
-	 ordinary variable reference either; must not be capture-eligible. */
-      if (tokbuf[i].type == TOK_COMMAND && tokbuf[i].nids >= 0) {
-	ComValue sv;
-	comterp()->token_to_comvalue(&tokbuf[i], &sv);
-	is_plain_var[i] = sv.type() == ComValue::SymbolType;
-      } else {
-	is_plain_var[i] = false;
-      }
-    }
+       than registered commands -- built by the same shared helper #170's
+       :help fire-time analysis uses (FuncObjVarScan::build_is_plain_var),
+       not reimplemented here. */
+    boolean* is_plain_var = FuncObjVarScan::build_is_plain_var(comterp(), tokbuf, toklen);
     AttributeList* classification = FuncObjVarScan::classify(tokbuf, toklen, is_plain_var);
     /* RAII guard, not dead code: the AttributeValue ctor/dtor pair
        ref/unrefs classification automatically (HACKING.md's "Resource

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -257,7 +257,7 @@ To add a new test script:
 | funcarg.comt  | func arg narg (positional args, keyword-as-variable, if incidental) | 1-11 | 18 | 26 | 69% |
 | funcclosure.comt | func local global (declaration-time capture, #310)         | 1-9,11  |      13 |    21 | 62% |
 | posteval.comt | func arg if (`:posteval` keyword)                            | 1-11    |      21 |    28 | 75% |
-| funchelp.comt | help func arg narg local global (`help(f)` on a bare FuncObj, #334) | 1,3,4,9,11 | 12 | 16 | 75% |
+| funchelp.comt | help func arg narg local global (`help(f)` on a bare FuncObj, #334/#336) | 1,3,4,9,11 | 19 | 24 | 79% |
 
 ### Planned coverage (ivtools-2.2)
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -257,6 +257,7 @@ To add a new test script:
 | funcarg.comt  | func arg narg (positional args, keyword-as-variable, if incidental) | 1-11 | 18 | 26 | 69% |
 | funcclosure.comt | func local global (declaration-time capture, #310)         | 1-9,11  |      13 |    21 | 62% |
 | posteval.comt | func arg if (`:posteval` keyword)                            | 1-11    |      21 |    28 | 75% |
+| funchelp.comt | help func arg narg local global (`help(f)` on a bare FuncObj, #334) | 1,3,4,9,11 | 12 | 16 | 75% |
 
 ### Planned coverage (ivtools-2.2)
 

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -122,5 +122,15 @@ ok=ok&&(size(r13)>0)
 print("12 help(print) and help(f2 print) -- ordinary/mixed help() calls unaffected (expect both non-empty): %v %v\n\n" size(r12) size(r13))
 check_fail(:ok ok)
 
+// --- test 13: a signature long enough to fill (and exceed) the formatter's
+// fixed 2048-byte buffer truncates safely instead of overflowing it
+// (Greptile, PR #337) -- arg(400) alone drives the rendered positional
+// list past the buffer; this must not crash or write out of bounds ---
+huge=func(arg(400))
+r13b=help(huge)
+ok=ok&&(size(r13b)==2047)
+print("13 huge=func(arg(400)); help(huge) truncates safely instead of overflowing (expect size 2047): %v\n\n" size(r13b))
+check_fail(:ok ok)
+
 print("funchelp: %v\n" ok)
 ok

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -172,10 +172,10 @@ check_fail(:ok ok)
 x=7
 ini3=func(if(x==nil :then 99 :else x))
 r14b=help(ini3)
-ok=ok&&(r14b=="(:x [99, captured 7])")
+ok=ok&&(r14b=="(:x [99, 7])")
 r14c=ini3()
 ok=ok&&(r14c==7)
-print("14b x=7 at declaration -- coded default shadowed by capture (expect \"(:x [99, captured 7])\" 7): %v %v\n\n" r14b r14c)
+print("14b x=7 at declaration -- coded default shadowed by capture (expect \"(:x [99, 7])\" 7): %v %v\n\n" r14b r14c)
 check_fail(:ok ok)
 
 // --- test 15: a computed (non-literal) default is silently skipped, not
@@ -209,8 +209,8 @@ check_fail(:ok ok)
 w2=42
 plain2=func(w2+1)
 r16d=help(plain2)
-ok=ok&&(r16d=="(:w2 [captured 42])")
-print("16b plain2=func(w2+1), w2=42 at declaration -- no if-nil idiom, still worth showing the capture (expect \"(:w2 [captured 42])\"): %v\n\n" r16d)
+ok=ok&&(r16d=="(:w2 [42])")
+print("16b plain2=func(w2+1), w2=42 at declaration -- no if-nil idiom, still worth showing the capture (expect \"(:w2 [42])\"): %v\n\n" r16d)
 check_fail(:ok ok)
 
 // --- test 17: a non-numeric literal default (string) also renders ---

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -149,6 +149,17 @@ ok=ok&&(size(r13b)==2047)
 print("13 huge=func(arg(400)); help(huge) truncates safely instead of overflowing (expect size 2047): %v\n\n" size(r13b))
 check_fail(:ok ok)
 
+// --- test 13c: a literal index large enough that the inferred positional
+// count itself (not just the rendered text) is huge must not turn into a
+// ~2 billion-iteration stall once the buffer is already full (Greptile,
+// PR #337) -- the render loop must stop as soon as the buffer fills,
+// not just stop writing while still counting up to posinfo.count ---
+huge2=func(arg(2000000000))
+r13c=help(huge2)
+ok=ok&&(size(r13c)==2047)
+print("13c huge2=func(arg(2000000000)); help(huge2) doesn't stall past a full buffer (expect size 2047): %v\n\n" size(r13c))
+check_fail(:ok ok)
+
 // --- test 14: the canonical optional-keyword idiom renders its literal
 // default inline (#336) ---
 x=nil   // prime before declaring -- #310 captures a read-only free

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -171,6 +171,20 @@ ok=ok&&(idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))
 print("13c huge2=func(arg(2000000000)); help(huge2) doesn't stall and names the true final index (expect true true): %v %v\n\n" (index(r13c "(arg0 arg1 arg2 arg3")==0) ((idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))))
 check_fail(:ok ok)
 
+// --- test 13d: a literal index right at INT_MAX must not overflow
+// scan_positionals' maxidx+1 arithmetic (Greptile, PR #337) -- a naive
+// int count wraps negative there, which describe_funcobj conflates with
+// "count couldn't be pinned down," so help() would wrongly report "(...)"
+// (dynamic) for a positional count that's actually known, just huge ---
+huge3=func(arg(2147483647))
+r13d=help(huge3)
+tail13d=" ... arg2147483647)"
+idx13d=index(r13d tail13d)
+ok=ok&&(index(r13d "(arg0 arg1 arg2 arg3")==0)
+ok=ok&&(idx13d!=nil)&&((idx13d+size(tail13d))==size(r13d))
+print("13d huge3=func(arg(2147483647)); help(huge3) doesn't overflow to \"(...)\" (expect true true): %v %v\n\n" (index(r13d "(arg0 arg1 arg2 arg3")==0) ((idx13d!=nil)&&((idx13d+size(tail13d))==size(r13d))))
+check_fail(:ok ok)
+
 // --- test 14: the canonical optional-keyword idiom renders its literal
 // default inline (#336) ---
 x=nil   // prime before declaring -- #310 captures a read-only free

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -142,22 +142,33 @@ check_fail(:ok ok)
 // --- test 13: a signature long enough to fill (and exceed) the formatter's
 // fixed 2048-byte buffer truncates safely instead of overflowing it
 // (Greptile, PR #337) -- arg(400) alone drives the rendered positional
-// list past the buffer; this must not crash or write out of bounds ---
+// list past the buffer; this must not crash or write out of bounds. It
+// must also end with an explicit "... argMAX)" tail rather than just
+// stopping mid-list with no indication anything was cut off (Scott,
+// live in chat: "after arg307 it should have a ...)") ---
 huge=func(arg(400))
 r13b=help(huge)
-ok=ok&&(size(r13b)==2047)
-print("13 huge=func(arg(400)); help(huge) truncates safely instead of overflowing (expect size 2047): %v\n\n" size(r13b))
+tail13=" ... arg400)"
+idx13=index(r13b tail13)
+ok=ok&&(index(r13b "(arg0 arg1 arg2 arg3")==0)
+ok=ok&&(idx13!=nil)&&((idx13+size(tail13))==size(r13b))
+print("13 huge=func(arg(400)); help(huge) truncates safely and ends with an explicit tail (expect true true): %v %v\n\n" (index(r13b "(arg0 arg1 arg2 arg3")==0) ((idx13!=nil)&&((idx13+size(tail13))==size(r13b))))
 check_fail(:ok ok)
 
 // --- test 13c: a literal index large enough that the inferred positional
 // count itself (not just the rendered text) is huge must not turn into a
 // ~2 billion-iteration stall once the buffer is already full (Greptile,
-// PR #337) -- the render loop must stop as soon as the buffer fills,
-// not just stop writing while still counting up to posinfo.count ---
+// PR #337) -- the render loop must stop as soon as the buffer fills, not
+// just stop writing while still counting up to posinfo.count -- and the
+// truncation tail must still name the TRUE final index (arg2000000000),
+// not just a generic "..." ---
 huge2=func(arg(2000000000))
 r13c=help(huge2)
-ok=ok&&(size(r13c)==2047)
-print("13c huge2=func(arg(2000000000)); help(huge2) doesn't stall past a full buffer (expect size 2047): %v\n\n" size(r13c))
+tail13c=" ... arg2000000000)"
+idx13c=index(r13c tail13c)
+ok=ok&&(index(r13c "(arg0 arg1 arg2 arg3")==0)
+ok=ok&&(idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))
+print("13c huge2=func(arg(2000000000)); help(huge2) doesn't stall and names the true final index (expect true true): %v %v\n\n" (index(r13c "(arg0 arg1 arg2 arg3")==0) ((idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))))
 check_fail(:ok ok)
 
 // --- test 14: the canonical optional-keyword idiom renders its literal

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -1,0 +1,126 @@
+// src/comterp_/tests/funchelp.comt -- test help(f) on a bare, unfired
+// FuncObj (#334, staged from #170 phase 1)
+//
+// funcs: func help arg narg local global
+//
+// help() already reads its arguments symbol-preserving (it's post_eval,
+// stack_arg(i, true)) so a FuncObj argument reaches help() completely
+// unfired -- the same non-firing read isclass(x :sym) relies on
+// elsewhere. When an argument resolves to a bare FuncObj, help() returns
+// its IO-contract signature instead of falling through to its usual
+// registered-command docstring lookup (which a FuncObj, never being a
+// registered command, would never match anyway).
+//
+// Signature shape: "(arg0 arg1 :key1 :key2)", derived from
+// FuncObjVarScan's read-only/read-before-write/write-before-read/escaping
+// classification (#310's classifier, reused here per its own comment) and
+// a new arg(n) positional scanner.  Escaping (local()/global()) variables
+// are reported in a trailing "  -- escapes: name->scope" annotation
+// instead of the parens, since they're not part of the func's own frame.
+// A positional count that can't be pinned down statically (narg() usage,
+// or a computed arg(i) index) renders as "(...)".
+//
+// Only read-only union read-before-write keywords appear -- write-before-
+// read is local scratch a caller's keyword would just be clobbering, not
+// a genuine input, so it's omitted (same framing #310's captures already
+// use for the identical classification).
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./funchelp.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: no positionals, no keywords ---
+f1=func(42)
+r1=help(f1)
+ok=ok&&(r1=="()")
+print("1 f1=func(42); help(f1) (expect \"()\"): %v\n\n" r1)
+check_fail(:ok ok)
+
+// --- test 2: positionals via arg(n), literal indices ---
+f2=func(arg(0)+arg(1))
+r2=help(f2)
+ok=ok&&(r2=="(arg0 arg1)")
+print("2 f2=func(arg(0)+arg(1)); help(f2) (expect \"(arg0 arg1)\"): %v\n\n" r2)
+check_fail(:ok ok)
+
+// --- test 3: read-only keyword shown, write-before-read local excluded ---
+f3=func(y=x; z=1; z=z+1; y+z)
+r3=help(f3)
+ok=ok&&(r3=="(:x)")
+print("3 f3=func(y=x; z=1; z=z+1; y+z); help(f3) -- x is read-only, z is pure local scratch (expect \"(:x)\"): %v\n\n" r3)
+check_fail(:ok ok)
+
+// --- test 4: read-before-write keyword shown the same as read-only ---
+f4=func(y=y+1; y)
+r4=help(f4)
+ok=ok&&(r4=="(:y)")
+print("4 f4=func(y=y+1; y); help(f4) -- y read before its own write, still a genuine input (expect \"(:y)\"): %v\n\n" r4)
+check_fail(:ok ok)
+
+// --- test 5: escaping local() reported in the trailer, not the parens ---
+f5=func(local(w)=1)
+r5=help(f5)
+ok=ok&&(r5=="()  -- escapes: w->local")
+print("5 f5=func(local(w)=1); help(f5) (expect \"()  -- escapes: w->local\"): %v\n\n" r5)
+check_fail(:ok ok)
+
+// --- test 6: escaping global() reported the same way ---
+f6=func(global(g)=1)
+r6=help(f6)
+ok=ok&&(r6=="()  -- escapes: g->global")
+print("6 f6=func(global(g)=1); help(f6) (expect \"()  -- escapes: g->global\"): %v\n\n" r6)
+check_fail(:ok ok)
+
+// --- test 7: dynamic positional count via narg() ---
+f7=func(n=narg(); n)
+r7=help(f7)
+ok=ok&&(r7=="(...)")
+print("7 f7=func(n=narg(); n); help(f7) -- variadic, can't pin down a count (expect \"(...)\"): %v\n\n" r7)
+check_fail(:ok ok)
+
+// --- test 8: a computed (non-literal) arg(n) index also forces dynamic ---
+f8=func(i=0; arg(i))
+r8=help(f8)
+ok=ok&&(r8=="(...)")
+print("8 f8=func(i=0; arg(i)); help(f8) -- computed index, not a literal (expect \"(...)\"): %v\n\n" r8)
+check_fail(:ok ok)
+
+// --- test 9: mixed -- read-only, read-before-write, write-before-read
+// (excluded), and an escape, all in one body ---
+mix=func(a=x; b=y; b=b+1; z=5; z=z+1; local(w)=1; a+b+z)
+r9=help(mix)
+ok=ok&&(r9=="(:x :y)  -- escapes: w->local")
+print("9 mix(:help) -- x read-only, y read-before-write, z excluded, w escapes (expect \"(:x :y)  -- escapes: w->local\"): %v\n\n" r9)
+check_fail(:ok ok)
+
+// --- test 10: help(f) never runs the body -- no side effects at all ---
+hits=list()
+sideeffecting=func(hits,1; arg(0)+arg(1))
+r10=help(sideeffecting)
+ok=ok&&(size(hits)==0)
+print("10 help(sideeffecting) never fires the body (expect size(hits)==0): %v\n\n" size(hits))
+check_fail(:ok ok)
+
+// --- test 11: help(f) on a :posteval target classifies correctly, and an
+// ordinary fire of the same target afterward is completely unaffected ---
+pe=func(a==b :posteval)
+r11a=help(pe)
+ok=ok&&(r11a=="(:a :b)")
+r11b=pe(:a func(1) :b func(1))
+ok=ok&&(r11b==true)
+print("11 pe=func(a==b :posteval); help(pe) then pe(:a func(1) :b func(1)) (expect \"(:a :b)\" true): %v %v\n\n" r11a r11b)
+check_fail(:ok ok)
+
+// --- test 12: help() still works normally on a registered command, and
+// mixing a FuncObj arg with a registered-command arg in one call works ---
+r12=help(print)
+ok=ok&&(size(r12)>0)
+r13=help(f2 print)
+ok=ok&&(size(r13)>0)
+print("12 help(print) and help(f2 print) -- ordinary/mixed help() calls unaffected (expect both non-empty): %v %v\n\n" size(r12) size(r13))
+check_fail(:ok ok)
+
+print("funchelp: %v\n" ok)
+ok

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -20,6 +20,12 @@
 // A positional count that can't be pinned down statically (narg() usage,
 // or a computed arg(i) index) renders as "(...)".
 //
+// A keyword with a recognized default (the canonical "if(x==nil :then
+// DEFAULT :else x)" idiom, #336 -- staged from #170's "Future" section)
+// renders as ":name [DEFAULT]" instead of bare ":name", but only when
+// DEFAULT is exactly one literal token; anything computed is silently
+// skipped rather than guessed at (tests 14-16).
+//
 // Only read-only union read-before-write keywords appear -- write-before-
 // read is local scratch a caller's keyword would just be clobbering, not
 // a genuine input, so it's omitted (same framing #310's captures already
@@ -46,6 +52,11 @@ print("2 f2=func(arg(0)+arg(1)); help(f2) (expect \"(arg0 arg1)\"): %v\n\n" r2)
 check_fail(:ok ok)
 
 // --- test 3: read-only keyword shown, write-before-read local excluded ---
+x=nil   // prime -- #310 captures at declaration time; an exact-string
+        // assertion on help()'s output needs a clean, deterministic
+        // capture regardless of what earlier test files left behind in
+        // global scope (see the funcs :x/:y/:z/:a/:b primes throughout
+        // this file, and this session's own "6" out of "a+b+c" story)
 f3=func(y=x; z=1; z=z+1; y+z)
 r3=help(f3)
 ok=ok&&(r3=="(:x)")
@@ -53,6 +64,7 @@ print("3 f3=func(y=x; z=1; z=z+1; y+z); help(f3) -- x is read-only, z is pure lo
 check_fail(:ok ok)
 
 // --- test 4: read-before-write keyword shown the same as read-only ---
+y=nil   // prime -- see test 3's note
 f4=func(y=y+1; y)
 r4=help(f4)
 ok=ok&&(r4=="(:y)")
@@ -89,6 +101,7 @@ check_fail(:ok ok)
 
 // --- test 9: mixed -- read-only, read-before-write, write-before-read
 // (excluded), and an escape, all in one body ---
+x=nil;y=nil   // prime -- see test 3's note
 mix=func(a=x; b=y; b=b+1; z=5; z=z+1; local(w)=1; a+b+z)
 r9=help(mix)
 ok=ok&&(r9=="(:x :y)  -- escapes: w->local")
@@ -105,6 +118,10 @@ check_fail(:ok ok)
 
 // --- test 11: help(f) on a :posteval target classifies correctly, and an
 // ordinary fire of the same target afterward is completely unaffected ---
+a=nil;b=nil   // prime -- see test 3's note; the explicit :a/:b keywords
+              // below still override regardless (add_attr replaces a
+              // capture by symid either way), so this can't break the
+              // firing check, only stabilize the help() string
 pe=func(a==b :posteval)
 r11a=help(pe)
 ok=ok&&(r11a=="(:a :b)")
@@ -130,6 +147,78 @@ huge=func(arg(400))
 r13b=help(huge)
 ok=ok&&(size(r13b)==2047)
 print("13 huge=func(arg(400)); help(huge) truncates safely instead of overflowing (expect size 2047): %v\n\n" size(r13b))
+check_fail(:ok ok)
+
+// --- test 14: the canonical optional-keyword idiom renders its literal
+// default inline (#336) ---
+x=nil   // prime before declaring -- #310 captures a read-only free
+        // variable at declaration time; see FUNC-AND-ARGS-DESIGN.md's
+        // note and funcarg.comt test 10 for why this line is required,
+        // not decorative (this is also why "6" out of "a+b+c" earlier
+        // this session wasn't a :posteval quirk -- same mechanism)
+ini=func(if(x==nil :then 99 :else x))
+r14=help(ini)
+ok=ok&&(r14=="(:x [99])")
+print("14 ini=func(if(x==nil :then 99 :else x)); help(ini) (expect \"(:x [99])\"): %v\n\n" r14)
+check_fail(:ok ok)
+
+// --- test 14b: if x already had a real value when THIS func() ran, the
+// coded default above is currently dead code -- #310's capture grabbed
+// x's value, not nil, so the body's x==nil check will never be true for
+// as long as that capture stands.  help() surfaces the shadowing rather
+// than let the coded "[99]" claim a default the func won't actually
+// produce (verified against the actual fired result, not just the
+// help() string) ---
+x=7
+ini3=func(if(x==nil :then 99 :else x))
+r14b=help(ini3)
+ok=ok&&(r14b=="(:x [99, captured 7])")
+r14c=ini3()
+ok=ok&&(r14c==7)
+print("14b x=7 at declaration -- coded default shadowed by capture (expect \"(:x [99, captured 7])\" 7): %v %v\n\n" r14b r14c)
+check_fail(:ok ok)
+
+// --- test 15: a computed (non-literal) default is silently skipped, not
+// guessed at -- same restraint as scan_positionals' computed arg(n) ---
+y=nil
+ini2=func(if(y==nil :then int(rand(0,10)) :else y))
+r15=help(ini2)
+ok=ok&&(r15=="(:y)")
+print("15 ini2=func(if(y==nil :then int(rand(0,10)) :else y)); help(ini2) -- computed default not shown (expect \"(:y)\"): %v\n\n" r15)
+check_fail(:ok ok)
+
+// --- test 16: a keyword with no default idiom at all, and truly nothing
+// captured (z primed to nil), is unaffected; the default rendering also
+// doesn't change how a DIFFERENT func (ini) actually fires ---
+z=nil   // prime -- see test 3's note
+plain=func(z+1)
+r16=help(plain)
+ok=ok&&(r16=="(:z)")
+r16b=ini(:x 5)
+r16c=ini()
+ok=ok&&(r16b==5)&&(r16c==99)
+print("16 plain=func(z+1); help(plain)=%v (expect \"(:z)\"); ini(:x 5)=%v ini()=%v -- firing unaffected by default rendering (expect 5 99): %v %v %v\n\n" r16 r16b r16c r16 r16b r16c)
+check_fail(:ok ok)
+
+// --- test 16b: the flip side of test 16 -- no coded default idiom, but
+// this read-only keyword WAS captured as a real, non-nil value.  #310's
+// capture is simple/stable/constant once func() has run (Scott's own
+// framing) -- help() surfaces it the same way it surfaces a coded
+// default, since from the caller's side both are "what do I get if I
+// don't supply this keyword" ---
+w2=42
+plain2=func(w2+1)
+r16d=help(plain2)
+ok=ok&&(r16d=="(:w2 [captured 42])")
+print("16b plain2=func(w2+1), w2=42 at declaration -- no if-nil idiom, still worth showing the capture (expect \"(:w2 [captured 42])\"): %v\n\n" r16d)
+check_fail(:ok ok)
+
+// --- test 17: a non-numeric literal default (string) also renders ---
+name=nil
+greet=func(if(name==nil :then "world" :else name))
+r17=help(greet)
+ok=ok&&(r17=="(:name [\"world\"])")
+print("17 greet=func(if(name==nil :then \"world\" :else name)); help(greet) (expect \"(:name [\\\"world\\\"])\"): %v\n\n" r17)
 check_fail(:ok ok)
 
 print("funchelp: %v\n" ok)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -101,6 +101,10 @@ if(run("./posteval.comt")
   :then print("pass: posteval\n")
   :else print("FAIL: posteval\n");topok=false)
 
+if(run("./funchelp.comt")
+  :then print("pass: funchelp\n")
+  :else print("FAIL: funchelp\n");topok=false)
+
 // networking: remote() round-trip over a real socket to a `comterp server`
 // child (launches/tears down its own servers; needs comterp on PATH)
 if(run("./updown.comt")

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c157e6da"
+#define PATCH_KEY "8e3f21b6"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "8e3f2bf5"
+#define PATCH_KEY "9f4c3ce6"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "7d2b1ae4"
+#define PATCH_KEY "8e3f2bf5"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "5b8ef4a2"
+#define PATCH_KEY "6c1a09d3"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "8e3f21b6"
+#define PATCH_KEY "d94c7a15"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "9f4c3ce6"
+#define PATCH_KEY "a05d4df7"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "6c1a09d3"
+#define PATCH_KEY "7d2b1ae4"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "d94c7a15"
+#define PATCH_KEY "5b8ef4a2"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Closes #334. Also lands #336's detection half early (explicitly allowed
by that issue's own text: "could in principle land earlier... can be
merged into stage 2 instead").

## Summary

`help(f)` on a bare, unfired FuncObj now returns its IO-contract signature
instead of falling through to "unknown" -- e.g. `help(f)` for
`f=func(arg(0)+arg(1))` returns `"(arg0 arg1)"`.

`help()` is already `post_eval()` and already reads its arguments symbol-
preserving (`stack_arg(i, true)`), so a FuncObj argument reaches it
completely unfired -- no new no-fire mechanism needed, the same guarantee
`isclass(x :sym)` relies on elsewhere.

Original design (#170) proposed `:help` as a reserved keyword on the funcobj
*fire* (`f(:help)`); landed as `help(f)` instead, matching the convention
every other command already uses (`help(print)`, `help("++")`). #334 and
#170 have been updated to reflect this correction.

## What changed (#334, stage 1)

- `FuncObjVarScan::build_is_plain_var()` (`funcobjscan.h`/`.c`): factored
  out of #310's inline `is_plain_var[]` construction so declaration-time
  capture and this call-time analysis share one implementation.
- `FuncObjVarScan::scan_positionals()` (`funcobjscan.h`/`.c`): derives
  positional count from the highest literal `arg(n)` index referenced,
  falling back to "dynamic" (rendered `...`) when `narg()` is used or an
  index is computed rather than a literal.
- `ComTerp::describe_funcobj(FuncObj*)` (`comterp.h`/`.c`): renders the
  phase-1 bare signature: `(arg0 arg1 :key1 :key2)`, read-only union
  read-before-write keywords only (write-before-read is local scratch, per
  #170's own framing, omitted); escaping (`local()`/`global()`) variables
  reported in a trailing `  -- escapes: name->scope` annotation.
- `HelpFunc::execute()` (`helpfunc.c`): dispatches to `describe_funcobj`
  when an argument resolves to a bare FuncObj. Composes with `help()`'s
  existing multi-arg and mixed-argument behavior.

## What changed (#336, detection half)

- `FuncObjVarScan::scan_defaults()`: recognizes the canonical
  `if(x==nil :then DEFAULT :else x)` optional-keyword idiom -- condition
  is exactly `x==nil`/`nil==x`, the `:else` branch is exactly the bare
  keyword unchanged, the `:then` branch is exactly one literal token.
  Anything more elaborate is silently skipped, not guessed at.
- `describe_funcobj()` renders a detected default inline: `:x [99]`.
- Also surfaces something #310's declaration-time capture already does:
  if a keyword's name already had a real value in scope when `func()`
  ran, that value was captured instead of `nil` -- a coded default can be
  silently dead as a result. Rendered as `:x [99, captured 7]` when a
  coded default exists and is shadowed, or `:w [captured 42]` when
  there's no coded default idiom at all but the keyword was still
  captured as something real.
- `doc/LANGUAGE.md`: new "Introspecting a func's IO contract: `help(f)`"
  section covering the whole feature.

## Explicitly out of scope

- Return-kind derivation (#170 phase 1 point 3).
- `:helpstrs` docstrings (#170 phase 2) -- #335.
- The cross-checking half of #336 (verify a `:helpstrs`-claimed default
  against the body) -- depends on #335 landing first.
- Simple computed-index resolution for `arg(n)` -- falls back to
  "dynamic" rather than attempting resolution.
- Column-aligned, one-line-per-item rendering (#170's "Future" section).

## Test plan

- [x] `run_all.comt` passes (`run_all: true`), both isolated and full-suite
- [x] `funchelp.comt`: 19 tests covering positionals, all four keyword
      classes, escapes, dynamic counts, buffer-overflow safety, coded
      defaults, capture-shadowed defaults, and plain (idiom-less) capture
      display
- [x] Verified live against several representative func shapes