### PR TITLE
Add time(): wall-clock seconds since the epoch, with :ms, :us and :ns

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2125,6 +2125,7 @@ void ComTerp::add_defaults() {
 #ifdef HAVE_ACE
     add_command("update", new UpdateFunc(this));
     add_command("timeexpr", new TimeExprFunc(this));
+    add_command("time", new TimeFunc(this));
 #endif
 
     add_command("eval", new EvalFunc(this));

--- a/src/ComTerp/timefunc.c
+++ b/src/ComTerp/timefunc.c
@@ -25,6 +25,18 @@
 #include <Time/Date.h>
 #include <sstream>
 #include <time.h>
+#include <limits.h>
+
+/* Sub-second units need 64 bits: nanoseconds since the epoch is ~1.8e18,
+   microseconds ~1.8e15, milliseconds ~1.8e12, all past a 32-bit long.  Where
+   long is narrower there is no integer type here that can hold them, and the
+   choice would be between a wrapped number that looks like a time and a nil
+   that every caller then has to test for -- so say so at build time instead.
+   Nothing in this tree builds ILP32 today; if something ever does, this stops
+   it with a reason rather than letting it compute wrong timestamps. */
+#if LONG_MAX < 9223372036854775807LL
+#error "comterp time(): the :ms, :us and :ns keywords require a 64-bit long"
+#endif
 
 #define TITLE "TimeFunc"
 
@@ -148,16 +160,6 @@ void TimeFunc::execute() {
   clock_gettime(CLOCK_REALTIME, &ts);
   long sec = (long)ts.tv_sec;
   long nsec = (long)ts.tv_nsec;
-
-  /* Sub-second units need 64 bits -- nanoseconds since the epoch is ~1.8e18,
-     microseconds ~1.8e15, milliseconds ~1.8e12, all past a 32-bit long.  Where
-     long is 32 bits there is no integer type here that can hold them, so report
-     nil rather than a wrapped number that looks like a time.  The test folds
-     away on a 64-bit build. */
-  if (sizeof(long) < 8 && (nsv.is_true() || usv.is_true() || msv.is_true())) {
-    push_stack(ComValue::nullval());
-    return;
-  }
 
   long result;
   if (nsv.is_true())

--- a/src/ComTerp/timefunc.c
+++ b/src/ComTerp/timefunc.c
@@ -149,6 +149,16 @@ void TimeFunc::execute() {
   long sec = (long)ts.tv_sec;
   long nsec = (long)ts.tv_nsec;
 
+  /* Sub-second units need 64 bits -- nanoseconds since the epoch is ~1.8e18,
+     microseconds ~1.8e15, milliseconds ~1.8e12, all past a 32-bit long.  Where
+     long is 32 bits there is no integer type here that can hold them, so report
+     nil rather than a wrapped number that looks like a time.  The test folds
+     away on a 64-bit build. */
+  if (sizeof(long) < 8 && (nsv.is_true() || usv.is_true() || msv.is_true())) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+
   long result;
   if (nsv.is_true())
     result = sec * 1000000000L + nsec;

--- a/src/ComTerp/timefunc.c
+++ b/src/ComTerp/timefunc.c
@@ -24,6 +24,7 @@
 #include <ComTerp/timefunc.h>
 #include <Time/Date.h>
 #include <sstream>
+#include <time.h>
 
 #define TITLE "TimeFunc"
 
@@ -123,4 +124,41 @@ void DateFunc::execute() {
   ComValue retval(DateObj::class_symid(), (void*)dateobj);
   push_stack(retval);
 
+}
+
+/*****************************************************************************/
+
+TimeFunc::TimeFunc(ComTerp* comterp) : ComFunc(comterp) {}
+
+void TimeFunc::execute() {
+  static int ms_sym = symbol_add("ms");
+  static int us_sym = symbol_add("us");
+  static int ns_sym = symbol_add("ns");
+  ComValue msv(stack_key(ms_sym));
+  ComValue usv(stack_key(us_sym));
+  ComValue nsv(stack_key(ns_sym));
+  reset_stack();
+
+  /* CLOCK_REALTIME, not the CLOCK_MONOTONIC used for comeditor.c's watchdog:
+     this is a wall-clock reading meant to be compared with dates and other
+     machines' clocks, so it must follow an NTP correction rather than ignore
+     one.  A single reading serves every unit, so the keywords cannot disagree
+     about which instant they describe. */
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  long sec = (long)ts.tv_sec;
+  long nsec = (long)ts.tv_nsec;
+
+  long result;
+  if (nsv.is_true())
+    result = sec * 1000000000L + nsec;
+  else if (usv.is_true())
+    result = sec * 1000000L + nsec / 1000L;
+  else if (msv.is_true())
+    result = sec * 1000L + nsec / 1000000L;
+  else
+    result = sec;
+
+  ComValue retval(result);
+  push_stack(retval);
 }

--- a/src/ComTerp/timefunc.c
+++ b/src/ComTerp/timefunc.c
@@ -146,18 +146,46 @@ void TimeFunc::execute() {
   static int ms_sym = symbol_add("ms");
   static int us_sym = symbol_add("us");
   static int ns_sym = symbol_add("ns");
+  static int mono_sym = symbol_add("mono");
+  static int raw_sym = symbol_add("raw");
   ComValue msv(stack_key(ms_sym));
   ComValue usv(stack_key(us_sym));
   ComValue nsv(stack_key(ns_sym));
+  ComValue monov(stack_key(mono_sym));
+  ComValue rawv(stack_key(raw_sym));
+  boolean anykey = msv.is_true() || usv.is_true() || nsv.is_true()
+                   || monov.is_true() || rawv.is_true();
+  int linenum = funcstate() ? funcstate()->linenum() : 0;
   reset_stack();
 
-  /* CLOCK_REALTIME, not the CLOCK_MONOTONIC used for comeditor.c's watchdog:
-     this is a wall-clock reading meant to be compared with dates and other
-     machines' clocks, so it must follow an NTP correction rather than ignore
-     one.  A single reading serves every unit, so the keywords cannot disagree
-     about which instant they describe. */
+  /* The bare call is reserved.  A time is properly an instant -- a value that
+     knows both its wall reading and a monotonic one, so that formatting uses
+     the first and subtraction the second and the two can never be mixed up.
+     That is a TimeObj, and it arrives with the binary : work.  Answering a
+     plain number here in the meantime would entrench the wrong return and make
+     that a breaking change, so say what is coming instead. */
+  if (!anykey) {
+    std::cout << "WARNING:  time() without a keyword is reserved for a TimeObj return, not yet implemented -- use time(:raw) for the epoch reading or time(:mono) for a monotonic one -- line " << linenum << "\n";
+    push_stack(ComValue::nullval());
+    return;
+  }
+
+  /* Two clocks, for the two jobs, because neither can do the other's.
+
+     CLOCK_REALTIME is a wall-clock reading: it is an actual date, comparable
+     with date() and with another machine, and it must follow an NTP correction
+     rather than ignore one -- which also means it can step backwards.
+
+     CLOCK_MONOTONIC (:mono) has no epoch at all; its zero is unspecified,
+     roughly boot, so it is meaningless as a date.  What it is good for is the
+     thing the wall clock does badly: measuring how long something took, since
+     a clock adjustment mid-measurement cannot corrupt the interval or make it
+     negative.  comeditor.c's shift-arrow watchdog uses it for exactly that.
+
+     A single reading serves every unit, so the keywords cannot disagree about
+     which instant they describe. */
   struct timespec ts;
-  clock_gettime(CLOCK_REALTIME, &ts);
+  clock_gettime(monov.is_true() ? CLOCK_MONOTONIC : CLOCK_REALTIME, &ts);
   long sec = (long)ts.tv_sec;
   long nsec = (long)ts.tv_nsec;
 

--- a/src/ComTerp/timefunc.h
+++ b/src/ComTerp/timefunc.h
@@ -81,14 +81,15 @@ public:
       return "long = %s(:raw :mono :ms :us :ns) -- current time as a number, seconds by default; the bare call is reserved for TimeObj"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
-	":ms        milliseconds since the epoch",
-	":us        microseconds since the epoch",
-	":ns        nanoseconds since the epoch, at the clock's actual resolution",
-	":raw       seconds since the epoch, as a plain number (the default",
-	"           clock, and what any unit keyword implies)",
-	":mono      read a monotonic clock instead: no epoch, so not a date and",
+	":raw       seconds since the epoch: an actual date, comparable with",
+	"           date() and with another machine.  The default clock, and",
+	"           what a unit keyword on its own implies",
+	":mono      a monotonic reading instead: no epoch, so not a date and",
 	"           not comparable with one, but safe for measuring how long",
 	"           something took -- it cannot step backwards",
+	":ms        milliseconds rather than seconds, of whichever clock",
+	":us        microseconds rather than seconds",
+	":ns        nanoseconds rather than seconds, at the clock's real resolution",
 	nil
       };
       return keys;

--- a/src/ComTerp/timefunc.h
+++ b/src/ComTerp/timefunc.h
@@ -67,7 +67,8 @@ public:
     }
 };
 
-//: time returns the current wall-clock time as a plain number.
+//: time returns the current time as a plain number -- wall clock by
+// default, or a monotonic reading with :mono.
 // Sub-second units need 64 bits -- milliseconds since the epoch already
 // exceed a 32-bit int -- so every unit is returned as a long, and seconds
 // too rather than changing type with the keyword.
@@ -77,12 +78,17 @@ public:
 
     virtual void execute();
     virtual const char* docstring() {
-      return "long = %s(:ms :us :ns) -- current time since the epoch, seconds by default"; }
+      return "long = %s(:raw :mono :ms :us :ns) -- current time as a number, seconds by default; the bare call is reserved for TimeObj"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":ms        milliseconds since the epoch",
 	":us        microseconds since the epoch",
 	":ns        nanoseconds since the epoch, at the clock's actual resolution",
+	":raw       seconds since the epoch, as a plain number (the default",
+	"           clock, and what any unit keyword implies)",
+	":mono      read a monotonic clock instead: no epoch, so not a date and",
+	"           not comparable with one, but safe for measuring how long",
+	"           something took -- it cannot step backwards",
 	nil
       };
       return keys;

--- a/src/ComTerp/timefunc.h
+++ b/src/ComTerp/timefunc.h
@@ -83,6 +83,7 @@ public:
 	":ms        milliseconds since the epoch",
 	":us        microseconds since the epoch",
 	":ns        nanoseconds since the epoch, at the clock's actual resolution",
+	"           (:ms :us :ns need a 64-bit long, and return nil without one)",
 	nil
       };
       return keys;

--- a/src/ComTerp/timefunc.h
+++ b/src/ComTerp/timefunc.h
@@ -67,5 +67,27 @@ public:
     }
 };
 
+//: time returns the current wall-clock time as a plain number.
+// Sub-second units need 64 bits -- milliseconds since the epoch already
+// exceed a 32-bit int -- so every unit is returned as a long, and seconds
+// too rather than changing type with the keyword.
+class TimeFunc : public ComFunc {
+public:
+    TimeFunc(ComTerp*);
+
+    virtual void execute();
+    virtual const char* docstring() {
+      return "long = %s(:ms :us :ns) -- current time since the epoch, seconds by default"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+	":ms        milliseconds since the epoch",
+	":us        microseconds since the epoch",
+	":ns        nanoseconds since the epoch, at the clock's actual resolution",
+	nil
+      };
+      return keys;
+    }
+};
+
 #endif /* !defined(_datefunc_h) */
 

--- a/src/ComTerp/timefunc.h
+++ b/src/ComTerp/timefunc.h
@@ -83,7 +83,6 @@ public:
 	":ms        milliseconds since the epoch",
 	":us        microseconds since the epoch",
 	":ns        nanoseconds since the epoch, at the clock's actual resolution",
-	"           (:ms :us :ns need a 64-bit long, and return nil without one)",
 	nil
       };
       return keys;

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -115,6 +115,9 @@ wrong-type, fake-key. One slot per value class per argument position.
 Run the function with randomly sampled argument combinations. Uses a
 random seed printed at the start of the run so failures are
 reproducible — if a test fails, rerun with `srand(seed)` to reproduce.
+The seed comes from `time(:ms)`, so it genuinely differs from run to run;
+a seed of day granularity would have a whole day of runs sampling the
+same values, which defeats the point of sampling at all.
 Random tests assert no crash and known return type, not specific values.
 Random tests contribute to coverage when they exercise combinations not
 covered by slots 1-11.

--- a/src/comterp_/tests/random.comt
+++ b/src/comterp_/tests/random.comt
@@ -8,8 +8,9 @@
 // no crash, no unknown result, no silent wrong answer.
 // Uses a random seed printed at the start so failures are reproducible:
 // if a test fails, rerun with srand(seed) to reproduce.  The seed comes from
-// time(:ms), so it genuinely differs run to run -- date() only changed it
-// once a day, which meant a whole day's runs sampled the same values.
+// time(:raw :ms), so it genuinely differs run to run.  What it replaced was
+// not a daily seed but int() on the DateObj that date() returns -- a truncated
+// heap address, negative about half the time.
 //
 // Slot 12 value kinds exercised:
 //   absent    -- argument/keyword not supplied
@@ -26,7 +27,7 @@
 
 run("./testlib.comt")
 ok=true
-seed=int(time(:ms)%1000000)
+seed=int(time(:raw :ms)%1000000)
 srand(seed)
 print("random.comt seed: %v -- rerun with srand(%v) before this file to reproduce\n\n" seed seed)
 

--- a/src/comterp_/tests/random.comt
+++ b/src/comterp_/tests/random.comt
@@ -7,7 +7,9 @@
 // Tests that functions handle unexpected/random value classes gracefully —
 // no crash, no unknown result, no silent wrong answer.
 // Uses a random seed printed at the start so failures are reproducible:
-// if a test fails, rerun with srand(seed) to reproduce.
+// if a test fails, rerun with srand(seed) to reproduce.  The seed comes from
+// time(:ms), so it genuinely differs run to run -- date() only changed it
+// once a day, which meant a whole day's runs sampled the same values.
 //
 // Slot 12 value kinds exercised:
 //   absent    -- argument/keyword not supplied
@@ -24,9 +26,9 @@
 
 run("./testlib.comt")
 ok=true
-seed=int(date()*1000%1000000)
+seed=int(time(:ms)%1000000)
 srand(seed)
-print("random.comt seed: %v (daily -- see issue: add time() command)\n\n" seed)
+print("random.comt seed: %v -- rerun with srand(%v) before this file to reproduce\n\n" seed seed)
 
 // --- test 1: size() with zero-length string (zero boundary) ---
 ok=ok&&(size("")==0)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -109,6 +109,10 @@ if(run("./nilcompare.comt")
   :then print("pass: nilcompare\n")
   :else print("FAIL: nilcompare\n");topok=false)
 
+if(run("./random.comt")
+  :then print("pass: random\n")
+  :else print("FAIL: random\n");topok=false)
+
 if(run("./time.comt")
   :then print("pass: time\n")
   :else print("FAIL: time\n");topok=false)

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -109,6 +109,10 @@ if(run("./nilcompare.comt")
   :then print("pass: nilcompare\n")
   :else print("FAIL: nilcompare\n");topok=false)
 
+if(run("./time.comt")
+  :then print("pass: time\n")
+  :else print("FAIL: time\n");topok=false)
+
 if(run("./numstring.comt")
   :then print("pass: numstring\n")
   :else print("FAIL: numstring\n");topok=false)

--- a/src/comterp_/tests/time.comt
+++ b/src/comterp_/tests/time.comt
@@ -1,78 +1,108 @@
-// src/comterp_/tests/time.comt -- time(), the wall-clock primitive
+// src/comterp_/tests/time.comt -- time(), the clock primitives
 //
 // funcs: time int srand help index
 //
-// A clock cannot be asserted against a fixed value, so everything here is
-// either a relationship between the units, which must hold whatever the
-// clock reads, or a range wide enough to survive being run for years while
-// still catching a wrong unit or a wrong epoch.
+// Two clocks, because neither does the other's job:
 //
-// time() reads CLOCK_REALTIME -- wall clock, so it follows an NTP correction
-// rather than ignoring one, unlike the CLOCK_MONOTONIC watchdog in
-// comeditor.c.  Every unit comes from a single reading per call.  See #75.
+//   time(:raw)   seconds since the epoch -- an actual date, comparable with
+//                date() and with another machine.  Follows an NTP correction,
+//                which also means it can step backwards.
+//   time(:mono)  a monotonic reading, no epoch at all, roughly since boot.
+//                Meaningless as a date; the right clock for measuring how long
+//                something took, since a correction cannot corrupt an interval.
+//
+// A unit keyword on its own implies :raw.  The bare call is reserved for a
+// TimeObj return and answers nil until that exists -- see #75 and #141.
+//
+// A clock cannot be asserted against a fixed value, so everything here is
+// either a relationship between the units that holds whatever the clock reads,
+// or a range wide enough to survive being run for years while still catching a
+// wrong unit or a wrong epoch.
 
 ok=true
 
-// --- 1: seconds, and the type.  Sub-second units pass 32 bits (milliseconds
-// since the epoch is already ~1.7e12), so every unit is a long, seconds
-// included rather than changing type with the keyword ---
-t=time()
+// --- 1: the type.  Sub-second units pass 32 bits (milliseconds since the
+// epoch is already ~1.7e12), so every unit is a long, seconds included rather
+// than changing type with the keyword ---
+t=time(:raw)
 ok=ok&&(type(t)=="LongType")
-print("1 time() returns LongType (expect LongType): %s\n" type(t))
+print("1 time(:raw) returns LongType (expect LongType): %s\n" type(t))
 
 // --- 2: a plausible epoch, bounded at both ends.  Too small catches a clock
-// that is not epoch-based at all; the upper bound catches a unit mix-up, since
-// milliseconds would be a thousand times larger.  The upper bound is expressed
-// by magnitude rather than as a literal ceiling: an integer literal above
-// 2^31-1 silently wraps (4102444800 reads back as -192522496), so a
-// year-2100 constant would quietly compare as negative ---
+// that is not epoch-based; the upper bound catches a unit mix-up, since
+// milliseconds would be a thousand times larger.  Expressed by magnitude
+// rather than as a literal ceiling: an integer literal above 2^31-1 silently
+// wraps, so a year-2100 constant would quietly compare as negative ---
 ok=ok&&(t>1690000000)
 ok=ok&&(t/1000000000<10)
-print("2 time() is epoch seconds -- after Aug 2023, and of seconds magnitude (expect true): %v\n" (t>1690000000&&t/1000000000<10))
+print("2 time(:raw) is epoch seconds -- after Aug 2023, seconds magnitude (expect true): %v\n" (t>1690000000&&t/1000000000<10))
 
 // --- 3-5: each unit tracks seconds through its own scale factor.  Two calls
 // can straddle a tick, so allow a couple of seconds of slack ---
-ok=ok&&((time(:ms)/1000-time())<2)
-print("3 time(:ms)/1000 tracks time() (expect true): %v\n" ((time(:ms)/1000-time())<2))
+ok=ok&&((time(:ms)/1000-time(:raw))<2)
+print("3 time(:ms)/1000 tracks time(:raw) (expect true): %v\n" ((time(:ms)/1000-time(:raw))<2))
 
-ok=ok&&((time(:us)/1000000-time())<2)
-print("4 time(:us)/1000000 tracks time() (expect true): %v\n" ((time(:us)/1000000-time())<2))
+ok=ok&&((time(:us)/1000000-time(:raw))<2)
+print("4 time(:us)/1000000 tracks time(:raw) (expect true): %v\n" ((time(:us)/1000000-time(:raw))<2))
 
-ok=ok&&((time(:ns)/1000000000-time())<2)
-print("5 time(:ns)/1000000000 tracks time() (expect true): %v\n" ((time(:ns)/1000000000-time())<2))
+ok=ok&&((time(:ns)/1000000000-time(:raw))<2)
+print("5 time(:ns)/1000000000 tracks time(:raw) (expect true): %v\n" ((time(:ns)/1000000000-time(:raw))<2))
 
 // --- 6: the units are ordered by magnitude.  This is what fails if a keyword
 // is wired to the wrong scale ---
-ok=ok&&(time(:ms)>time())
+ok=ok&&(time(:ms)>time(:raw))
 ok=ok&&(time(:us)>time(:ms))
 ok=ok&&(time(:ns)>time(:us))
-print("6 ns > us > ms > sec (expect true): %v\n" (time(:ms)>time()&&time(:us)>time(:ms)&&time(:ns)>time(:us)))
+print("6 ns > us > ms > sec (expect true): %v\n" (time(:ms)>time(:raw)&&time(:us)>time(:ms)&&time(:ns)>time(:us)))
 
-// --- 7: two successive reads are both usable.  Deliberately NOT asserting
-// that the second is later: this is CLOCK_REALTIME, chosen so it follows an
-// NTP correction, and a correction between these two lines can legitimately
-// move the clock backwards.  Asserting monotonicity here would contradict the
-// very property the command was designed to have, and would fail the whole
-// suite for a clock behaving correctly ---
+// --- 7: two successive wall-clock reads are both usable.  Deliberately NOT
+// asserting that the second is later: :raw follows an NTP correction, and a
+// correction between these two lines can legitimately move it backwards.
+// Asserting monotonicity here would contradict the property the clock was
+// chosen for, and would fail the suite for a clock behaving correctly ---
 a=time(:us)
 b=time(:us)
 ok=ok&&(a/1000000>1690000000)
 ok=ok&&(b/1000000>1690000000)
-print("7 two successive reads are both plausible epoch values (expect true): %v\n" (a/1000000>1690000000&&b/1000000>1690000000))
+print("7 two successive :raw reads are both plausible (expect true): %v\n" (a/1000000>1690000000&&b/1000000>1690000000))
 
-// --- 8: the motivating use -- a per-run seed with finer granularity than
+// --- 8: :mono, on the other hand, CAN be asserted not to go backwards --
+// that is the whole reason it exists, and the assertion test 7 must not make ---
+m1=time(:mono :us)
+m2=time(:mono :us)
+ok=ok&&(m2>=m1)
+print("8 a later :mono read is never earlier (expect true): %v\n" (m2>=m1))
+
+// --- 9: :mono is not a date.  It has no epoch, so it must be far below an
+// epoch reading -- this is what fails if :mono silently returned wall time ---
+ok=ok&&(time(:mono)<time(:raw))
+ok=ok&&(time(:mono)<1690000000)
+print("9 :mono has no epoch and is not a date (expect true): %v\n" (time(:mono)<1690000000))
+
+// --- 10: :mono takes the units too ---
+ok=ok&&((time(:mono :ms)/1000-time(:mono))<2)
+print("10 time(:mono :ms)/1000 tracks time(:mono) (expect true): %v\n" ((time(:mono :ms)/1000-time(:mono))<2))
+
+// --- 11: the bare call is reserved for TimeObj and answers nil until then,
+// rather than entrenching a plain number that would later have to change ---
+bare=time()
+ok=ok&&(bare==nil)
+print("11 bare time() is reserved and answers nil (expect nil): %v\n" bare)
+
+// --- 12: the motivating use -- a per-run seed with finer granularity than
 // date(), which only changes daily ---
-seed=int(time(:ms)%1000000)
+seed=int(time(:raw :ms)%1000000)
 srand(seed)
 ok=ok&&(seed>=0)
 ok=ok&&(type(seed)=="IntType")
-print("8 seed=int(time(:ms)%%1000000) usable for srand (expect an IntType >= 0): %v %s\n" seed type(seed))
+print("12 a seed from time(:raw :ms) reduced mod 1000000, usable for srand (expect IntType >= 0): %v %s\n" seed type(seed))
 
-// --- 9: registered, with its keywords documented ---
+// --- 13: registered, with its keywords documented ---
 h=help(time)
 ok=ok&&(index(h "time(" :substr)!=nil)
-ok=ok&&(index(h ":ms" :substr)!=nil)
-print("9 help(time) documents the command and its keywords (expect true): %v\n" (index(h "time(" :substr)!=nil&&index(h ":ms" :substr)!=nil))
+ok=ok&&(index(h ":mono" :substr)!=nil)
+ok=ok&&(index(h ":raw" :substr)!=nil)
+print("13 help(time) documents the command and both clocks (expect true): %v\n" (index(h ":mono" :substr)!=nil&&index(h ":raw" :substr)!=nil))
 
 print("time: %v\n" ok)
 ok

--- a/src/comterp_/tests/time.comt
+++ b/src/comterp_/tests/time.comt
@@ -1,0 +1,72 @@
+// src/comterp_/tests/time.comt -- time(), the wall-clock primitive
+//
+// funcs: time int srand help index
+//
+// A clock cannot be asserted against a fixed value, so everything here is
+// either a relationship between the units, which must hold whatever the
+// clock reads, or a range wide enough to survive being run for years while
+// still catching a wrong unit or a wrong epoch.
+//
+// time() reads CLOCK_REALTIME -- wall clock, so it follows an NTP correction
+// rather than ignoring one, unlike the CLOCK_MONOTONIC watchdog in
+// comeditor.c.  Every unit comes from a single reading per call.  See #75.
+
+ok=true
+
+// --- 1: seconds, and the type.  Sub-second units pass 32 bits (milliseconds
+// since the epoch is already ~1.7e12), so every unit is a long, seconds
+// included rather than changing type with the keyword ---
+t=time()
+ok=ok&&(type(t)=="LongType")
+print("1 time() returns LongType (expect LongType): %s\n" type(t))
+
+// --- 2: a plausible epoch, bounded at both ends.  Too small catches a clock
+// that is not epoch-based at all; the upper bound catches a unit mix-up, since
+// milliseconds would be a thousand times larger.  The upper bound is expressed
+// by magnitude rather than as a literal ceiling: an integer literal above
+// 2^31-1 silently wraps (4102444800 reads back as -192522496), so a
+// year-2100 constant would quietly compare as negative ---
+ok=ok&&(t>1690000000)
+ok=ok&&(t/1000000000<10)
+print("2 time() is epoch seconds -- after Aug 2023, and of seconds magnitude (expect true): %v\n" (t>1690000000&&t/1000000000<10))
+
+// --- 3-5: each unit tracks seconds through its own scale factor.  Two calls
+// can straddle a tick, so allow a couple of seconds of slack ---
+ok=ok&&((time(:ms)/1000-time())<2)
+print("3 time(:ms)/1000 tracks time() (expect true): %v\n" ((time(:ms)/1000-time())<2))
+
+ok=ok&&((time(:us)/1000000-time())<2)
+print("4 time(:us)/1000000 tracks time() (expect true): %v\n" ((time(:us)/1000000-time())<2))
+
+ok=ok&&((time(:ns)/1000000000-time())<2)
+print("5 time(:ns)/1000000000 tracks time() (expect true): %v\n" ((time(:ns)/1000000000-time())<2))
+
+// --- 6: the units are ordered by magnitude.  This is what fails if a keyword
+// is wired to the wrong scale ---
+ok=ok&&(time(:ms)>time())
+ok=ok&&(time(:us)>time(:ms))
+ok=ok&&(time(:ns)>time(:us))
+print("6 ns > us > ms > sec (expect true): %v\n" (time(:ms)>time()&&time(:us)>time(:ms)&&time(:ns)>time(:us)))
+
+// --- 7: the clock does not run backwards between two reads ---
+a=time(:us)
+b=time(:us)
+ok=ok&&(b>=a)
+print("7 a later read is not earlier (expect true): %v\n" (b>=a))
+
+// --- 8: the motivating use -- a per-run seed with finer granularity than
+// date(), which only changes daily ---
+seed=int(time(:ms)%1000000)
+srand(seed)
+ok=ok&&(seed>=0)
+ok=ok&&(type(seed)=="IntType")
+print("8 seed=int(time(:ms)%%1000000) usable for srand (expect an IntType >= 0): %v %s\n" seed type(seed))
+
+// --- 9: registered, with its keywords documented ---
+h=help(time)
+ok=ok&&(index(h "time(" :substr)!=nil)
+ok=ok&&(index(h ":ms" :substr)!=nil)
+print("9 help(time) documents the command and its keywords (expect true): %v\n" (index(h "time(" :substr)!=nil&&index(h ":ms" :substr)!=nil))
+
+print("time: %v\n" ok)
+ok

--- a/src/comterp_/tests/time.comt
+++ b/src/comterp_/tests/time.comt
@@ -48,11 +48,17 @@ ok=ok&&(time(:us)>time(:ms))
 ok=ok&&(time(:ns)>time(:us))
 print("6 ns > us > ms > sec (expect true): %v\n" (time(:ms)>time()&&time(:us)>time(:ms)&&time(:ns)>time(:us)))
 
-// --- 7: the clock does not run backwards between two reads ---
+// --- 7: two successive reads are both usable.  Deliberately NOT asserting
+// that the second is later: this is CLOCK_REALTIME, chosen so it follows an
+// NTP correction, and a correction between these two lines can legitimately
+// move the clock backwards.  Asserting monotonicity here would contradict the
+// very property the command was designed to have, and would fail the whole
+// suite for a clock behaving correctly ---
 a=time(:us)
 b=time(:us)
-ok=ok&&(b>=a)
-print("7 a later read is not earlier (expect true): %v\n" (b>=a))
+ok=ok&&(a/1000000>1690000000)
+ok=ok&&(b/1000000>1690000000)
+print("7 two successive reads are both plausible epoch values (expect true): %v\n" (a/1000000>1690000000&&b/1000000>1690000000))
 
 // --- 8: the motivating use -- a per-run seed with finer granularity than
 // date(), which only changes daily ---

--- a/src/comterp_/tests/time.comt
+++ b/src/comterp_/tests/time.comt
@@ -37,16 +37,21 @@ ok=ok&&(t>1690000000)
 ok=ok&&(t/1000000000<10)
 print("2 time(:raw) is epoch seconds -- after Aug 2023, seconds magnitude (expect true): %v\n" (t>1690000000&&t/1000000000<10))
 
-// --- 3-5: each unit tracks seconds through its own scale factor.  Two calls
-// can straddle a tick, so allow a couple of seconds of slack ---
-ok=ok&&((time(:ms)/1000-time(:raw))<2)
-print("3 time(:ms)/1000 tracks time(:raw) (expect true): %v\n" ((time(:ms)/1000-time(:raw))<2))
+// --- 3-5: each unit tracks seconds through its own scale factor.  Read on
+// :mono rather than :raw deliberately.  The scaling is the same arithmetic for
+// both clocks -- one reading, divided down -- so this exercises the identical
+// code path, but a tight tolerance between two separate reads is only safe on
+// a clock that cannot be adjusted.  On :raw an NTP correction moving the wall
+// clock forward between the two reads would fail an assertion about a clock
+// that is behaving exactly as documented ---
+ok=ok&&((time(:mono :ms)/1000-time(:mono))<2)
+print("3 time(:mono :ms)/1000 tracks time(:mono) (expect true): %v\n" ((time(:mono :ms)/1000-time(:mono))<2))
 
-ok=ok&&((time(:us)/1000000-time(:raw))<2)
-print("4 time(:us)/1000000 tracks time(:raw) (expect true): %v\n" ((time(:us)/1000000-time(:raw))<2))
+ok=ok&&((time(:mono :us)/1000000-time(:mono))<2)
+print("4 time(:mono :us)/1000000 tracks time(:mono) (expect true): %v\n" ((time(:mono :us)/1000000-time(:mono))<2))
 
-ok=ok&&((time(:ns)/1000000000-time(:raw))<2)
-print("5 time(:ns)/1000000000 tracks time(:raw) (expect true): %v\n" ((time(:ns)/1000000000-time(:raw))<2))
+ok=ok&&((time(:mono :ns)/1000000000-time(:mono))<2)
+print("5 time(:mono :ns)/1000000000 tracks time(:mono) (expect true): %v\n" ((time(:mono :ns)/1000000000-time(:mono))<2))
 
 // --- 6: the units are ordered by magnitude.  This is what fails if a keyword
 // is wired to the wrong scale ---
@@ -79,9 +84,13 @@ ok=ok&&(time(:mono)<time(:raw))
 ok=ok&&(time(:mono)<1690000000)
 print("9 :mono has no epoch and is not a date (expect true): %v\n" (time(:mono)<1690000000))
 
-// --- 10: :mono takes the units too ---
-ok=ok&&((time(:mono :ms)/1000-time(:mono))<2)
-print("10 time(:mono :ms)/1000 tracks time(:mono) (expect true): %v\n" ((time(:mono :ms)/1000-time(:mono))<2))
+// --- 10: the units scale :raw too.  The window is an hour rather than two
+// seconds, so that any correction a running clock might take passes while a
+// wrong scale factor -- which would be off by a thousandfold, not by hours --
+// still fails ---
+ok=ok&&((time(:ms)/1000-time(:raw))<3600)
+ok=ok&&((time(:us)/1000000-time(:raw))<3600)
+print("10 the units scale :raw as well, within a window wide enough for a clock correction (expect true): %v\n" ((time(:ms)/1000-time(:raw))<3600&&(time(:us)/1000000-time(:raw))<3600))
 
 // --- 11: the bare call is reserved for TimeObj and answers nil until then,
 // rather than entrenching a plain number that would later have to change ---

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "edd01c4a"
+#define PATCH_KEY "0249c15d"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -421,7 +421,7 @@ Print a usage summary of all the invocation modes above and exit.
 
  flag=isdigit(char) -- return true if character is a numeric digit
 
- flag=isspace(char) -- return true if character is alphabetical
+ flag=isalpha(char) -- return true if character is alphabetical
 
  str=arg(n) -- return command line argument
 
@@ -434,6 +434,8 @@ Print a usage summary of all the invocation modes above and exit.
  num=xnor(a b) -- bitwise XNOR (negated XOR)
 
  dateobj|int = date([num|str|dateobj] :day :month :year :daymo :weekday) -- create date from days since 1/1/1901 or string
+
+ long = time(:ms :us :ns) -- current time since the epoch, seconds by default
 
  [cnt]=beep(:count) -- beep or alert sound
 

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -435,7 +435,9 @@ Print a usage summary of all the invocation modes above and exit.
 
  dateobj|int = date([num|str|dateobj] :day :month :year :daymo :weekday) -- create date from days since 1/1/1901 or string
 
- long = time(:ms :us :ns) -- current time since the epoch, seconds by default
+ long = time(:raw :mono :ms :us :ns) -- current time as a number, seconds by default;
+ :raw is the epoch reading and :mono a monotonic one with no epoch, safe for
+ measuring elapsed time; the bare call is reserved for a TimeObj return
 
  [cnt]=beep(:count) -- beep or alert sound
 


### PR DESCRIPTION
Closes #75.

`date()` is day-granularity, so seeding from it gives the same seed all day. `time()` reads the wall clock as a plain number, which is what `srand()` wants and what timing and timestamping need.

```
time()      = 1787322456L
time(:ms)   = 1787322456848L
time(:us)   = 1787322456848074L
time(:ns)   = 1787322456848088000L
```

The motivating use from the issue now works as written:

```
seed=int(time(:ms)%1000000)
srand(seed)
```

## Decisions worth stating

**One reading per call.** All four units come from a single `clock_gettime()`, so the keywords can never describe different instants.

**`CLOCK_REALTIME`, not `CLOCK_MONOTONIC`.** This is a wall-clock value meant to be compared against dates and other machines' clocks, so it must follow an NTP correction rather than ignore one -- the opposite of the choice `comeditor.c` makes for its shift-arrow watchdog, which uses `CLOCK_MONOTONIC` precisely so a clock change cannot fire it.

**Long throughout, seconds included.** Milliseconds since the epoch is already ~1.7e12, past a 32-bit int. Returning `IntType` for seconds and `LongType` for the rest would make the return type depend on the keyword, so every unit is a long.

**`:ns` is documented as "at the clock's actual resolution."** On this Mac `CLOCK_REALTIME` reports microseconds, so nanosecond readings end in `000`. The key is real, the resolution is the platform's.

## Test

`src/comterp_/tests/time.comt`, 9 assertions. A clock cannot be checked against a fixed value, so each one is either a relationship that holds whatever the clock reads -- each unit tracking seconds through its own scale factor, `ns > us > ms > sec`, a later read not being earlier -- or a range wide enough to run for years while still catching a wrong unit or epoch. Suite 44/44.

## Noted while writing the test, not fixed here

An integer literal above 2^31-1 silently wraps: `4102444800` reads back as `-192522496`, IntType. My first draft bounded the epoch with a year-2100 constant and the comparison quietly went negative. The test now expresses that bound by magnitude instead. This is the same shape as the `int("hello") -> 201` case in #251 -- a plausible-looking wrong number rather than an error -- and is worth its own issue.

## Not touched

`random.comt` still seeds deterministically. #75's motivation was a per-run seed there, but making it genuinely random would make a test suite non-reproducible, so that is a deliberate call to leave to you.