### PR TITLE
Overdrive a funcobj invocation by its stream args

### DIFF
--- a/doc/FUNC-AND-ARGS-DESIGN.md
+++ b/doc/FUNC-AND-ARGS-DESIGN.md
@@ -115,7 +115,16 @@ streaming, it's just running them; firing the func once isn't streaming either.
 
 Streaming returns one level up and **orthogonal**: you can *overdrive* the func
 across a stream — one finite invocation per element. That streams the
-*invocations*, not the body.
+*invocations*, not the body. Each invocation still sees scalars: `arg(n)` is
+bound to that element, so a `while` or `if` in the body is ordinary scalar
+control flow, and the same func works called with numbers or with streams.
+
+`func(:posteval)` inverts this, which is why it is never overdriven. Its
+arguments stay unevaluated, so there is no stream to drive anything from
+outside; the body fires once, sees the stream itself, and *is* the drain —
+pulling elements with `*arg(n)`. Overdrive puts the iteration outside the
+func and hands the body elements; `:posteval` puts it inside and hands the
+body the stream.
 
 ## `func()` the command
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1870,9 +1870,31 @@ command is not exempt from streams entirely:
 - it can **return a stream**, becoming the overdrive source for whatever
   it is combined with downstream
 
-In short: streams overdrive *into* non-post-eval commands through their
-arguments, and *around* post-eval commands through external combination
-or return values -- never *through* a post-eval command's own arguments.
+**FuncObj invocations** follow the non-post-eval rule. A func called with
+a stream argument is overdriven the same way a command is: the stream
+drives the *invocation*, firing the body once per element with `arg(n)`
+bound to a scalar. The body is then ordinary scalar code -- a `while` or
+`if` inside it sees scalars, never the stream -- so the same func serves
+both uses unchanged:
+
+```
+gcd=func(a=arg(0); b=arg(1); while(b!=0 t=b; b=a%b; a=t); a)
+
+gcd(48 18)                                   // 6
+list(gcd((48 1071 17 270) (18 462 5 192)))   // {6,21,1,6} -- one firing per pair
+```
+
+`func(:posteval)` is the exception, and deliberately so: its contract is
+the opposite one. Its arguments stay unevaluated, and the body itself is
+the drain, pulling elements with `*arg(n)`. A `:posteval` func is never
+overdriven -- it fires once, and sees the stream rather than an element
+of it.
+
+In short: streams overdrive *into* non-post-eval commands and ordinary
+func invocations through their arguments, and *around* post-eval commands
+through external combination or return values -- never *through* a
+post-eval command's own arguments, and never into a `:posteval` func,
+which drains its stream from the inside instead.
 
 ### The spread operator `~~`: apply instead of map
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -663,6 +663,57 @@ void ComTerp::eval_expr_internals(int pedepth) {
     }
   }
 
+  /* a funcobj call with a stream arg and no :posteval overdrives like a
+     command call -- the stream drives the INVOCATION, firing the body once per
+     element with arg(n) bound to a scalar, so control flow inside the body is
+     ordinary scalar code.  :posteval is excluded: its contract is the opposite,
+     internal one, where the arguments stay unevaluated and the body itself
+     drains the pinned stream with *arg(n).  Only symbol-bound funcobjs reach
+     here; that is every named call site. */
+  if (sv.type() == ComValue::SymbolType && (sv.narg() || sv.nkey())) {
+    AttributeValue* funcval = lookup_symval(&sv, false);
+    if (funcval && funcval->is_object(FuncObj::class_symid()) &&
+	!((FuncObj*)funcval->obj_val())->posteval()) {
+      boolean has_streams = false;
+      for(int i=0; i<sv.narg()+sv.nkey(); i++) {
+	if (!stack_top(-i).is_symbol() && !stack_top(-i).is_attribute())
+	  has_streams = stack_top(-i).is_stream();
+	else if (stack_top(-i).is_symbol() &&
+		 is_posteval_pending(stack_top(-i).symbol_val()))
+	  has_streams = false;   /* same rule as the CommandType scan below */
+	else {
+	  AttributeValue* testval = lookup_symval(&stack_top(-i), false);
+	  has_streams = testval ? testval->is_stream() : false;
+	}
+	if (has_streams) break;
+      }
+      if (has_streams) {
+	AttributeValueList* avl = new AttributeValueList();
+	for(int i=0; i<sv.narg()+sv.nkey(); i++) {
+	  /* resolve every stream-valued arg, so a stream held in a variable
+	     zips per-element like a stream literal instead of arriving as an
+	     unresolved symbol; scalars stay unresolved for per-element
+	     broadcast -- identical to the CommandType pack below. */
+	  boolean argstream;
+	  if (!stack_top().is_symbol() && !stack_top().is_attribute())
+	    argstream = stack_top().is_stream();
+	  else {
+	    AttributeValue* tv = lookup_symval(&stack_top(), false);
+	    argstream = tv ? tv->is_stream() : false;
+	  }
+	  ComValue topval(pop_stack(argstream));
+	  avl->Prepend(new AttributeValue(topval));
+	}
+	/* the FuncObj rides in the same void* slot a ComFunc* normally uses;
+	   STREAM_FUNCOBJ tells NextFunc to fire it rather than exec() it. */
+	ComValue strmval((void*)funcval->obj_val(), avl);
+	strmval.stream_mode(STREAM_EXTERNAL|STREAM_FUNCOBJ);
+	push_stack(strmval);
+	return;
+      }
+    }
+  }
+
   if (sv.type() == ComValue::CommandType) {
 
     /* if func has StreamType ComValue's for arguments */

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -905,7 +905,18 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv) {
         // fprintf(stdout, "Stack before streamed func %s\n", symbol_pntr(funcptr->funcid()));
         // comterp->print_stack();
 
-	funcptr->exec(narg, nkey);
+	if (streamv.stream_mode()&STREAM_FUNCOBJ) {
+	  /* the packed callee is a FuncObj, not a registered command -- fire
+	     the body for this element's args instead of exec'ing.
+	     fire_funcobj's contract is exactly what the arg loop above just
+	     set up: narg() worth of evaluated positionals sitting on the
+	     stack, topmost = last. */
+	  ComValue fobjv(FuncObj::class_symid(), (void*)funcptr);
+	  fobjv.narg(narg);
+	  fobjv.nkey(nkey);
+	  comterp->fire_funcobj(fobjv);
+	} else
+	  funcptr->exec(narg, nkey);
 
 	// recurse until not a stream
 	while (comterp->stack_top().is_stream()) {

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -38,6 +38,7 @@ class ComValue;
 #define STREAM_INTERNAL 2
 #define STREAM_NESTED   4
 #define STREAM_SPREAD   8  // ~~ tag: drain into the enclosing call's positionals
+#define STREAM_FUNCOBJ 16  // packed callee is a FuncObj, not a ComFunc
 
 //: base class for ComTerp stream commands.
 class StrmFunc : public ComFunc {

--- a/src/comterp_/examples/README.md
+++ b/src/comterp_/examples/README.md
@@ -51,3 +51,19 @@ comterp run src/comterp_/examples/<name>.comt
   re-fires the caller's expression for real, so `retry(flaky())` makes
   up to three genuine calls to `flaky()`, not one call retried against a
   cached failure.
+
+- **gcd.comt** -- Euclid's algorithm two ways. A single scalar
+  `gcd=func(a=arg(0); b=arg(1); while(...); a)` is called first with plain
+  numbers, then handed two streams of `(m n)` pairs: the streams drive the
+  invocation, so the body fires once per pair with `arg(0)`/`arg(1)` bound
+  to scalars and the `while` inside is the same scalar loop, run four
+  times -- the func itself is unchanged between the two uses, and `$$`
+  hands out copies so the same `m`/`n` can drive it again. The second half
+  rewrites the same algorithm branch-free, hoisting the loop out of the
+  func so every pair reduces in lockstep: `b + (b==0)` guards the modulo
+  so a finished lane parks at zero instead of dividing by it, and
+  `(b!=0)*b + (b==0)*a` masks the update so that lane keeps its answer
+  while the others keep going. Worth reading against the first version --
+  it is what vectorizing by hand costs, and it is also the shape that maps
+  onto data-parallel hardware, where per-lane control flow is the
+  expensive part.

--- a/src/comterp_/examples/gcd.comt
+++ b/src/comterp_/examples/gcd.comt
@@ -1,0 +1,64 @@
+// src/comterp_/examples/gcd.comt -- Euclid's algorithm two ways: one
+// scalar func overdriven by streams of (m n) pairs, and the same
+// algorithm rewritten branch-free so every pair reduces in lockstep.
+// The first is what you write; the second is what the first would look
+// like if you had to vectorize it by hand -- worth reading side by side,
+// because the branch-free form is also the shape that maps onto data-
+// parallel hardware, where per-lane control flow is the expensive part.
+//
+// Delimiter notation, in the code and in the printed labels:
+//   f(a b)     space -- positional args to a command
+//   (a b c)    space -- a stream literal
+//   x,y,z      comma -- a list
+// A stream literal is declared ONCE and used as many times as needed via
+// $$, which hands out a copy rather than consuming the original.
+//
+// Run from the repo root:
+//   comterp run src/comterp_/examples/gcd.comt
+
+print("\n-- the scalar gcd: ';' glues the body, args read once into locals --\n")
+
+gcd=func(a=arg(0); b=arg(1); while(b!=0 t=b; b=a%b; a=t); a)
+
+print("gcd(48 18)    = %v\n" gcd(48 18))
+print("gcd(1071 462) = %v\n" gcd(1071 462))
+print("gcd(17 5)     = %v\n" gcd(17 5))
+print("gcd(270 192)  = %v\n" gcd(270 192))
+
+print("\n-- the same func, overdriven by two streams --\n")
+// Nothing about gcd changes.  The streams drive the invocation: the body
+// fires once per (m n) pair with arg(0)/arg(1) bound to scalars, so the
+// while() inside runs exactly the scalar loop above, once per pair.
+// list() drains the resulting stream of gcds onto one line.
+
+m=(48 1071 17 270)
+n=(18 462 5 192)
+
+print("gcd(m n)      = %v\n" list(gcd($$m $$n)))
+print("again, same m n = %v\n" list(gcd($$m $$n)))
+
+print("\n-- branch-free: every pair reduced in lockstep, no per-lane loop --\n")
+// Euclid without any per-element control flow.  The loop is hoisted out
+// of the func entirely and each step becomes one overdriven expression
+// across the whole vector, so all four pairs advance on every pass and
+// the only loop left counts passes, not pairs.  Two tricks make the
+// branching disappear:
+//
+//   guard  b + (b==0)                 -- a%1 == 0, so a lane that has
+//                                        finished parks at b=0 instead of
+//                                        dividing by zero
+//   mask   a' = (b!=0)*b + (b==0)*a   -- a finished lane keeps its answer
+//                                        while the others keep reducing
+//
+// Watch lane 3 (17 5) finish on pass 3 and hold at 1 while the rest run on.
+
+a=(48 1071 17 270)
+b=(18 462 5 192)
+
+while(sum(list($$b))!=0
+      na=($$b!=0)*$$b + ($$b==0)*$$a;
+      nb=$$a % ($$b + ($$b==0));
+      a=na; b=nb;
+      print("  pass: a=%v  b=%v\n" list($$a) list($$b)))
+
+print("branch-free    = %v\n" list($$a))

--- a/src/comterp_/tests/funcstream.comt
+++ b/src/comterp_/tests/funcstream.comt
@@ -1,0 +1,118 @@
+// src/comterp_/tests/funcstream.comt -- a func invocation overdriven by stream args
+//
+// funcs: func arg narg if while list local print
+//
+// A func called with a stream argument and no :posteval is overdriven
+// EXTERNALLY: the stream drives the invocation, firing the body once per
+// element with arg(n) bound to a scalar.  Before issue #351 the body fired
+// exactly once with the whole stream sitting in arg(n), so only the scalar
+// operators that happened to appear in the body lifted it -- which made
+// pure-dataflow bodies look correct while any body with control flow got a
+// stream where it expected a scalar (while() spun forever on a
+// permanently-truthy stream object).
+//
+// :posteval keeps the opposite, INTERNAL contract: the body itself is the
+// drain, seeing the stream and pulling from it with *arg(n) (posteval.comt
+// tests 11/12).  Test 9 below guards that distinction.
+//
+// Firing counts use local() rather than a bare captured variable: #310
+// freezes a read-before-write free variable at declaration time, so a bare
+// counter re-seeds from that snapshot every firing and never accumulates.
+// local() writes through to the default table instead, escaping the func
+// frame (local.comt test 12).
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./funcstream.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: the body fires once PER ELEMENT, not once for the stream ---
+local(n1)=0
+f1=func(local(n1)=local(n1)+1; arg(0)*10)
+r1=list(f1((1 2 3)))
+ok=ok&&(r1==(10,20,30))&&(local(n1)==3)
+print("1 f1=func(arg(0)*10); f1((1 2 3)) fires per element (expect {10,20,30} 3): %v %v\n" r1 local(n1))
+check_fail(:ok ok)
+
+// --- test 2: two stream args zip, one firing per pair ---
+f2=func(arg(0)*100+arg(1))
+r2=list(f2((1 2 3) (7 8 9)))
+ok=ok&&(r2==(107,208,309))
+print("2 f2=func(arg(0)*100+arg(1)); two streams zip (expect {107,208,309}): %v\n" r2)
+check_fail(:ok ok)
+
+// --- test 3: every arg(n) read within one firing sees that firing's scalar,
+// not a shared cursor -- three reads, three related values, per element ---
+h3=func(a=arg(0); b=arg(0)+1; c=arg(0)+2; a,b,c)
+r3=list(h3(1..3))
+ok=ok&&(size(r3)==3)&&(at(r3 0)==(1,2,3))&&(at(r3 1)==(2,3,4))&&(at(r3 2)==(3,4,5))
+print("3 h3=func(a=arg(0); b=arg(0)+1; c=arg(0)+2; a,b,c); h3(1..3) (expect {{1,2,3},{2,3,4},{3,4,5}}): %v\n" r3)
+check_fail(:ok ok)
+
+// --- test 4: a body with a LOOP overdrives -- the whole point of #351.
+// Euclid's algorithm, one scalar gcd per (m n) pair ---
+// Gated on test 1's per-element firing: if the lift ever regresses, arg(1)
+// is the whole stream again, b!=0 is a permanently-truthy stream object, and
+// this while() spins forever -- wedging the suite (and CI) for hours instead
+// of failing it.  Only run the overdriven call once test 1 has proved the
+// lift; otherwise report the failure and move on.
+gcd4=func(a=arg(0); b=arg(1); while(b!=0 t=b; b=a%b; a=t); a)
+s4=gcd4(48 18)
+lifted4=(local(n1)==3)
+if(lifted4 :then r4=list(gcd4((48 1071 17 270) (18 462 5 192))) :else r4=nil)
+ok=ok&&(s4==6)&&lifted4&&(r4==(6,21,1,6))
+print("4 gcd4 scalar then overdriven by two streams (expect 6 {6,21,1,6}): %v %v\n" s4 r4)
+check_fail(:ok ok)
+
+// --- test 5: a body that BRANCHES on its args picks per element ---
+b5=func(if(arg(1)==0 :then arg(0) :else arg(0)+arg(1)))
+r5=list(b5((1 2 3) (7 0 9)))
+ok=ok&&(r5==(8,2,12))
+print("5 b5=func(if(arg(1)==0 :then arg(0) :else arg(0)+arg(1))) per-element branch (expect {8,2,12}): %v\n" r5)
+check_fail(:ok ok)
+
+// --- test 6: a scalar arg broadcasts across the firings ---
+f6=func(arg(0)+arg(1))
+r6=list(f6((1 2 3) 100))
+ok=ok&&(r6==(101,102,103))
+print("6 f6((1 2 3) 100) scalar arg broadcasts (expect {101,102,103}): %v\n" r6)
+check_fail(:ok ok)
+
+// --- test 7: narg() is the per-firing arg count, once per element ---
+n7=func(narg())
+r7=list(n7((1 2 3) (7 8 9)))
+ok=ok&&(r7==(2,2,2))
+print("7 n7=func(narg()); n7 over two streams (expect {2,2,2}): %v\n" r7)
+check_fail(:ok ok)
+
+// --- test 8: a stream held in a VARIABLE overdrives like a literal
+// (the same parity scalar overdrive got in PR #196) ---
+s8=(1 2 3)
+f8=func(arg(0)*10)
+r8=list(f8(s8))
+ok=ok&&(r8==(10,20,30))
+print("8 f8(s8) stream-in-a-variable overdrives (expect {10,20,30}): %v\n" r8)
+check_fail(:ok ok)
+
+// --- test 9: :posteval is NOT overdriven -- its body keeps the internal
+// drain contract, seeing the stream itself and pulling with *arg(0).
+// One firing, three pulls off the one pinned stream (cf. posteval.comt 12) ---
+local(n9)=0
+p9=func(local(n9)=local(n9)+1; a=*arg(0); b=*arg(0); c=*arg(0); a,b,c :posteval)
+r9=p9(1..3)
+ok=ok&&(r9==(1,2,3))&&(local(n9)==1)
+print("9 p9(:posteval) drains internally, ONE firing (expect {1,2,3} 1): %v %v\n" r9 local(n9))
+check_fail(:ok ok)
+
+// --- test 10: no stream args means no overdrive -- an ordinary scalar call
+// still fires exactly once and returns a plain value ---
+local(n10)=0
+f10=func(local(n10)=local(n10)+1; arg(0)*10)
+r10=f10(7)
+ok=ok&&(r10==70)&&(local(n10)==1)
+print("10 f10(7) plain scalar call unaffected (expect 70 1): %v %v\n" r10 local(n10))
+check_fail(:ok ok)
+
+print("funcstream: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -101,6 +101,10 @@ if(run("./posteval.comt")
   :then print("pass: posteval\n")
   :else print("FAIL: posteval\n");topok=false)
 
+if(run("./funcstream.comt")
+  :then print("pass: funcstream\n")
+  :else print("FAIL: funcstream\n");topok=false)
+
 if(run("./funchelp.comt")
   :then print("pass: funchelp\n")
   :else print("FAIL: funchelp\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c27f6f19"
+#define PATCH_KEY "0b46ad40"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Fixes #351.

## What was wrong

The overdrive pack in `eval_expr_internals` is gated on the callee being a
registered command (`ComValue::CommandType`). A funcobj call resolves through
the `SymbolType` branch to `fire_funcobj` instead, so the pack was
structurally unreachable for it -- the two branches are mutually exclusive.

The whole stream therefore landed in `arg(n)` and the body fired **once**,
with only whatever scalar operators happened to appear in the body doing any
lifting. That made pure-dataflow bodies look correct while anything with
control flow silently broke:

```
fe=func(print("  fire\n"); arg(0)*10)
list(fe((1 2 3)))     //   fire        <- once, should be three times
                      // {10,20,30}    <- right answer, wrong mechanism: * lifted it
```

```
h=func(a=arg(0); b=arg(0)+1; c=arg(0)+2; a,b,c)
list(h(1..3))    // {{1,3,5},}   -- one shared cursor, comma-zip drains it in one tuple
list(h(1..9))    // {{1,3,5},{4,6,8},{7,9,11}}
```

`if()` saw a truthy stream *object* and took one branch once; `while()` spun
forever on a permanently-truthy condition, so a scalar Euclid could not be
overdriven at all.

## What changed

- `eval_expr_internals` gains a funcobj arm ahead of the `CommandType` block:
  a symbol with a pending arglist resolving to a non-`:posteval` FuncObj runs
  the same stream detection and the same pack, resolving every stream-valued
  arg (so a stream in a variable zips like a literal, as PR #196 did for
  scalar overdrive) and leaving scalars unresolved for per-element broadcast.
- The FuncObj rides in the `void*` slot a `ComFunc*` normally occupies --
  `ComValue(void*, AttributeValueList*)` already took a `void*`, so no new
  representation. A new `STREAM_FUNCOBJ` mode bit marks it.
- `NextFunc::execute_impl` fires the funcobj per element instead of `exec`ing
  a command. `fire_funcobj`'s existing contract already matches what the arg
  loop sets up ("`narg()` worth of evaluated positionals on the stack,
  topmost = last"), so that step is a four-line branch.

`:posteval` is deliberately excluded -- its contract is the opposite,
internal one, where arguments stay unevaluated and the body itself drains the
pinned stream with `*arg(n)` (PR #338). Overdrive puts the iteration outside
the func and hands the body elements; `:posteval` puts it inside and hands
the body the stream.

## Result

```
gcd=func(a=arg(0); b=arg(1); while(b!=0 t=b; b=a%b; a=t); a)

gcd(48 18)                                   // 6
list(gcd((48 1071 17 270) (18 462 5 192)))   // {6,21,1,6}  -- was an infinite loop
```

The func is unchanged between the two calls; the body sees scalars either
way, so the `while` inside is the same scalar loop run once per pair.

## Tests

New `src/comterp_/tests/funcstream.comt` (10 tests, registered in
`run_all.comt`): per-element firing counts, two-stream zip, repeated `arg(n)`
reads within one firing, loop and branch bodies, scalar broadcast, `narg()`,
stream-in-a-variable, the `:posteval` exclusion, and that a plain scalar call
is unaffected.

Two notes on the test design:

- Firing counts go through `local()`, which writes to the default table and
  escapes the func frame (local.comt test 12). A bare counter would re-seed
  from its declaration-time capture every firing and never accumulate.
- Test 4 is gated on test 1's firing count. If this lift ever regresses, its
  `while()` would spin forever and wedge CI for hours rather than fail, so it
  only runs once test 1 has confirmed per-element firing.

Full suite green: 38 suites, zero failures, `posteval.comt` still 12/12.

## Docs and example

`LANGUAGE.md`'s "Overdrive rules" section enumerated post-eval vs
non-post-eval *commands* and never mentioned funcobjs at all; it now covers
them and the `:posteval` exception. `FUNC-AND-ARGS-DESIGN.md` already
described overdriving a func across a stream as the orthogonal answer to "the
body isn't streaming" -- extended with what each invocation actually sees and
with the `:posteval` inversion.

New `src/comterp_/examples/gcd.comt` gives Euclid both ways: the overdriven
one-liner, and the same algorithm written branch-free with the loop hoisted
out so all four pairs reduce in lockstep (`b+(b==0)` guards the modulo so a
finished lane parks at zero; `(b!=0)*b + (b==0)*a` masks the update so it
holds its answer). The second is kept deliberately -- it is what vectorizing
by hand costs, and it is the shape that maps onto data-parallel hardware.

## Known limits

- Only symbol-bound funcobjs reach the new arm. That covers every named call
  site, but not an inline `func(...)(args)`.
- The packed stream holds the FuncObj by raw pointer, so reassigning the func
  before draining dangles -- same family as #344.
