### PR TITLE
Apply print's :prefix to the format-string path; document what a CommandType answer from istype means

### DIFF
--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -274,7 +274,18 @@ void PrintFunc::execute() {
          here has a legitimate use for %n, so it's refused unconditionally.
          Both fall back to the value's normal string representation, same
          as Boolean already did for just the %s case (generalized below). */
+      /* A list reaching a format spec is a type mismatch like the others
+         below, not an invitation for print to iterate it.  print used to
+         hand-roll an overdrive here -- re-invoking itself per element via
+         exec(2,0) -- which rendered the elements through a fresh stream of
+         their own instead of this call's, so they bypassed :str entirely
+         (leaking to stdout) and left the stack unbalanced.  Streams already
+         overdrive print at the language level, and correctly:
+         print("%d\n" $$lst) formats each element.  So the list prints as
+         the value it is, and per-element formatting is spelled the one way
+         the language already spells it. */
       if (specchar == 'n' || speccount > 1 ||
+          printval.type() == ComValue::ArrayType ||
           (specchar == 's' &&
            printval.type() != ComValue::StringType &&
            printval.type() != ComValue::SymbolType &&
@@ -285,6 +296,9 @@ void PrintFunc::execute() {
                 : speccount > 1
                 ? "print: more format specs than remaining values -- "
                   "printing the value's default representation instead\n"
+                : printval.type() == ComValue::ArrayType
+                ? "print: a format spec given a list -- printing it as a value "
+                  "instead (overdrive with a stream to format each element)\n"
                 : "print: %%s given a non-string value -- "
                   "printing its default representation instead\n");
         fbuf[specstart] = '\0';
@@ -343,24 +357,6 @@ void PrintFunc::execute() {
 	out_form(out, fbuf, printval.double_ref());
 	break;
 	
-      case ComValue::ArrayType: 
-      {
-	
-        ALIterator i;
-        AttributeValueList* avl = printval.array_val();
-        avl->First(i);
-        boolean first = true;
-        while (!avl->Done(i)) {
-          ComValue val(*avl->GetAttrVal(i));
-          push_stack(formatstr);
-          push_stack(val);
-          exec(2,0);
-          avl->Next(i);
-          if (!avl->Done(i)) out << "\n";
-        }
-      }
-      break;
-      
       case ComValue::BlankType:
 	out << "<blank>";
 	break;

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -178,6 +178,14 @@ void PrintFunc::execute() {
     }
 
   } else {
+    /* :prefix applies to a real format string too.  Only the narg==1 branch
+       above ever emitted it, so a prefix supplied alongside a format string
+       and its values was silently discarded, along with the trailing newline
+       the docstring promises ("insert str before and new-line after").
+       Emitted once around the whole formatted result rather than per
+       argument -- one prefix and one newline for the statement, matching
+       what the single-argument branch produces. */
+    if (prefixv.is_string()) out << prefixv.symbol_ptr();
     const char* fstrptr = fstr;
     int curr=1;
     while (curr<narg) {
@@ -370,6 +378,7 @@ void PrintFunc::execute() {
 	break;
       }
     }
+    if (prefixv.is_string()) out << "\n";
   }
 
   reset_stack();

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -68,7 +68,7 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "flag=%s(var [typesym] :sym) -- test var's type without evaluating it"; }
+      return "flag=%s(var [typesym] :sym) -- test var's type without evaluating it -- a compound expression reports CommandType, the unevaluated call at its head, not the type its result would have"; }
 };
 
 //: command to test a variable's class without ever evaluating it.
@@ -85,7 +85,7 @@ public:
 
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "flag=%s(var [classsym] :sym) -- test var's class without evaluating it"; }
+      return "flag=%s(var [classsym] :sym) -- test var's class without evaluating it -- a compound expression has no class to report, being an unevaluated call, not a value"; }
 };
 
 //: shortcut for istype(var CommandType), without evaluating var.

--- a/src/comterp_/tests/print.comt
+++ b/src/comterp_/tests/print.comt
@@ -188,5 +188,35 @@ ok=ok&&(p27=="42")
 print("27 print(\"%d\" 42 :str) without :prefix is unchanged (expect 42, no newline): %v\n\n" p27)
 prev_ok=check_fail(:ok ok)
 
+// --- test 28: a format spec applied to a list is a type mismatch like the
+// others above -- the list prints as the value it is, into THIS call's own
+// stream, so :str captures it.  print used to hand-roll an overdrive here,
+// re-invoking itself per element through a stream of its own: the elements
+// bypassed :str and leaked to stdout, :str returned the format string, and
+// the stack was left unbalanced.  A warning on stderr names the mechanism
+// that does do per-element formatting (test 29) ---
+lst28=1,2,3
+p28=print("%d" lst28 :str)
+ok=ok&&(p28=="{1,2,3}")
+print("28 print(\"%d\" lst :str) captures the list as a value (expect {1,2,3}): %v\n\n" p28)
+prev_ok=check_fail(:ok ok)
+
+// --- test 29: per-element formatting is spelled with a stream, which
+// overdrives print at the language level -- the mechanism test 28's removed
+// loop was duplicating ---
+lst29=1,2,3
+p29=list(print("%d;" $$lst29 :str))
+ok=ok&&(p29==("1;","2;","3;"))
+print("29 print(\"%d;\" $$lst :str) overdrives per element (expect {\"1;\",\"2;\",\"3;\"}): %v\n\n" p29)
+prev_ok=check_fail(:ok ok)
+
+// --- test 30: the prefix wraps that formatted list value once, rather than
+// being stranded in a stream the values never reach ---
+lst30=1,2,3
+p30=print("%d" lst30 :str :prefix "P")
+ok=ok&&(p30=="P{1,2,3}\n")
+print("30 print(\"%d\" lst :str :prefix \"P\") wraps the value (expect P{1,2,3} and a newline): %v\n\n" p30)
+prev_ok=check_fail(:ok ok)
+
 print("print: %v\n" ok)
 ok

--- a/src/comterp_/tests/print.comt
+++ b/src/comterp_/tests/print.comt
@@ -165,5 +165,28 @@ ok=ok&&(s=="42 %n")
 print("24 print(\"%d %n\" 42 :str) extra unmatched spec stays literal (expect 42 %n): %v\n\n" s)
 prev_ok=check_fail(:ok ok)
 
+// --- test 25: :prefix applies to a real format string too.  Only the
+// single-argument path used to emit it, so a prefix given alongside a
+// format string and its values was silently dropped, along with the
+// trailing newline the docstring promises ---
+p25=print("%d" 42 :prefix "P" :str)
+ok=ok&&(p25=="P42\n")
+print("25 print(\"%d\" 42 :prefix \"P\" :str) (expect P42 and a newline): %v\n\n" p25)
+prev_ok=check_fail(:ok ok)
+
+// --- test 26: one prefix and one newline for the whole statement, not one
+// per value, when several values fill the format string ---
+p26=print("%d-%d" 1 2 :prefix "P" :str)
+ok=ok&&(p26=="P1-2\n")
+print("26 print(\"%d-%d\" 1 2 :prefix \"P\" :str) wraps the whole result once (expect P1-2 and a newline): %v\n\n" p26)
+prev_ok=check_fail(:ok ok)
+
+// --- test 27: no prefix keyword, no added newline -- the format path is
+// otherwise untouched ---
+p27=print("%d" 42 :str)
+ok=ok&&(p27=="42")
+print("27 print(\"%d\" 42 :str) without :prefix is unchanged (expect 42, no newline): %v\n\n" p27)
+prev_ok=check_fail(:ok ok)
+
 print("print: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a3d0bbf5"
+#define PATCH_KEY "969e53f2"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Three things in `print` and the lazy type predicates, all surfaced by `istype(print("x" :str :prefix "P")@2 :sym)` reporting `CommandType`.

## 1. `:prefix` was silently dropped whenever `print` had a format string

`:prefix` is documented as "insert str before and new-line after". It did that only when `print` had exactly one fixed argument:

```
print("a"          :str :prefix "P")   // "Pa\n"    correct
print("%d" 42      :str :prefix "P")   // "42"      prefix and newline both gone
print("%d-%d" 1 2  :str :prefix "P")   // "1-2"     same
```

In `iofunc.c`, `prefixv` was referenced only inside the `if (narg==1)` branch; the multi-argument branch that handles a real format string never consulted it. So the keyword worked only on the degenerate case where you are least likely to want it, and the docstring states no such exception.

Fixed by emitting the prefix once before the formatting loop and the newline once after, so one prefix wraps the whole statement rather than appearing per value.

## 2. `print` was hand-rolling its own overdrive over a list

The `ArrayType` case re-invoked `print` once per element via `exec(2,0)`, rendering each element through a stream of its own rather than the caller's. Consequences: the elements bypassed `:str` and leaked to stdout, `:str` returned the *format string* instead of any values, and the call left the stack unbalanced ("print pushed more than a single value on stack").

That block is in the 2011 upstream import of ivtools 0.7.9 -- originally `push_funcstate(2,0); execute();` -- from before `print` participated in streaming at all. It is a decade-old duplicate of a language feature that arrived later and works: streams overdrive `print` per element already.

A format spec applied to a list is now the type mismatch it is, handled exactly like the `%s`-given-a-non-string and `%n` cases directly above it -- warn on stderr, write the value's default representation into this call's stream, continue:

```
print("%d" a :str)              // "{1,2,3}"    was "%d", with 123 on stdout and a stack error
print("%d" a :str :prefix "P")  // "P{1,2,3}\n"
list(print("%d;" $$a :str))     // {"1;","2;","3;"}   -- the mechanism that does per-element work
```

The warning names that mechanism rather than only complaining, so the fix is discoverable from the message.

This also resolves the review finding on this PR, which was accurate about the stream split but attributed it to the prefix change -- the array path's output was byte-identical before and after that change, and is fixed here by deleting the loop it was really about.

## 3. `istype`/`isclass` now say what a `CommandType` answer means

`istype` is post-eval -- it reports on its argument *without evaluating it*. Hand it a variable or literal and it describes what is there; hand it an expression and the only thing present is the unevaluated call, whose head is a command:

```
e=s@0 ; istype(e :sym)   ->  CharType        a value
istype(s@0 :sym)         ->  CommandType     an unevaluated call to @
istype(1+1 :sym)         ->  CommandType
```

Correct behavior, and already explained -- in `istype.comt`'s header comment, which is not where anyone looks while staring at an unexpected `CommandType` in the REPL. `help(istype)` said only "test var's type without evaluating it": true, and silent about what you get instead. Both docstrings now carry it. No behavior change.

## Testing

`print.comt` gains tests 25-30: formatted output with and without `:prefix`, the multi-value case, the list captured as a value, the stream overdrive that replaces the removed loop, and the prefix wrapping that value once.

Full suite green: **41 suites, zero failures**, on a clean build of current master.
