### PR TITLE
Support (stream).field lazy dot access over a stream's LHS (#304)

### DIFF
--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -28,6 +28,7 @@
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/postfunc.h>
 #include <ComTerp/boolfunc.h>
+#include <ComTerp/strmfunc.h>
 #include <Attribute/attrlist.h>
 #include <Attribute/attribute.h>
 #include <iostream>
@@ -42,6 +43,7 @@ using std::cerr;
 /*****************************************************************************/
 
 int DotFunc::_symid = -1;
+int DotStreamNextFunc::_symid = -1;
 
 /* off by default -- capturing the pre-fire source text of both args (see
    execute() below) costs a cout redirect + two print_stack_arg_post_eval
@@ -350,13 +352,64 @@ void DotFunc::peek_and_fire(ComValue& before_part, ComValue& after_raw, int& aft
 	 full finalization (resolve a symbol, unwrap an Attribute down to
 	 its own Value()), not the raw, unprocessed result. */
       before_part = stack_arg_post_eval(0);
+    } else if (before_part.type()==ComValue::BlankType) {
+      /* a parenthesized sub-expression whose OWN result is a never-yet-
+	 pulled stream (e.g. ($$barnyard) inside ($$barnyard).calls) reads
+	 back as BlankType through the plain stack_arg(0,true) peek above
+	 -- comterp's own "streams don't self-evaluate mid-expression"
+	 discipline (see flowgraph-natural-computation-goal) leaves a Blank
+	 placeholder rather than surfacing the raw, unconsumed stream to an
+	 ordinary read.  stack_arg_post_eval(0) -- the SAME firing this
+	 function already uses for the CommandType case just above --
+	 correctly recovers the real StreamType value instead (confirmed
+	 live: probed both, Blank vs. a real is_stream()==true result).
+	 #304's LHS-stream support (execute_core() below) needs the real
+	 value, not the placeholder. */
+      before_part = stack_arg_post_eval(0);
     }
     after_raw = stack_arg(1, true);
     after_nids = after_raw.nids();
 }
 
 void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_nids,
-			    const std::string& before_expr_text, const std::string& after_expr_text) {
+			    const std::string& before_expr_text, const std::string& after_expr_text,
+			    boolean force_named_field) {
+    /* A named variable bound to a stream (sb=$$barnyard; sb.calls)
+       arrives here as a raw, unresolved SymbolType -- peek_and_fire()
+       never had reason to resolve it eagerly for the ordinary case,
+       since execute_core()'s own symbol-lookup logic below does that
+       itself. Resolve a copy just far enough to test is_stream() below;
+       before_part itself stays untouched so the ordinary (non-stream)
+       path further down still receives the ordinary bare symbol it
+       already knows how to resolve. */
+    ComValue before_resolved = before_part;
+    if (before_resolved.is_symbol()) {
+      AttributeValue* rv = comterp()->lookup_symval(&before_resolved, false);
+      if (rv) before_resolved = ComValue(*rv);
+    }
+    if (before_resolved.is_stream() && after_nids==-1) {
+      /* (stream).field -- lazy, pulling .field from each element on
+	 demand rather than erroring on a raw StreamType before_part
+	 (#304).  Method-call-with-streaming-LHS (stream.method(args))
+	 isn't handled here yet -- that falls through to the ordinary
+	 validity check below, which correctly warns rather than
+	 mishandling it silently. */
+      reset_stack();
+      int after_symid = after_raw.symbol_val();
+      if (after_raw.type()==ComValue::StringType) symbol_reference(after_symid);
+      static DotStreamNextFunc* dsnfunc = nil;
+      if (!dsnfunc) {
+	dsnfunc = new DotStreamNextFunc(comterp());
+	dsnfunc->funcid(symbol_add("dotstreamnext"));
+      }
+      AttributeValueList* avl = new AttributeValueList();
+      avl->Append(new AttributeValue(before_resolved));                      // [0] underlying before-stream (resolved)
+      avl->Append(new AttributeValue(after_symid, AttributeValue::SymbolType)); // [1] fixed field symbol
+      ComValue stream(dsnfunc, avl);
+      stream.stream_mode(STREAM_INTERNAL); // for internal use (use by DotStreamNextFunc)
+      push_stack(stream);
+      return;
+    }
     if (!before_part.is_symbol() &&
 	!(before_part.is_attribute() &&
 	  (((Attribute*)before_part.obj_val())->Value()->is_unknown() ||
@@ -481,7 +534,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       postfix_token* argtoks = copy_stack_arg_post_eval(1, nargtoks);
       reset_stack();
       fire_attrlist_method(this, comterp(), al, argtoks, nargtoks);
-    } else if (nargs()>1) {
+    } else if (force_named_field || nargs()>1) {
       int after_symid = after_raw.symbol_val();
       if (after_raw.type()==ComValue::StringType) {
         symbol_reference(after_symid);
@@ -534,6 +587,84 @@ void DotFunc::execute() {
     std::string before_expr_text, after_expr_text;
     peek_and_fire(before_part, after_raw, after_nids, before_expr_text, after_expr_text);
     execute_core(before_part, after_raw, after_nids, before_expr_text, after_expr_text);
+}
+
+/*****************************************************************************/
+
+DotStreamNextFunc::DotStreamNextFunc(ComTerp* comterp) : DotFunc(comterp) {
+}
+
+void DotStreamNextFunc::execute() {
+    /* invoked by the next mechanism -- arg 0 is our own stream, carrying
+       [0] the underlying before-stream and [1] the fixed after-dot field
+       symbol in its stream_list() (see the STREAM_INTERNAL construction
+       in DotFunc::execute_core() above). */
+    /* Deliberately no reset_stack() here, unlike every other *NextFunc
+       sibling's execute() -- this one delegates its actual dispatch to
+       execute_core() below, which already does its own single
+       reset_stack() in whichever branch it takes (mirroring how
+       DotFunc::execute() itself never resets directly -- peek_and_fire()
+       only peeks, execute_core() is the one reset). A second reset_stack()
+       call here, now that post_eval() is false, would flat decr_stack(1)
+       a SECOND time and silently cancel out this function's own final
+       push_stack() below -- confirmed live: stack height netted to zero
+       across the whole call, so the caller (NextFunc::execute_impl) saw
+       no growth and substituted a blank instead of the real value. */
+    ComValue selfstream(stack_arg(0));
+
+    AttributeValueList* avl = selfstream.stream_list();
+    if (!avl) {
+      reset_stack();
+      push_stack(ComValue::nullval());
+      return;
+    }
+    Iterator i;
+    avl->First(i);
+    AttributeValue* beforeval = avl->GetAttrVal(i);   // [0] underlying before-stream
+    avl->Next(i);
+    AttributeValue* afterval = avl->GetAttrVal(i);    // [1] fixed field symbol
+
+    ComValue before_next;
+    if (beforeval->is_stream()) {
+      /* same temporary-copy-then-drive pattern ConcatNextFunc/
+	 ReplayNextFunc already use: the copy shares the same underlying
+	 (ref-counted) stream_list() as the original, so advancing it via
+	 NextFunc::execute_impl persists back through *beforeval on the
+	 next pull, without this function needing to mutate *beforeval
+	 itself. */
+      ComValue beforecopy(*beforeval);
+      NextFunc::execute_impl(comterp(), beforecopy);
+      if (comterp()->stack_top().is_unknown()) {
+	comterp()->pop_stack();
+	reset_stack();
+	push_stack(ComValue::nullval());
+	return;
+      }
+      before_next = comterp()->pop_stack();
+    } else {
+      /* not exercised by the LHS-only case this lands in (#304's first
+	 slice) -- kept generic so a future RHS/zip extension (a fixed,
+	 non-stream "before" reused every pull while args advance) can
+	 reuse this same next-func without a second implementation. */
+      before_next = ComValue(*beforeval);
+    }
+
+    ComValue after_raw(afterval->symbol_val(), ComValue::SymbolType);
+    execute_core(before_next, after_raw, -1, "", "", true);
+
+    /* execute_core()'s named-field branch pushes the raw internal
+       dotted-pair Attribute* wrapper (there's no attribute literal in
+       the language itself -- see its own comment), same as an ordinary
+       non-streamed .field access does. An ordinary read unwraps that
+       automatically further up the call chain (ComTerp::pop_stack's own
+       lookupsym=true branch, e.g. via assignment) before a caller ever
+       sees it; this synthetic per-pull call has no such caller, so do
+       the same unwrap explicitly here -- otherwise each pulled stream
+       element is the opaque wrapper, not its value (confirmed live:
+       list(sb.calls) rendered {,,}, three unwrapped Attribute objects,
+       instead of the actual :calls values). */
+    ComValue unwrapped(comterp()->pop_stack(true));
+    push_stack(unwrapped);
 }
 
 /*****************************************************************************/

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -59,9 +59,16 @@ protected:
 			std::string& before_expr_text, std::string& after_expr_text);
     /* Everything after peek_and_fire(): the before/after validity checks,
        attrlist lookup-or-create, and the actual dispatch (attribute
-       fetch, or obj.method(args) self-bound firing). */
+       fetch, or obj.method(args) self-bound firing). force_named_field,
+       default false, lets a caller that already knows after_raw is a
+       genuine field symbol (DotStreamNextFunc::execute(), #304) skip the
+       nargs()>1 gate that distinguishes "al.field" from the rare 1-arg
+       dot(name) form -- nargs() there reflects THIS invocation (always 1,
+       the driving stream itself), not the original dot-expression's own
+       arg count, so it can't be relied on for a synthetic per-pull call. */
     void execute_core(ComValue before_part, ComValue after_raw, int after_nids,
-		       const std::string& before_expr_text, const std::string& after_expr_text);
+		       const std::string& before_expr_text, const std::string& after_expr_text,
+		       boolean force_named_field = false);
     /* Get/set the debug-expr flag at runtime via a :dbg keyword --
        intentionally not in DotFunc's public docstring above: a malformed-
        dot warning already shows both sides' resolved values unconditionally
@@ -78,6 +85,37 @@ protected:
        top, or dot(:dbg true) silently never reaches it and always
        misfires as a malformed dot expression instead. */
     boolean check_dbg_keyword();
+};
+
+//: hidden func used by next() to drive a lazy (stream).field access (#304).
+// Holds, in its own stream's stream_list(): [0] the underlying before-
+// stream, [1] the fixed after-dot field symbol. Each pull advances the
+// before-stream one element and re-runs DotFunc's own dispatch
+// (execute_core) on that element, exactly reproducing what an ordinary,
+// non-streaming bare field access would do for it -- same Attribute
+// wrapping, same auto-vivify-if-missing behavior, no separate field-
+// lookup logic duplicated here. A DotFunc subclass (not StrmFunc, unlike
+// its next-func siblings) specifically so it can call the protected
+// execute_core() it inherits, the same way GrDotFunc already does.
+class DotStreamNextFunc : public DotFunc {
+public:
+    DotStreamNextFunc(ComTerp*);
+
+    virtual void execute();
+    /* Override DotFunc's post_eval()==true back to false: this is
+       invoked directly via exec(1,0) by the "next" stream-driving
+       mechanism (NextFunc::execute_impl and friends), the same ordinary
+       calling convention every other *NextFunc sibling uses -- not
+       through real post-eval dispatch, so there's no valid postfix-
+       buffer bookmark for stack_arg_post()'s offset arithmetic to read.
+       Left at DotFunc's inherited true, stack_arg(0) silently read
+       garbage memory instead (confirmed via lldb: a SIGBUS inside the
+       ComValue this constructed from that garbage). */
+    virtual boolean post_eval() { return false; }
+    virtual const char* docstring() {
+      return "hidden func used by next command for (stream).field dot access (#304)."; }
+
+    CLASS_SYMID("DotStreamNextFunc");
 };
 
 //: name returns name field of a dotted pair

--- a/src/comterp_/examples/ducktyping.comt
+++ b/src/comterp_/examples/ducktyping.comt
@@ -68,8 +68,8 @@ for(i=0 i<size(barnyard) i++ a=at(barnyard i); a.speak())
 print("\n-- speaking directly from the list of animals -- at(barnyard i).speak --\n")
 for(i=0 i<size(barnyard) i++ at(barnyard i).speak())
 
-print("\n-- streaming over the barnyard -- will work after #304\n")
-print("%v\n" list(($$barnyard).cnt))
+print("\n-- streaming over the barnyard -- (stream).field, #304 --\n")
+print("%v\n" list(($$barnyard).calls))
 
 print("\n-- each object kept its own state, genuinely, not a copy --\n")
 print("duck.calls=%v cow.calls=%v robot.calls=%v\n" duck.calls cow.calls robot.calls)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -470,5 +470,35 @@ ok=ok&&(attrval(at(al50 0))==99)
 print("50 at()'s snapshot is detached both ways (expect snap50=42, al50=99, still 99 after snap50@0=7): %v %v %v\n\n" attrval(snap50) attrval(at(al50 0)) attrval(at(al50 0)))
 prev_ok=check_fail(:ok ok)
 
+// --- test 51: (stream).field lazily maps a field access across a stream
+// of objects (#304) -- a named variable bound to a stream is resolved to
+// its actual value before checking is_stream() (it arrives as a raw,
+// unresolved symbol otherwise), and each pull re-runs the ordinary
+// dot-dispatch on that element, unwrapped to its bare value the same way
+// an ordinary non-streamed .field access is. ---
+duck51=(:calls 3)
+cow51=(:calls 5)
+robot51=(:calls 1)
+barnyard51=duck51,cow51,robot51
+sb51=$$barnyard51
+r51=list(sb51.calls)
+ok=ok&&(r51==(3,5,1))
+print("51 sb51=$$barnyard51; list(sb51.calls) (expect {3,5,1}): %v\n\n" r51)
+prev_ok=check_fail(:ok ok)
+
+// --- test 52: the inline form of #304, ($$barnyard).field -- deeper than
+// test 51's named-variable case. The parenthesized $$barnyard sub-
+// expression, evaluated normally (not through a bound variable), reads
+// back as BlankType through an ordinary peek: comterp's own "streams
+// don't self-evaluate mid-expression" discipline leaves a Blank
+// placeholder rather than surfacing the raw, unconsumed stream. Firing
+// it via stack_arg_post_eval() (the same mechanism peek_and_fire()
+// already uses to fire an unfired nested command reference) recovers
+// the real stream instead. ---
+r52=list(($$barnyard51).calls)
+ok=ok&&(r52==(3,5,1))
+print("52 list(($$barnyard51).calls) -- inline paren form (expect {3,5,1}): %v\n\n" r52)
+prev_ok=check_fail(:ok ok)
+
 print("attrlist: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a05d4df7"
+#define PATCH_KEY "f5ac924c"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`DotFunc` required its LHS to resolve to a symbol, attribute, or attributelist -- a raw `StreamType` before_part just hit the "needs to evaluate to a symbol or <AttributeList>" warning. This adds a new `DotStreamNextFunc` (a `DotFunc` subclass, not `StrmFunc` like its next-func siblings, so it can call the protected `execute_core()` it inherits) that lazily maps a field access across a stream: each pull advances the underlying stream one element and re-runs the ordinary dot-dispatch on that element, unwrapped to its bare value the same way a non-streamed `.field` access already is.

Two distinct cases needed separate handling to reach a real `StreamType` value:
- A **named variable** bound to a stream (`sb=$$xs; sb.field`) arrives at `execute_core()` as a raw, unresolved `SymbolType` -- resolved via `lookup_symval()` before testing `is_stream()`.
- A **parenthesized sub-expression** whose own result is a never-yet-pulled stream (`($$xs).field`) reads back as `BlankType` through an ordinary peek -- comterp's "streams don't self-evaluate mid-expression" discipline leaves a placeholder. `peek_and_fire()` now also fires via `stack_arg_post_eval()` (the same mechanism already used for an unfired `CommandType` operand) when the first read comes back Blank.

Two real bugs surfaced and got fixed along the way (both confirmed via lldb, both would otherwise have shipped as crashes/silent-wrong-results in this same feature):
1. `DotStreamNextFunc` needed `post_eval()==false` overriding the inherited `DotFunc` default -- it's invoked via the ordinary `exec(1,0)` "next" calling convention, not real post-eval dispatch; inheriting `true` routed `stack_arg(0)` through postfix-bookmark logic with no valid bookmark, reading garbage (SIGBUS).
2. `execute_core()`'s own internal `reset_stack()` double-popped against the reset `DotStreamNextFunc::execute()` already does for its own `exec(1,0)` argument, silently canceling the final `push_stack()` -- the caller saw no stack growth and substituted a blank instead of the real value.

`execute_core()` also gained a `force_named_field` parameter: its existing `nargs()>1` check (distinguishing `al.field` from the rare 1-arg `dot(name)` form) reflects the *calling invocation's own* arg count, which for a synthetic per-pull call is always 1, never the original dot-expression's real shape.

**Not in this change:** method-call-with-streaming-LHS (`stream.method(args)`) and a stream among the method's own args -- both still fall through to the ordinary validity check (a correct warning, not silent mishandling). Follow-up per the updated #304 issue text (one unified mechanism for LHS/RHS/zipped, once implemented).

Also fixes `ducktyping.comt`'s own "streaming over the barnyard" example, which anticipated this feature and was calling a field these objects don't have (`:cnt` instead of `:calls`) -- never actually runnable before now.

Incidentally found and filed separately (unrelated to this change): #348, `dot(name)`'s rare 1-arg form segfaulting instead of constructing an empty dotted-pair list as its own docstring promises.

## Test plan
- [x] Regression tests added (`attrlist.comt` tests 51-52: named-variable and inline-paren forms).
- [x] `ducktyping.comt` example runs end-to-end, matches expected output.
- [x] Full suite (`run_all.comt`) green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)