### PR TITLE
Guard IterateFunc against non-numeric operands (fixes #344)

### DIFF
--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -696,7 +696,7 @@ void IterateFunc::execute() {
 	avl->Next(i);
 	AttributeValue* nextval = avl->GetAttrVal(i);
 	push_stack(*nextval);
-	if (nextval->int_val()==stopval->int_val()) 
+	if (nextval->int_val()==stopval->int_val())
 	  *nextval = ComValue::nullval();
 	else {
 	  if (startval->int_val()<=stopval->int_val())
@@ -717,6 +717,21 @@ void IterateFunc::execute() {
     reset_stack();
 
     if (operand1.is_nil() || operand2.is_nil()) {
+      push_stack(ComValue::nullval());
+      return;
+    }
+
+    /* a non-stream, non-numeric operand (e.g. a plain array/list passed
+       where a stream was expected -- (1,2,3) is an ArrayType literal, not
+       a stream, so it never triggers the caller's broadcast/overdrive
+       packing and arrives here whole) must not fall through to int_val()/
+       int_ref() below: those blindly reinterpret whatever's in the
+       operand's union as an int, and for an ArrayType/ObjectType value
+       that union slot is a real heap pointer -- int_ref()++ on the drive-
+       forward branch corrupts that pointer in place, crashing on the next
+       dereference (segfault repro, issue #344). Fail gracefully instead,
+       same as the already-nil case just above. */
+    if (!operand1.is_num() || !operand2.is_num()) {
       push_stack(ComValue::nullval());
       return;
     }

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -400,6 +400,21 @@ ok=ok&&(next(s45)==21 && next(s45)==22 && next(s45)==23)
 print("45 s45=$$(21,22,23); $$s45 (copy auto-drains, s45 unaffected, expect 21,22,23): %v\n" ok)
 prev_ok=check_fail(:ok ok)
 
+// --- test 46: a non-numeric, non-stream operand to ".." (e.g. a plain
+// array/list literal, which -- unlike (1 2 3) or $$(1 2 3) -- never
+// triggers the caller's broadcast/overdrive packing and arrives here as
+// a single whole value) must fail gracefully instead of corrupting
+// memory. IterateFunc::execute() used to call int_val()/int_ref() on
+// whatever it was handed with no type check; for an ArrayType operand
+// that reinterprets a real heap pointer as an int and increments it in
+// place, corrupting the pointer -- segfault on the next dereference
+// (issue #344). Confirmed fixed: this must return nil, not crash. ---
+badop=(1,2,3)
+r46=badop..5
+ok=ok&&(r46==nil)
+print("46 (1,2,3)..5 -- non-numeric operand fails gracefully (expect nil): %v\n" r46)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -415,6 +415,17 @@ ok=ok&&(r46==nil)
 print("46 (1,2,3)..5 -- non-numeric operand fails gracefully (expect nil): %v\n" r46)
 prev_ok=check_fail(:ok ok)
 
+// --- test 46b: the contrasting good case, right next to 46 above -- (1 2
+// 3) (space-separated) IS a stream, so it broadcasts normally: 1..5,
+// then 2..5, then 3..5, all fully expanded and concatenated. This is
+// the exact behavior test 46's guard must never interfere with -- only
+// a genuinely non-numeric operand should fail gracefully. ---
+goodop=(1 2 3)
+r46b=list(goodop..5)
+ok=ok&&(r46b==(1,2,3,4,5,2,3,4,5,3,4,5))
+print("46b (1 2 3)..5 -- a real stream still broadcasts normally (expect {1,2,3,4,5,2,3,4,5,3,4,5}): %v\n" r46b)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a05d4df7"
+#define PATCH_KEY "b16e5e08"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b16e5e08"
+#define PATCH_KEY "c27f6f19"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `(1,2,3)` (comma-separated) is a plain `ArrayType` literal, not a stream -- unlike `(1 2 3)` or `$$(1 2 3)`, it never triggers the caller's broadcast/overdrive packing, so it arrives at `IterateFunc::execute()` as a single whole value.
- The "build a new range" branch blindly called `int_val()`/`int_ref()` on it with no type check. `int_ref()` reinterprets whatever sits in the operand's union as an int and increments it in place -- for an `ArrayType` value that union slot is a real heap pointer, so this corrupted the pointer, crashing on the next dereference (confirmed via lldb, pinning the exact corruption site).
- Adds an `is_num()` check alongside the existing `is_nil()` guard, failing gracefully (`nil`) instead of proceeding into `int_val()`/`int_ref()` on a non-numeric operand.

Closes #344. Related to #343 (same neighborhood -- keyword override lost across overdrive re-fires -- but a distinct root cause, not fixed here).

## Test plan
- [x] Regression test added (`stream.comt` test 46): `(1,2,3)..5` must return `nil`, not crash.
- [x] `stream.comt` passes standalone and within the full `run_all.comt` suite.
- [x] Full suite (`run_all.comt`) green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)