### PR TITLE
Pin a :posteval arg/keyword to its resolved stream object instead of re-firing

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1267,10 +1267,61 @@ how the pull works:
   decide whether to run it" pattern the `steer` example above leans on,
   without needing any bare-vs-parens distinction at all: `:sym` is the
   look-without-firing escape hatch, bare use is the fire.
+- *Streams are pinned, not re-fired.* "Every access re-fires" (above) has
+  exactly one exception: if the pulled result is a **stream**, it's
+  pinned in place after that first resolution instead of being re-fired
+  on later reads. Without this, a caller expression that *constructs* a
+  stream (a range literal, `$$list`, ...) would hand back a brand-new,
+  never-exhausted stream on every single read — a `while` loop pulling
+  from it could never see it end:
+  ```
+  // BEFORE this pin existed: infinite loop. Every *s re-fires 1..10 from
+  // scratch, and a freshly-built range's first element is always non-nil.
+  f=func(while(*s print("%v\n" x)) :posteval)
+  f(:s 1..10 :x int(rand(0,10)))   // never terminates
+  ```
+  The fix: the first read that resolves to a stream writes that object
+  back in place of the pending marker — the same mechanism an explicit
+  write already uses to fix a keyword's value — so every later read, for
+  `arg(n)` and keywords alike, finds the one real, same-identity stream
+  object directly:
+  ```
+  g=func(a=*s; b=*s; c=*s; a,b,c :posteval)
+  g(:s 1..3)   // 1,2,3 -- correctly advances, not 1,1,1
+  ```
+  This costs nothing for the case that was already safe: re-firing a
+  caller expression that's just a bare reference to an already-built
+  stream variable (`g(:s mystream)`) was always harmless, since
+  re-resolving a symbol just re-fetches the same object — the pin is a
+  no-op there, not a rescue. It only changes behavior for the genuinely
+  dangerous case: a caller expression that mints a fresh stream on every
+  evaluation.
 
 None of this was purpose-built — it's what falls out of "a keyword is a
 deferred pull against the callee's own in-progress scope, resolved as an
 ordinary read on demand."
+
+**A stream's truthiness is not an exhaustion signal — watch for this even
+outside `:posteval`.** `while(arg(0) ...)` (bare, no `*`/`next()`) looks
+like it should loop until the stream runs out, but a raw stream's
+truthiness reflects a static mode flag, not remaining-element count — so
+that condition never goes false no matter how exhausted the stream gets,
+`:posteval` or not. The correct idiom always pulls explicitly and checks
+against `nil`: `while((v=next(arg(0)))!=nil ...)`. This matters even more
+once you're pulling elements out one at a time, because a *pulled*
+element is an ordinary value with its own, unrelated truthiness — `0`,
+`false`, or `""` are all perfectly valid stream contents, and confusing
+"the value I just pulled happens to be falsy" with "the stream is
+exhausted" silently ends a loop early on legitimate data:
+```
+f=func(while(v=*arg(0) print("%v\n" v)))
+f(0..1)   // prints nothing -- the first element, 0, is falsy, so the
+          // loop exits immediately; it never reaches "exhausted"
+f(1..2)   // 1  2  -- works, because neither element happens to be falsy
+```
+`nil` is the only signal `next()`/`*` actually use for exhaustion; nothing
+else pulled from a stream should ever be treated as one, no matter how
+falsy it looks.
 
 Follow the `isclass(:sym)` case one step further and a pattern falls
 out: a bare variable, or a `:posteval`-pulled keyword, both treat *any*

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2363,7 +2363,23 @@ ComValue ComTerp::funcobj_arg(int n) {
     return ComValue::nullval();
   if (_funcobj_argvals[n].is_object(FuncObjPendingArg::class_symid())) {
     FuncObjPendingArg* marker = (FuncObjPendingArg*)_funcobj_argvals[n].obj_val();
-    return pull_funcobj_pending(marker);  /* re-fires every call, never memoized */
+    ComValue pulled(pull_funcobj_pending(marker));
+    if (pulled.is_stream()) {
+      /* pin it, don't keep re-firing -- a stream is a stateful, single-
+	 pass cursor, not a value; re-running the caller's constructing
+	 expression on every read doesn't give a "fresh draw" the way it
+	 does for a scalar (see the :posteval LANGUAGE.md caveat), it hands
+	 back an eternally-unexhausted stream that silently discards
+	 whatever progress a prior read already made -- a while loop
+	 pulling from it can never see it end.  Same write-back-and-delete
+	 treatment an explicit write already gives a keyword marker (see
+	 pull_alist_pending): every later arg(n) read here finds the real,
+	 same-identity stream object directly, no second pull. */
+      _funcobj_argvals[n] = pulled;
+      delete marker;
+      return _funcobj_argvals[n];
+    }
+    return pulled;  /* re-fires every call, never memoized, for anything else */
   }
   return _funcobj_argvals[n];
 }
@@ -2419,7 +2435,21 @@ AttributeValue* ComTerp::peek_alist_pending(AttributeList* al, int id, Attribute
   if (!found || !found->is_object(FuncObjPendingArg::class_symid()))
     return found;
   FuncObjPendingArg* marker = (FuncObjPendingArg*)found->obj_val();
-  *_peek_scratch = pull_funcobj_pending(marker);  /* fresh every call --
+  ComValue pulled(pull_funcobj_pending(marker));
+  if (pulled.is_stream()) {
+    /* pin it instead of peeking -- same reasoning as funcobj_arg's
+       identical stream case: a stream is a stateful cursor, not a value,
+       so treating it like any other re-firable keyword would silently
+       reset it to "just constructed" on every read, never advancing (or
+       never exhausting, if something loops on it).  Write it back and
+       delete the marker exactly like an explicit write already does
+       (pull_alist_pending) -- every later read of this id, peek or pull,
+       finds the one real, same-identity stream object directly. */
+    al->add_attr(id, pulled);
+    delete marker;
+    return al->find(id);
+  }
+  *_peek_scratch = pulled;  /* fresh every call for anything else --
      never written to al, marker never deleted here (fire_funcobj()'s
      cleanup pass frees it at invocation end if it's never frozen by a
      write) */

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -392,12 +392,16 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* l
      how to clean up ArrayType/StreamType/StringType and (for ObjectType)
      AttributeList/Attribute specifically, nothing generic for an arbitrary
      ObjectType payload, so a marker nobody explicitly deletes just leaks.
-     A positional's marker is always still here regardless of whether
-     arg(n) ever pulled it (arg(n) never overwrites its own slot, see
-     funcobj_arg()); a keyword's marker only survives to here if it was
-     never read at all -- one that was gets replaced by
-     pull_alist_pending()'s own add_attr call, which deletes the old
-     marker there instead, right as it's overwritten. */
+     A positional's marker is usually still here regardless of whether
+     arg(n) ever pulled it -- UNLESS the pulled result was a stream, in
+     which case funcobj_arg() already replaced the slot with the real
+     stream object and deleted the marker itself (pinning, not re-firing
+     -- see its own comment); is_object() below correctly skips those,
+     since they're no longer markers at all by the time we get here.  A
+     keyword's marker only survives to here if it was never read at all
+     -- one that was gets replaced by pull_alist_pending()'s (or, for a
+     stream result, peek_alist_pending()'s) own add_attr call, which
+     deletes the old marker there instead, right as it's overwritten. */
   for (int i=0; i<npos; i++) {
     if (posvals[i].is_object(FuncObjPendingArg::class_symid()))
       delete (FuncObjPendingArg*)posvals[i].obj_val();

--- a/src/comterp_/tests/posteval.comt
+++ b/src/comterp_/tests/posteval.comt
@@ -28,7 +28,21 @@
 //     expression twice, not once-and-reuse).  A write still wins as an
 //     ordinary local assignment would: once the body assigns the keyword's
 //     name, later reads see that plain value instead of re-pulling.
+//   - the one exception to "always re-fires": if the pulled result is a
+//     STREAM, it's pinned in place after that first resolution instead of
+//     re-firing on later reads (arg(n) and keywords alike -- tests 11/12).
+//     A stream is a stateful, single-pass cursor, not a value; re-running
+//     a stream-constructing caller expression (a range literal, $$list,
+//     ...) on every read doesn't give a "fresh draw" the way it does for
+//     a scalar, it hands back an eternally-unexhausted stream that
+//     silently discards whatever progress a prior read already made --
+//     a while loop pulling from it could never see it end.  Pinning
+//     converts it into an ordinary, correctly-advancing stream object
+//     from the first read on, matching what a caller-held stream
+//     variable already does safely (re-firing a bare symbol reference
+//     just re-fetches the same object, harmless either way).
 //
+
 // Side effects are counted via a list append (hits,1) rather than a
 // captured/reassigned scalar counter: a bare scalar read before any local
 // write inside a func body gets captured by #310 at declaration time,
@@ -134,6 +148,29 @@ h10=func(a==b :posteval)
 r10=h10(:a func(1) :b func(2))
 ok=ok&&(r10==false)
 print("10 h10=func(a==b); h10(:a func(1) :b func(2)) two distinct fires, not aliased (expect false): %v\n\n" r10)
+check_fail(:ok ok)
+
+// --- test 11: a :posteval keyword bound to a caller expression that
+// CONSTRUCTS a stream (not a reference to one) is pinned to the first
+// resolved object on read, not re-fired -- regression test for the
+// infinite-loop/never-advances hazard: before this fix, every read of a
+// stream-valued keyword re-ran the caller's constructing expression from
+// scratch, handing back a brand-new, never-exhausted stream each time (a
+// while loop pulling from it could never see it end) ---
+g11=func(a=*s; b=*s; c=*s; ok11=(a==1)&&(b==2)&&(c==3); ok11 :posteval)
+r11=g11(:s 1..3)
+ok=ok&&(r11==true)
+print("11 g11(:s 1..3) -- keyword bound to a stream literal pins on first read, correctly advances 1,2,3 (expect true): %v\n\n" r11)
+check_fail(:ok ok)
+
+// --- test 12: same pin-on-stream fix for a POSITIONAL arg(n), not just
+// keywords -- arg(n) under :posteval normally re-fires unconditionally on
+// every read (test 3's whole point), but a stream result is the one
+// exception: pinned after its first resolution, same reasoning as test 11 ---
+h12=func(a=*arg(0); b=*arg(0); c=*arg(0); ok12=(a==1)&&(b==2)&&(c==3); ok12 :posteval)
+r12=h12(1..3)
+ok=ok&&(r12==true)
+print("12 h12(1..3) -- positional arg(0) bound to a stream literal pins on first read, correctly advances 1,2,3 (expect true): %v\n\n" r12)
 check_fail(:ok ok)
 
 print("posteval: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c157e6da"
+#define PATCH_KEY "3fa8d612"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "3fa8d612"
+#define PATCH_KEY "b6d29e47"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`:posteval`'s "every access re-fires" rule (`arg(n)` and keywords alike) is
safe for value-producing caller expressions, but actively dangerous for a
caller expression that *constructs* a stream (a range literal, `$$list`,
...): every read hands back a brand-new, never-exhausted stream object,
discarding whatever progress a prior read already made. Confirmed as a
genuine, reproducible infinite loop:

```
f=func(while(*s print("%v\n" x)) :posteval)
f(:s 1..10 :x int(rand(0,10)))   // never terminates
```

## Fix

The first read that resolves to a stream writes that object back in place
of the pending marker (`funcobj_arg` for positionals, `peek_alist_pending`
for keywords) -- the same write-back-and-delete `pull_alist_pending`
already does for an explicit write. Every later read then finds the one
real, same-identity stream object directly.

This is a no-op for the case that was already safe (a caller expression
that's just a bare reference to an existing stream variable -- re-firing a
symbol lookup just re-fetches the same object) and fixes the case that
wasn't (a caller expression that mints a fresh stream on every
evaluation).

## Also documented

An independent, pre-existing hazard found while chasing this down: a raw
stream's truthiness reflects a static mode flag, not remaining-element
count, so `while(arg(0) ...)` (bare, no `*`/`next()`) never terminates via
exhaustion, `:posteval` or not -- and once you *are* pulling elements
explicitly, a pulled value's own truthiness (`0`, `false`, `""`) must
never be confused with the `nil` that `next()`/`*` actually use to signal
exhaustion. Documented in `LANGUAGE.md`, not fixed here (it's a separate,
`:posteval`-independent matter -- happy to file a follow-up issue if
wanted).

## Test plan

- [x] `posteval.comt` tests 11/12 (keyword and positional stream pinning)
- [x] `run_all.comt` passes (`run_all: true`)
- [x] Original repro re-run 6x consecutively, all terminate cleanly