### PR TITLE
Backtick-protect symbol values in attrlist serialization

### DIFF
--- a/src/Attribute/attrlist.c
+++ b/src/Attribute/attrlist.c
@@ -251,6 +251,9 @@ ostream& AttributeList::serialize(ostream& out, boolean parens) const {
 	   out << nm[j];
 	}
 	out << " ";
+	/* a symbol here is data, not a variable reference -- backtick it so it
+	   reads back as the symbol itself, the way a string keeps its quotes */
+	if (attr->Value()->is_type(AttributeValue::SymbolType)) out << "`";
 	out << *attr->Value();
     }
     if (parens) out << ")";

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -500,5 +500,36 @@ ok=ok&&(r52==(3,5,1))
 print("52 list(($$barnyard51).calls) -- inline paren form (expect {3,5,1}): %v\n\n" r52)
 prev_ok=check_fail(:ok ok)
 
+// --- tests 53-56: a SymbolType attribute VALUE serializes backtick-protected.
+// An attrlist holds values, not variable references, so a bare symbol in the
+// emitted text would be looked up on read-back and come back as whatever it
+// happened to be bound to -- silently, and as a different value.  The backtick
+// is to a symbol value what the quotes are to a string value. ---
+r53=attrlist(:name `foo :label "bar" :count 3)
+s53=print("%v" r53 :str)
+ok=ok&&(index(s53 ":name `foo" :substr)!=nil)
+print("53 a symbol attribute value keeps its backtick (expect the text to contain :name `foo): %v\n\n" s53)
+prev_ok=check_fail(:ok ok)
+
+// a string value keeps its quotes in the same emission -- the symmetry the
+// backtick restores
+r54=index(s53 ":label \"bar\"" :substr)
+ok=ok&&(r54!=nil)
+print("54 a string attribute value still keeps its quotes (expect a position, not nil): %v\n\n" r54)
+prev_ok=check_fail(:ok ok)
+
+// the round trip that the backtick exists for: with it the value reads back
+// as the symbol, without it the reader looks the name up instead
+foo55=99
+r55=(:name `foo55)
+ok=ok&&(r55.name==`foo55)
+print("55 a backticked symbol value reads back as the symbol (expect foo55, not 99): %v\n\n" r55.name)
+prev_ok=check_fail(:ok ok)
+
+r56=(:name foo55)
+ok=ok&&(r56.name==99)
+print("56 an unprotected symbol is looked up on read-back instead -- what the backtick prevents (expect 99): %v\n\n" r56.name)
+prev_ok=check_fail(:ok ok)
+
 print("attrlist: %v\n" ok)
 ok

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -500,7 +500,7 @@ ok=ok&&(r52==(3,5,1))
 print("52 list(($$barnyard51).calls) -- inline paren form (expect {3,5,1}): %v\n\n" r52)
 prev_ok=check_fail(:ok ok)
 
-// --- tests 53-56: a SymbolType attribute VALUE serializes backtick-protected.
+// --- tests 53-57: a SymbolType attribute VALUE serializes backtick-protected.
 // An attrlist holds values, not variable references, so a bare symbol in the
 // emitted text would be looked up on read-back and come back as whatever it
 // happened to be bound to -- silently, and as a different value.  The backtick
@@ -518,17 +518,31 @@ ok=ok&&(r54!=nil)
 print("54 a string attribute value still keeps its quotes (expect a position, not nil): %v\n\n" r54)
 prev_ok=check_fail(:ok ok)
 
-// the round trip that the backtick exists for: with it the value reads back
-// as the symbol, without it the reader looks the name up instead
+// the round trip this exists for, run on the emitted text itself rather than
+// on a hand-written literal: serialize, read the result back, and check the
+// value survives.  foo55 is deliberately bound to something else, so a lost
+// backtick shows up as that binding instead of the symbol.
 foo55=99
-r55=(:name `foo55)
-ok=ok&&(r55.name==`foo55)
-print("55 a backticked symbol value reads back as the symbol (expect foo55, not 99): %v\n\n" r55.name)
+r55=(:name `foo55 :label "bar" :count 3)
+s55=print("%v" r55 :str)
+b55=eval(s55)
+ok=ok&&(b55.name==`foo55)
+ok=ok&&(b55.label=="bar")
+ok=ok&&(b55.count==3)
+print("55 eval() of the emitted text gives back the symbol (expect foo55, not 99): %v\n\n" b55.name)
 prev_ok=check_fail(:ok ok)
 
-r56=(:name foo55)
-ok=ok&&(r56.name==99)
-print("56 an unprotected symbol is looked up on read-back instead -- what the backtick prevents (expect 99): %v\n\n" r56.name)
+// and re-emitting the read-back value reproduces the same text -- emit/parse
+// is a fixed point, not merely close enough to survive one pass
+ok=ok&&(print("%v" b55 :str)==s55)
+print("56 re-emitting the reparsed attrlist reproduces the text exactly (expect the two to match): %v\n    %v\n\n" (print("%v" b55 :str)==s55) s55)
+prev_ok=check_fail(:ok ok)
+
+// the counter-case: without the backtick the reader looks the name up, which
+// is the silent substitution the protection prevents
+r57=(:name foo55)
+ok=ok&&(r57.name==99)
+print("57 an unprotected symbol is looked up on read-back instead (expect 99): %v\n\n" r57.name)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "1815d86f"
+#define PATCH_KEY "a880a799"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Fixes #125, at the narrowed scope settled in the issue comments: attrlist serialization only, not a global backtick on every symbol result.

## The bug, and why it is data loss rather than cosmetics

An attrlist holds *values*. A `StringType` value is already emitted with its quotes, but a `SymbolType` value was emitted bare -- so on read-back the reader treats it as a variable reference and looks it up:

```
foo=99
a=(:name `foo)     // emitted before this change as: (:name foo)
b=(:name foo)      // which is what reading that emission back produces

a.name  ->  foo    // the symbol, which is what was stored
b.name  ->  99     // the lookup, which is not
```

So a round trip through the emitted text silently replaced the stored symbol with whatever that name happened to be bound to. The backtick is to a symbol value exactly what the quotes are to a string value, and it was the only one of the pair missing.

Concretely, before and after:

```
(:name foo :count 3 :label "bar")     ->  (:name `foo :count 3 :label "bar")
(:func streamliteralnext :ntoks 3 ...) ->  (:func `streamliteralnext :ntoks 3 ...)
```

The second is the `info((10 20 30))` case from the issue. Worth noting its producer already believed this worked -- `strmfunc.c:1271` sets `funcnamev->bquote(1)` under the comment "func name of the backing NextFunc -- back-quoted symbol". The flag was set and then dropped at emission, since `bquote` lives on `ComValue` while the attrlist serializer takes an `AttributeValue&` and `operator<<` is a free function that binds at compile time.

## Scope held to the narrowing

The general case stays as it is: a bare top-level symbol result still prints bare. Backquote is an operator that evaluates away, so `a=`b; a` printing `b` is correct in the same way `1+2` printing `3` is, and there is no way after the fact to know a given symbol value was meant to re-quote. The one place that knowledge exists by construction is an attrlist attribute value, which is where the change is made -- inside `AttributeList::serialize`, four lines, nothing else touched.

Extracting the value back out and printing it (`al.name`) is therefore still bare, unchanged.

## Test

`attrlist.comt` tests 53-56: the backtick is present; the string value still keeps its quotes in the same emission (the symmetry being restored); a backticked value reads back as the symbol; and the unprotected form reads back as the looked-up `99`, which is the failure being prevented. Local suite 42/42 green.