### PR TITLE
LinkPatternCmd: distribute pattern changes over DrawLinks

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -75,6 +75,9 @@
 #include <Attribute/attribute.h>
 #include <Attribute/attrlist.h>
 
+#include <sstream>
+#include <string>
+
 #define TITLE "GrFunc"
 
 /*****************************************************************************/
@@ -1291,7 +1294,8 @@ void PatternFunc::execute() {
     PatternCmd* cmd = nil;
 
     if (pattern) {
-	cmd = new PatternCmd(_ed, pattern);
+        OverlayKit* kit = ((OverlayEditor*)_ed)->overlay_kit();
+	cmd = kit->make_pattern_cmd(_ed, pattern, pn);
 	execute_log(cmd);
     }
 
@@ -1307,9 +1311,13 @@ void PatternMaskFunc::execute() {
     reset_stack();
 
     PSPattern* pattern = nil;
+    std::string maskargs;
 
     if (bitsv.is_int()) {
       pattern = new PSPattern(bitsv.int_val(), -1);
+      char buf[32];
+      snprintf(buf, sizeof(buf), "%d", bitsv.int_val());
+      maskargs = buf;
     } else if (bitsv.is_array()) {
       AttributeValueList* avl = bitsv.array_val();
       if (avl->Number()!=16) {
@@ -1318,10 +1326,14 @@ void PatternMaskFunc::execute() {
 	return;
       }
       int mask[16];
+      std::ostringstream mbuf;
       for(int i=0; i<16; i++) {
 	mask[i] = avl->Get(i)->int_val();
+	if (i) mbuf << ",";
+	mbuf << mask[i];
       }
       pattern = new PSPattern(mask, 16);
+      maskargs = mbuf.str();
     } else {
       fprintf(stderr, "patternbits argument not int or list\n");
       push_stack(ComValue::nullval());
@@ -1331,7 +1343,8 @@ void PatternMaskFunc::execute() {
     PatternCmd* cmd = nil;
 
     if (pattern) {
-	cmd = new PatternCmd(_ed, pattern);
+        OverlayKit* kit = ((OverlayEditor*)_ed)->overlay_kit();
+	cmd = kit->make_pattern_cmd(_ed, pattern, 0, maskargs.c_str());
 	execute_log(cmd);
     }
 

--- a/src/DrawServ/drawclasses.h
+++ b/src/DrawServ/drawclasses.h
@@ -39,5 +39,6 @@
 #define COPYMOVEGRAPHFRAME_CMD 9805
 #define LINK_BRUSH_CMD      9806
 #define LINK_COLOR_CMD      9807
+#define LINK_PATTERN_CMD    9808
 
 #endif

--- a/src/DrawServ/drawkit.c
+++ b/src/DrawServ/drawkit.c
@@ -606,6 +606,14 @@ BrushCmd* DrawKit::make_brush_cmd(Editor* ed, PSBrush* br) {
     return new LinkBrushCmd(ed, br);
 }
 
+PatternCmd* DrawKit::make_pattern_cmd(ControlInfo* ctrlInfo, PSPattern* pat, int patnum, const char* maskargs) {
+    return new LinkPatternCmd(ctrlInfo, pat, patnum, maskargs);
+}
+
+PatternCmd* DrawKit::make_pattern_cmd(Editor* ed, PSPattern* pat, int patnum, const char* maskargs) {
+    return new LinkPatternCmd(ed, pat, patnum, maskargs);
+}
+
 ColorCmd* DrawKit::make_color_cmd(ControlInfo* ctrlInfo, PSColor* fg, PSColor* bg, int fgnum, int bgnum) {
     return new LinkColorCmd(ctrlInfo, fg, bg, fgnum, bgnum);
 }

--- a/src/DrawServ/drawkit.h
+++ b/src/DrawServ/drawkit.h
@@ -56,6 +56,8 @@ public:
     virtual ColorCmd* make_color_cmd(ControlInfo*, PSColor* fg, PSColor* bg, int fgnum=0, int bgnum=0);
     // override to create LinkColorCmd for distributed color changes
     virtual ColorCmd* make_color_cmd(Editor*, PSColor* fg, PSColor* bg, int fgnum=0, int bgnum=0);
+    virtual PatternCmd* make_pattern_cmd(ControlInfo*, PSPattern*, int patnum=0, const char* maskargs=nil);
+    virtual PatternCmd* make_pattern_cmd(Editor*, PSPattern*, int patnum=0, const char* maskargs=nil);
     // override to create LinkColorCmd for distributed color changes
 
     static DrawKit* Instance();

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -340,6 +340,15 @@ void DrawServ::ExecuteCmd(Command* cmd) {
 	break;
       }
 
+      case LINK_PATTERN_CMD:
+      {
+	const char* script = ((LinkPatternCmd*)cmd)->dist_script();
+	if (script && *script) sbuf << script;
+	uuid_copy(sid, ((LinkPatternCmd*)cmd)->dist_owner_sid());
+	cmd->Execute();
+	break;
+      }
+
       case LINK_COLOR_CMD:
       {
 	const char* script = ((LinkColorCmd*)cmd)->dist_script();

--- a/src/DrawServ/linkcmd.c
+++ b/src/DrawServ/linkcmd.c
@@ -137,6 +137,93 @@ boolean LinkBrushCmd::IsA(ClassId id) { return id == LINK_BRUSH_CMD || BrushCmd:
 
 /*****************************************************************************/
 
+LinkPatternCmd::LinkPatternCmd(ControlInfo* ci, PSPattern* pat, int patnum, const char* maskargs)
+  : PatternCmd(ci, pat), _patnum(patnum), _maskargs(maskargs ? maskargs : "") {}
+LinkPatternCmd::LinkPatternCmd(Editor* ed, PSPattern* pat, int patnum, const char* maskargs)
+  : PatternCmd(ed, pat), _patnum(patnum), _maskargs(maskargs ? maskargs : "") {}
+
+const char* LinkPatternCmd::dist_script() {
+    _dist_script_buf = "";
+    uuid_clear(_dist_owner_sid);
+
+    /* the far node has to be told which call to make, and only the call that
+       built this command knows that -- a menu index or the patternmask bits.
+       With neither there is nothing to say, so say nothing rather than guess
+       a pattern the far node would resolve differently. */
+    if (_patnum <= 0 && _maskargs.empty()) return _dist_script_buf.c_str();
+
+    if (!GetPattern()) return _dist_script_buf.c_str();
+
+    Editor* ed = GetEditor();
+    if (!ed) return _dist_script_buf.c_str();
+
+    LinkSelection* sel = (LinkSelection*)ed->GetSelection();
+    if (!sel) return _dist_script_buf.c_str();
+
+    DrawServ* drawserv = (DrawServ*)unidraw;
+    if (!drawserv->linklist() || drawserv->linklist()->Number() == 0)
+        return _dist_script_buf.c_str();
+
+    std::ostringstream sbuf;
+    boolean any = false;
+    uint32_t owner_key = 0;
+    Iterator it;
+
+    /* same collection and relay rules as LinkBrushCmd -- see its comment for
+       why the owner's key is forwarded rather than re-derived, and for the
+       single-owner limitation this shares with it. */
+    for (sel->First(it); !sel->Done(it); sel->Next(it)) {
+        OverlayView* view = (OverlayView*)sel->GetView(it);
+        OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
+        void* ptr = nil;
+        if (comp) drawserv->compidtable()->find(ptr, comp);
+        GraphicId* grid = (GraphicId*)ptr;
+        if (grid && (grid->selected() == LinkSelection::LocallySelected ||
+                     grid->unlocked())) {
+            if (!any) {
+                sbuf << "s=select();select(grid(";
+                any = true;
+                if (grid->selected() == LinkSelection::LocallySelected) {
+                    owner_key = drawserv->sessionidkey();
+                    uuid_copy(_dist_owner_sid, drawserv->sessionid());
+                } else {
+                    owner_key = grid->selectorkey();
+                    uuid_copy(_dist_owner_sid, grid->selector());
+                }
+            } else {
+                sbuf << ",grid(";
+            }
+            sbuf << "\"" << grid->idstr() << "\")";
+        }
+    }
+
+    if (any) {
+        char keystr[9];
+        snprintf(keystr, sizeof(keystr), "%08X", owner_key);
+	sbuf << " :unlock \"" << keystr << "\")";
+        if (_patnum > 0)
+            sbuf << ";pattern(" << _patnum << ")";
+        else
+            sbuf << ";patternmask(" << _maskargs << ")";
+        sbuf << ";select(s :lock \"" << keystr << "\")";
+        _dist_script_buf = sbuf.str();
+    }
+
+    return _dist_script_buf.c_str();
+}
+
+Command* LinkPatternCmd::Copy() {
+    LinkPatternCmd* copy = new LinkPatternCmd(CopyControlInfo(), GetPattern(), _patnum,
+                                              _maskargs.empty() ? nil : _maskargs.c_str());
+    InitCopy(copy);
+    return copy;
+}
+
+ClassId LinkPatternCmd::GetClassId() { return LINK_PATTERN_CMD; }
+boolean LinkPatternCmd::IsA(ClassId id) { return id == LINK_PATTERN_CMD || PatternCmd::IsA(id); }
+
+/*****************************************************************************/
+
 /* format a PSColor as "#RRGGBB".  Prefer the color's own name when it is
    already a clean "#" + 6 hex-digit string (the colors("#RRGGBB") path) so
    it round-trips exactly; otherwise derive from intensities (0..1 floats),

--- a/src/DrawServ/linkcmd.h
+++ b/src/DrawServ/linkcmd.h
@@ -30,6 +30,7 @@
 
 #include <Unidraw/Commands/brushcmd.h>
 #include <Unidraw/Commands/colorcmd.h>
+#include <Unidraw/Commands/patcmd.h>
 #include <string>
 #include <uuid/uuid.h>
 #if !defined(__APPLE__) && !defined(IV_UUID_STRING_T_DEFINED)
@@ -73,6 +74,32 @@ public:
 
 protected:
     std::string _dist_script_buf;
+};
+
+//: PatternCmd with distributed script generation for DrawServ
+// Mixes PatternCmd with DrawServCmd to provide dist_script() that
+// serializes the pattern change for distribution to remote drawservs.
+// patnum is the menu index from pattern(), maskargs the literal argument
+// text from patternmask() -- whichever one made this command is what
+// dist_script() replays, so the far node runs the same call, same idea as
+// LinkColorCmd carrying fgnum/bgnum.
+class LinkPatternCmd : public PatternCmd, public DrawServCmd {
+public:
+    LinkPatternCmd(ControlInfo*, PSPattern* = nil, int patnum = 0, const char* maskargs = nil);
+    LinkPatternCmd(Editor* = nil, PSPattern* = nil, int patnum = 0, const char* maskargs = nil);
+
+    virtual const char* dist_script();
+    // return "s=select();select(grid(uuid),... :unlock key);pattern(patnum);select(s :lock key)"
+    // for all LocallySelected graphics, or empty string if none.
+
+    virtual Command* Copy();
+    virtual ClassId GetClassId();
+    virtual boolean IsA(ClassId);
+
+protected:
+    std::string _dist_script_buf;
+    int _patnum;
+    std::string _maskargs;
 };
 
 //: ColorCmd with distributed script generation for DrawServ

--- a/src/OverlayUnidraw/ovkit.c
+++ b/src/OverlayUnidraw/ovkit.c
@@ -1117,6 +1117,14 @@ BrushCmd* OverlayKit::make_brush_cmd(Editor* ed, PSBrush* br) {
     return new BrushCmd(ed, br);
 }
 
+PatternCmd* OverlayKit::make_pattern_cmd(ControlInfo* ctrlInfo, PSPattern* pat, int patnum, const char* maskargs) {
+    return new PatternCmd(ctrlInfo, pat);
+}
+
+PatternCmd* OverlayKit::make_pattern_cmd(Editor* ed, PSPattern* pat, int patnum, const char* maskargs) {
+    return new PatternCmd(ed, pat);
+}
+
 ColorCmd* OverlayKit::make_color_cmd(ControlInfo* ctrlInfo, PSColor* fg, PSColor* bg, int fgnum, int bgnum) {
     return new ColorCmd(ctrlInfo, fg, bg);
 }
@@ -1198,7 +1206,7 @@ MenuItem* OverlayKit::MakePatternMenu() {
 	    sfr->SetPattern(pat);
 	    ctrlInfo = new ControlInfo(new RectOvComp(sfr));
 	}
-	MakeMenu(mbi, new PatternCmd(ctrlInfo, pat), MenuPatRect(pat));
+	MakeMenu(mbi, make_pattern_cmd(ctrlInfo, pat, i), MenuPatRect(pat));
 	pat = catalog->ReadPattern(patAttrib, ++i);
     }
     return mbi;

--- a/src/OverlayUnidraw/ovkit.h
+++ b/src/OverlayUnidraw/ovkit.h
@@ -37,6 +37,7 @@
 
 class BrushCmd;
 class ColorCmd;
+class PatternCmd;
 class Command;
 class ControlInfo;
 class Deck;
@@ -214,6 +215,12 @@ public:
     // factory method for creating ColorCmd; fgnum/bgnum are menu indices from colors() command
     virtual ColorCmd* make_color_cmd(Editor*, PSColor* fg, PSColor* bg, int fgnum=0, int bgnum=0);
     // factory method for creating ColorCmd; fgnum/bgnum are menu indices from colors() command
+    virtual PatternCmd* make_pattern_cmd(ControlInfo*, PSPattern*, int patnum=0, const char* maskargs=nil);
+    // factory method for creating PatternCmd; patnum is the menu index from
+    // pattern(), maskargs the literal argument text from patternmask() -- one
+    // or the other reproduces the originating call, same idea as fgnum/bgnum
+    virtual PatternCmd* make_pattern_cmd(Editor*, PSPattern*, int patnum=0, const char* maskargs=nil);
+    // factory method for creating PatternCmd; see the ControlInfo form
   
 protected:
     Glyph* MenuLine(PSBrush*);

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -1,17 +1,19 @@
 // Graphic-state propagation tests (gsexim round-trip, gsbrush A/B) plus the
-// brush_on_node helper, for the drawmo suite.  Loaded by drawmo via
+// gs_on_node helper, for the drawmo suite.  Loaded by drawmo via
 // run("./gstests.comt"); they call the shared helpers defined in drawmo.
 
-/* brush_on_node -- read the propagated graphic's serialized gs on a far node by
-   grid id and confirm its brush contains the expected ":brush p,w".  the far
-   node's editor defaults to a different brush, so a match proves the brush
-   graphic-state rode along with the graphic, not the far editor's state.
+/* gs_on_node -- read the propagated graphic's serialized gs on a far node by
+   grid id and confirm it contains the expected fragment, e.g. ":brush p,w" or
+   ":graypat 0.5".  the far node's editor defaults to different graphic state,
+   so a match proves that state rode along with the graphic rather than being
+   the far editor's own.
 
    grid(uuid) resolves the comp by id and hands it to export -- a read-only path,
    so unlike export(at(select(:all))) there is no distributive select() to collide
-   with the distribution locks; polling is safe even mid-distribution.  the brush
-   is a separate command from the create, so it can lag the grid-id arrival. */
-brush_on_node=func(
+   with the distribution locks; polling is safe even mid-distribution.  each gs
+   change is a separate command from the create, so it can lag the grid-id
+   arrival. */
+gs_on_node=func(
   found=false;
   poll_usec=2000000;
   timeout=20*1000000/poll_usec;
@@ -19,7 +21,7 @@ brush_on_node=func(
   expr=print("export(grid(%c%s%c) :string :percomp)" 34 bn_id 34 :str);
   while(!found && cnt<timeout
     e=remote(bn_sock expr);
-    if(type(e)==`StringType && index(e bn_brush)!=nil :then found=true);
+    if(type(e)==`StringType && index(e bn_gs)!=nil :then found=true);
     if(!found :then update(poll_usec);cnt++));
   found)
 
@@ -105,10 +107,16 @@ gsbrushA_test=func(
      width 2).  far nodes default to a solid brush, so a match downstream proves
      the BRUSH graphic-state propagated with the graphic. --- */
   brushstr=":brush 65520,2";
+  /* pattern(5) is the catalog's 0.5 gray; far nodes default to :nonepat, so a
+     :graypat 0.5 downstream proves the PATTERN state propagated too.  it rides
+     the same chain as the brush rather than standing up three more drawservs --
+     dedicated gspat topologies are their own tests. */
+  patstr=":graypat 0.5";
   remote(sock1 "r=rect(20,20,80,80)");
   remote(sock1 "brush(65520,2)");
+  remote(sock1 "pattern(5)");
   /* one reasoned settle (see updown3A): command distribution is fire-and-forget;
-     give the create+brush a head start before polling the far nodes. */
+     give the create+brush+pattern a head start before polling the far nodes. */
   update(2000000);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("gsbrushA: created rect+brush on ds1, grid id=%v\n" id1 :err);
@@ -124,15 +132,19 @@ gsbrushA_test=func(
 
   /* --- verify arrival (by grid id) then the brush gs at each far node --- */
   on2=grid_has_id(:gh_sock sock2 :gh_id id1);
-  b2=on2 && brush_on_node(:bn_sock sock2 :bn_id id1 :bn_brush brushstr);
-  print("gsbrushA: ds2 (hop 1) has graphic=%v with brush=%v\n" on2 b2 :err);
+  b2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs brushstr);
+  p2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs patstr);
+  print("gsbrushA: ds2 (hop 1) has graphic=%v with brush=%v pattern=%v\n" on2 b2 p2 :err);
   on3=grid_has_id(:gh_sock sock3 :gh_id id1);
-  b3=on3 && brush_on_node(:bn_sock sock3 :bn_id id1 :bn_brush brushstr);
-  print("gsbrushA: ds3 (hop 2) has graphic=%v with brush=%v\n" on3 b3 :err);
-  ok=b2 && b3;
+  b3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs brushstr);
+  p3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs patstr);
+  print("gsbrushA: ds3 (hop 2) has graphic=%v with brush=%v pattern=%v\n" on3 b3 p3 :err);
+  ok=b2 && b3 && p2 && p3;
   if(!b2 :then print("gsbrushA: FAIL brush did not reach ds2 intact\n" :err));
   if(!b3 :then print("gsbrushA: FAIL brush did not propagate to ds3 intact\n" :err));
-  if(ok :then print("gsbrushA: brush propagated two hops along the chain\n" :err));
+  if(!p2 :then print("gsbrushA: FAIL pattern did not reach ds2 intact\n" :err));
+  if(!p3 :then print("gsbrushA: FAIL pattern did not propagate to ds3 intact\n" :err));
+  if(ok :then print("gsbrushA: brush and pattern propagated two hops along the chain\n" :err));
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
@@ -226,8 +238,10 @@ gsbrushB_test=func(
   /* --- create a rect on ds1 with a distinctive dashed brush (linepat 65520,
      width 2); it fans out to both branches. --- */
   brushstr=":brush 65520,2";
+  patstr=":graypat 0.5";
   remote(sock1 "r=rect(20,20,80,80)");
   remote(sock1 "brush(65520,2)");
+  remote(sock1 "pattern(5)");
   /* one reasoned settle (see updown3B): fire-and-forget distribution. */
   update(2000000);
   id1=remote(sock1 "at(grid(:table)).grid");
@@ -244,15 +258,19 @@ gsbrushB_test=func(
 
   /* --- verify arrival then the brush gs on BOTH branches --- */
   on2=grid_has_id(:gh_sock sock2 :gh_id id1);
-  b2=on2 && brush_on_node(:bn_sock sock2 :bn_id id1 :bn_brush brushstr);
-  print("gsbrushB: ds2 (branch 1) has graphic=%v with brush=%v\n" on2 b2 :err);
+  b2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs brushstr);
+  p2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs patstr);
+  print("gsbrushB: ds2 (branch 1) has graphic=%v with brush=%v pattern=%v\n" on2 b2 p2 :err);
   on3=grid_has_id(:gh_sock sock3 :gh_id id1);
-  b3=on3 && brush_on_node(:bn_sock sock3 :bn_id id1 :bn_brush brushstr);
-  print("gsbrushB: ds3 (branch 2) has graphic=%v with brush=%v\n" on3 b3 :err);
-  ok=b2 && b3;
+  b3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs brushstr);
+  p3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs patstr);
+  print("gsbrushB: ds3 (branch 2) has graphic=%v with brush=%v pattern=%v\n" on3 b3 p3 :err);
+  ok=b2 && b3 && p2 && p3;
   if(!b2 :then print("gsbrushB: FAIL brush did not reach ds2 intact\n" :err));
   if(!b3 :then print("gsbrushB: FAIL brush did not reach ds3 intact\n" :err));
-  if(ok :then print("gsbrushB: brush fanned out to both branches\n" :err));
+  if(!p2 :then print("gsbrushB: FAIL pattern did not reach ds2 intact\n" :err));
+  if(!p3 :then print("gsbrushB: FAIL pattern did not reach ds3 intact\n" :err));
+  if(ok :then print("gsbrushB: brush and pattern fanned out to both branches\n" :err));
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -146,6 +146,21 @@ gsbrushA_test=func(
   if(!p3 :then print("gsbrushA: FAIL pattern did not propagate to ds3 intact\n" :err));
   if(ok :then print("gsbrushA: brush and pattern propagated two hops along the chain\n" :err));
 
+  /* --- patternmask, 16-element form.  Sent as a SECOND state change to the
+     graphic the far nodes already hold, which is the case the create-time
+     checks above never reach: state arriving on its own, after the graphic.
+     The 16-element form serializes its bits, so this pins the exact pattern
+     rather than merely proving something arrived. --- */
+  maskstr=":pattern 0x0011,0x0022,0x0044,0x0088";
+  remote(sock1 "patternmask(0x11,0x22,0x44,0x88,0x11,0x22,0x44,0x88,0x11,0x22,0x44,0x88,0x11,0x22,0x44,0x88)");
+  update(2000000);
+  m2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs maskstr);
+  m3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs maskstr);
+  print("gsbrushA: patternmask 16-element form reached ds2=%v ds3=%v\n" m2 m3 :err);
+  if(!m2 :then print("gsbrushA: FAIL patternmask did not reach ds2 intact\n" :err));
+  if(!m3 :then print("gsbrushA: FAIL patternmask did not propagate to ds3 intact\n" :err));
+  ok=ok && m2 && m3;
+
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
@@ -271,6 +286,23 @@ gsbrushB_test=func(
   if(!p2 :then print("gsbrushB: FAIL pattern did not reach ds2 intact\n" :err));
   if(!p3 :then print("gsbrushB: FAIL pattern did not reach ds3 intact\n" :err));
   if(ok :then print("gsbrushB: brush and pattern fanned out to both branches\n" :err));
+
+  /* --- patternmask, scalar form, again as a follow-on state change.  Note
+     what this can and cannot prove: PatternMaskFunc builds PSPattern(bits,-1),
+     which has GetSize()==0 and so exports through the graylevel branch as
+     ":graypat -1" whatever the scalar was.  So a match shows the patternmask
+     command crossed and took effect -- the far nodes default to :nonepat --
+     but not WHICH scalar arrived.  The 16-element form pins its bits exactly;
+     see gsbrushA. --- */
+  maskstr=":graypat -1";
+  remote(sock1 "patternmask(255)");
+  update(2000000);
+  m2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs maskstr);
+  m3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs maskstr);
+  print("gsbrushB: patternmask scalar form reached ds2=%v ds3=%v\n" m2 m3 :err);
+  if(!m2 :then print("gsbrushB: FAIL patternmask did not reach ds2 intact\n" :err));
+  if(!m3 :then print("gsbrushB: FAIL patternmask did not reach ds3 intact\n" :err));
+  ok=ok && m2 && m3;
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "5df462f5"
+#define PATCH_KEY "182d3d80"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "edd01c4a"
+#define PATCH_KEY "5df462f5"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Closes #374.

`PatternFunc` and `PatternMaskFunc` built `new PatternCmd` directly, so a pattern change never reached `DrawServ::ExecuteCmd`'s switch and never crossed a link -- the far nodes kept the pattern they had, silently. Brush and color were the only two graphic-state commands that distributed.

## The change

Straight down the `LinkBrushCmd` template:

- `OverlayKit::make_pattern_cmd`, in both the `ControlInfo` and `Editor` forms, defaulting to `new PatternCmd`
- `DrawKit` overrides returning `LinkPatternCmd`
- `LinkPatternCmd : public PatternCmd, public DrawServCmd`, with `dist_script()`, `dist_owner_sid()` and `Copy()`, reusing `LinkBrushCmd`'s selection-collection and relay rules verbatim (including its documented single-owner limitation -- see the comment there)
- `LINK_PATTERN_CMD` at 9808, and the matching arm in `DrawServ::ExecuteCmd`
- the three construction sites routed through the factory: the menu at `ovkit.c`, and `PatternFunc` / `PatternMaskFunc`

## What gets sent, and why it is carried rather than derived

`PSPattern` exposes enough to reconstruct a pattern -- `None()`, `GetGrayLevel()`, `GetData()`, `GetSize()` -- and `OverlayScript::Pattern()` already serializes one that way for the file format. That was tempting and is the wrong thing here.

The file format writes graphic-state *keywords* (`:graypat`, `:pattern`, `:nonepat`). Distribution sends a *command* for the far node to run, and the commands are `pattern(n)` and `patternmask(bits)`. Deriving one from a `PSPattern` would mean inventing a mapping back to a menu index the far node might resolve differently. So `LinkPatternCmd` carries whichever thing the originating call actually used -- the menu index, or the `patternmask` argument text -- and replays exactly that. Same reasoning as `LinkColorCmd` carrying `fgnum`/`bgnum` so it can emit `colors(fgn bgn)` matching the local command.

With neither (a `PatternCmd` built some other way), `dist_script()` returns empty rather than guessing.

## Tests

`gstests.comt`'s `brush_on_node` was already substring-generic -- only its name and keyword said "brush" -- so it becomes `gs_on_node` and now serves both. `gsbrushA` (chain ds1->ds2->ds3) and `gsbrushB` (tree, ds1 hub) each set `pattern(5)` alongside the brush and assert `:graypat 0.5` arrives at both far nodes. `pattern(5)` is the catalog's 0.5 gray and far nodes default to `:nonepat`, so a match is real evidence rather than a coincidence of defaults; I confirmed the catalog mapping by exporting each index rather than assuming it.

Riding the existing chains costs nothing, where a dedicated `gspat` topology would stand up three more drawservs on the heaviest suite in CI. Dedicated `gspat` tests stay in #154.

Locally: comdraw suite 11/11, and 11/11 again under drawserv, which is what actually exercises `DrawKit`'s factory and `LinkPatternCmd`'s construction and execution. The distributed `dist_script()` path itself needs the multi-node drawmo suite, which CI runs -- I did not install binaries system-wide to run it here.
