### PR TITLE
LinkFontCmd: distribute font changes over DrawLinks

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1092,8 +1092,13 @@ void FontByNameFunc::execute() {
   
   if (!xfs){
     char* xfontval=psfonttoxfont(fontvaldup);
-    free(fontvaldup);
-    fontvaldup = strdup(xfontval);
+    /* psfonttoxfont hands back its own argument for a name already in X form,
+       so only replace the buffer when it actually converted -- otherwise the
+       free would leave xfontval dangling for the strdup and the retry below */
+    if (xfontval != fontvaldup) {
+      free(fontvaldup);
+      fontvaldup = strdup(xfontval);
+    }
     xfs = XLoadQueryFont(dpy,xfontval);
     if (!xfs){
       fprintf(stderr, "Can not load font:  %s, \n", fontval);
@@ -1127,8 +1132,8 @@ void FontByNameFunc::execute() {
       snprintf(fontsizeptr, sizeof(fontsizeptr),"%d",(unsigned int)(value/10));
 
     font = catalog->FindFont(fontvaldup,fontname,fontsizeptr);
-    free(fontvaldup);
   }
+  free(fontvaldup);
   FontCmd* cmd = nil;
   
   if (font) {

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -990,7 +990,8 @@ void FontFunc::execute() {
     FontCmd* cmd = nil;
 
     if (font) {
-	cmd = new FontCmd(_ed, font);
+        OverlayKit* kit = ((OverlayEditor*)_ed)->overlay_kit();
+	cmd = kit->make_font_cmd(_ed, font, fn);
 	execute_log(cmd);
     }
 
@@ -1091,6 +1092,7 @@ void FontByNameFunc::execute() {
   
   if (!xfs){
     char* xfontval=psfonttoxfont(fontvaldup);
+    free(fontvaldup);
     fontvaldup = strdup(xfontval);
     xfs = XLoadQueryFont(dpy,xfontval);
     if (!xfs){
@@ -1102,24 +1104,36 @@ void FontByNameFunc::execute() {
     unsigned long value;
     char fontname[CHARBUFSIZE];
     char fontsizeptr[CHARBUFSIZE];
-    char fontfullname[CHARBUFSIZE];
-    
-    XGetFontProperty(xfs, XA_FULL_NAME, &value);
-    strcpy(fontfullname, XGetAtomName(dpy, (Atom)value));
-    
-    XGetFontProperty(xfs, XA_FONT_NAME, &value);
-    strcpy(fontname, XGetAtomName(dpy, (Atom)value));
-    
-    XGetFontProperty(xfs,XA_POINT_SIZE, &value);
-    snprintf(fontsizeptr, sizeof(fontsizeptr),"%d",(unsigned int)(value/10));
-    
+
+    /* A wildcarded name -- the form font() hands back, and the form :font
+       exports -- loads fine but carries none of these properties.
+       XGetFontProperty then leaves value untouched, and XGetAtomName(0) is a
+       BadAtom that takes the whole editor down, so every lookup has to be
+       guarded and the atom freed.  FindFont defaults the print font and size
+       when they arrive empty, which is the right answer for a name that
+       simply does not carry them. */
+    fontname[0] = '\0';
+    if (XGetFontProperty(xfs, XA_FONT_NAME, &value) && value) {
+      char* atom = XGetAtomName(dpy, (Atom)value);
+      if (atom) {
+	strncpy(fontname, atom, sizeof(fontname)-1);
+	fontname[sizeof(fontname)-1] = '\0';
+	XFree(atom);
+      }
+    }
+
+    fontsizeptr[0] = '\0';
+    if (XGetFontProperty(xfs, XA_POINT_SIZE, &value) && value)
+      snprintf(fontsizeptr, sizeof(fontsizeptr),"%d",(unsigned int)(value/10));
+
     font = catalog->FindFont(fontvaldup,fontname,fontsizeptr);
-    delete fontvaldup;
+    free(fontvaldup);
   }
   FontCmd* cmd = nil;
   
   if (font) {
-    cmd = new FontCmd(_ed, font);
+    OverlayKit* kit = ((OverlayEditor*)_ed)->overlay_kit();
+    cmd = kit->make_font_cmd(_ed, font, 0, fontval);
     execute_log(cmd);
   }
   

--- a/src/DrawServ/drawclasses.h
+++ b/src/DrawServ/drawclasses.h
@@ -40,5 +40,6 @@
 #define LINK_BRUSH_CMD      9806
 #define LINK_COLOR_CMD      9807
 #define LINK_PATTERN_CMD    9808
+#define LINK_FONT_CMD       9809
 
 #endif

--- a/src/DrawServ/drawkit.c
+++ b/src/DrawServ/drawkit.c
@@ -606,6 +606,14 @@ BrushCmd* DrawKit::make_brush_cmd(Editor* ed, PSBrush* br) {
     return new LinkBrushCmd(ed, br);
 }
 
+FontCmd* DrawKit::make_font_cmd(ControlInfo* ctrlInfo, PSFont* font, int fontnum, const char* fontname) {
+    return new LinkFontCmd(ctrlInfo, font, fontnum, fontname);
+}
+
+FontCmd* DrawKit::make_font_cmd(Editor* ed, PSFont* font, int fontnum, const char* fontname) {
+    return new LinkFontCmd(ed, font, fontnum, fontname);
+}
+
 PatternCmd* DrawKit::make_pattern_cmd(ControlInfo* ctrlInfo, PSPattern* pat, int patnum, const char* maskargs) {
     return new LinkPatternCmd(ctrlInfo, pat, patnum, maskargs);
 }

--- a/src/DrawServ/drawkit.h
+++ b/src/DrawServ/drawkit.h
@@ -58,6 +58,8 @@ public:
     virtual ColorCmd* make_color_cmd(Editor*, PSColor* fg, PSColor* bg, int fgnum=0, int bgnum=0);
     virtual PatternCmd* make_pattern_cmd(ControlInfo*, PSPattern*, int patnum=0, const char* maskargs=nil);
     virtual PatternCmd* make_pattern_cmd(Editor*, PSPattern*, int patnum=0, const char* maskargs=nil);
+    virtual FontCmd* make_font_cmd(ControlInfo*, PSFont*, int fontnum=0, const char* fontname=nil);
+    virtual FontCmd* make_font_cmd(Editor*, PSFont*, int fontnum=0, const char* fontname=nil);
     // override to create LinkColorCmd for distributed color changes
 
     static DrawKit* Instance();

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -340,6 +340,15 @@ void DrawServ::ExecuteCmd(Command* cmd) {
 	break;
       }
 
+      case LINK_FONT_CMD:
+      {
+	const char* script = ((LinkFontCmd*)cmd)->dist_script();
+	if (script && *script) sbuf << script;
+	uuid_copy(sid, ((LinkFontCmd*)cmd)->dist_owner_sid());
+	cmd->Execute();
+	break;
+      }
+
       case LINK_PATTERN_CMD:
       {
 	const char* script = ((LinkPatternCmd*)cmd)->dist_script();

--- a/src/DrawServ/linkcmd.c
+++ b/src/DrawServ/linkcmd.c
@@ -137,6 +137,90 @@ boolean LinkBrushCmd::IsA(ClassId id) { return id == LINK_BRUSH_CMD || BrushCmd:
 
 /*****************************************************************************/
 
+LinkFontCmd::LinkFontCmd(ControlInfo* ci, PSFont* font, int fontnum, const char* fontname)
+  : FontCmd(ci, font), _fontnum(fontnum), _fontname(fontname ? fontname : "") {}
+LinkFontCmd::LinkFontCmd(Editor* ed, PSFont* font, int fontnum, const char* fontname)
+  : FontCmd(ed, font), _fontnum(fontnum), _fontname(fontname ? fontname : "") {}
+
+const char* LinkFontCmd::dist_script() {
+    _dist_script_buf = "";
+    uuid_clear(_dist_owner_sid);
+
+    /* only the call that built this command knows which form to replay */
+    if (_fontnum <= 0 && _fontname.empty()) return _dist_script_buf.c_str();
+
+    if (!GetFont()) return _dist_script_buf.c_str();
+
+    Editor* ed = GetEditor();
+    if (!ed) return _dist_script_buf.c_str();
+
+    LinkSelection* sel = (LinkSelection*)ed->GetSelection();
+    if (!sel) return _dist_script_buf.c_str();
+
+    DrawServ* drawserv = (DrawServ*)unidraw;
+    if (!drawserv->linklist() || drawserv->linklist()->Number() == 0)
+        return _dist_script_buf.c_str();
+
+    std::ostringstream sbuf;
+    boolean any = false;
+    uint32_t owner_key = 0;
+    Iterator it;
+
+    /* same collection and relay rules as LinkBrushCmd -- see its comment for
+       why the owner's key is forwarded rather than re-derived, and for the
+       single-owner limitation this shares with it. */
+    for (sel->First(it); !sel->Done(it); sel->Next(it)) {
+        OverlayView* view = (OverlayView*)sel->GetView(it);
+        OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
+        void* ptr = nil;
+        if (comp) drawserv->compidtable()->find(ptr, comp);
+        GraphicId* grid = (GraphicId*)ptr;
+        if (grid && (grid->selected() == LinkSelection::LocallySelected ||
+                     grid->unlocked())) {
+            if (!any) {
+                sbuf << "s=select();select(grid(";
+                any = true;
+                if (grid->selected() == LinkSelection::LocallySelected) {
+                    owner_key = drawserv->sessionidkey();
+                    uuid_copy(_dist_owner_sid, drawserv->sessionid());
+                } else {
+                    owner_key = grid->selectorkey();
+                    uuid_copy(_dist_owner_sid, grid->selector());
+                }
+            } else {
+                sbuf << ",grid(";
+            }
+            sbuf << "\"" << grid->idstr() << "\")";
+        }
+    }
+
+    if (any) {
+        char keystr[9];
+        snprintf(keystr, sizeof(keystr), "%08X", owner_key);
+	sbuf << " :unlock \"" << keystr << "\")";
+        if (_fontnum > 0)
+            sbuf << ";font(" << _fontnum << ")";
+        else
+            sbuf << ";fontbyname(\"" << _fontname << "\")";
+        sbuf << ";select(s :lock \"" << keystr << "\")";
+        _dist_script_buf = sbuf.str();
+    }
+
+    return _dist_script_buf.c_str();
+}
+
+Command* LinkFontCmd::Copy() {
+    LinkFontCmd* copy = new LinkFontCmd(CopyControlInfo(), GetFont(), _fontnum,
+                                        _fontname.empty() ? nil : _fontname.c_str());
+    InitCopy(copy);
+    return copy;
+}
+
+ClassId LinkFontCmd::GetClassId() { return LINK_FONT_CMD; }
+boolean LinkFontCmd::IsA(ClassId id) { return id == LINK_FONT_CMD || FontCmd::IsA(id); }
+
+/*****************************************************************************/
+
 LinkPatternCmd::LinkPatternCmd(ControlInfo* ci, PSPattern* pat, int patnum, const char* maskargs)
   : PatternCmd(ci, pat), _patnum(patnum), _maskargs(maskargs ? maskargs : "") {}
 LinkPatternCmd::LinkPatternCmd(Editor* ed, PSPattern* pat, int patnum, const char* maskargs)

--- a/src/DrawServ/linkcmd.h
+++ b/src/DrawServ/linkcmd.h
@@ -30,6 +30,7 @@
 
 #include <Unidraw/Commands/brushcmd.h>
 #include <Unidraw/Commands/colorcmd.h>
+#include <Unidraw/Commands/font.h>
 #include <Unidraw/Commands/patcmd.h>
 #include <string>
 #include <uuid/uuid.h>
@@ -74,6 +75,40 @@ public:
 
 protected:
     std::string _dist_script_buf;
+};
+
+//: FontCmd with distributed script generation for DrawServ
+// Mixes FontCmd with DrawServCmd to provide dist_script() that serializes
+// the font change for distribution to remote drawservs.
+//
+// fontnum is the menu index from font(), fontname the name given to
+// fontbyname() -- whichever one made this command is what dist_script()
+// replays, same as LinkPatternCmd and LinkColorCmd.
+//
+// Sending the font's own X name instead, for both paths, looks tempting: it is
+// self-describing where a menu index depends on both nodes enumerating the
+// same font resources.  It is also lossy.  A wildcarded X name carries no
+// FONT_NAME or POINT_SIZE property, so FindFont defaults the print font and
+// size, and the far node ends up with the right screen font but a blank
+// PostScript name and a different line height -- text that lays out
+// differently.  Replaying the original call keeps all three.
+class LinkFontCmd : public FontCmd, public DrawServCmd {
+public:
+    LinkFontCmd(ControlInfo*, PSFont* = nil, int fontnum = 0, const char* fontname = nil);
+    LinkFontCmd(Editor* = nil, PSFont* = nil, int fontnum = 0, const char* fontname = nil);
+
+    virtual const char* dist_script();
+    // return "s=select();select(grid(uuid),... :unlock key);font(n);select(s :lock key)"
+    // for all LocallySelected graphics, or empty string if none.
+
+    virtual Command* Copy();
+    virtual ClassId GetClassId();
+    virtual boolean IsA(ClassId);
+
+protected:
+    std::string _dist_script_buf;
+    int _fontnum;
+    std::string _fontname;
 };
 
 //: PatternCmd with distributed script generation for DrawServ

--- a/src/OverlayUnidraw/ovkit.c
+++ b/src/OverlayUnidraw/ovkit.c
@@ -1096,7 +1096,7 @@ MenuItem* OverlayKit::MakeFontMenu() {
     while (font != nil) {
 	text = new TextGraphic(font->GetPrintFontAndSize(), stdgraphic);
 	text->SetFont(font);
-	MakeMenu(mbi, new FontCmd(new ControlInfo(new TextOvComp(text)), font),
+	MakeMenu(mbi, make_font_cmd(new ControlInfo(new TextOvComp(text)), font, i),
 		 lk.hbox(lk.hglue(),
 			 lk.hcenter(new Label(font->GetPrintFontAndSize(),
 					      font,
@@ -1115,6 +1115,14 @@ BrushCmd* OverlayKit::make_brush_cmd(ControlInfo* ctrlInfo, PSBrush* br) {
 
 BrushCmd* OverlayKit::make_brush_cmd(Editor* ed, PSBrush* br) {
     return new BrushCmd(ed, br);
+}
+
+FontCmd* OverlayKit::make_font_cmd(ControlInfo* ctrlInfo, PSFont* font, int fontnum, const char* fontname) {
+    return new FontCmd(ctrlInfo, font);
+}
+
+FontCmd* OverlayKit::make_font_cmd(Editor* ed, PSFont* font, int fontnum, const char* fontname) {
+    return new FontCmd(ed, font);
 }
 
 PatternCmd* OverlayKit::make_pattern_cmd(ControlInfo* ctrlInfo, PSPattern* pat, int patnum, const char* maskargs) {

--- a/src/OverlayUnidraw/ovkit.h
+++ b/src/OverlayUnidraw/ovkit.h
@@ -37,6 +37,7 @@
 
 class BrushCmd;
 class ColorCmd;
+class FontCmd;
 class PatternCmd;
 class Command;
 class ControlInfo;
@@ -52,6 +53,7 @@ class OverlayEditor;
 class OverlaySelection;
 class PSBrush;
 class PSColor;
+class PSFont;
 class PSPattern;
 class Patch;
 class Selection;
@@ -221,6 +223,12 @@ public:
     // or the other reproduces the originating call, same idea as fgnum/bgnum
     virtual PatternCmd* make_pattern_cmd(Editor*, PSPattern*, int patnum=0, const char* maskargs=nil);
     // factory method for creating PatternCmd; see the ControlInfo form
+    virtual FontCmd* make_font_cmd(ControlInfo*, PSFont*, int fontnum=0, const char* fontname=nil);
+    // factory method for creating FontCmd; fontnum is the menu index from
+    // font(), fontname the name given to fontbyname() -- whichever made the
+    // command is what gets replayed, same as make_pattern_cmd
+    virtual FontCmd* make_font_cmd(Editor*, PSFont*, int fontnum=0, const char* fontname=nil);
+    // factory method for creating FontCmd; see the ControlInfo form
   
 protected:
     Glyph* MenuLine(PSBrush*);

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -161,6 +161,31 @@ gsbrushA_test=func(
   if(!m3 :then print("gsbrushA: FAIL patternmask did not propagate to ds3 intact\n" :err));
   ok=ok && m2 && m3;
 
+  /* --- font.  Needs its own graphic: a rect emits MinGS, which carries no
+     font at all, so only a text graphic can show one propagating.  Created
+     second, so it is the second entry in the grid table.  font(3) is the
+     catalog's courier-bold; far nodes default to helvetica, so "courier-bold"
+     downstream is the FONT state having crossed. --- */
+  fontstr="courier-bold";
+  remote(sock1 "t=text(30,30 \"gs\")");
+  remote(sock1 "font(3)");
+  update(2000000);
+  /* pick the entry that is not the rect rather than trusting table order */
+  ida=remote(sock1 "at(grid(:table) 0).grid");
+  idb=remote(sock1 "at(grid(:table) 1).grid");
+  id2=idb;
+  if(ida!=id1 :then id2=ida);
+  if(type(id2)!=`StringType :then
+    print("gsbrushA: FAIL could not read the text graphic's grid id (got %v)\n" id2 :err);
+    ok=false);
+  if(type(id2)==`StringType :then
+    f2=gs_on_node(:bn_sock sock2 :bn_id id2 :bn_gs fontstr);
+    f3=gs_on_node(:bn_sock sock3 :bn_id id2 :bn_gs fontstr);
+    print("gsbrushA: font reached ds2=%v ds3=%v\n" f2 f3 :err);
+    if(!f2 :then print("gsbrushA: FAIL font did not reach ds2 intact\n" :err));
+    if(!f3 :then print("gsbrushA: FAIL font did not propagate to ds3 intact\n" :err));
+    ok=ok && f2 && f3);
+
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "5df462f5"
+#define PATCH_KEY "9471d959"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Closes #375. Stacked on #377 (`link-pattern-cmd`) -- same files, so review or merge that first.

`FontFunc` and `FontByNameFunc` built `new FontCmd` directly, so a font change never reached `DrawServ::ExecuteCmd`'s switch and never crossed a link. Same shape as #377: a `make_font_cmd` factory on `OverlayKit`, a `DrawKit` override, `LinkFontCmd : public FontCmd, public DrawServCmd`, `LINK_FONT_CMD` at 9809, a switch arm, and the three construction sites routed through the factory.

## The decision #375 was waiting on, and how it went

The issue's open question was what to do about a font the far node cannot resolve. The attractive answer was to stop sending the `font(n)` menu index -- meaningful only if both nodes enumerate the same font resources -- and send the font's own X name via `fontbyname()` instead: self-describing, and it refuses with a message rather than substituting silently.

Probing it first turned that answer down, and turned up a crash on the way.

**`fontbyname()` was fatal on exactly the string `font()` returns.** `font()` hands back a wildcarded X name and its docstring calls it "valid input to fontbyname(fontname)". Feeding it back aborts the editor:

```
X Error of failed request:  BadAtom (invalid Atom parameter)
  Major opcode of failed request:  17 (X_GetAtomName)
  Atom id in failed request:  0x0
```

A wildcarded name loads through `XLoadQueryFont` but carries no `FULL_NAME`/`FONT_NAME`/`POINT_SIZE` properties. `XGetFontProperty`'s return value was ignored, so `value` stayed 0 and `XGetAtomName(dpy, 0)` killed the connection. Fixed here: guard each lookup, free the atom, and drop the `FULL_NAME` read entirely -- it fed `fontfullname`, which nothing ever read. Two allocation bugs in the same block went with it: a `strdup` released with `delete`, and a second `strdup` overwriting the first.

**With the crash fixed, the measurement rejected the design anyway.** Setting `font(3)` and then re-applying the name it reports:

| | X name | print font | size |
|---|---|---|---|
| `font(3)` | `-*-courier-bold-...-12-*` | `"Courier-Bold"` | 12 |
| `fontbyname(that name)` | `-*-courier-bold-...-12-*` | `""` | 8 |

The screen font survives; the PostScript name and the point size do not, because `FindFont` defaults what the wildcarded name cannot supply. Line height goes 12 to 8 -- the text lays out differently. Sending the name would have traded a silent-substitution risk for a guaranteed loss on every font change.

So `LinkFontCmd` replays the originating call, exactly as `LinkPatternCmd` and `LinkColorCmd` do: the menu index when `font(n)` made it, the name when `fontbyname()` did. Both nodes run the same application with the same font resources, so an index names the same font on each; what differs is only whether a given display can load it, and that is a property of that display rather than of the relay.

That leaves the unresolvable case genuinely open, and it should stay open rather than be papered over: `fontbyname` refuses and prints locally, `font(n)` substitutes through the catalog, and neither reports back to the originator. Reporting back needs the chained-ack work in #151. Worth noting the round-trip loss above is its own pre-existing bug, independent of distribution -- `font()`'s output is not losslessly `fontbyname()`-able despite what the docstring says.

## Tests

Font needed its own graphic. A rect emits `MinGS` -- brush, colors, pattern, no font -- so only a text graphic can show a font propagating at all. `gsbrushA` now creates one alongside the rect, applies `font(3)`, and asserts "courier-bold" reaches both far nodes; they default to helvetica, so a match is the font state having crossed. The grid id is picked as the entry that is not the rect's rather than by trusting table order.

Locally: comdraw suite 11/11 under drawserv, which is what constructs and executes a `LinkFontCmd`. The `dist_script()` wire path needs the multi-node drawmo suite, which CI runs.
