### PR TITLE
Extend the loop-condition gotcha: a value pulled from a stream is a poor condition, test its type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,15 @@ C++ work. The essentials:
   (`>`, `<`) over the one that answers it (`!=` manufactures a `true`;
   `==` at least lands on `false`). Priming the inputs before declaring the
   func removes the nil at the source instead.
+- **Don't let a value pulled from a stream be the loop condition — test its
+  type instead.** `while(item=*fifo ...)` reads naturally and mis-terminates
+  silently, because a pulled value's truthiness rarely matches the intent: a
+  stream object is *true* (so `while(b!=0 ...)` where `b` is a whole stream
+  never ends), a bquoted symbol is *false* (so a `` `EOS `` marker ends the
+  loop the moment it arrives, having been delivered correctly), and a string
+  is true where a `0` is false. Prime the variable before the loop, make the
+  condition an explicit type test (`istype(item StreamType)`,
+  `istype(item SymbolType)`), and re-read at the bottom of the body.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,15 +286,28 @@ C++ work. The essentials:
   (`>`, `<`) over the one that answers it (`!=` manufactures a `true`;
   `==` at least lands on `false`). Priming the inputs before declaring the
   func removes the nil at the source instead.
-- **Don't let a value pulled from a stream be the loop condition — test its
-  type instead.** `while(item=*fifo ...)` reads naturally and mis-terminates
+- **Don't let a value pulled from a stream be the loop condition — test what
+  you got instead.** `while(item=*fifo ...)` reads naturally and mis-terminates
   silently, because a pulled value's truthiness rarely matches the intent: a
   stream object is *true* (so `while(b!=0 ...)` where `b` is a whole stream
   never ends), a bquoted symbol is *false* (so a `` `EOS `` marker ends the
   loop the moment it arrives, having been delivered correctly), and a string
-  is true where a `0` is false. Prime the variable before the loop, make the
-  condition an explicit type test (`istype(item StreamType)`,
-  `istype(item SymbolType)`), and re-read at the bottom of the body.
+  is true where a `0` is false. Prime the variable, make the condition an
+  explicit test, and re-read at the bottom of the body:
+
+  ```
+  item=*fifo;
+  while(<test on item>
+    ...body...;
+    item=*fifo);
+  ```
+
+  The test names what you want to *continue* on, so its polarity follows what
+  the fifo carries: `!istype(item SymbolType)` for ordinary data terminated by
+  a `` `EOS `` marker (the marker is the one symbol, so the negation is the
+  continuation), or `istype(item StreamType)||istype(item SymbolType)` for a
+  ring carrying streams plus a marker the body also acts on. Taking either
+  pair verbatim from the other case inverts the loop.
 
 ---
 

--- a/src/comterp_/tests/nilcompare.comt
+++ b/src/comterp_/tests/nilcompare.comt
@@ -107,5 +107,33 @@ ok=ok&&(a9==1)&&istype(b9 SymbolType)
 print("9 a fifo hands back the marker as a symbol (expect 1 true): %v %v\n" a9 istype(b9 SymbolType))
 check_fail(:ok ok)
 
+// --- test 10: the loop shape the rule prescribes, in both polarities.  The
+// predicate names what you CONTINUE on, so it follows what the fifo carries:
+// negated for ordinary data terminated by a marker, un-negated for a ring
+// carrying streams plus a marker the body also acts on.  Taking one verbatim
+// for the other case inverts the loop ---
+f10=feed()
+feed(f10 10)
+feed(f10 20)
+feed(f10 30)
+feed(f10 `EOS)
+tot10=0
+item10=*f10
+while(!istype(item10 SymbolType)
+  tot10=tot10+item10;
+  item10=*f10)
+g10=feed()
+strm10=(1 2)
+feed(g10 strm10 :raw)
+feed(g10 `EOS)
+n10=0
+item10=*g10
+while(istype(item10 StreamType)||istype(item10 SymbolType)
+  n10=n10+1;
+  item10=*g10)
+ok=ok&&(tot10==60)&&(n10==2)
+print("10 both loop polarities terminate correctly (expect 60 2): %v %v\n" tot10 n10)
+check_fail(:ok ok)
+
 print("nilcompare: %v\n" ok)
 ok

--- a/src/comterp_/tests/nilcompare.comt
+++ b/src/comterp_/tests/nilcompare.comt
@@ -76,5 +76,36 @@ ok=ok&&(r6a==48)&&(r6b==18)
 print("6 gcd5 with a negative operand stops rather than iterating (expect 48 18): %v %v\n" r6a r6b)
 check_fail(:ok ok)
 
+// --- test 7: the same hazard, one step out -- a value pulled from a stream
+// is a poor loop condition because its truthiness rarely matches intent.  A
+// bquoted symbol is FALSE, so a marker circulating in a fifo ends a
+// while(item=*fifo ...) the moment it is (correctly) delivered ---
+sym7=`EOS
+r7=if(sym7 :then "true-branch" :else "false-branch")
+ok=ok&&(r7=="false-branch")
+print("7 a bquoted symbol is falsy (expect false-branch): %v\n" r7)
+check_fail(:ok ok)
+
+// --- test 8: and a stream object is TRUE, which is why a whole stream left
+// in a condition spins instead of terminating -- the other direction of the
+// same mistake ---
+strm8=(1 2 3)
+r8=if(strm8 :then "true-branch" :else "false-branch")
+ok=ok&&(r8=="true-branch")
+print("8 a stream object is truthy (expect true-branch): %v\n" r8)
+check_fail(:ok ok)
+
+// --- test 9: the marker IS delivered -- next() hands back the symbol, so the
+// loop above ends on truthiness, not on a missing value.  Testing the type is
+// what makes it usable ---
+f9=feed()
+feed(f9 1)
+feed(f9 `EOS)
+a9=next(f9)
+b9=next(f9)
+ok=ok&&(a9==1)&&istype(b9 SymbolType)
+print("9 a fifo hands back the marker as a symbol (expect 1 true): %v %v\n" a9 istype(b9 SymbolType))
+check_fail(:ok ok)
+
 print("nilcompare: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a3d0bbf5"
+#define PATCH_KEY "de717e99"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Extends the nil-termination gotcha added in #355 to the general case it turned out to be, after the same shape bit three separate ways while building a stream transpose.

## The rule

`while(item=*fifo ...)` reads naturally and mis-terminates silently, because a pulled value's truthiness rarely matches the intent:

| value | truthiness | consequence |
|-------|-----------|-------------|
| `nil` after `!=` | true | `while(b!=0 ...)` on an unsupplied arg spins forever (#355) |
| a stream object | **true** | a whole stream left in a condition never terminates |
| a bquoted symbol | **false** | a `` `EOS `` ring marker ends the loop the moment it is delivered |
| a string | true | (works, which is what makes the symbol case surprising) |

So the condition should be an explicit type test, not the value: prime the variable before the loop, test what came back (`istype(item StreamType)`, `istype(item SymbolType)`), and re-read at the bottom of the body.

## Where each one bit

The nil case is #355's. The other two came out of a circulating-fifo matrix transpose:

- A column stream left whole in `arg(n)` made `while(b!=0 ...)` spin, because the condition was a stream object rather than a number.
- A `` `EOS `` marker circulating in the ring to mark a pass boundary ended the loop instead of closing a row. The marker was being delivered correctly -- `*fifo` hands back the symbol, confirmed in `nilcompare.comt` test 9 -- it was the `while` that rejected it. Swapping the marker for a plain string "fixed" it for the wrong reason: strings are truthy and symbols are not.

That last one is the reason this is worth writing down. The failure looks like a delivery problem (the marker seems to vanish) and is actually a truthiness problem, so the natural debugging move -- checking whether the marker comes back -- confirms it does and leaves you no wiser.

## Tests

`nilcompare.comt` gains tests 7-9: a bquoted symbol is falsy, a stream object is truthy, and a fifo does hand the marker back as a symbol. The third is what separates "not delivered" from "delivered and rejected", which is the distinction that cost the time.

Full suite green: **41 suites, zero failures**.
