### PR TITLE
Resolve _alist-bound scalar keywords at pack time (fixes #343)

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -714,13 +714,32 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	   stream value that zips per-element like a stream literal.  Scalar args
 	   stay unresolved (symbols) for per-element re-evaluation (broadcast). */
 	boolean argstream;
+	boolean alist_bound = false;
 	if (!stack_top().is_symbol() && !stack_top().is_attribute())
 	  argstream = stack_top().is_stream();
 	else {
+	  /* a symbol bound through _alist (a func-local keyword or #310
+	     capture) is fixed for the life of this call -- nothing
+	     legitimately mutates it mid-broadcast, so there's no "re-read
+	     fresh each iteration" benefit to leaving it as a deferred
+	     symbol the way a true outer-scope global's comment above
+	     intends.  Worse, leaving it deferred is actively wrong: the
+	     packed value returned here can propagate out past this call
+	     (e.g. as the func's own return value, driven forward later by
+	     whatever pulls it -- list(), an outer print(), etc.), and by
+	     then _alist no longer points at this call's AttributeList at
+	     all, so the deferred read silently falls through to global
+	     scope instead (#343).  Resolve now, same as a genuinely
+	     stream-valued operand already does, whenever the symbol
+	     resolves through the CURRENT _alist specifically; a true
+	     global stays deferred, unchanged. */
+	  if (!stack_top().global_flag() && _alist &&
+	      _alist->find(stack_top().symbol_val()))
+	    alist_bound = true;
 	  AttributeValue* tv = lookup_symval(&stack_top(), false);
 	  argstream = tv ? tv->is_stream() : false;
 	}
-	ComValue topval(pop_stack(argstream));
+	ComValue topval(pop_stack(argstream || alist_bound));
 	avl->Prepend(new AttributeValue(topval));
       }
 

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -696,7 +696,7 @@ void IterateFunc::execute() {
 	avl->Next(i);
 	AttributeValue* nextval = avl->GetAttrVal(i);
 	push_stack(*nextval);
-	if (nextval->int_val()==stopval->int_val()) 
+	if (nextval->int_val()==stopval->int_val())
 	  *nextval = ComValue::nullval();
 	else {
 	  if (startval->int_val()<=stopval->int_val())
@@ -717,6 +717,21 @@ void IterateFunc::execute() {
     reset_stack();
 
     if (operand1.is_nil() || operand2.is_nil()) {
+      push_stack(ComValue::nullval());
+      return;
+    }
+
+    /* a non-stream, non-numeric operand (e.g. a plain array/list passed
+       where a stream was expected -- (1,2,3) is an ArrayType literal, not
+       a stream, so it never triggers the caller's broadcast/overdrive
+       packing and arrives here whole) must not fall through to int_val()/
+       int_ref() below: those blindly reinterpret whatever's in the
+       operand's union as an int, and for an ArrayType/ObjectType value
+       that union slot is a real heap pointer -- int_ref()++ on the drive-
+       forward branch corrupts that pointer in place, crashing on the next
+       dereference (segfault repro, issue #344). Fail gracefully instead,
+       same as the already-nil case just above. */
+    if (!operand1.is_num() || !operand2.is_num()) {
       push_stack(ComValue::nullval());
       return;
     }

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -400,6 +400,21 @@ ok=ok&&(next(s45)==21 && next(s45)==22 && next(s45)==23)
 print("45 s45=$$(21,22,23); $$s45 (copy auto-drains, s45 unaffected, expect 21,22,23): %v\n" ok)
 prev_ok=check_fail(:ok ok)
 
+// --- test 46: a non-numeric, non-stream operand to ".." (e.g. a plain
+// array/list literal, which -- unlike (1 2 3) or $$(1 2 3) -- never
+// triggers the caller's broadcast/overdrive packing and arrives here as
+// a single whole value) must fail gracefully instead of corrupting
+// memory. IterateFunc::execute() used to call int_val()/int_ref() on
+// whatever it was handed with no type check; for an ArrayType operand
+// that reinterprets a real heap pointer as an int and increments it in
+// place, corrupting the pointer -- segfault on the next dereference
+// (issue #344). Confirmed fixed: this must return nil, not crash. ---
+badop=(1,2,3)
+r46=badop..5
+ok=ok&&(r46==nil)
+print("46 (1,2,3)..5 -- non-numeric operand fails gracefully (expect nil): %v\n" r46)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -426,6 +426,25 @@ ok=ok&&(r46b==(1,2,3,4,5,2,3,4,5,3,4,5))
 print("46b (1 2 3)..5 -- a real stream still broadcasts normally (expect {1,2,3,4,5,2,3,4,5,3,4,5}): %v\n" r46b)
 prev_ok=check_fail(:ok ok)
 
+// --- test 47: a func-local keyword override must survive a broadcast
+// triggered by ANOTHER keyword bound to a stream (issue #343). f's body
+// (a..b) reads both a and b as free variables/keywords; when :a is
+// bound to a multi-element stream, the whole call broadcasts -- once
+// per element -- and each of those internal re-fires must still see
+// :b's explicit override (14), not silently fall back to b's
+// declaration-time capture (13, from the outer global b=13 in scope
+// when f was declared). Before the fix, every re-fire used the stale
+// captured 13 instead, because the scalar keyword symbol was left
+// unresolved for later re-evaluation, resolving outside f's own call
+// frame by the time anything actually pulled it. ---
+b=13
+f47=func(a..b)
+sa47=$$(1 2 3)
+r47=list(f47(:a sa47 :b 14))
+ok=ok&&(r47==(1,2,3,4,5,6,7,8,9,10,11,12,13,14,2,3,4,5,6,7,8,9,10,11,12,13,14,3,4,5,6,7,8,9,10,11,12,13,14))
+print("47 f47(:a stream(1,2,3) :b 14), b captured as 13 -- override must win on every re-fire (expect ends at 14, not 13): %v\n" r47)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 

--- a/src/comterp_/tests/stream.comt
+++ b/src/comterp_/tests/stream.comt
@@ -415,6 +415,17 @@ ok=ok&&(r46==nil)
 print("46 (1,2,3)..5 -- non-numeric operand fails gracefully (expect nil): %v\n" r46)
 prev_ok=check_fail(:ok ok)
 
+// --- test 46b: the contrasting good case, right next to 46 above -- (1 2
+// 3) (space-separated) IS a stream, so it broadcasts normally: 1..5,
+// then 2..5, then 3..5, all fully expanded and concatenated. This is
+// the exact behavior test 46's guard must never interfere with -- only
+// a genuinely non-numeric operand should fail gracefully. ---
+goodop=(1 2 3)
+r46b=list(goodop..5)
+ok=ok&&(r46b==(1,2,3,4,5,2,3,4,5,3,4,5))
+print("46b (1 2 3)..5 -- a real stream still broadcasts normally (expect {1,2,3,4,5,2,3,4,5,3,4,5}): %v\n" r46b)
+prev_ok=check_fail(:ok ok)
+
 print("stream: %v\n" ok)
 ok
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c27f6f19"
+#define PATCH_KEY "d38a702a"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a05d4df7"
+#define PATCH_KEY "b16e5e08"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b16e5e08"
+#define PATCH_KEY "c27f6f19"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `eval_expr_internals`'s stream-broadcast packing deliberately leaves scalar operands unresolved (as bare symbols) so they re-evaluate fresh on each broadcast iteration -- correct for a true outer-scope global, but wrong for a symbol bound through `_alist` (a func-local keyword or #310 capture).
- `_alist` is fixed for the life of a call -- nothing legitimately mutates it mid-broadcast -- and the packed value this loop returns can propagate out past the call itself (e.g. as a func's own return value, driven forward later by `list()`, an outer `print()`, etc). By the time that deferred read happens, `_alist` no longer points at the originating call's `AttributeList` at all, so it silently falls through to global scope instead of the call's actual keyword value.
- Concretely: `f=func(a..b)` called as `f(:a stream :b 10)`, where global `b` happens to be a stale, different value captured at `f`'s declaration -- every broadcast re-fire used the stale captured value, never the call's own `:b 10` override.
- Fix: resolve immediately, at pack time, whenever the symbol resolves through the *current* `_alist` specifically -- same treatment a genuinely stream-valued operand already gets. A true global symbol stays deferred, unchanged.

Closes #343.

**Note:** this branch stacks on top of `iterate-nonnum-guard-344` (#345), since the regression test (stream.comt test 47) continues right after that PR's tests 46/46b. Rebase onto master after #345 merges, or merge #345 first.

## Test plan
- [x] Regression test added (`stream.comt` test 47): keyword override survives a broadcast triggered by another stream-bound keyword.
- [x] Full suite (`run_all.comt`) green, no regressions -- including `funchelp.comt`, `posteval.comt`, `funcarg.comt`, `atop.comt` (all heavy on func/keyword mechanics) checked individually.
- [x] Confirmed the #344 crash fix and #343 fix compose correctly together (same repro script, both issues resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)