### PR TITLE
Groundwork from the stream-transpose work: keyword-at-line-end parse fix, feed(:raw), and the nil-termination rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,14 @@ C++ work. The essentials:
   `func name (...)`. A func that "returns nil" is usually this mistake.
 - **Append with `,` (the tuple operator), not `list()`.** `lst,x` appends in
   place; `list(lst x)` builds a nested list-of-lists.
+- **Never use a termination test that goes true on nil.** An unsupplied
+  `arg(n)` reads nil, so every arg-based func has a "called with too few
+  arguments" path landing straight in the body. `nil!=0` is `true`, so
+  `while(b!=0 ...)` spins forever on a bare call; `nil>0` is nil, so
+  `while(b>0 ...)` just ends. Prefer the comparison that propagates nil
+  (`>`, `<`) over the one that answers it (`!=` manufactures a `true`;
+  `==` at least lands on `false`). Priming the inputs before declaring the
+  func removes the nil at the source instead.
 
 ---
 

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -1343,6 +1343,16 @@ void FeedFunc::execute() {
      StreamLiteralNextFunc's lazy comterpserv()->run() re-evaluation already
      preserves it (that path never goes through stack_arg_post_eval at all). */
   for (int i=0; i<n; i++) argv[i] = stack_arg_post_eval(i, true);
+  /* :raw -- store a stream argument as an opaque, undrained element instead
+     of tagging it STREAM_NESTED for the lazy per-next() unwrap below.  The
+     stored ComValue is the stream OBJECT, so its read position travels with
+     it: pulling the element back out later yields the same cursor, advanced
+     by whatever was taken from it in the meantime.  That is what lets a FIFO
+     hold a set of streams and rotate them (take one value from each, requeue
+     the ones still live) rather than flattening them on the way in. */
+  static int raw_symid = symbol_add("raw");
+  ComValue rawv(stack_key_post_eval(raw_symid));
+  boolean rawflag = rawv.is_true();
   reset_stack();
 
   boolean arg0_is_fifo = n>0 && argv[0].is_stream() &&
@@ -1361,9 +1371,9 @@ void FeedFunc::execute() {
        order would copy correctly. */
     AttributeValueList* avl = argv[0].stream_list();
     for (int i=1; i<n; i++) {
-      boolean tag_nested = argv[i].is_stream();
+      boolean tag_nested = argv[i].is_stream() && !rawflag;
       AttributeValue* elt;
-      if (tag_nested && argv[i].stream_list() == avl) {
+      if (argv[i].is_stream() && argv[i].stream_list() == avl) {
         /* feed(f f): the fed-in stream's own backing list *is* this FIFO's
            list.  Storing it directly would make avl contain an element
            whose stream_list() is avl itself -- a self-referential list
@@ -1377,7 +1387,8 @@ void FeedFunc::execute() {
            never exists. */
         AttributeValueList* snapshot = new AttributeValueList(avl);
         elt = new AttributeValue(argv[i].stream_func(), snapshot);
-        elt->stream_mode(argv[i].stream_mode_raw()|STREAM_NESTED);
+        elt->stream_mode(rawflag ? argv[i].stream_mode_raw()
+                                 : (argv[i].stream_mode_raw()|STREAM_NESTED));
       } else {
         int mode = tag_nested ? (argv[i].stream_mode_raw()|STREAM_NESTED) : 0;
         elt = new AttributeValue(argv[i]);
@@ -1396,7 +1407,7 @@ void FeedFunc::execute() {
      feed(fifo 0..2) behave identically. */
   AttributeValueList* avl = new AttributeValueList();
   for (int i=0; i<n; i++) {
-    boolean tag_nested = argv[i].is_stream();
+    boolean tag_nested = argv[i].is_stream() && !rawflag;
     int mode = tag_nested ? (argv[i].stream_mode_raw()|STREAM_NESTED) : 0;
     AttributeValue* elt = new AttributeValue(argv[i]);
     if (tag_nested) elt->stream_mode(mode);

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -307,7 +307,7 @@ public:
 
 //: command to build or append to a growable FIFO stream, the write-end
 //: complement to next().
-// fifo=feed([fifo] [val ...]) -- build or append to a growable FIFO stream
+// fifo=feed([fifo] [val ...] :raw) -- build or append to a growable FIFO stream
 class FeedFunc : public ComFunc {
 public:
     FeedFunc(ComTerp*);
@@ -315,7 +315,14 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "fifo=%s([fifo] [val ...]) -- build or append to a growable FIFO stream"; }
+      return "fifo=%s([fifo] [val ...] :raw) -- build or append to a growable FIFO stream"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+	":raw       store a stream argument whole instead of draining it",
+	nil
+      };
+      return keys;
+    }
 
     CLASS_SYMID("FeedFunc");
 };

--- a/src/ComUtil/_parser.c
+++ b/src/ComUtil/_parser.c
@@ -1291,6 +1291,20 @@ int status;
 
       /* Take everything off of the operator stack until the matching */
       /* parenthesis is found.                                        */
+      /* A keyword is pushed onto the operator stack only when the     */
+      /* look-ahead at its own token said a value follows it.  That    */
+      /* look-ahead cannot see past the end of the input buffer, so    */
+      /* under a one-shot infunc -- the line-at-a-time path a run()    */
+      /* file takes -- a keyword ending a line is pushed even when the */
+      /* closing paren it is really followed by sits on the next line, */
+      /* unread.  Such a keyword reaches here having never received a  */
+      /* value, and emitting narg 1 for it fabricates an argument that */
+      /* was never supplied (which then swallows the paren and leaves  */
+      /* the whole expression unterminated).  Expecting a unary prefix */
+      /* at the closing paren is exactly the "no value arrived" state, */
+      /* and only the innermost pending keyword can be in it -- any    */
+      /* deeper one was completed by the value that followed it.       */
+	 { int kw_novalue = ( expecting == OPTYPE_UNARY_PREFIX );
 	 while ( (OperStack[TopOfOperStack].oper_type != LEFTPAREN) &&
                  (TopOfOperStack >= 0 ))
          {
@@ -1303,9 +1317,10 @@ int status;
              else
              {
                  OPERSTK_POP( temp_id );
-                 PFOUT( TOK_KEYWORD, temp_id, 1, 0, 0);
+                 PFOUT( TOK_KEYWORD, temp_id, kw_novalue ? 0 : 1, 0, 0);
+                 kw_novalue = 0;
              }
-	 }
+	 } }
          OPERSTK_POP( temp_id );
 
       /* If this parenthesis corresponds to a command, set up the */

--- a/src/comterp_/tests/feed.comt
+++ b/src/comterp_/tests/feed.comt
@@ -238,5 +238,57 @@ ok=ok&&(selffed1==(1,2,3,1,2,3) && size(selffed2)==0)
 print("18 f=feed(1 2 3); feed(f f); list(f); list(f) (expect {1,2,3,1,2,3} {}): %v\n\n" (selffed1==(1,2,3,1,2,3) && size(selffed2)==0))
 check_fail(:ok ok)
 
+// --- test 19: :raw stores a stream argument whole instead of draining it.
+// Without :raw a stream arg is tagged STREAM_NESTED and flattens one value
+// per next() (test 13); with :raw the element that comes back out IS the
+// stream, undrained ---
+raws1=(6 7)
+fifoR=feed()
+feed(fifoR raws1 :raw)
+rawelt=next(fifoR)
+rawisstrm=istype(rawelt StreamType)
+rawdrain=list(rawelt)
+ok=ok&&rawisstrm&&(rawdrain==(6,7))
+print("19 feed(f strm :raw); next(f) hands back the stream itself (expect true {6,7}): %v %v\n\n" rawisstrm rawdrain)
+check_fail(:ok ok)
+
+// --- test 20: the stored stream carries its read position with it, which is
+// what lets a FIFO hold and rotate a set of streams.  Take one value, requeue
+// the same object, take another -- the cursor advances across the round trip ---
+raws2=(1 2 3)
+ring=feed()
+feed(ring raws2 :raw)
+c1=next(ring); v1=next(c1); feed(ring c1 :raw)
+c2=next(ring); v2=next(c2); feed(ring c2 :raw)
+c3=next(ring); v3=next(c3)
+ok=ok&&(v1==1)&&(v2==2)&&(v3==3)
+print("20 a :raw stream requeued keeps advancing (expect 1 2 3): %v %v %v\n\n" v1 v2 v3)
+check_fail(:ok ok)
+
+// --- test 21: :raw does not disturb the ordinary flattening path -- the same
+// fifo can hold a raw stream and a drained one side by side ---
+raws3=(8 9)
+raws4=(4 5)
+mixed=feed()
+feed(mixed raws3 :raw)
+feed(mixed raws4)
+m1=next(mixed)
+m2=next(mixed)
+m3=next(mixed)
+ok=ok&&istype(m1 StreamType)&&(m2==4)&&(m3==5)
+print("21 raw element then flattened element in one fifo (expect true 4 5): %v %v %v\n\n" istype(m1 StreamType) m2 m3)
+check_fail(:ok ok)
+
+// --- test 22: the self-feed cycle guard still fires under :raw -- feeding a
+// fifo into itself would otherwise store an element whose backing list is the
+// fifo's own, and :raw must not become a way around that (cf. test 18) ---
+fifoS=feed(1 2 3)
+feed(fifoS fifoS :raw)
+selfraw=list(fifoS)
+selfrawn=size(selfraw)
+ok=ok&&(selfrawn>0)
+print("22 feed(f f :raw) does not crash or cycle (expect non-empty): %v\n\n" selfrawn)
+check_fail(:ok ok)
+
 print("\nfeed: %v\n" ok)
 ok

--- a/src/comterp_/tests/funcstream.comt
+++ b/src/comterp_/tests/funcstream.comt
@@ -114,5 +114,22 @@ ok=ok&&(r10==70)&&(local(n10)==1)
 print("10 f10(7) plain scalar call unaffected (expect 70 1): %v %v\n" r10 local(n10))
 check_fail(:ok ok)
 
+// --- test 11: issue #206's reproducer -- a post-eval command in the body.
+// Reported as "overdrive stops after the first element when the body
+// contains a post-eval command"; the actual cause was that the invocation
+// was never lifted at all, so cond() saw the whole stream as one truthy
+// object, took one branch once, and yielded a single element.  Its own
+// control case (an eager body) appeared to work only because * overdrove
+// internally.  Both shapes belong here as a pair ---
+k11=func(arg(0)*10)
+r11a=list(k11((1 0 1)))
+h11=func(cond(arg(0) 1 2))
+r11b=h11(1)
+r11c=h11(0)
+r11d=list(h11((1 0 1)))
+ok=ok&&(r11a==(10,0,10))&&(r11b==1)&&(r11c==2)&&(r11d==(1,2,1))
+print("11 #206: eager body, scalar cond calls, and cond body overdriven (expect {10,0,10} 1 2 {1,2,1}): %v %v %v %v\n" r11a r11b r11c r11d)
+check_fail(:ok ok)
+
 print("funcstream: %v\n" ok)
 ok

--- a/src/comterp_/tests/keyword_lineend.comt
+++ b/src/comterp_/tests/keyword_lineend.comt
@@ -1,0 +1,69 @@
+// src/comterp_/tests/keyword_lineend.comt -- a bare keyword as the last token
+// on a line, with its closing paren on the next line, under run()
+//
+// funcs: func arg run help print list
+//
+// A keyword does not know at parse time whether it is a bare flag (:posteval)
+// or takes a value (:prefix "P").  The parser decides by looking ahead one
+// token: a following keyword or closing paren means bare, anything else means
+// a value is coming.  That look-ahead cannot see past the end of the input
+// buffer, and run() feeds a file one line at a time -- so a keyword ending a
+// line is pushed as if a value follows even when the very next line is just
+// the closing paren.  Piping the same file to stdin does not hit this, since
+// there the parser reads the FILE directly and can look across lines.
+//
+// The pending keyword is resolved where the closing paren unwinds the
+// operator stack: a keyword still waiting for a value when its paren arrives
+// never got one, so it is a bare flag.  Before that, it was emitted as though
+// it had an argument, which swallowed the paren and left the whole expression
+// unterminated -- the definition was silently lost and its body ran as
+// top-level statements instead (test 3 below is the witness for that).
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./keyword_lineend.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: a bare keyword ending a line, closing paren on the next ---
+run("./keyword_lineend_sub.comt")
+r1=help(klsub)
+ok=ok&&(r1=="klsub(arg0)")
+print("1 run() a func whose :posteval ends a line, ) on the next (expect \"klsub(arg0)\"): %v\n\n" r1)
+check_fail(:ok ok)
+
+// --- test 2: and the definition actually works when called ---
+r2=klsub(4)
+ok=ok&&(r2==40)
+print("2 the func recovered from run() is callable (expect 40): %v\n\n" r2)
+check_fail(:ok ok)
+
+// --- test 3: the body must NOT have run while being defined.  If the
+// definition is cut at the keyword, "marks,1" executes as a top-level
+// statement and lengthens marks; a properly captured body leaves it alone ---
+marks=list()
+run("./keyword_lineend_body_sub.comt")
+n3=size(marks)
+ok=ok&&(n3==0)
+print("3 defining a func does not execute its body (expect 0): %v\n\n" n3)
+check_fail(:ok ok)
+
+// --- test 4: the other side of the same look-ahead -- a keyword whose VALUE
+// arrives on the following line still binds that value, rather than being
+// mistaken for a bare flag.  This is what a fix at the look-ahead itself
+// would have broken, and why the resolution happens at the closing paren ---
+run("./keyword_lineend_val_sub.comt")
+n4=size(klval)
+ok=ok&&(n4==4)
+print("4 a keyword whose value is on the next line still takes it (expect 4): %v\n\n" n4)
+check_fail(:ok ok)
+
+// --- test 5: the same-line form was never broken and still is not ---
+klsame=func(a=arg(0); a*10 :posteval)
+r5=help(klsame)
+ok=ok&&(r5=="klsame(arg0)")
+print("5 the same-line :posteval) form is unaffected (expect \"klsame(arg0)\"): %v\n\n" r5)
+check_fail(:ok ok)
+
+print("keyword_lineend: %v\n" ok)
+ok

--- a/src/comterp_/tests/keyword_lineend_body_sub.comt
+++ b/src/comterp_/tests/keyword_lineend_body_sub.comt
@@ -1,0 +1,6 @@
+// sub-script for keyword-lineend.comt -- if the definition is cut short at
+// the keyword, the body runs as a top-level statement and appends to marks.
+klbody=func(marks,1;
+  0
+  :posteval
+)

--- a/src/comterp_/tests/keyword_lineend_sub.comt
+++ b/src/comterp_/tests/keyword_lineend_sub.comt
@@ -1,0 +1,7 @@
+// sub-script for keyword-lineend.comt -- a bare keyword is the last token on
+// its line and the closing paren is on the next line.  Parsed by run(), which
+// feeds one line at a time, so the keyword's look-ahead cannot see the paren.
+klsub=func(a=arg(0);
+  a*10
+  :posteval
+)

--- a/src/comterp_/tests/keyword_lineend_val_sub.comt
+++ b/src/comterp_/tests/keyword_lineend_val_sub.comt
@@ -1,0 +1,5 @@
+// sub-script for keyword_lineend.comt -- the other side of the same
+// look-ahead: a keyword whose value legitimately arrives on the next line
+// must still bind that value rather than be taken for a bare flag.
+klval=list(:size
+  4)

--- a/src/comterp_/tests/nilcompare.comt
+++ b/src/comterp_/tests/nilcompare.comt
@@ -1,0 +1,80 @@
+// src/comterp_/tests/nilcompare.comt -- how comparisons behave on nil, and
+// the loop-termination rule that follows from it
+//
+// funcs: func arg while list print
+//
+// The comparison operators split two ways on a nil operand: some answer with
+// a definite boolean, others propagate the nil.  That split decides whether a
+// loop written around them terminates, because while() runs its body only on
+// a true condition -- a propagated nil ends the loop, a manufactured "true"
+// does not.
+//
+//   nil != 0   ->  true     definite, and the wrong side -- the trap
+//   nil == 0   ->  false    definite, safe side
+//   nil > 0    ->  nil      propagates
+//   nil < 0    ->  nil      propagates
+//
+// This matters because an unsupplied arg(n) reads nil, so every arg-based
+// func has an implicit "called with too few arguments" path that lands
+// straight in the body.  A gcd written with while(b!=0 ...) hangs forever on
+// a bare call; the same gcd with while(b>0 ...) returns nil and stops.  The
+// rule, stated once: never use a termination test that goes true on nil.
+// See AGENTS.md's ComTerp scripting gotchas.
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./nilcompare.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: != answers true on nil -- the trap ---
+n1=nil
+r1=(n1!=0)
+ok=ok&&(r1==true)
+print("1 nil!=0 answers a definite true (expect true): %v\n" r1)
+check_fail(:ok ok)
+
+// --- test 2: == answers false on nil -- definite, but the safe side ---
+r2=(n1==0)
+ok=ok&&(r2==false)
+print("2 nil==0 answers a definite false (expect false): %v\n" r2)
+check_fail(:ok ok)
+
+// --- test 3: the ordering operators propagate nil instead of answering ---
+r3a=(n1>0)
+r3b=(n1<0)
+ok=ok&&(r3a==nil)&&(r3b==nil)
+print("3 nil>0 and nil<0 propagate rather than answer (expect nil nil): %v %v\n" r3a r3b)
+check_fail(:ok ok)
+
+// --- test 4: a propagated nil ends a while loop.  Guarded by test 3 so a
+// regression there reports a failure instead of hanging the suite forever ---
+if(r3a==nil
+   :then i4=0; while(nil>0 i4=i4+1); r4=i4
+   :else r4=-1)
+ok=ok&&(r4==0)
+print("4 while(nil>0 ...) never enters the body (expect 0): %v\n" r4)
+check_fail(:ok ok)
+
+// --- test 5: the rule applied -- gcd with while(b>0) survives a bare call
+// with no arguments, where while(b!=0) would spin on nil forever.  The
+// nil-safe form is the one exercised here on purpose; the trap form is
+// deliberately NOT run, since running it would never return ---
+gcd5=func(a=arg(0); b=arg(1); while(b>0 t=b; b=a%b; a=t); a)
+r5a=gcd5(48 18)
+r5b=gcd5(1071 462)
+r5c=gcd5()
+ok=ok&&(r5a==6)&&(r5b==21)&&(r5c==nil)
+print("5 gcd5 with while(b>0): real args still correct, bare call returns instead of hanging (expect 6 21 nil): %v %v %v\n" r5a r5b r5c)
+check_fail(:ok ok)
+
+// --- test 6: b>0 is a semantic choice as well as a safety one -- it stops on
+// a negative operand rather than iterating through negatives ---
+r6a=gcd5(48 -18)
+r6b=gcd5(-48 18)
+ok=ok&&(r6a==48)&&(r6b==18)
+print("6 gcd5 with a negative operand stops rather than iterating (expect 48 18): %v %v\n" r6a r6b)
+check_fail(:ok ok)
+
+print("nilcompare: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -105,6 +105,10 @@ if(run("./funcstream.comt")
   :then print("pass: funcstream\n")
   :else print("FAIL: funcstream\n");topok=false)
 
+if(run("./nilcompare.comt")
+  :then print("pass: nilcompare\n")
+  :else print("FAIL: nilcompare\n");topok=false)
+
 if(run("./funchelp.comt")
   :then print("pass: funchelp\n")
   :else print("FAIL: funchelp\n");topok=false)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -109,6 +109,10 @@ if(run("./nilcompare.comt")
   :then print("pass: nilcompare\n")
   :else print("FAIL: nilcompare\n");topok=false)
 
+if(run("./keyword_lineend.comt")
+  :then print("pass: keyword_lineend\n")
+  :else print("FAIL: keyword_lineend\n");topok=false)
+
 if(run("./funchelp.comt")
   :then print("pass: funchelp\n")
   :else print("FAIL: funchelp\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "6f8db659"
+#define PATCH_KEY "d9f94f1e"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "d9f94f1e"
+#define PATCH_KEY "a3d0bbf5"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Groundwork uncovered while building a stream-driven matrix transpose (#283). Three unrelated fixes, each with its own tests.

## 1. A keyword ending a line silently lost the rest of its expression under `run()`

```
dubstrm=func(
  sofs=arg(0);
  ...
  :posteval
)
```

Piped to stdin this defines `dubstrm`. Through `run("dubstrm.comt")` it defined nothing, `help(dubstrm)` came back empty, and the body *executed* during the load.

A keyword does not know at parse time whether it is a bare flag (`:posteval`) or takes a value (`:prefix "P"`). The parser decides with a one-token look-ahead (`_parser.c:1143`): a following keyword or closing paren means bare, anything else means a value is coming. That look-ahead cannot see past the end of the input buffer -- and `run()` feeds a file **one line at a time** through a one-shot infunc (`ComTerpServ::runfile` -> `load_string`/`s_fgets`), so a keyword ending a line never sees the `)` sitting unread on the next line. It gets pushed onto the operator stack as though a value were coming. Piping the same text does not hit this, because `ComTerp::runfile` hands the parser the `FILE*` directly and the look-ahead reads across lines freely. Same file, two input paths, different parse.

Fixed where the closing paren unwinds the operator stack, not at the look-ahead. A pending keyword was emitted with `narg 1`, fabricating an argument that never arrived, which swallowed the paren and left the expression unterminated. A keyword still waiting for a value when its paren arrives never got one:

```c
int kw_novalue = ( expecting == OPTYPE_UNARY_PREFIX );
...
PFOUT( TOK_KEYWORD, temp_id, kw_novalue ? 0 : 1, 0, 0);
kw_novalue = 0;   /* only the innermost pending keyword can lack a value */
```

Deliberately not fixed at the look-ahead: it genuinely cannot know yet, and forcing it to guess would break a keyword whose *value* is on the next line -- which works today and still does (test 4). `nkey` needed no change, being counted at the keyword token regardless.

New `keyword_lineend.comt` plus three sub-scripts: the failing shape now defines and calls correctly, the body is *not* executed while being defined (the witness for the old silent loss), a cross-line keyword value still binds, and the same-line form is unaffected.

## 2. `feed(:raw)` -- store a stream argument whole instead of draining it

A stream fed to `feed()` is tagged `STREAM_NESTED` and flattened one value per `next()`. `:raw` skips that tag, so the element comes back out as the stream object itself:

```
s1=(6 7)
f=feed()
feed(f s1 :raw)
next(f)            // the stream, not 6
```

The point is that the stored ComValue is the stream *object*, so its read position travels with it -- pull it out, take one value, requeue it, and it comes back advanced. That is what lets a FIFO hold a set of streams and rotate them, which is the transpose:

```
txpose=func(
  colmajor=arg(0);
  colcirc=feed;
  rowmajor=feed;
  while(col=*colmajor
    feed(colcirc col :raw));
  while(col=*colcirc
    feed(rowmajor *col);
    feed(colcirc col :raw));
  rowmajor
  :posteval)

txpose(((6 7) (8 9) (10 12)))   // {6,8,10,7,9,12}
```

That rotation self-terminates without a guard, because an exhausted stream requeued raw comes back reading as not-a-stream, so the column drops out of the ring on its own.

`:raw` does not bypass the self-feed cycle guard -- storing an element whose backing list is the FIFO's own recurses without bound regardless of tagging, so the guard is re-keyed on `is_stream()` (feed.comt test 22). Tests 19-22 cover the round trip, the requeue-keeps-advancing property, raw and flattened elements coexisting in one FIFO, and the cycle guard.

## 3. The nil-termination rule, documented and tested

`nil!=0` is `true`, so `while(b!=0 ...)` on an unsupplied `arg(n)` spins forever; `nil>0` is nil, so `while(b>0 ...)` ends. Since an unsupplied positional reads nil, every arg-based func has an implicit "called with too few arguments" path landing straight in the body.

Added to AGENTS.md's ComTerp scripting gotchas, with `nilcompare.comt` making the operator split executable fact:

```
nil != 0   ->  true     definite, and the wrong side
nil == 0   ->  false    definite, safe side
nil > 0    ->  nil      propagates
nil < 0    ->  nil      propagates
```

The trap form is described but never executed -- running it would wedge the suite -- and test 4 is gated on test 3, so a regression in nil-propagation reports a failure instead of hanging CI.

## Also

`funcstream.comt` gains issue #206's reproducer as a regression guard. #206 was closed as fixed by #352; its symptom was exact but its diagnosis ("a post-eval command in the body") was not the cause, so both shapes it reported are pinned here as a pair.

## Testing

Full suite green: **40 suites, zero failures**, on a clean build of current master.
