### PR TITLE
Make int/long/float/double's string conversion honest about what it parsed

### DIFF
--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1057,7 +1057,7 @@ IntFunc::IntFunc(ComTerp* comterp) : ComFunc(comterp) {}
    interned symbol id, a wrong answer that reads like a valid parse. */
 static ComValue scan_number_string(const char* numstr) {
     const char* str = numstr;
-    while (isspace(*str)) str++;
+    while (isspace((unsigned char)*str)) str++;
     boolean negflag = *str=='-';
     if (*str=='-' || *str=='+') str++;
     AttributeValue* av =

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -34,6 +34,7 @@
 #include <OS/math.h>
 #include <math.h>
 #include <string.h>
+#include <ctype.h>
 #include <vector>
 
 #define TITLE "NumFunc"
@@ -1049,19 +1050,36 @@ void ShortFunc::execute() {
 
 IntFunc::IntFunc(ComTerp* comterp) : ComFunc(comterp) {}
 
+/* Start a string-to-number conversion where atoi/strtol does: skip leading
+   whitespace and take an explicit sign, neither of which the lexical scanner
+   counts as part of a number.  Returns nil unless the scan really produced
+   one -- a non-numeric string lexes as a symbol, and its int_val() is the
+   interned symbol id, a wrong answer that reads like a valid parse. */
+static ComValue scan_number_string(const char* numstr) {
+    const char* str = numstr;
+    while (isspace(*str)) str++;
+    boolean negflag = *str=='-';
+    if (*str=='-' || *str=='+') str++;
+    AttributeValue* av =
+      ParamList::lexscan()->get_attrval((char*)str, strlen(str));
+    ComValue result;
+    if (av->is_num()) {
+      if (av->is_floatingpoint())
+	result = ComValue(negflag ? -av->double_val() : av->double_val());
+      else
+	result = ComValue(negflag ? -av->long_val() : av->long_val());
+    }
+    delete av;
+    return result;
+}
+
 void IntFunc::execute() {
     ComValue operand(stack_arg(0, false, ComValue::zeroval()));
     static int u_symid = symbol_add("u");
     int uval_flag = stack_key(u_symid).is_true(); 
     reset_stack();
-    if (operand.is_string()) {
-      const char* numstr = operand.symbol_ptr();
-      int negflag = *numstr=='-';
-      AttributeValue* av = ParamList::lexscan()->get_attrval((char*)numstr+negflag, strlen(numstr+negflag));
-      operand = ComValue(av->int_val(), ComValue::IntType);
-      if (negflag) operand.int_ref() = - operand.int_val();
-      delete av;
-    }
+    if (operand.is_string())
+      operand = scan_number_string(operand.symbol_ptr());
     ComValue result(operand.int_val(),  
 		    operand.is_nil() ? ComValue::UnknownType :
                     (uval_flag ? ComValue::UIntType : ComValue::IntType));
@@ -1075,14 +1093,9 @@ void LongFunc::execute() {
     static int u_symid = symbol_add("u");
     int uval_flag = stack_key(u_symid).is_true(); 
     reset_stack();
-    if (operand.is_string()) {
-      const char* numstr = operand.symbol_ptr();
-      int negflag = *numstr=='-';
-      AttributeValue* av = ParamList::lexscan()->get_attrval((char*)numstr+negflag, strlen(numstr+negflag));
-      operand = ComValue(av->long_val());
-      if (negflag) operand.long_ref() = - operand.long_val();
-      delete av;
-    }
+    if (operand.is_string())
+      operand = scan_number_string(operand.symbol_ptr());
+    if (operand.is_nil()) { push_stack(ComValue::nullval()); return; }
     ComValue result(operand.long_val());
     if(uval_flag) result.type(ComValue::ULongType);
 
@@ -1095,14 +1108,9 @@ void FloatFunc::execute() {
     static ComValue float_zero = ComValue((float)0.0);
     ComValue operand(stack_arg(0, false, float_zero));
     reset_stack();
-    if (operand.is_string()) {
-      const char* numstr = operand.symbol_ptr();
-      int negflag = *numstr=='-';
-      AttributeValue* av = ParamList::lexscan()->get_attrval((char*)numstr+negflag, strlen(numstr+negflag));
-      operand = ComValue(av->float_val());
-      if (negflag) operand.float_ref() = - operand.float_val();
-      delete av;
-    }
+    if (operand.is_string())
+      operand = scan_number_string(operand.symbol_ptr());
+    if (operand.is_nil()) { push_stack(ComValue::nullval()); return; }
     ComValue result(operand.float_val());
     push_stack(result);
 }
@@ -1113,14 +1121,9 @@ void DoubleFunc::execute() {
     static ComValue double_zero = ComValue((double)0.0);
     ComValue operand(stack_arg(0, false, double_zero));
     reset_stack();
-    if (operand.is_string()) {
-      const char* numstr = operand.symbol_ptr();
-      int negflag = *numstr=='-';
-      AttributeValue* av = ParamList::lexscan()->get_attrval((char*)numstr+negflag, strlen(numstr+negflag));
-      operand = ComValue(av->double_val());
-      if (negflag) operand.double_ref() = - operand.double_val();
-      delete av;
-    }
+    if (operand.is_string())
+      operand = scan_number_string(operand.symbol_ptr());
+    if (operand.is_nil()) { push_stack(ComValue::nullval()); return; }
     ComValue result(operand.double_val());
     push_stack(result);
 }

--- a/src/comterp_/tests/numstring.comt
+++ b/src/comterp_/tests/numstring.comt
@@ -1,0 +1,72 @@
+// src/comterp_/tests/numstring.comt -- int()/long()/float()/double() applied
+// to a string argument
+//
+// funcs: int long float double print
+//
+// These four are comterp's atoi/strtol, and they begin the way atoi does:
+// skip leading whitespace, take an explicit sign, then hand the rest to the
+// lexical scanner.  The scanner counts neither the whitespace nor the sign as
+// part of a number, so both have to be dealt with before it sees the string.
+//
+// A string that does not scan as a number returns nil.  That matters more
+// than it looks: a non-numeric string lexes as a symbol, and a symbol's
+// int_val() is its interned symbol id -- so int("hello") used to answer 201,
+// a wrong number wearing the shape of a right one.  See issue #251.
+//
+// What the scanner's own C-literal rules decide is left to the scanner on
+// purpose: "017" is octal (15), and a partial parse like "42abc" is not a
+// number at all rather than a silent 42.
+
+ok=true
+
+// --- explicit sign: the scanner treats a bare sign as an operator, so both
+// signs have to be consumed before it is asked to scan ---
+ok=ok&&(int("+5")==5)
+print("1 int(\"+5\") (expect 5): %v\n" int("+5"))
+
+ok=ok&&(int("-42")==-42)
+print("2 int(\"-42\") (expect -42): %v\n" int("-42"))
+
+// --- leading whitespace, with and without a sign ---
+ok=ok&&(int("  -5")==-5)
+print("3 int(\"  -5\") (expect -5): %v\n" int("  -5"))
+
+ok=ok&&(int("   7")==7)
+print("4 int(\"   7\") (expect 7): %v\n" int("   7"))
+
+// --- a string that is not a number is nil, not a number-shaped answer ---
+ok=ok&&(int("hello")==nil)
+print("5 int(\"hello\") (expect nil, not a symbol id): %v\n" int("hello"))
+
+ok=ok&&(int("42abc")==nil)
+print("6 int(\"42abc\") partial parse is not a number (expect nil): %v\n" int("42abc"))
+
+ok=ok&&(int("")==nil)
+print("7 int(\"\") (expect nil): %v\n" int(""))
+
+// --- the scanner's own literal rules, unchanged on purpose ---
+ok=ok&&(int("0x1F")==31)
+print("8 int(\"0x1F\") hex still scans (expect 31): %v\n" int("0x1F"))
+
+ok=ok&&(int("017")==15)
+print("9 int(\"017\") leading zero is octal, by the scanner's rules (expect 15): %v\n" int("017"))
+
+// --- a non-string argument is untouched by any of this ---
+ok=ok&&(int(5)==5)
+print("10 int(5) non-string path (expect 5): %v\n" int(5))
+
+// --- the other three convert and reject the same way ---
+ok=ok&&(long("+7")==7)
+ok=ok&&(long("x")==nil)
+print("11 long(\"+7\") and long(\"x\") (expect 7 and nil): %v %v\n" long("+7") long("x"))
+
+ok=ok&&(float(" -2.5")==-2.5)
+ok=ok&&(float("x")==nil)
+print("12 float(\" -2.5\") and float(\"x\") (expect -2.5 and nil): %v %v\n" float(" -2.5") float("x"))
+
+ok=ok&&(double("+1.5")==1.5)
+ok=ok&&(double("x")==nil)
+print("13 double(\"+1.5\") and double(\"x\") (expect 1.5 and nil): %v %v\n" double("+1.5") double("x"))
+
+print("numstring: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -109,6 +109,10 @@ if(run("./nilcompare.comt")
   :then print("pass: nilcompare\n")
   :else print("FAIL: nilcompare\n");topok=false)
 
+if(run("./numstring.comt")
+  :then print("pass: numstring\n")
+  :else print("FAIL: numstring\n");topok=false)
+
 if(run("./keyword_lineend.comt")
   :then print("pass: keyword_lineend\n")
   :else print("FAIL: keyword_lineend\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "1815d86f"
+#define PATCH_KEY "a3dec621"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Fixes #251, scoped as the issue proposes: causes (1), (2) and (3). The scanner-semantics questions (4) octal-leading-zero and (5) partial parse are left alone deliberately -- see below.

## What was wrong

All four of `IntFunc`/`LongFunc`/`FloatFunc`/`DoubleFunc::execute()` carried the same block: hand-strip a leading `-`, hand the rest to `LexScan::get_attrval()`, then force the result to the target type.

That leaks three ways:

- **A leading `+` was not handled** -- only `-` was. The scanner never counts a sign as part of a number (a bare sign lexes as an operator), so `int("+5")` fell through to `int_val()`s `default:` and answered `0`.
- **No leading-whitespace skip**, so `*numstr==-` was tested against the raw string and `int("  -5")` mis-tokenized the same way. `atoi`/`strtol` both skip whitespace first.
- **Worst: a non-numeric string produced a plausible wrong number.** `"hello"` lexes as `TOK_IDENTIFIER` -> `SymbolType`, and `AttributeValue::int_val()` on a symbol returns its *interned symbol id*. So `int("hello")` answered **201** -- not 0, not nil, just a number that looks like a parse succeeded. `IntFunc`s existing `operand.is_nil()` guard could never fire, because `operand` had already been force-typed to `IntType` two lines above.

## The fix

One shared `scan_number_string()` replaces the four copies. It starts where `atoi` starts -- skip whitespace, take an explicit sign -- and then returns nil unless `av->is_num()` confirms the scan actually produced a number. `IntFunc`s `is_nil()` check stops being dead code; the other three get the same guard, which they never had.

## Measured, before and after

```
int("+5")       0    ->  5
int("  -5")     0    ->  -5
int("hello")    201  ->  nil          <- the dangerous one
int("42abc")    0    ->  nil
int("")         0    ->  nil
int("-42")      -42  ->  -42          (unchanged)
int("0x1F")     31   ->  31           (unchanged)
int("017")      15   ->  15           (unchanged, see below)
int(5)          5    ->  5            (non-string path untouched)
long("+7")/long("x"), float(" -2.5")/float("x"), double("+1.5")/double("x")
                                       all convert and reject alike
```

## What is deliberately not changed

`int("017")` still answers 15. Leading-zero-is-octal is the *scanners* C-literal rule, and issue #251 flags matching C `atoi` exactly as a semantics decision to settle before touching -- so it is untouched here.

`int("42abc")` returns nil rather than 42. That is not the partial-parse feature from (5): it is (3) applied consistently, since `"42abc"` does not scan as a number. The change is from a silent `0` to an honest nil. If comterp later wants `atoi`s stop-at-first-invalid-char behaviour, that is still an open decision.

## Test

`src/comterp_/tests/numstring.comt`, 13 assertions covering both signs, whitespace with and without a sign, the three non-numeric shapes, the two scanner rules held unchanged, the non-string path, and all four commands. Registered in `run_all.comt`; local suite 43/43 green.