### PR TITLE
Add chunk(strm n): re-grain a stream so a script loop pays interpretation per block, not per element

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2302,6 +2302,17 @@ void ComTerp::list_commands(ostream& out, boolean sorted) {
   }
 }
 
+/* double the buffer when the next write would not fit */
+static int* grow_if_full(int* buffer, int& bufsiz, int ncomm) {
+  if (ncomm < bufsiz) return buffer;
+  int* newbuf = new int[bufsiz*2];
+  for (int j=0; j<ncomm; j++)
+    newbuf[j] = buffer[j];
+  bufsiz *= 2;
+  delete [] buffer;
+  return newbuf;
+}
+
 int* ComTerp::get_commands(int& ncomm, boolean sort) {
   TableIterator(ComValueTable) i(*localtable());
   int bufsiz = 256;
@@ -2320,19 +2331,15 @@ int* ComTerp::get_commands(int& ncomm, boolean sort) {
       const char* command_name = symbol_pntr(key);
       int opid = opr_tbl_opstr(key);
       const char* operator_name = symbol_pntr(opr_tbl_operid(opid));
+      /* An operator-bearing command writes twice per iteration, so capacity
+         has to be checked before each write, not once between them. */
       if (operator_name) {
+        buffer = grow_if_full(buffer, bufsiz, ncomm);
         buffer[ncomm++] = key;
 	key = opr_tbl_operid(opid);
 	opercnt++;
       }
-      if (ncomm==bufsiz) {
-	int* newbuf = new int[bufsiz*2];
-	for (int j=0; j<bufsiz; j++) 
-	  newbuf[j] = buffer[j];
-	bufsiz *= 2;
-	delete [] buffer;
-	buffer = newbuf;
-      }
+      buffer = grow_if_full(buffer, bufsiz, ncomm);
       buffer[ncomm++] = key;
     }
     i.next();

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2026,6 +2026,7 @@ void ComTerp::add_defaults() {
     add_command("each", new EachFunc(this));
     add_command("filter", new FilterFunc(this));
     add_command("feed", new FeedFunc(this));
+    add_command("chunk", new ChunkFunc(this));
 
     add_command("dot", new DotFunc(this));
     add_command("attrname", new DotNameFunc(this));

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -1426,6 +1426,104 @@ void FeedFunc::execute() {
 
 /*****************************************************************************/
 
+int ChunkFunc::_symid;
+
+ChunkFunc::ChunkFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+/* chunk(strm n) -- re-grain a stream.  The cost a script pays per element is
+   not producing it (a computed range and a fully materialized list hand one
+   over at the same speed) but crossing into the interpreter to ask: the *
+   dispatch, the ComValue, the assignment, the loop test.  A buffer behind a
+   per-element * cannot touch any of that.  Handing back n elements at a time
+   can: the script loop then runs total/n times, and the per-element work
+   inside a block happens wherever the block is consumed.
+
+   The block is an ordinary indexed list, deliberately -- at()/@/size()/xpose()
+   already work on one, so chunk needs no companion commands to be useful, and
+   the two access operators stay honest about the two grains: * for the next
+   block, @ within it. */
+void ChunkFunc::execute() {
+  static ChunkNextFunc* cnfunc = nil;
+  if (!cnfunc) {
+    cnfunc = new ChunkNextFunc(comterp());
+    cnfunc->funcid(symbol_add("chunknext"));
+  }
+
+  ComValue srcv(stack_arg_post_eval(0));
+  ComValue nv(stack_arg_post_eval(1));
+  reset_stack();
+
+  if (!srcv.is_stream()) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+  int n = nv.is_known() ? nv.int_val() : 1;
+  if (n < 1) n = 1;
+
+  /* the state this stream carries: its source, and the block size.  Kept in
+     the stream's own backing list, the same slot every other internal-mode
+     stream uses for its state. */
+  AttributeValueList* avl = new AttributeValueList();
+  avl->Append(new AttributeValue(srcv));
+  avl->Append(new AttributeValue(n, AttributeValue::IntType));
+
+  ComValue stream(cnfunc, avl);
+  stream.stream_mode(STREAM_INTERNAL);
+  push_stack(stream);
+}
+
+/*****************************************************************************/
+
+int ChunkNextFunc::_symid;
+
+ChunkNextFunc::ChunkNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
+}
+
+void ChunkNextFunc::execute() {
+  ComValue streamv(stack_arg(0));
+  reset_stack();
+
+  AttributeValueList* state = streamv.stream_list();
+  if (!state) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+  Iterator i;
+  state->First(i);
+  if (state->Done(i)) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+  /* the source ComValue lives in the state list, so advancing through this
+     copy advances the one stored there -- a stream's read position travels
+     with the object, which is what lets successive next()s resume where the
+     last block stopped. */
+  ComValue srcv(*state->GetAttrVal(i));
+  state->Next(i);
+  int n = state->Done(i) ? 1 : state->GetAttrVal(i)->int_val();
+
+  AttributeValueList* block = new AttributeValueList();
+  for (int k=0; k<n; k++) {
+    int before = comterp()->stack_height();
+    NextFunc::execute_impl(comterp(), srcv);
+    if (comterp()->stack_height() <= before) break;
+    ComValue elt(comterp()->pop_stack());
+    if (elt.is_null() || elt.is_unknown() || elt.is_nil()) break;
+    block->Append(new AttributeValue(elt));
+  }
+
+  if (block->Number()==0) {
+    delete block;
+    push_stack(ComValue::nullval());
+    return;
+  }
+  ComValue retval(block);
+  push_stack(retval);
+}
+
+/*****************************************************************************/
+
 int FeedNextFunc::_symid;
 
 FeedNextFunc::FeedNextFunc(ComTerp* comterp) : StrmFunc(comterp) {

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -1426,7 +1426,7 @@ void FeedFunc::execute() {
 
 /*****************************************************************************/
 
-int ChunkFunc::_symid;
+int ChunkFunc::_symid = -1;
 
 ChunkFunc::ChunkFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
@@ -1475,7 +1475,7 @@ void ChunkFunc::execute() {
 
 /*****************************************************************************/
 
-int ChunkNextFunc::_symid;
+int ChunkNextFunc::_symid = -1;
 
 ChunkNextFunc::ChunkNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -1514,6 +1514,13 @@ void ChunkNextFunc::execute() {
   }
 
   if (block->Number()==0) {
+    /* No elements this pull, so report exhaustion -- which for an ordinary
+       stream it is.  Over a growable feed() FIFO it is the known ambiguity of
+       an empty read: nil there means "nothing queued right now", not "done",
+       and chunk cannot tell the two apart any better than its caller can.
+       Ending here matches what every other stream consumer does with that
+       nil, and leaves the FIFO's own contents untouched for a fresh chunk()
+       to pick up. */
     delete block;
     push_stack(ComValue::nullval());
     return;

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -327,6 +327,37 @@ public:
     CLASS_SYMID("FeedFunc");
 };
 
+//: command to re-grain a stream: pull up to n elements into an indexed list,
+//: one block per next(), so a script loop pays interpretation once per block
+//: instead of once per element.
+// lst=chunk(strm n) -- convert a stream into a stream of n-element lists
+class ChunkFunc : public ComFunc {
+public:
+    ChunkFunc(ComTerp*);
+
+    virtual void execute();
+    /* post_eval so a stream argument arrives whole: a non-post-eval command
+       with a stream arg is overdriven, which would lift chunk over the very
+       stream it is meant to re-grain. */
+    virtual boolean post_eval() { return true; }
+    virtual const char* docstring() {
+      return "strm=%s(strm n) -- re-grain a stream into a stream of n-element lists, so a script loop pays interpretation once per block instead of once per element"; }
+
+    CLASS_SYMID("ChunkFunc");
+};
+
+//: hidden func used by next command for chunk-built block streams
+class ChunkNextFunc : public StrmFunc {
+public:
+    ChunkNextFunc(ComTerp*);
+
+    virtual void execute();
+    virtual const char* docstring() {
+      return "hidden func used by next command for chunk-built block streams"; }
+
+    CLASS_SYMID("ChunkNextFunc");
+};
+
 //: hidden func used by next command for feed-built FIFO streams
 class FeedNextFunc : public StrmFunc {
 public:

--- a/src/comterp_/examples/README.md
+++ b/src/comterp_/examples/README.md
@@ -66,3 +66,14 @@ comterp run src/comterp_/examples/<name>.comt
   it is what vectorizing by hand costs, and it is also the shape that maps
   onto data-parallel hardware, where per-lane control flow is the
   expensive part.
+
+- **chunking.comt** -- `chunk(strm n)` re-grains a stream into a stream of
+  n-element indexed lists, so a script loop runs `total/n` times instead of
+  `total` times. Sums 60,000 elements three ways and times each: per element
+  (0.73s), chunked with `sum()` folding each block in C (0.11s), and chunked
+  but indexed per element from script (0.89s -- *slower* than not chunking,
+  since the same interpreted operations remain and the chunking is added on
+  top). That third one is the trap, and it is what you write if you think of
+  `chunk` as buffering for speed. The afterword states the rule: it is about
+  the consumer, not the stream -- `chunk` pays when C can swallow a block
+  whole, and does nothing when every element read must be emitted again.

--- a/src/comterp_/examples/chunking.comt
+++ b/src/comterp_/examples/chunking.comt
@@ -1,0 +1,96 @@
+// src/comterp_/examples/chunking.comt -- chunk(), and when re-graining a
+// stream is worth anything
+//
+// funcs: chunk sum size istype list open float print
+//
+// An interpreted operation in comterp costs about 5 microseconds.  Measured
+// directly: a bare loop of 60,000 iterations takes 0.33s, and adding one more
+// assignment to its body takes 0.62s.  Everything below follows from that one
+// number -- the only way to go faster is to do MORE PER OPERATION, which means
+// handing C a unit of work worth doing.
+//
+// chunk(strm n) hands back a stream of n-element indexed lists instead of a
+// stream of elements, so a script loop runs total/n times instead of total
+// times.  It is not a buffer: pulling from a fully materialized list is no
+// faster than pulling from a computed range, because the cost is crossing into
+// the interpreter, not producing the value.  What chunk changes is the NUMBER
+// of crossings.
+//
+// Run from the repo root:
+//   comterp run src/comterp_/examples/chunking.comt
+
+now=func(float(*$$open("perl -MTime::HiRes -e '$t=Time::HiRes::time(); printf \"%.3f\", $t-int($t/3600)*3600'" :pipe)))
+
+print("\nsumming 60,000 elements three ways\n\n")
+
+// --- 1: one element at a time, the ordinary way -------------------------
+t0=now()
+r=0..59999
+tot=0
+v=*r
+while(v!=nil tot=tot+v; v=*r)
+t_elem=now()-t0
+print("1. per-element script loop      total=%v  %v s\n" tot t_elem)
+
+// --- 2: chunked, and folded in C ---------------------------------------
+// sum() reduces a whole block in C, so the script crosses over 60 times
+// instead of 60,000 -- and each crossing carries 1000 elements of work.
+t0=now()
+r=0..59999
+ch=chunk(r 1000)
+tot=0
+b=*ch
+while(istype(b ListType) tot=tot+sum(b); b=*ch)
+t_fold=now()-t0
+print("2. chunked, sum() per block     total=%v  %v s\n" tot t_fold)
+
+// --- 3: chunked, but walked in script anyway ---------------------------
+// The trap.  Blocking the stream and then indexing each element from script
+// leaves the same 60,000 interpreted operations and adds the chunking on top,
+// so it is SLOWER than not chunking at all.  chunk creates the opportunity to
+// hand C a block; it does not take it for you.
+t0=now()
+r=0..59999
+ch=chunk(r 1000)
+tot=0
+b=*ch
+while(istype(b ListType)
+  i=0; nb=size(b);
+  while((i<nb) (tot=tot+b@i; i=i+1));
+  b=*ch)
+t_walk=now()-t0
+print("3. chunked, indexed in script   total=%v  %v s\n" tot t_walk)
+
+print("\n---------------------------------------------------------------\n")
+print("  1. per element                %v s\n" t_elem)
+print("  2. chunked, folded in C       %v s\n" t_fold)
+print("  3. chunked, walked in script  %v s   <- slower than 1\n" t_walk)
+print("---------------------------------------------------------------\n")
+
+// ------------------------------------------------------------------------
+// Afterword: what chunk is and is not for
+// ------------------------------------------------------------------------
+//
+// IT PAYS WHEN THE CONSUMER FOLDS.  Variant 2 wins because sum() consumes a
+// whole block and keeps almost nothing -- 60 crossings instead of 60,000, each
+// carrying real work.  Any consumer shaped like that benefits: totals, counts,
+// extrema, a histogram, anything that reduces many values to few.
+//
+// IT DOES NOTHING WHEN THE OUTPUT IS AS BIG AS THE INPUT.  If every element
+// read has to be emitted again, the emission costs one interpreted operation
+// per element no matter how the reading was grained, and that dominates.
+// Transposing a matrix is exactly that shape, which is why a blocked transpose
+// built on chunk() loses to simply draining the whole matrix into lists and
+// calling xpose() once -- the latter does O(columns) interpreted operations in
+// total, and no amount of input re-graining beats that.  See examples/txpose.comt.
+//
+// SO THE RULE IS ABOUT THE CONSUMER, NOT THE STREAM.  Ask what happens to a
+// block once you have it.  If C can swallow it whole, chunk helps by the block
+// size.  If the script has to walk it, chunk is overhead -- variant 3 is the
+// measured proof, and it is the natural thing to write if you think of chunk
+// as "buffering for speed".
+//
+// THE BLOCK IS AN ORDINARY LIST, deliberately, so at()/@/size()/sum()/xpose()
+// work on it with no companion commands.  That also keeps the two access
+// operators honest about the two grains: * for the next block, @ within it.
+true

--- a/src/comterp_/tests/chunk.comt
+++ b/src/comterp_/tests/chunk.comt
@@ -1,0 +1,106 @@
+// src/comterp_/tests/chunk.comt -- chunk(), re-graining a stream into blocks
+//
+// funcs: chunk feed list sum xpose istype print
+//
+// chunk(strm n) hands back a stream of n-element lists instead of a stream of
+// elements, so a script loop runs total/n times instead of total times.  The
+// point is not buffering -- a fully materialized source is no faster to pull
+// from than a computed one, since the cost is crossing into the interpreter,
+// not producing the value.  The point is grain: one crossing per block instead
+// of one per element.
+//
+// That only pays when the per-block work is ALSO in C.  chunk() plus a script
+// loop indexing each block is slower than not chunking at all (the chunking is
+// pure overhead then), while chunk() plus sum()/xpose() over the whole block
+// is several times faster.  Test 9 pins that contract.
+//
+// The block is an ordinary indexed list on purpose, so at()/@/size()/sum()/
+// xpose() all work on it with no companion commands -- and the two access
+// operators stay honest about the two grains: * for the next block, @ within.
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./chunk.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: successive blocks of the requested size ---
+c1=chunk(0..9 4)
+b1a=*c1
+b1b=*c1
+ok=ok&&(b1a==(0,1,2,3))&&(b1b==(4,5,6,7))
+print("1 chunk(0..9 4) first two blocks (expect {0,1,2,3} {4,5,6,7}): %v %v\n" b1a b1b)
+check_fail(:ok ok)
+
+// --- test 2: a short final block, then nil ---
+b1c=*c1
+b1d=*c1
+ok=ok&&(b1c==(8,9))&&(b1d==nil)
+print("2 short final block then exhaustion (expect {8,9} nil): %v %v\n" b1c b1d)
+check_fail(:ok ok)
+
+// --- test 3: the block is an ordinary indexed list ---
+c3=chunk(0..5 3)
+b3=*c3
+ok=ok&&istype(b3 ListType)&&(size(b3)==3)&&(b3@1==1)
+print("3 a block is a plain list, indexable (expect true 3 1): %v %v %v\n" istype(b3 ListType) size(b3) b3@1)
+check_fail(:ok ok)
+
+// --- test 4: n of 1 is the ungrained case, one element per block ---
+c4=chunk(0..2 1)
+b4a=*c4
+b4b=*c4
+ok=ok&&(b4a==(0,))&&(b4b==(1,))
+print("4 chunk(strm 1) yields one-element blocks (expect {0,} {1,}): %v %v\n" b4a b4b)
+check_fail(:ok ok)
+
+// --- test 5: a block size larger than the stream gives one short block ---
+c5=chunk(0..2 100)
+b5=*c5
+b5b=*c5
+ok=ok&&(b5==(0,1,2))&&(b5b==nil)
+print("5 block bigger than the stream (expect {0,1,2} nil): %v %v\n" b5 b5b)
+check_fail(:ok ok)
+
+// --- test 6: a block size below 1 clamps to 1 rather than spinning ---
+c6=chunk(0..1 0)
+b6=*c6
+ok=ok&&(b6==(0,))
+print("6 chunk(strm 0) clamps to 1 (expect {0,}): %v\n" b6)
+check_fail(:ok ok)
+
+// --- test 7: a non-stream argument returns nil instead of guessing ---
+r7=chunk(5 2)
+ok=ok&&(r7==nil)
+print("7 chunk on a non-stream (expect nil): %v\n" r7)
+check_fail(:ok ok)
+
+// --- test 8: it re-grains a feed()-built FIFO too, not just ranges ---
+f8=feed()
+feed(f8 10)
+feed(f8 20)
+feed(f8 30)
+c8=chunk(f8 2)
+b8a=*c8
+b8b=*c8
+ok=ok&&(b8a==(10,20))&&(b8b==(30,))
+print("8 chunk over a fifo (expect {10,20} {30,}): %v %v\n" b8a b8b)
+check_fail(:ok ok)
+
+// --- test 9: the contract -- a block is worth having when something C-level
+// consumes the whole block.  sum() reduces one in C; xpose() transposes a
+// tile of them.  Both are the shape chunk exists to enable ---
+c9=chunk(0..9 5)
+t9=0
+b9=*c9
+while(istype(b9 ListType) t9=t9+sum(b9); b9=*c9)
+tile9=list(:size 2)
+tile9@0=*chunk(0..2 3)
+tile9@1=*chunk(100..102 3)
+x9=xpose(tile9)
+ok=ok&&(t9==45)&&(size(x9)==3)&&(at(x9 0)==(0,100))
+print("9 blocks consumed in C -- sum over blocks, xpose over a tile (expect 45 3 {0,100}): %v %v %v\n" t9 size(x9) at(x9 0))
+check_fail(:ok ok)
+
+print("chunk: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -134,6 +134,10 @@ if(run("./feed.comt")
   :then print("pass: feed\n")
   :else print("FAIL: feed\n");topok=false)
 
+if(run("./chunk.comt")
+  :then print("pass: chunk\n")
+  :else print("FAIL: chunk\n");topok=false)
+
 if(run("./istype.comt")
   :then print("pass: istype\n")
   :else print("FAIL: istype\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "de717e99"
+#define PATCH_KEY "1815d86f"
 
 #endif /* _patch_h */


### PR DESCRIPTION
A new stream command, plus the example that shows what it is and is not for.

## `chunk(strm n)`

Re-grains a stream into a stream of n-element indexed lists, so a script loop runs `total/n` times instead of `total` times.

It is not a buffer, and the distinction matters. Pre-loading buys nothing on its own -- pulling from a fully materialized list (0.78s) is no faster than pulling from a lazily computed range (0.70s), because the cost is crossing into the interpreter, not producing the value. What `chunk` changes is the *number of crossings*.

The premise, measured: an interpreted operation costs about **4.8us**. A bare 60,000-iteration loop takes 0.33s; adding one assignment to its body takes 0.62s. So the only lever available anywhere is doing more per operation, which means handing C a unit of work worth doing.

## The contract, which is about the consumer

Summing 60,000 elements three ways (`examples/chunking.comt` measures this live):

```
1. per-element script loop        0.73s
2. chunked, sum() folds in C      0.11s     6.9x faster
3. chunked, indexed from script   0.89s     SLOWER than not chunking
```

Variant 2 wins because `sum()` swallows a whole block in C -- 60 crossings instead of 60,000, each carrying real work. Variant 3 is the trap: blocking the stream and then walking each block from script leaves the same 60,000 interpreted operations and adds the chunking on top. It is also exactly what you write if you think of `chunk` as "buffering for speed", so the example measures it rather than warning about it.

The corollary is that `chunk` does nothing when the output is as big as the input: if every element read must be emitted again, the emission costs one operation per element regardless of how the reading was grained. A blocked matrix transpose built on `chunk` loses to simply draining the matrix into lists and calling `xpose()` once -- that does O(columns) interpreted operations in total, which no amount of input re-graining beats. Noted in the afterword and cross-referenced, so the primitive is not oversold.

## Implementation notes

- It has to be `post_eval()`. Without it a stream argument is overdriven, so `chunk` gets lifted over the very stream it exists to re-grain -- it returned `nil` for every block until that was fixed.
- The block is an ordinary indexed list, deliberately: `at()`/`@`/`size()`/`sum()`/`xpose()` all work on it with no companion commands, and `*` versus `@` stays honest about the two grains -- `*` for the next block, `@` within it.
- Blocks inherit the existing cost of `$$` on a list, which copies (see #360); nothing here changes that.

## Tests

`chunk.comt`, 9 tests: successive blocks, the short final block, exhaustion, the block being a plain indexable list, `n=1` as the ungrained case, `n` larger than the stream, clamping `n<1` to 1 rather than spinning, a non-stream argument returning nil, re-graining a `feed()` FIFO, and the C-level-consumer contract.

Full suite green: **42 suites, zero failures.**
