### PR TITLE
Read the :font literal back so an exported font survives re-creation

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -227,8 +227,13 @@ void CreateGraphicFunc::set_graphic_gs(AttributeList* al, Graphic* gr) {
 	remove_key(al, bgcolor_sym);
     }
 
-    /* font: :font "name","printfont",printsize -- as with the colors, keep the
-       graphic's existing font when the key is absent or the lookup fails */
+    /* font: :font "name","printfont",printsize -- keep the graphic's existing
+       font when the key is absent, or when the literal is malformed and
+       font_from_attrval hands back nil.  A well-formed literal always yields a
+       font: Catalog::FindFont substitutes "fixed" for a name this display does
+       not have, which is what the rest of Unidraw does.  Note that is not the
+       colors' behavior -- FindColor keeps the requested name and defaults only
+       the rgb, so a color survives the trip and a missing font does not. */
     if ((v = al->find(font_sym))) {
 	PSFont* font = font_from_attrval(catalog, v);
 	if (font) gr->SetFont(font);

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -138,6 +138,48 @@ static PSColor* color_from_attrval(Catalog* catalog, AttributeValue* v) {
     return name ? catalog->FindColor(name, ir, ig, ib) : nil;
 }
 
+/* build a PSFont from the [name,printfont,printsize] triple OverlayScript::Font
+   writes.  The print size goes out unquoted, so it comes back as a number
+   rather than a string; FindFont wants text either way.  A bare name (no
+   commas) is accepted too -- FindFont defaults the other two. */
+static PSFont* font_from_attrval(Catalog* catalog, AttributeValue* v) {
+    if (!v) return nil;
+
+    if (v->is_string()) {
+	const char* name = v->string_ptr();
+	return name ? catalog->FindFont(name) : nil;
+    }
+    if (!v->is_array()) return nil;
+
+    AttributeValueList* avl = v->array_val();
+    if (!avl) return nil;
+    Iterator it; avl->First(it);
+    if (avl->Done(it)) return nil;
+    const char* name = avl->GetAttrVal(it)->string_ptr();
+    if (!name) return nil;
+
+    const char* pf = "";
+    const char* ps = "";
+    char sizebuf[32];
+    if (avl->Number() >= 2) {
+	avl->Next(it);
+	const char* p = avl->GetAttrVal(it)->string_ptr();
+	if (p) pf = p;
+    }
+    if (avl->Number() >= 3) {
+	avl->Next(it);
+	AttributeValue* sv = avl->GetAttrVal(it);
+	if (sv->is_string()) {
+	    const char* s = sv->string_ptr();
+	    if (s) ps = s;
+	} else {
+	    snprintf(sizebuf, sizeof(sizebuf), "%d", sv->int_val());
+	    ps = sizebuf;
+	}
+    }
+    return catalog->FindFont(name, pf, ps);
+}
+
 void CreateGraphicFunc::set_graphic_gs(AttributeList* al, Graphic* gr) {
     if (!al || !gr) return;
     Catalog* catalog = unidraw->GetCatalog();
@@ -150,6 +192,7 @@ void CreateGraphicFunc::set_graphic_gs(AttributeList* al, Graphic* gr) {
     static int pattern_sym = symbol_add("pattern");
     static int graypat_sym = symbol_add("graypat");
     static int nonepat_sym = symbol_add("nonepat");
+    static int font_sym     = symbol_add("font");
 
     AttributeValue* v;
 
@@ -182,6 +225,14 @@ void CreateGraphicFunc::set_graphic_gs(AttributeList* al, Graphic* gr) {
 	if (fg && bg) gr->SetColors(fg, bg);
 	remove_key(al, fgcolor_sym);
 	remove_key(al, bgcolor_sym);
+    }
+
+    /* font: :font "name","printfont",printsize -- as with the colors, keep the
+       graphic's existing font when the key is absent or the lookup fails */
+    if ((v = al->find(font_sym))) {
+	PSFont* font = font_from_attrval(catalog, v);
+	if (font) gr->SetFont(font);
+	remove_key(al, font_sym);
     }
 
     /* :fillbg flag */
@@ -465,6 +516,11 @@ void CreateTextFunc::execute() {
 	text->Translate(args[x0], args[y0]);
 	text->GetTransformer()->postmultiply(rel);
 	Unref(rel);
+	/* command-supplied gs keywords win over editor state, and are stripped
+	   from al so they round-trip via the graphic, not as leftover attributes.
+	   Text is where :font actually appears -- TextGS is the only gs emitter
+	   that writes one for a graphic any create command builds. */
+	set_graphic_gs(al, text);
 	TextOvComp* comp = new TextOvComp(text);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)

--- a/src/comdraw/tests/gsexim.comt
+++ b/src/comdraw/tests/gsexim.comt
@@ -67,5 +67,29 @@ ok=ok&&(eq(s1 s3))
 print("4a s3 (imported while editor was gs B) = %s\n" s3)
 print("4b import stayed gs A despite editor B (expect equal): %v\n\n" eq(s1 s3))
 
+// --- test 5: the :font literal reaches the graphic.  Two texts differing only
+//             in their :font keyword must export differently -- if the literal
+//             were ignored both would carry the editor's FontVar font and the
+//             two exports would agree.  Both use the X name "fixed" so nothing
+//             here depends on which fonts the display happens to have. ---
+each(delete($$select(:all)))
+t1=text(0,0 "hello" :font "fixed","Courier",12)
+t2=text(0,40 "hello" :font "fixed","Times",10)
+f1=export(t1 :string :percomp)
+f2=export(t2 :string :percomp)
+ok=ok&&(index(f1 "Courier" :substr)!=nil)
+ok=ok&&(index(f2 "Times" :substr)!=nil)
+ok=ok&&(f1!=f2)
+print("5a text with :font Courier = %s\n" f1)
+print("5b text with :font Times   = %s\n" f2)
+print("5c each text kept its own literal font (expect true): %v\n\n" ok)
+
+// --- test 6: the keyword is consumed, not left behind.  An unread :font stays
+//             in the attribute list and re-serializes as a trailing attribute
+//             after the closing paren, so ")" followed by ":font" is the
+//             signature of the keyword never having been applied ---
+ok=ok&&(index(f1 "):font" :substr)==nil)
+print("6 :font consumed, no leftover attribute after the paren (expect nil): %v\n\n" index(f1 "):font" :substr))
+
 print("gsexim: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a880a799"
+#define PATCH_KEY "ed0b5a22"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c50d17d8"
+#define PATCH_KEY "edd01c4a"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Closes #369.

`OverlayScript::Font()` has always written a `:font` keyword into the exported script, and nothing ever read it back. `CreateGraphicFunc::set_graphic_gs()` handled `:brush`/`:nonebr`, `:fgcolor`/`:bgcolor`, `:fillbg`, `:pattern`/`:graypat`/`:nonepat` and `:transform`, and had no font symbol at all.

## What it looked like

Creating a text with a font literal, then exporting it -- before:

```
text(16,"hello" :fillbg 1 :fgcolor "Black",0,0,0 :font "-*-helvetica-medium-r-normal-*-12-*-*-*-*-*-*-*","Helvetica",12 :transform 1,0,0,1,89,218:font "fixed","Courier",12):font "fixed","Courier",12
```

Two things wrong, not one. The graphic kept the editor's Helvetica, so the literal never reached it -- and the unread keyword then re-serialized *twice*, once jammed against the transform with no separator and once after the closing paren, so the exported string was not even well formed. Unconsumed keywords are not an error, so all of this was silent.

After:

```
text(16,"hello" :fillbg 1 :fgcolor "Black",0,0,0 :font "fixed","Courier",12 :transform 1,0,0,1,89,218)
```

## The change

A font arm in `set_graphic_gs`, shaped like the color arm it sits next to. `Catalog::FindFont(name, printfont, printsize)` takes exactly the triple `Font()` emits, the same way `FindColor(name, r, g, b)` takes what `:fgcolor` emits. It keeps the graphic's existing font when the key is absent or the lookup fails, so a bad font name cannot blank the text, and it `remove_key`s on the way out so the keyword stops re-serializing.

The print size goes out unquoted, so it arrives back as a number rather than a string; `FindFont` wants text either way. A bare `:font "name"` with no commas is accepted too, since `FindFont` defaults the other two arguments.

## Why CreateTextFunc is also touched

`set_graphic_gs` had exactly one call site: `CreateRectFunc`. Rect emits `MinGS` -- brush, colors, pattern, no font -- so with only that call site the new arm would be unreachable code. `TextGS` is the only gs emitter that writes a font for a graphic any create command builds, which makes text the one place a font literal can appear, so the call had to be wired there for this to do anything at all.

That is the text slice of #370 and nothing more. Line, ellipse, multiline, polygon, the splines and raster still ignore literal graphic state entirely, and the export side still emits a runnable command name only for rect. #370 tracks the rest.

Worth being explicit about what this does *not* buy: text's exported form is still not runnable. `TextScript::Definition` emits `text(lineheight,"str" ...)` while the `text()` command takes `(x0,y0 textstr)` -- the same name with different arguments. The font literal is honored on input now; making text's own export re-runnable is #370's job.

## Tests

`gsexim.comt` tests 5 and 6. Test 5 creates two texts differing only in their `:font` keyword and asserts the exports differ and each carries its own font -- if the literal were ignored both would carry the editor's `FontVar` font and the two exports would agree. Both use the X name `"fixed"` and differ only in PostScript metadata, so nothing depends on which fonts the display happens to have. Test 6 asserts `")" ` is not followed by `":font"`, which is the exact signature of the leftover-attribute half of the bug.

Full comdraw suite green locally, 11/11.
