### PR TITLE
Honor literal graphic state in every create command, and emit flat point lists under :percomp

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -863,14 +863,19 @@ void CreateRasterFunc::execute() {
       
       OverlayRasterRect* rasterrect = new OverlayRasterRect(raster, stdgraphic);
       
-#if 1
       Transformer* t = new Transformer();
       t->Translate(dcoords[x0], dcoords[y0]);
       rasterrect->SetTransformer(t);
       Unref(t);
-#else
-      Transformer* rel = get_transformer(al);
-#endif
+      /* the screen coords imply the translate above, so the viewer-relative
+         transformer the other create commands start from would double it --
+         but an explicit :transform off a re-created command still has to win */
+      if (al && al->find(symbol_add("transform"))) {
+	Transformer* rel = get_transformer(al);
+	rasterrect->SetTransformer(rel);
+	Unref(rel);
+      }
+      set_graphic_gs(al, rasterrect);
       
       RasterOvComp* comp = new RasterOvComp(rasterrect);
       comp->SetAttributeList(al);
@@ -937,6 +942,12 @@ RasterOvComp* CreateRasterFunc::create_from_rgb(ComValue& rgbv, AttributeList* a
 
     Transformer* rel = get_transformer(al);
     if (rel) rasterrect->SetTransformer(rel);
+    Unref(rel);
+    set_graphic_gs(al, rasterrect);
+    /* the pixels now live in the raster, so drop the keyword that carried them
+       -- left in the list it re-serializes as a trailing attribute alongside
+       the raster's own emitted pixel data */
+    remove_key(al, symbol_add("rgb"));
 
     RasterOvComp* comp = new RasterOvComp(rasterrect);
     comp->SetAttributeList(al);

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -386,6 +386,7 @@ void CreateLineFunc::execute() {
             }
 	line->SetTransformer(rel);
 	Unref(rel);
+	set_graphic_gs(al, line);
 	ArrowLineOvComp* comp = new ArrowLineOvComp(line);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)
@@ -450,6 +451,7 @@ void CreateEllipseFunc::execute() {
             }
 	ellipse->SetTransformer(rel);
 	Unref(rel);
+	set_graphic_gs(al, ellipse);
 	EllipseOvComp* comp = new EllipseOvComp(ellipse);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)
@@ -587,6 +589,7 @@ void CreateMultiLineFunc::execute() {
             }
 	multiline->SetTransformer(rel);
 	Unref(rel);
+	set_graphic_gs(al, multiline);
 	ArrowMultiLineOvComp* comp = new ArrowMultiLineOvComp(multiline);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)
@@ -653,6 +656,7 @@ void CreateOpenSplineFunc::execute() {
             }
 	openspline->SetTransformer(rel);
 	Unref(rel);
+	set_graphic_gs(al, openspline);
 	ArrowSplineOvComp* comp = new ArrowSplineOvComp(openspline);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)
@@ -717,6 +721,7 @@ void CreatePolygonFunc::execute() {
             }
 	polygon->SetTransformer(rel);
 	Unref(rel);
+	set_graphic_gs(al, polygon);
 	PolygonOvComp* comp = new PolygonOvComp(polygon);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)
@@ -782,6 +787,7 @@ void CreateClosedSplineFunc::execute() {
             }
 	closedspline->SetTransformer(rel);
 	Unref(rel);
+	set_graphic_gs(al, closedspline);
 	ClosedSplineOvComp* comp = new ClosedSplineOvComp(closedspline);
 	comp->SetAttributeList(al);
 	if (PasteModeFunc::paste_mode()==0)

--- a/src/ComUnidraw/unifunc.c
+++ b/src/ComUnidraw/unifunc.c
@@ -470,14 +470,23 @@ void ExportFunc::execute() {
        to run, vs the drawtool() document the default/socket export sends to
        another editor's import port. */
     boolean percomp_mode = percomp.is_true();
-    if (percomp_mode) OverlayScript::percomp_format(true);
+    /* the create commands take a flat coordinate run, not parenthesized pairs,
+       so a runnable emission has to drop the parens -- the same reason DrawServ
+       drops them before serializing a command for another editor to execute */
+    boolean old_ptlist_parens = OverlayScript::ptlist_parens();
+    if (percomp_mode) {
+      OverlayScript::percomp_format(true);
+      OverlayScript::ptlist_parens(false);
+    }
     ostream* out = new std::strstream();
 
     if (!compviewv.is_array()) {
 
       ComponentView* view = (ComponentView*)compviewv.obj_val();
       OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
-      if (!comp) { if (percomp_mode) OverlayScript::percomp_format(false); delete out; return; }
+      if (!comp) { if (percomp_mode) { OverlayScript::percomp_format(false);
+	                               OverlayScript::ptlist_parens(old_ptlist_parens); }
+	           delete out; return; }
       if (!eps_flag.is_true() && !idraw_flag.is_true()) {
 	if (!percomp_mode) *out << appname() << "(\n";
 	compout(comp, out);
@@ -526,7 +535,10 @@ void ExportFunc::execute() {
 
     }
     
-    if (percomp_mode) OverlayScript::percomp_format(false);
+    if (percomp_mode) {
+      OverlayScript::percomp_format(false);
+      OverlayScript::ptlist_parens(old_ptlist_parens);
+    }
     *out << '\0'; out->flush();
     const char* result = ((std::strstream*)out)->str();
 

--- a/src/comdraw/tests/gsexim.comt
+++ b/src/comdraw/tests/gsexim.comt
@@ -91,5 +91,40 @@ print("5c each text kept its own literal font (expect true): %v\n\n" ok)
 ok=ok&&(index(f1 "):font" :substr)==nil)
 print("6 :font consumed, no leftover attribute after the paren (expect nil): %v\n\n" index(f1 "):font" :substr))
 
+// --- test 7: every create command honors literal graphic state, not just
+//             rect.  rt() exports a graphic, changes the editor gs out from
+//             under it, re-creates from that very string and exports again --
+//             equal means the gs rode in on the command.  Same shape as tests
+//             3 and 4, run across each kind of graphic. ---
+rt=func(nm=arg(0); g=arg(1);
+  s1=export(g :string :percomp);
+  brush(0,0); colors(`Blue `Yellow);
+  s2=export(run(s1 :str) :string :percomp);
+  same=eq(s1 s2);
+  if(!same :then (print("   %s s1=%s\n" nm s1); print("   %s s2=%s\n" nm s2)));
+  brush(65535,0); colors(`Red `White);
+  same
+  :posteval)
+
+each(delete($$select(:all)))
+brush(65535,0); colors(`Red `White)
+r7a=rt("line        " line(0,0,50,50))
+r7b=rt("ellipse     " ellipse(60,60,20,10))
+ok=ok&&r7a&&r7b
+print("7 line and ellipse round-trip under a changed editor gs (expect true true): %v %v\n\n" r7a r7b)
+
+// --- test 8: the point-list graphics.  These also need :percomp to emit the
+//             flat coordinate run the create commands accept -- with the
+//             parenthesized pairs of the file format, re-creation reads only
+//             the first point and the geometry collapses. ---
+each(delete($$select(:all)))
+brush(65535,0); colors(`Red `White)
+r8a=rt("multiline   " multiline(0,0,20,20,40,0))
+r8b=rt("polygon     " polygon(60,0,80,20,100,0))
+r8c=rt("openspline  " openspline(0,60,20,80,40,60))
+r8d=rt("closedspline" closedspline(60,60,80,80,100,60))
+ok=ok&&r8a&&r8b&&r8c&&r8d
+print("8 multiline/polygon/openspline/closedspline round-trip (expect 4 true): %v %v %v %v\n\n" r8a r8b r8c r8d)
+
 print("gsexim: %v\n" ok)
 ok

--- a/src/comdraw/tests/gsexim.comt
+++ b/src/comdraw/tests/gsexim.comt
@@ -126,5 +126,19 @@ r8d=rt("closedspline" closedspline(60,60,80,80,100,60))
 ok=ok&&r8a&&r8b&&r8c&&r8d
 print("8 multiline/polygon/openspline/closedspline round-trip (expect 4 true): %v %v %v %v\n\n" r8a r8b r8c r8d)
 
+// --- test 9: raster.  Its gs comes from the graphic's own defaults rather
+//             than the editor, so the round trip is what matters here: the
+//             re-created raster must export identically.  This caught a
+//             second leftover -- :rgb carries the pixels in, and once the gs
+//             stopped re-serializing it was the remaining keyword still being
+//             echoed back out alongside the raster's own pixel data. ---
+each(delete($$select(:all)))
+ra=raster(0,0,8,8)
+q1=export(ra :string :percomp)
+q2=export(run(q1 :str) :string :percomp)
+r9=eq(q1 q2)
+ok=ok&&r9
+print("9 raster export re-creates and re-exports identically (expect true): %v\n\n" r9)
+
 print("gsexim: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "ed0b5a22"
+#define PATCH_KEY "97de00c1"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Part of #370. Stacked on #372 (`font-literal-roundtrip`), which carries the `CreateTextFunc` call site this builds on -- review or merge that one first.

`CreateGraphicFunc::set_graphic_gs()` had exactly one caller, `CreateRectFunc`. Every other create command pulled `BrushVar`/`PatternVar`/`ColorVar` off the editor and ignored the literal graphic-state keywords entirely.

## What it looked like

Export a red line, change the editor to blue, re-create from that exported string, export again -- before:

```
arrowline(0,0,50,50 :fillbg 1 :brush 0,0 :fgcolor "Blue",0,0,1 :bgcolor "Yellow",1,1,0 :graypat 0 :transform 1,0,0,1,89,163:fillbg 1 :brush 65535,0 :fgcolor "Red",1,0,0 … :transform 1,0,0,1,89,163):fillbg 1 :brush 65535,0 …
```

Two failures, the same pair the font hole had. The graphic came back blue -- the editor's state, not the script's -- and every unread keyword then re-serialized twice, once jammed against the transform with no separator and once past the closing paren, so the string was not even well formed. After, it round-trips exactly.

## The two changes

**`set_graphic_gs` from every create command.** Six call sites added -- line, ellipse, multiline, polygon, openspline, closedspline -- at the same point rect uses it: after the editor defaults and the transformer, before the comp is built, so literals win and are stripped from the attribute list.

**`:percomp` emits flat coordinate runs.** The point-list graphics need this or they still do not round-trip: the file format writes `((0,0),(20,20),(40,0))` while `multiline`/`polygon`/`openspline`/`closedspline` take a flat run, so re-creation read only the first point and the geometry collapsed to `(0,0)`. `OverlayScript::ptlist_parens(false)` is exactly the switch for this, and `DrawServ::ExecuteCmd` already sets it before serializing a command for another editor to execute -- same reason, same fix, now applied to the other place that emits runnable commands. Saved and restored around the export, as `percomp_format` already is, including on the early-return path.

Worth noting what this reveals: rect needed `percomp_format` only because its script name is `rectangle(` while its command is `rect(`. Line, ellipse and the point-list graphics already emit their own command's name with matching arguments, so honoring the literals was the only thing missing for them.

## Not included

~~**Raster.**~~ Now included -- see the follow-up commit. The blocker was an `#if 1`/`#else` that hid `get_transformer(al)` behind dead code, and `git log -S` dates that switch to the initial ivtools-1.2.11 import, so it was an ancient either/or rather than a considered choice. Resolved by keeping the screen-coord translate (the viewer-relative transformer the other commands start from would double it) and letting an explicit `:transform` override it, which is the case a re-created command actually needs. Both raster paths now call `set_graphic_gs`.

Two things fell out of doing it. `create_from_rgb` was leaking the transformer it built -- every other site `Unref`s it -- and `:rgb` was consumed to fill the pixels but never stripped, so once the gs stopped re-serializing, `:rgb` was left echoing the whole pixel run back out as a trailing attribute beside the raster's own emitted data. Same class as the `:font` bug in #372, and only visible once everything around it was clean.

**Text's export.** Still not runnable: `TextScript::Definition` emits `text(lineheight,"str" …)` while the `text()` command takes `(x0,y0 textstr)` -- the same name at different arity. #372 made text honor a `:font` literal on input; making its own export re-runnable is separate and stays in #370.

## Tests

`gsexim.comt` tests 7 and 8, using the same discrimination as tests 3 and 4: export, change the editor gs out from under it, re-create from that very string, export again, expect equal. Test 7 covers line and ellipse, test 8 the four point-list graphics.

Full comdraw suite green locally, 11/11. The drawserv `gstests.comt` path needs the multi-node drawmo harness, so that one is on CI.

