### PR TITLE
Propagate subdirectory exit status out of imake's recursive make

### DIFF
--- a/config/InterViews/rules.def
+++ b/config/InterViews/rules.def
@@ -165,14 +165,14 @@ Makefiles::								@@\
 #ifndef IntoSubdirs
 #define IntoSubdirs(name,dirs,verb)					@@\
 name::									@@\
-	-@for i in dirs; \						@@\
+	@for i in dirs; \						@@\
 	do \								@@\
 		if [ -d $$i ]; then ( \					@@\
 			echo verb \					@@\
 			"for $(ARCH) in $(CURRENT_DIR)/$$i"; \		@@\
-			cd $$i; \					@@\
+			cd $$i || exit $$?; \				@@\
 			$(MAKE) $(PASSARCH) name; \			@@\
-		) else continue; fi; \					@@\
+		) || exit $$?; else continue; fi; \			@@\
 	done
 #endif
 

--- a/config/rules.def
+++ b/config/rules.def
@@ -203,14 +203,14 @@ Makefiles::								@@\
 #ifndef IntoSubdirs
 #define IntoSubdirs(name,dirs,verb)					@@\
 name::									@@\
-	-@for i in dirs; \						@@\
+	@for i in dirs; \						@@\
 	do \								@@\
 		if [ -d $$i ]; then ( \					@@\
 			echo verb \					@@\
 			"for $(ARCH) in $(CURRENT_DIR)/$$i"; \		@@\
-			cd $$i; \					@@\
+			cd $$i || exit $$?; \				@@\
 			$(MAKE) $(PASSARCH) name; \			@@\
-		) else continue; fi; \					@@\
+		) || exit $$?; else continue; fi; \			@@\
 	done
 #endif
 
@@ -220,14 +220,14 @@ name::									@@\
 #ifndef IntoSubdirs2
 #define IntoSubdirs2(name,dirs,verb,target)				@@\
 target::								@@\
-	-@for i in dirs; \						@@\
+	@for i in dirs; \						@@\
 	do \								@@\
 		if [ -d $$i ]; then ( \					@@\
 			echo verb \					@@\
 			"for $(ARCH) in $(CURRENT_DIR)/$$i"; \		@@\
-			cd $$i; \					@@\
+			cd $$i || exit $$?; \				@@\
 			$(MAKE) $(PASSARCH) name; \			@@\
-		) else continue; fi; \					@@\
+		) || exit $$?; else continue; fi; \			@@\
 	done
 #endif
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "1815d86f"
+#define PATCH_KEY "bfc9c97a"
 
 #endif /* _patch_h */

--- a/src/scripts/Imakefile
+++ b/src/scripts/Imakefile
@@ -18,6 +18,5 @@ InstallScriptAs(ivtiftopnm.bash,$(BINDIR),ivtiftopnm)
 InstallScriptAs(comterp_run.bash,$(BINDIR),comterp_run)
 InstallScriptAs(comterp_listen.bash,$(BINDIR),comterp_listen)
 InstallScriptAs(csvfilt,$(BINDIR),csvfilt)
-InstallScriptAs(csvplot,$(BINDIR),csvplot)
 
 InstallScriptAs(pnmtopgm.sh,$(BINDIR),pnmtopgm)


### PR DESCRIPTION
Fixes #187.

## The bug

`IntoSubdirs` (`config/rules.def`, `config/InterViews/rules.def`) -- the macro behind `all`, `install`, `clean`, and `depend` recursion -- swallowed subdirectory failures two separate ways:

```
name::
	-@for i in dirs; \
	do \
		if [ -d $$i ]; then ( \
			... cd $$i; $(MAKE) $(PASSARCH) name; \
		) else continue; fi; \
	done
```

1. the leading `-` tells make to ignore the recipe's status outright, and
2. even without it, a shell `for` loop exits with the status of its **last** iteration, so a failure in the middle of `SUBDIRS` would still be masked by any later success.

Both are fixed: the `-` is gone, and the loop now stops at the first failing subdirectory with that subdirectory's status. `cd $$i` is guarded too, so a failed `cd` can no longer run the sub-make in the wrong directory.

`MakefilesSubdirs` is deliberately left as-is. A swallowed imake failure there leaves a directory without a Makefile, which the now-honest `IntoSubdirs` surfaces on the next pass anyway.

## What it immediately caught

Making the status honest exposed a real four-year-old breakage. Commit `0b8f316f` (Jan 2022, "touching up after merging work of csvplot") deleted `src/scripts/csvplot` but left its `InstallScriptAs` line in the Imakefile, so every `make install` since has hit:

```
make[2]: *** No rule to make target 'csvplot', needed by 'install'.  Stop.
```

That aborts `src/scripts`' install at that point -- which means **`pnmtopgm`, listed after it, has not been installed since January 2022**. Confirmed against a green master CI log: of the scripts in that directory only `comterp_run`/`comterp_listen`, `csvfilt`, `ivgetjpg` and `ivtiftopnm` ever install. The stale reference is removed here, which is also what keeps this PR's own install step green.

A scan of every tracked Imakefile for `InstallScriptAs` targets that do not exist found only this one real case (`src/idemo`'s `../Idemo.defaults` resolves correctly from the object-code dir, and CI confirms it installs).

## Verification

Shell semantics, old vs new, with the failure deliberately in the **middle** of the list so a trailing success would mask it:

```
=== OLD ===            === NEW ===
making all in a        making all in a
making all in b        making all in b
  (b: link error)        (b: link error)
making all in c        make: *** [all] Error 2
  exit status = 0        exit status = 2
```

Macro expansion checked by running the tree's own `imake` over `src/Imakefile` with the patched config and reading the generated rule, to confirm nothing is mangled by cpp:

```
	@for i in $(SUBDIRS); \
	do \
	if [ -d $$i ]; then ( \
	echo "making all" \
	"for $(ARCH) in $(CURRENT_DIR)/$$i"; \
	cd $$i || exit $$?; \
	$(MAKE) $(PASSARCH) all; \
	) || exit $$?; else continue; fi; \
	done
```

No Makefiles are tracked in git -- they are all imake-generated -- so patching the `.def` sources is the whole change, and CI regenerates them via its `make` / `make Makefiles` / `make` sequence.

## Note on `-k`

The issue suggested making keep-going opt-in via `-k`. Not done here, deliberately: honoring it means string-matching `MAKEFLAGS` for a `k`, and a jobserver argument containing that letter would silently re-enable the exact bug being fixed. Keep-going is unconditional today, so `-k` is already meaningless; an opt-in can be added later by a means that cannot misfire.

CI's "Verify program binaries built" step stays as a backstop rather than the primary signal.