### PR TITLE
Hold tty echo off only while a line executes, so typing is visible in a raw terminal

### DIFF
--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -30,6 +30,7 @@ using namespace std;
 #include <vector>
 
 #include <ComTerp/comhandler.h>
+#include <ComUtil/comutil.h>
 #include <ComTerp/comterpserv.h>
 #include <ComTerp/comvalue.h>
 
@@ -247,6 +248,11 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
 	delete comterp_;
 	comterp_ = nil;
       }
+      /* Back to the reactor to wait.  This handler assembles its own line
+         with read(), so the lexer never reads the tty here and _lexscan.c's
+         before-read hook never runs -- without this, echo stays off from the
+         first command on and typing goes invisible (ttyecho.c). */
+      if (fd == 0) tty_echo_before_read();
       return input_good&&(status==0||status==3||status==2) ? 0 : -1;
     } else {
       if (inbuf[0]!='\004')

--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -188,6 +188,12 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
 	return 0;
     }
 
+    /* This handler assembles its own line and evaluates it from a string, so
+       the lexer's terminal hooks do not apply here (_lexscan.c gates them on
+       reading stdin).  Hold echo across the evaluation, and hand it back on
+       the way out, below. */
+    if (fd == 0) tty_echo_hold();
+
     if (!ComterpHandler::logger_mode() && !log_only()) {
 
       /* Typed input can arrive while a script is already running on this same

--- a/src/ComTerp/comhandler.c
+++ b/src/ComTerp/comhandler.c
@@ -254,12 +254,19 @@ ComterpHandler::handle_input (ACE_HANDLE fd)
 	delete comterp_;
 	comterp_ = nil;
       }
-      /* Back to the reactor to wait.  This handler assembles its own line
-         with read(), so the lexer never reads the tty here and _lexscan.c's
-         before-read hook never runs -- without this, echo stays off from the
-         first command on and typing goes invisible (ttyecho.c). */
-      if (fd == 0) tty_echo_before_read();
-      return input_good&&(status==0||status==3||status==2) ? 0 : -1;
+      /* This handler assembles its own line with read(), so the lexer never
+         reads the tty here and _lexscan.c's before-read hook never runs --
+         without this, echo stays off from the first command on and typing
+         goes invisible (ttyecho.c).  Returning anything but 0 retires the
+         handler, and a retired handler gets no further read to restore from,
+         so give echo back unconditionally on that path rather than only when
+         nothing is queued. */
+      { int staying = input_good && (status==0||status==3||status==2);
+        if (fd == 0) {
+          if (staying) tty_echo_before_read();
+          else tty_echo_restore();
+        }
+        return staying ? 0 : -1; }
     } else {
       if (inbuf[0]!='\004')
 	cout << "from pipe(" << fd << "):  " << inbuf << "\n";

--- a/src/ComUtil/_lexscan.c
+++ b/src/ComUtil/_lexscan.c
@@ -283,10 +283,15 @@ int bs_ident = 0;
 	    echoing here or was already shown by the OS (ttyecho.c). */
 	 { int echo_suppressed = tty_echo_consume_suppress_next();
 	   int self_echo = 0;
+	   /* only when this lexer is reading the terminal itself.  A string
+	      source (ComTerpServ::s_fgets -- comdraw/drawserv, and every
+	      internal eval such as the startup update() seed) must leave the
+	      tty alone, or it turns echo off with nothing to turn it back on. */
+	   int on_tty = (infile == (void*)stdin);
 	 if (linecmtchr || linecmtstr)
-	   while( (tty_echo_before_read(),
+	   while( (on_tty ? tty_echo_before_read() : (void)0,
 		   infunc_retval = (*infunc)( buffer, bufsiz, infile )) != NULL &&
-		  (self_echo = tty_echo_after_read(buffer),
+		  (self_echo = on_tty ? tty_echo_after_read(buffer) : 0,
 		   buffer[0] == linecmtchr || strncmp(buffer, linecmtstr, strlen(linecmtstr))==0)) {
 	     if (outfunc && !_continuation_prompt_disabled && !echo_suppressed
 		 && outfunc == (int(*)(const char*,void*))&stdout_puts && self_echo)
@@ -297,9 +302,9 @@ int bs_ident = 0;
              (*linenum)++;  /* skip all script comments */
          }
 	 else {
-	   tty_echo_before_read();
+	   if (on_tty) tty_echo_before_read();
 	   infunc_retval = (*infunc)( buffer, bufsiz, infile );
-	   if (infunc_retval != NULL) self_echo = tty_echo_after_read(buffer);
+	   if (infunc_retval != NULL && on_tty) self_echo = tty_echo_after_read(buffer);
 	 }
 	 if (infunc_retval != NULL && outfunc && !_continuation_prompt_disabled && !echo_suppressed
 	     && outfunc == (int(*)(const char*,void*))&stdout_puts

--- a/src/ComUtil/_lexscan.c
+++ b/src/ComUtil/_lexscan.c
@@ -276,23 +276,34 @@ int bs_ident = 0;
 	    comdraw/drawserv's startup seed update(); consumed here exactly
 	    once regardless of whether this line turns out to be a comment
 	    or the real one, so it only ever swallows the next line read. */
+	 /* tty_echo_before_read() hands echo back to the OS when nothing is
+	    buffered, so typing is visible and line-edited normally; each read
+	    is followed by tty_echo_after_read(), which suppresses echo for the
+	    execution that follows and reports whether this line still needs
+	    echoing here or was already shown by the OS (ttyecho.c). */
 	 { int echo_suppressed = tty_echo_consume_suppress_next();
+	   int self_echo = 0;
 	 if (linecmtchr || linecmtstr)
-	   while( (infunc_retval = (*infunc)( buffer, bufsiz, infile )) != NULL &&
-		  (buffer[0] == linecmtchr || strncmp(buffer, linecmtstr, strlen(linecmtstr))==0)) {
+	   while( (tty_echo_before_read(),
+		   infunc_retval = (*infunc)( buffer, bufsiz, infile )) != NULL &&
+		  (self_echo = tty_echo_after_read(buffer),
+		   buffer[0] == linecmtchr || strncmp(buffer, linecmtstr, strlen(linecmtstr))==0)) {
 	     if (outfunc && !_continuation_prompt_disabled && !echo_suppressed
-		 && outfunc == (int(*)(const char*,void*))&stdout_puts && tty_echo_is_off())
+		 && outfunc == (int(*)(const char*,void*))&stdout_puts && self_echo)
 	       (*outfunc) ( buffer, outfile );  /* echo the comment line too -- it's
 	                                            still being silently consumed
 	                                            here, just no longer shown by
 	                                            OS echo on its own */
              (*linenum)++;  /* skip all script comments */
          }
-	 else
+	 else {
+	   tty_echo_before_read();
 	   infunc_retval = (*infunc)( buffer, bufsiz, infile );
+	   if (infunc_retval != NULL) self_echo = tty_echo_after_read(buffer);
+	 }
 	 if (infunc_retval != NULL && outfunc && !_continuation_prompt_disabled && !echo_suppressed
 	     && outfunc == (int(*)(const char*,void*))&stdout_puts
-	     && tty_echo_is_off())
+	     && self_echo)
 	   (*outfunc) ( buffer, outfile );
 	 }
 	 if( infunc_retval == NULL ) {

--- a/src/ComUtil/comutil.h
+++ b/src/ComUtil/comutil.h
@@ -194,6 +194,8 @@ const char* get_command_prompt();
    tty_echo_off() itself, but is also public so a deliberate early-exit
    path (one that bypasses atexit, e.g. _exit()) can call it directly. */
 void tty_echo_off(void);
+void tty_echo_before_read(void);
+int tty_echo_after_read(const char* line);
 void tty_echo_restore(void);
 int tty_echo_is_off(void);
 

--- a/src/ComUtil/comutil.h
+++ b/src/ComUtil/comutil.h
@@ -196,6 +196,7 @@ const char* get_command_prompt();
 void tty_echo_off(void);
 void tty_echo_before_read(void);
 int tty_echo_after_read(const char* line);
+void tty_echo_hold(void);
 void tty_echo_restore(void);
 int tty_echo_is_off(void);
 

--- a/src/ComUtil/ttyecho.c
+++ b/src/ComUtil/ttyecho.c
@@ -103,6 +103,7 @@ int tty_echo_is_off(void) { return _tty_echo_off; }
    already pending -- and therefore already echoed -- at the moment echo went
    off, and they are charged off line by line. */
 static long _pre_echoed = 0;
+void tty_echo_hold(void);
 
 static int tty_pending_bytes(void) {
     int navail = 0;
@@ -131,11 +132,17 @@ int tty_echo_after_read(const char* line) {
         if (_pre_echoed < 0) _pre_echoed = 0;
         self_echo = 0;
     }
+    tty_echo_hold();
+    return self_echo;
+}
+
+/* suppress echo for the execution about to start, remembering how much input
+   was already pending -- those bytes the OS has already shown */
+void tty_echo_hold(void) {
     if (!_tty_echo_off) {
-        _pre_echoed = tty_pending_bytes();  /* already echoed by the OS */
+        _pre_echoed = tty_pending_bytes();
         tty_echo_off();
     }
-    return self_echo;
 }
 
 

--- a/src/ComUtil/ttyecho.c
+++ b/src/ComUtil/ttyecho.c
@@ -51,12 +51,15 @@ History:         Added for issue #76, July 2026
 */
 
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <termios.h>
 #include <signal.h>
+#include <sys/ioctl.h>
 
 static int _tty_echo_off = 0;
+static int _atexit_registered = 0;
 static struct termios _tty_saved_state;
 
 void tty_echo_restore(void) {
@@ -80,10 +83,61 @@ void tty_echo_off(void) {
     if (tcsetattr(fileno(stdin), TCSANOW, &raw) != 0)
         return;
     _tty_echo_off = 1;
-    atexit(tty_echo_restore);
+    if (!_atexit_registered) {
+        _atexit_registered = 1;
+        atexit(tty_echo_restore);
+    }
 }
 
 int tty_echo_is_off(void) { return _tty_echo_off; }
+
+/* Echo is held off only while a line is being executed, not for the whole
+   session (issue #76 did the latter, which left typing invisible in a raw
+   terminal -- ICANON gives the app nothing until Return, so with ECHO clear
+   nobody shows the keystrokes).  Waiting at the prompt runs with ECHO on, so
+   the OS shows typing and does its own line editing.
+
+   The cost is that a paste landing at an idle prompt is echoed by the OS as
+   one block.  Those bytes are already on screen, so self-echoing them as they
+   are consumed would show them twice; _pre_echoed records how many bytes were
+   already pending -- and therefore already echoed -- at the moment echo went
+   off, and they are charged off line by line. */
+static long _pre_echoed = 0;
+
+static int tty_pending_bytes(void) {
+    int navail = 0;
+    if (!isatty(fileno(stdin))) return 0;
+    if (ioctl(fileno(stdin), FIONREAD, &navail) != 0) return 0;
+    return navail;
+}
+
+/* about to block for input: with nothing buffered a person is about to type,
+   so give the OS its echo back.  Input already waiting is the rest of a burst
+   -- leave echo off so it stays interleaved with each line's own result. */
+void tty_echo_before_read(void) {
+    if (tty_pending_bytes() == 0)
+        tty_echo_restore();
+}
+
+/* a line has been read and execution is about to start: suppress echo so any
+   further input arriving meanwhile is not shown ahead of its result.  Returns
+   whether this line still needs echoing here -- false when the OS already did
+   it, either because echo was on when it arrived or because it was part of a
+   block counted in _pre_echoed. */
+int tty_echo_after_read(const char* line) {
+    int self_echo = _tty_echo_off;
+    if (self_echo && _pre_echoed > 0) {
+        _pre_echoed -= (long)strlen(line);
+        if (_pre_echoed < 0) _pre_echoed = 0;
+        self_echo = 0;
+    }
+    if (!_tty_echo_off) {
+        _pre_echoed = tty_pending_bytes();  /* already echoed by the OS */
+        tty_echo_off();
+    }
+    return self_echo;
+}
+
 
 /* One-shot self-echo suppression for a single internal, not-typed-by-the-
    user eval -- e.g. comdraw/drawserv's startup seed update(1000000).  NOT

--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -367,10 +367,9 @@ int main (int argc, char** argv) {
 	    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							  ACE_Event_Handler::READ_MASK)==-1)
 	      cerr << "comdraw: unable to open stdin with ACE\n";
-	    else
-	      tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
-	                        // handler is actually live, or OS echo goes off
-	                        // with no self-echo ever registered to replace it
+	    // echo is held off only while a line is executing now, by
+	    // tty_echo_before_read()/tty_echo_after_read() around each read
+	    // in _lexscan.c -- nothing to set up here
 
 	  fprintf(stderr, "ivtools-%s comdraw: see \"man comdraw\" or type help here for command info %s\n", VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY));
 	  starter_line = true;

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -341,7 +341,6 @@ int main(int argc, char *argv[]) {
       if (S_ISREG(buf.st_mode) || S_ISFIFO(buf.st_mode))
 	terp->disable_prompt();
       else {
-	tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c
 	fprintf(stdout, "ivtools-%s comterp: type help for more info %s\n%s", VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY), get_command_prompt());
       }
       return terp->run();
@@ -421,7 +420,6 @@ int main(int argc, char *argv[]) {
         if (S_ISREG(buf.st_mode) || S_ISFIFO(buf.st_mode))
 	  terp->disable_prompt();
 	else {
-	  tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c
 	  fprintf(stdout, "ivtools-%s comterp:  type help for more info %s\n%s", VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY), get_command_prompt());
 	}
 	return terp->run();

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -382,10 +382,9 @@ int main (int argc, char** argv) {
 	    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							  ACE_Event_Handler::READ_MASK)==-1)
 	      cerr << "drawserv: unable to open stdin with ACE\n";
-	    else
-	      tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
-	                        // handler is actually live, or OS echo goes off
-	                        // with no self-echo ever registered to replace it
+	    // echo is held off only while a line is executing now, by
+	    // tty_echo_before_read()/tty_echo_after_read() around each read
+	    // in _lexscan.c -- nothing to set up here
 	    ed->stdio_setup(stdin_handler);
 	}
 	fprintf(stderr, "ivtools-%s drawserv: type help here for command info %s\n", VersionString, build_stamp(__DATE__, __TIME__, PATCH_KEY));

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -302,10 +302,9 @@ int main (int argc, char** argv) {
 	    if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							  ACE_Event_Handler::READ_MASK)==-1)
 	      cerr << "flipbook: unable to open stdin with ACE\n";
-	    else
-	      tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
-	                        // handler is actually live, or OS echo goes off
-	                        // with no self-echo ever registered to replace it
+	    // echo is held off only while a line is executing now, by
+	    // tty_echo_before_read()/tty_echo_after_read() around each read
+	    // in _lexscan.c -- nothing to set up here
 	    ed->stdio_setup(stdin_handler);
 	}
 

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -279,10 +279,7 @@ int main (int argc, char** argv) {
 	if (ComterpHandler::reactor_singleton()->register_handler(0, stdin_handler,
 							      ACE_Event_Handler::READ_MASK)==-1)
 	  cerr << "graphdraw: unable to open stdin with ACE\n";
-	else
-	  tty_echo_off();  // issue #76 -- see ComUtil/ttyecho.c; only if the
-	                    // handler is actually live, or OS echo goes off
-	                    // with no self-echo ever registered to replace it
+	// echo is held off only while a line executes now (ttyecho.c)
 	ed->stdio_setup(stdin_handler);
     }
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a880a799"
+#define PATCH_KEY "c50d17d8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Follow-on to #76. Typing into `comterp` from a plain terminal shows nothing until Return -- reported for macOS Terminal, and it applies to every terminal emulator.

## Cause

`tty_echo_off()` was called once at startup for any tty and stayed in effect for the whole session (`comterp_/main.c:344` and `:424`, plus the four GUI mains). Under `ICANON` the kernel does not hand the app any characters until Return, so with `ECHO` cleared **nobody** shows the keystrokes: not the kernel, and not comterp, which has not been given them yet. The line only appears afterwards, self-echoed by `_lexscan.c`.

Measured inside live sessions, before this change:

```
idle at the prompt:  -echo
```

## Why it went unnoticed

It works in emacs, but not because emacs is a terminal -- because comint echoes locally into its own buffer, independent of the tty. Before comterp runs, an emacs shell shows each command **twice** (comint local echo plus the pty echo). Inside comterp it still shows twice: comint local echo plus comterp's self-echo. The count never changed, so nothing looked wrong. In a raw terminal the pty echo was the only one, and clearing it left one copy, appearing only after Return.

```
                            while typing        after Return      seen
emacs, before comterp   comint -> buffer        pty echoes        2 copies
emacs, inside comterp   comint -> buffer        comterp self-echo 2 copies
terminal, inside comterp    nothing             comterp self-echo 1 copy
```

## The change

Echo is now held off only across the execution of a line, not the session:

- `tty_echo_before_read()` -- about to block with nothing buffered means a person is about to type, so give the OS its echo back, along with its own line editing (backspace, Ctrl-U). Input already waiting is the rest of a burst, so echo stays off and the line is self-echoed, keeping it interleaved with its own result.
- `tty_echo_after_read()` -- a line has been read and execution is starting, so suppress echo; anything arriving meanwhile is not shown ahead of its result.

The subtlety is not double-showing a paste. A block landing at an idle prompt is echoed by the OS in one go, so those bytes are already on screen; `_pre_echoed` records how many bytes were pending -- and therefore already echoed -- at the moment echo went off, and charges them off line by line so they are not self-echoed a second time. Input that arrives *after* that snapshot was never echoed and still gets self-echoed, which is the case #76 cared about.

Also fixed: `tty_echo_off()` called `atexit()` every time. Harmless when it ran once per session, a slow leak of the atexit table now that echo toggles per line -- registration is guarded.

The four GUI mains no longer call `tty_echo_off()` at startup. They reach the same lexer (`ComterpHandler` calls `read_expr()`, `comhandler.c:130`), so they get this behavior for free.

## Verified

Idle-prompt state, probed from outside the session while it waits at the prompt:

```
before:  -echo
after:    echo
```

Typed slowly through a pty -- one copy of each line, results in order:

```
(comt) 1+2
3
(comt) 3*4
12
```

Pasted as a block at an idle prompt -- echoed once, no duplicate self-echo, results interleaved:

```
(comt) 1+2
3*4
5+6
3
(comt) 12
(comt) 11
```

Piped (non-tty) path unchanged, comterp suite 43/43.

## Known limits

The first pasted block still arrives while echo is on, so the OS shows it all at once rather than line by line -- #76's symptom partially returns for that first block, which is the accepted trade here. Getting both would mean turning `ICANON` off and doing comterp's own line editing, a much larger change to the input path.

Human confirmation of live typing is still worth doing; the automated checks above drive a pty rather than a keyboard.