### PR TITLE
Lead a bare FuncObj's help() signature with its name

### DIFF
--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -208,6 +208,14 @@ void HelpFunc::execute() {
 	  first = false;
 	else
 	  *out << '\n';
+	/* lead with the name the caller asked about, so a funcobj signature
+	   reads like a call site -- gcd(arg0 arg1), not a bare (arg0 arg1).
+	   A command's docstring already carries its own name via the %s the
+	   snprintf below fills in; a funcobj has no docstring to carry one,
+	   and the object itself is nameless (a value that may be bound to
+	   any number of symbols), so the name has to come from the symbol
+	   this call actually named. */
+	*out << symbol_pntr(command_ids[i]);
 	*out << funcobj_help[i].string_ptr();
 	printed = true;
       }

--- a/src/comterp_/examples/README.md
+++ b/src/comterp_/examples/README.md
@@ -21,14 +21,13 @@ comterp run src/comterp_/examples/<name>.comt
   `:speak` -- calling `.speak()` uniformly across a list of them works
   because comterp only ever asks "does this have the attribute I want,"
   never "what kind of thing is this." Exercises the `obj.method(args)`
-  self-bound dispatch from issue #295: real per-object mutation
-  (a `:calls` counter that persists across calls), positional args via
-  `arg(n)`, and a keyword arg (`:times`) that reverts after the call
-  because nothing inside the method writes to it. Also shows chaining
-  straight off a list index (`at(barnyard i).speak()`, no intermediate
-  variable) and previews the not-yet-built `(stream).field` lift over
-  `$$barnyard` (issue #304) -- that line still warns today, on purpose,
-  as a marker of where that feature will land.
+  self-bound dispatch: real per-object mutation (a `:calls` counter that
+  persists across calls), positional args via `arg(n)`, and a keyword arg
+  (`:times`) that reverts after the call because nothing inside the method
+  writes to it. Also shows chaining straight off a list index
+  (`at(barnyard i).speak()`, no intermediate variable) and the
+  `(stream).field` lift over `$$barnyard`, reading one field across every
+  object in the list at once.
 
 - **testpatterns.comt** -- classic signal/video test pattern generators
   (ramp, sawtooth, square wave, staircase, triangle wave, sine wave),

--- a/src/comterp_/examples/gcd.comt
+++ b/src/comterp_/examples/gcd.comt
@@ -62,3 +62,38 @@ while(sum(list($$b))!=0
       print("  pass: a=%v  b=%v\n" list($$a) list($$b)))
 
 print("branch-free    = %v\n" list($$a))
+
+print("\n-- redefinition: the same name, a simpler interface --\n")
+// Nothing about a func's name is part of the func.  gcd is just a variable
+// holding a FuncObj, so rebinding it swaps the interface out from under the
+// name -- and help() reports whatever it is bound to right now.  Here is the
+// positional definition from the top of this file, still in force:
+
+print("help(gcd) before = %v\n" help(gcd))
+
+// Now the same algorithm with no arg(n) at all: a and b are plain free
+// variables of the body, primed before the func is declared.  One line of
+// priming buys three things at once --
+//
+//   it makes a bare call work    -- with b nil, b!=0 is true and b=a%b
+//                                   regenerates nil, a loop that never ends
+//   it names the inputs          -- they are the func's declared interface
+//   it supplies their defaults   -- a free variable is captured at
+//                                   declaration time, and help() renders
+//                                   that captured value in [brackets]
+//
+// So initializing the inputs IS documenting them, and help() reads back as a
+// call you can copy, edit, and run.  Keywords override the captures per call
+// without disturbing them -- the bare call at the end still answers 1.
+//
+// (Keywords list in first-read order, not the order primed: the body reads
+// b first, in b!=0.)
+
+a=b=1
+gcd=func(while(b!=0 t=b; b=a%b; a=t); a)
+
+print("help(gcd) after  = %v\n" help(gcd))
+print("gcd bare         = %v\n" gcd)
+print("gcd(:a 22 :b 77) = %v\n" gcd(:a 22 :b 77))
+print("gcd(:a 7 :b 77)  = %v\n" gcd(:a 7 :b 77))
+print("gcd bare again   = %v\n" gcd)

--- a/src/comterp_/tests/funchelp.comt
+++ b/src/comterp_/tests/funchelp.comt
@@ -11,7 +11,7 @@
 // registered-command docstring lookup (which a FuncObj, never being a
 // registered command, would never match anyway).
 //
-// Signature shape: "(arg0 arg1 :key1 :key2)", derived from
+// Signature shape: "name(arg0 arg1 :key1 :key2)", derived from
 // FuncObjVarScan's read-only/read-before-write/write-before-read/escaping
 // classification (#310's classifier, reused here per its own comment) and
 // a new arg(n) positional scanner.  Escaping (local()/global()) variables
@@ -40,15 +40,15 @@ ok=true
 // --- test 1: no positionals, no keywords ---
 f1=func(42)
 r1=help(f1)
-ok=ok&&(r1=="()")
-print("1 f1=func(42); help(f1) (expect \"()\"): %v\n\n" r1)
+ok=ok&&(r1=="f1()")
+print("1 f1=func(42); help(f1) (expect \"f1()\"): %v\n\n" r1)
 check_fail(:ok ok)
 
 // --- test 2: positionals via arg(n), literal indices ---
 f2=func(arg(0)+arg(1))
 r2=help(f2)
-ok=ok&&(r2=="(arg0 arg1)")
-print("2 f2=func(arg(0)+arg(1)); help(f2) (expect \"(arg0 arg1)\"): %v\n\n" r2)
+ok=ok&&(r2=="f2(arg0 arg1)")
+print("2 f2=func(arg(0)+arg(1)); help(f2) (expect \"f2(arg0 arg1)\"): %v\n\n" r2)
 check_fail(:ok ok)
 
 // --- test 3: read-only keyword shown, write-before-read local excluded ---
@@ -59,44 +59,44 @@ x=nil   // prime -- #310 captures at declaration time; an exact-string
         // this file, and this session's own "6" out of "a+b+c" story)
 f3=func(y=x; z=1; z=z+1; y+z)
 r3=help(f3)
-ok=ok&&(r3=="(:x)")
-print("3 f3=func(y=x; z=1; z=z+1; y+z); help(f3) -- x is read-only, z is pure local scratch (expect \"(:x)\"): %v\n\n" r3)
+ok=ok&&(r3=="f3(:x)")
+print("3 f3=func(y=x; z=1; z=z+1; y+z); help(f3) -- x is read-only, z is pure local scratch (expect \"f3(:x)\"): %v\n\n" r3)
 check_fail(:ok ok)
 
 // --- test 4: read-before-write keyword shown the same as read-only ---
 y=nil   // prime -- see test 3's note
 f4=func(y=y+1; y)
 r4=help(f4)
-ok=ok&&(r4=="(:y)")
-print("4 f4=func(y=y+1; y); help(f4) -- y read before its own write, still a genuine input (expect \"(:y)\"): %v\n\n" r4)
+ok=ok&&(r4=="f4(:y)")
+print("4 f4=func(y=y+1; y); help(f4) -- y read before its own write, still a genuine input (expect \"f4(:y)\"): %v\n\n" r4)
 check_fail(:ok ok)
 
 // --- test 5: escaping local() reported in the trailer, not the parens ---
 f5=func(local(w)=1)
 r5=help(f5)
-ok=ok&&(r5=="()  -- escapes: w->local")
-print("5 f5=func(local(w)=1); help(f5) (expect \"()  -- escapes: w->local\"): %v\n\n" r5)
+ok=ok&&(r5=="f5()  -- escapes: w->local")
+print("5 f5=func(local(w)=1); help(f5) (expect \"f5()  -- escapes: w->local\"): %v\n\n" r5)
 check_fail(:ok ok)
 
 // --- test 6: escaping global() reported the same way ---
 f6=func(global(g)=1)
 r6=help(f6)
-ok=ok&&(r6=="()  -- escapes: g->global")
-print("6 f6=func(global(g)=1); help(f6) (expect \"()  -- escapes: g->global\"): %v\n\n" r6)
+ok=ok&&(r6=="f6()  -- escapes: g->global")
+print("6 f6=func(global(g)=1); help(f6) (expect \"f6()  -- escapes: g->global\"): %v\n\n" r6)
 check_fail(:ok ok)
 
 // --- test 7: dynamic positional count via narg() ---
 f7=func(n=narg(); n)
 r7=help(f7)
-ok=ok&&(r7=="(...)")
-print("7 f7=func(n=narg(); n); help(f7) -- variadic, can't pin down a count (expect \"(...)\"): %v\n\n" r7)
+ok=ok&&(r7=="f7(...)")
+print("7 f7=func(n=narg(); n); help(f7) -- variadic, can't pin down a count (expect \"f7(...)\"): %v\n\n" r7)
 check_fail(:ok ok)
 
 // --- test 8: a computed (non-literal) arg(n) index also forces dynamic ---
 f8=func(i=0; arg(i))
 r8=help(f8)
-ok=ok&&(r8=="(...)")
-print("8 f8=func(i=0; arg(i)); help(f8) -- computed index, not a literal (expect \"(...)\"): %v\n\n" r8)
+ok=ok&&(r8=="f8(...)")
+print("8 f8=func(i=0; arg(i)); help(f8) -- computed index, not a literal (expect \"f8(...)\"): %v\n\n" r8)
 check_fail(:ok ok)
 
 // --- test 9: mixed -- read-only, read-before-write, write-before-read
@@ -104,8 +104,8 @@ check_fail(:ok ok)
 x=nil;y=nil   // prime -- see test 3's note
 mix=func(a=x; b=y; b=b+1; z=5; z=z+1; local(w)=1; a+b+z)
 r9=help(mix)
-ok=ok&&(r9=="(:x :y)  -- escapes: w->local")
-print("9 mix(:help) -- x read-only, y read-before-write, z excluded, w escapes (expect \"(:x :y)  -- escapes: w->local\"): %v\n\n" r9)
+ok=ok&&(r9=="mix(:x :y)  -- escapes: w->local")
+print("9 mix(:help) -- x read-only, y read-before-write, z excluded, w escapes (expect \"mix(:x :y)  -- escapes: w->local\"): %v\n\n" r9)
 check_fail(:ok ok)
 
 // --- test 10: help(f) never runs the body -- no side effects at all ---
@@ -124,10 +124,10 @@ a=nil;b=nil   // prime -- see test 3's note; the explicit :a/:b keywords
               // firing check, only stabilize the help() string
 pe=func(a==b :posteval)
 r11a=help(pe)
-ok=ok&&(r11a=="(:a :b)")
+ok=ok&&(r11a=="pe(:a :b)")
 r11b=pe(:a func(1) :b func(1))
 ok=ok&&(r11b==true)
-print("11 pe=func(a==b :posteval); help(pe) then pe(:a func(1) :b func(1)) (expect \"(:a :b)\" true): %v %v\n\n" r11a r11b)
+print("11 pe=func(a==b :posteval); help(pe) then pe(:a func(1) :b func(1)) (expect \"pe(:a :b)\" true): %v %v\n\n" r11a r11b)
 check_fail(:ok ok)
 
 // --- test 12: help() still works normally on a registered command, and
@@ -150,9 +150,9 @@ huge=func(arg(400))
 r13b=help(huge)
 tail13=" ... arg400)"
 idx13=index(r13b tail13)
-ok=ok&&(index(r13b "(arg0 arg1 arg2 arg3")==0)
+ok=ok&&(index(r13b "huge(arg0 arg1 arg2 arg3")==0)
 ok=ok&&(idx13!=nil)&&((idx13+size(tail13))==size(r13b))
-print("13 huge=func(arg(400)); help(huge) truncates safely and ends with an explicit tail (expect true true): %v %v\n\n" (index(r13b "(arg0 arg1 arg2 arg3")==0) ((idx13!=nil)&&((idx13+size(tail13))==size(r13b))))
+print("13 huge=func(arg(400)); help(huge) truncates safely and ends with an explicit tail (expect true true): %v %v\n\n" (index(r13b "huge(arg0 arg1 arg2 arg3")==0) ((idx13!=nil)&&((idx13+size(tail13))==size(r13b))))
 check_fail(:ok ok)
 
 // --- test 13c: a literal index large enough that the inferred positional
@@ -166,9 +166,9 @@ huge2=func(arg(2000000000))
 r13c=help(huge2)
 tail13c=" ... arg2000000000)"
 idx13c=index(r13c tail13c)
-ok=ok&&(index(r13c "(arg0 arg1 arg2 arg3")==0)
+ok=ok&&(index(r13c "huge2(arg0 arg1 arg2 arg3")==0)
 ok=ok&&(idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))
-print("13c huge2=func(arg(2000000000)); help(huge2) doesn't stall and names the true final index (expect true true): %v %v\n\n" (index(r13c "(arg0 arg1 arg2 arg3")==0) ((idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))))
+print("13c huge2=func(arg(2000000000)); help(huge2) doesn't stall and names the true final index (expect true true): %v %v\n\n" (index(r13c "huge2(arg0 arg1 arg2 arg3")==0) ((idx13c!=nil)&&((idx13c+size(tail13c))==size(r13c))))
 check_fail(:ok ok)
 
 // --- test 13d: a literal index right at INT_MAX must not overflow
@@ -180,9 +180,9 @@ huge3=func(arg(2147483647))
 r13d=help(huge3)
 tail13d=" ... arg2147483647)"
 idx13d=index(r13d tail13d)
-ok=ok&&(index(r13d "(arg0 arg1 arg2 arg3")==0)
+ok=ok&&(index(r13d "huge3(arg0 arg1 arg2 arg3")==0)
 ok=ok&&(idx13d!=nil)&&((idx13d+size(tail13d))==size(r13d))
-print("13d huge3=func(arg(2147483647)); help(huge3) doesn't overflow to \"(...)\" (expect true true): %v %v\n\n" (index(r13d "(arg0 arg1 arg2 arg3")==0) ((idx13d!=nil)&&((idx13d+size(tail13d))==size(r13d))))
+print("13d huge3=func(arg(2147483647)); help(huge3) doesn't overflow to \"(...)\" (expect true true): %v %v\n\n" (index(r13d "huge3(arg0 arg1 arg2 arg3")==0) ((idx13d!=nil)&&((idx13d+size(tail13d))==size(r13d))))
 check_fail(:ok ok)
 
 // --- test 14: the canonical optional-keyword idiom renders its literal
@@ -194,8 +194,8 @@ x=nil   // prime before declaring -- #310 captures a read-only free
         // this session wasn't a :posteval quirk -- same mechanism)
 ini=func(if(x==nil :then 99 :else x))
 r14=help(ini)
-ok=ok&&(r14=="(:x [99])")
-print("14 ini=func(if(x==nil :then 99 :else x)); help(ini) (expect \"(:x [99])\"): %v\n\n" r14)
+ok=ok&&(r14=="ini(:x [99])")
+print("14 ini=func(if(x==nil :then 99 :else x)); help(ini) (expect \"ini(:x [99])\"): %v\n\n" r14)
 check_fail(:ok ok)
 
 // --- test 14b: if x already had a real value when THIS func() ran, the
@@ -208,10 +208,10 @@ check_fail(:ok ok)
 x=7
 ini3=func(if(x==nil :then 99 :else x))
 r14b=help(ini3)
-ok=ok&&(r14b=="(:x [99, 7])")
+ok=ok&&(r14b=="ini3(:x [99, 7])")
 r14c=ini3()
 ok=ok&&(r14c==7)
-print("14b x=7 at declaration -- coded default shadowed by capture (expect \"(:x [99, 7])\" 7): %v %v\n\n" r14b r14c)
+print("14b x=7 at declaration -- coded default shadowed by capture (expect \"ini3(:x [99, 7])\" 7): %v %v\n\n" r14b r14c)
 check_fail(:ok ok)
 
 // --- test 15: a computed (non-literal) default is silently skipped, not
@@ -219,8 +219,8 @@ check_fail(:ok ok)
 y=nil
 ini2=func(if(y==nil :then int(rand(0,10)) :else y))
 r15=help(ini2)
-ok=ok&&(r15=="(:y)")
-print("15 ini2=func(if(y==nil :then int(rand(0,10)) :else y)); help(ini2) -- computed default not shown (expect \"(:y)\"): %v\n\n" r15)
+ok=ok&&(r15=="ini2(:y)")
+print("15 ini2=func(if(y==nil :then int(rand(0,10)) :else y)); help(ini2) -- computed default not shown (expect \"ini2(:y)\"): %v\n\n" r15)
 check_fail(:ok ok)
 
 // --- test 16: a keyword with no default idiom at all, and truly nothing
@@ -229,11 +229,11 @@ check_fail(:ok ok)
 z=nil   // prime -- see test 3's note
 plain=func(z+1)
 r16=help(plain)
-ok=ok&&(r16=="(:z)")
+ok=ok&&(r16=="plain(:z)")
 r16b=ini(:x 5)
 r16c=ini()
 ok=ok&&(r16b==5)&&(r16c==99)
-print("16 plain=func(z+1); help(plain)=%v (expect \"(:z)\"); ini(:x 5)=%v ini()=%v -- firing unaffected by default rendering (expect 5 99): %v %v %v\n\n" r16 r16b r16c r16 r16b r16c)
+print("16 plain=func(z+1); help(plain)=%v (expect \"plain(:z)\"); ini(:x 5)=%v ini()=%v -- firing unaffected by default rendering (expect 5 99): %v %v %v\n\n" r16 r16b r16c r16 r16b r16c)
 check_fail(:ok ok)
 
 // --- test 16b: the flip side of test 16 -- no coded default idiom, but
@@ -245,16 +245,16 @@ check_fail(:ok ok)
 w2=42
 plain2=func(w2+1)
 r16d=help(plain2)
-ok=ok&&(r16d=="(:w2 [42])")
-print("16b plain2=func(w2+1), w2=42 at declaration -- no if-nil idiom, still worth showing the capture (expect \"(:w2 [42])\"): %v\n\n" r16d)
+ok=ok&&(r16d=="plain2(:w2 [42])")
+print("16b plain2=func(w2+1), w2=42 at declaration -- no if-nil idiom, still worth showing the capture (expect \"plain2(:w2 [42])\"): %v\n\n" r16d)
 check_fail(:ok ok)
 
 // --- test 17: a non-numeric literal default (string) also renders ---
 name=nil
 greet=func(if(name==nil :then "world" :else name))
 r17=help(greet)
-ok=ok&&(r17=="(:name [\"world\"])")
-print("17 greet=func(if(name==nil :then \"world\" :else name)); help(greet) (expect \"(:name [\\\"world\\\"])\"): %v\n\n" r17)
+ok=ok&&(r17=="greet(:name [\"world\"])")
+print("17 greet=func(if(name==nil :then \"world\" :else name)); help(greet) (expect \"greet(:name [\\\"world\\\"])\"): %v\n\n" r17)
 check_fail(:ok ok)
 
 print("funchelp: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "0b46ad40"
+#define PATCH_KEY "6f8db659"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## What changed

`help(f)` on a bare FuncObj rendered only the IO-contract signature, with no
indication of what it described:

```
gcd=func(a=arg(0); b=arg(1); while(b!=0 t=b; b=a%b; a=t); a)
help(gcd)     // "(arg0 arg1)"
```

It now leads with the name the caller asked about, so the signature reads like
a call site:

```
help(gcd)     // "gcd(arg0 arg1)"
```

A registered command's help already carries its own name -- the docstring's
`%s` is filled in with `symbol_pntr(command_ids[i])` -- so a bare funcobj was
the odd one out. A funcobj has no docstring to carry a name, and the object
itself is nameless (a value that may be bound to any number of symbols, or
none), so the name has to come from the symbol the `help()` call actually
named. `HelpFunc::execute` already records exactly that in `command_ids[i]`,
immediately before the `describe_funcobj` call, so this is a one-line emit
change. Printed and returned forms both pick it up, since the return value is
built from the same buffer.

This pays off most with the externally-initialized-inputs idiom, where the
initialization is what documents the inputs and #310's declaration-time
capture supplies each default:

```
a=b=1
gcd=func(while(b!=0 t=b; b=a%b; a=t); a)

help(gcd)          // "gcd(:b [1] :a [1])"
gcd                // 1 -- terminates; without the priming, b is nil,
                   //      nil!=0 is true and b=a%b regenerates nil forever
gcd(:a 22 :b 77)   // 11
```

`(:b [1] :a [1])` is a fragment; `gcd(:b [1] :a [1])` is something you can
copy, edit the values in, and run.

## Tests

`funchelp.comt`'s 21 tests assert exact signature strings, so all of them move
-- each expectation gains its own func's name, including tests 13/13c/13d,
whose truncation checks anchor the signature at index 0 and so needed the name
folded into the anchor string. Full suite green: 38 suites, zero failures.

Note that keywords render in first-read order within the body, not declaration
order -- `gcd`'s body touches `b` first, hence `gcd(:b [1] :a [1])` from
`a=b=1`. That is pre-existing behavior, unchanged here, but it is more visible
now that the signature reads as a call. Worth revisiting separately if the
call-site reading is meant to be literal.

## Also in this PR

The examples README described `ducktyping.comt`'s `(stream).field` lift over
`$$barnyard` as "the not-yet-built ... lift" that "still warns today, on
purpose, as a marker of where that feature will land". That shipped, so the
passage is now false; it is rewritten to describe what the example does. The
two issue references in that entry are dropped at the same time -- issue
numbers in `.md` files are what let this go stale in the first place, while
the same references in `.comt` files are a useful historical trail and stay.

Happy to split that into its own PR if you would rather keep this one to the
help change.
