### PR TITLE
Reconcile TESTING.md's coverage summary with what the scripts declare

### DIFF
--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -240,24 +240,70 @@ To add a new test script:
 
 ## Current Coverage Summary
 
-| script        | funcs                                                        | slots   | covered | total |  %  |
-|---------------|--------------------------------------------------------------|---------|---------|-------|-----|
-| hello.comt    | (smoke test only)                                            | —       |       — |     — |  —  |
-| return.comt   | return func if for while run                                 | 1-10,11 |      34 |    50 | 68% |
-| stream.comt   | $$ $ ,, next each size .. **                                 | 1-10    |      46 |    50 | 92% |
-| string.comt   | index substr split join eq size print(+:str) +               | 1-10,11 |      78 |    97 | 80% |
-| global.comt   | global                                                       | 1-10,11 |      13 |    14 | 93% |
-| assignops.comt| mod_assign mpy_assign add_assign sub_assign div_assign incr incr_after decr decr_after | 1-9,11 | 33 | 53 | 62% |
-| attrlist.comt | dot list(:attr) attrlist at size attrname attrval + -        | 1-10    |      42 |    55 | 76% |
-| print.comt    | print                                                        | 1-9     |      22 |    35 | 63% |
-| parser.comt   | attrlist(:literal) errmsg postfix class type                 | 1-9     |      28 |    38 | 74% |
-| symbol.comt   | ` symadd symid symbol symstr symval symvar strref eq(:sym) lt gt switch cond | 1-9 |  36 |    42 | 86% |
-| help.comt     | help() help(:posteval) help(:top) help("op") optable(:table) optable(:bypri :byopr :bycom) | 1-14 | 14 | 14 |100% |
-| random.comt   | (slot 12 stress: all funcs from return/stream/string/global) | 12      |      24 |    24 |100% |
-| funcarg.comt  | func arg narg (positional args, keyword-as-variable, if incidental) | 1-11 | 18 | 26 | 69% |
-| funcclosure.comt | func local global (declaration-time capture, #310)         | 1-9,11  |      13 |    21 | 62% |
-| posteval.comt | func arg if (`:posteval` keyword)                            | 1-11    |      21 |    28 | 75% |
-| funchelp.comt | help func arg narg local global (`help(f)` on a bare FuncObj, #334/#336) | 1,3,4,9,11 | 19 | 24 | 79% |
+Every script `run_all.comt` runs, in the order it runs them. Three states:
+
+- **declared** -- the script carries a `// coverage: N/T (P%)` header and this
+  table repeats it. The header is the source of truth; this table follows it.
+- **table-only** -- a number recorded here that the script itself does not
+  declare. Unverifiable until the script gets a header, and marked with a dagger.
+- **untracked** (`—`) -- no coverage header anywhere. The script runs and asserts,
+  it has simply never been scored against the slot taxonomy.
+
+13 of 43 scripts are scored. The rest are real tests with no coverage number,
+not gaps in testing -- do not read `—` as untested.
+
+| script | funcs | covered | total |  %  |
+|--------|-------|---------|-------|-----|
+| assignops.comt            | mod_assign mpy_assign add_assign sub_assign div_assi… |      33 |    53 |  62% |
+| atop.comt                 | @ (at) at() attrname attrval postfix                  |       — |     — |    — |
+| attrlist.comt             | dot list(:attr) attrlist at size attrname attrval + - |      56 |    68 |  82% |
+| bigbuf.comt               | + sum                                                 |       — |     — |    — |
+| bracket-brace-parity.comt | —                                                     |       — |     — |    — |
+| char.comt                 | char-constant ('x', '\xNN')  print(:str)  ==          |       — |     — |    — |
+| chunk.comt                | chunk feed list sum xpose istype print                |       — |     — |    — |
+| deeptest.comt             | list attrlist at size attrname attrval + - . for whi… |       — |     — |    — |
+| feed.comt                 | feed                                                  |      18 |    22 |  82% |
+| filter.comt               | —                                                     |       — |     — |    — |
+| funcarg.comt †              | func arg narg (positional args, keyword-as-variable,… |      18 |    26 |  69% |
+| funcclosure.comt †          | func local global (declaration-time capture, #310)    |      13 |    21 |  62% |
+| funchelp.comt †             | help func arg narg local global (`help(f)` on a bare… |      19 |    24 |  79% |
+| funcstream.comt           | func arg narg if while list local print               |       — |     — |    — |
+| global.comt               | global                                                |      17 |    18 |  94% |
+| hello.comt                | —                                                     |       — |     — |    — |
+| help.comt                 | help() help(:posteval) help(:top) help("op")          |      13 |    13 | 100% |
+| istype.comt               | istype isclass iscomm isfunc                          |      27 |    32 |  84% |
+| keyword_lineend.comt      | func arg run help print list                          |       — |     — |    — |
+| listat.comt               | at  list  size                                        |       — |     — |    — |
+| local.comt                | local                                                 |      14 |    15 |  93% |
+| matrixmult.comt           | sum() list() at() func() for() print() check_fail()   |       — |     — |    — |
+| nilcompare.comt           | func arg while list print                             |       — |     — |    — |
+| numstring.comt            | int long float double print                           |       — |     — |    — |
+| optable.comt              | —                                                     |       — |     — |    — |
+| parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
+| posteval.comt †             | func arg if (`:posteval` keyword)                     |      21 |    28 |  75% |
+| print.comt                | print                                                 |      24 |    35 |  69% |
+| replay.comt               | %% replay optable(:insert) optable(:delete) postfix … |       — |     — |    — |
+| return.comt               | return func if for while run                          |      34 |    50 |  68% |
+| runfile.comt              | —                                                     |       — |     — |    — |
+| spread.comt               | spread stream print echo attrlist func narg list      |       — |     — |    — |
+| stackkey.comt             | at  list                                              |       — |     — |    — |
+| starnext.comt             | * (unary next) * (binary mpy) optable(:table) optabl… |       — |     — |    — |
+| stream-argcnt.comt        | —                                                     |       — |     — |    — |
+| stream-info.comt          | —                                                     |       — |     — |    — |
+| stream-literal.comt       | postfix() errmsg() index() next() list() each() size… |       — |     — |    — |
+| stream.comt               | $$ $ ,, next each size .. **                          |      46 |    50 |  92% |
+| string.comt               | index substr split join eq size print(+:str) +        |      78 |    97 |  80% |
+| symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |
+| symboldrain.comt          | —                                                     |       — |     — |    — |
+| updown.comt               | shell()  socket()  remote()  remote(:nowait)  close(… |       — |     — |    — |
+| wrapper.comt              | —                                                     |       — |     — |    — |
+
+† recorded here but not declared by the script itself.
+
+`random.comt` is not in this table because `run_all.comt` does not run it --
+it is present in the directory, was previously listed here at 100%, and is
+invoked by nothing. Wiring it in would add a randomly-seeded script to CI, so
+that is a deliberate decision rather than an omission to quietly fix.
 
 ### Planned coverage (ivtools-2.2)
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -252,62 +252,64 @@ Every script `run_all.comt` runs, in the order it runs them. Three states:
 - **untracked** (`—`) -- no coverage header anywhere. The script runs and asserts,
   it has simply never been scored against the slot taxonomy.
 
-13 of 43 scripts are scored. The rest are real tests with no coverage number,
+13 of 45 scripts are scored. The rest are real tests with no coverage number,
 not gaps in testing -- do not read `—` as untested.
 
 | script | funcs | covered | total |  %  |
 |--------|-------|---------|-------|-----|
-| assignops.comt            | mod_assign mpy_assign add_assign sub_assign div_assi… |      33 |    53 |  62% |
-| atop.comt                 | @ (at) at() attrname attrval postfix                  |       — |     — |    — |
-| attrlist.comt             | dot list(:attr) attrlist at size attrname attrval + - |      56 |    68 |  82% |
-| bigbuf.comt               | + sum                                                 |       — |     — |    — |
-| bracket-brace-parity.comt | —                                                     |       — |     — |    — |
-| char.comt                 | char-constant ('x', '\xNN')  print(:str)  ==          |       — |     — |    — |
-| chunk.comt                | chunk feed list sum xpose istype print                |       — |     — |    — |
-| deeptest.comt             | list attrlist at size attrname attrval + - . for whi… |       — |     — |    — |
-| feed.comt                 | feed                                                  |      18 |    22 |  82% |
-| filter.comt               | —                                                     |       — |     — |    — |
-| funcarg.comt †              | func arg narg (positional args, keyword-as-variable,… |      18 |    26 |  69% |
-| funcclosure.comt †          | func local global (declaration-time capture, #310)    |      13 |    21 |  62% |
-| funchelp.comt †             | help func arg narg local global (`help(f)` on a bare… |      19 |    24 |  79% |
-| funcstream.comt           | func arg narg if while list local print               |       — |     — |    — |
-| global.comt               | global                                                |      17 |    18 |  94% |
 | hello.comt                | —                                                     |       — |     — |    — |
-| help.comt                 | help() help(:posteval) help(:top) help("op")          |      13 |    13 | 100% |
-| istype.comt               | istype isclass iscomm isfunc                          |      27 |    32 |  84% |
-| keyword_lineend.comt      | func arg run help print list                          |       — |     — |    — |
-| listat.comt               | at  list  size                                        |       — |     — |    — |
-| local.comt                | local                                                 |      14 |    15 |  93% |
-| matrixmult.comt           | sum() list() at() func() for() print() check_fail()   |       — |     — |    — |
-| nilcompare.comt           | func arg while list print                             |       — |     — |    — |
-| numstring.comt            | int long float double print                           |       — |     — |    — |
-| optable.comt              | —                                                     |       — |     — |    — |
-| parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
-| posteval.comt †             | func arg if (`:posteval` keyword)                     |      21 |    28 |  75% |
-| print.comt                | print                                                 |      24 |    35 |  69% |
-| replay.comt               | %% replay optable(:insert) optable(:delete) postfix … |       — |     — |    — |
 | return.comt               | return func if for while run                          |      34 |    50 |  68% |
-| runfile.comt              | —                                                     |       — |     — |    — |
-| spread.comt               | spread stream print echo attrlist func narg list      |       — |     — |    — |
-| stackkey.comt             | at  list                                              |       — |     — |    — |
-| starnext.comt             | * (unary next) * (binary mpy) optable(:table) optabl… |       — |     — |    — |
-| stream-argcnt.comt        | —                                                     |       — |     — |    — |
-| stream-info.comt          | —                                                     |       — |     — |    — |
-| stream-literal.comt       | postfix() errmsg() index() next() list() each() size… |       — |     — |    — |
 | stream.comt               | $$ $ ,, next each size .. **                          |      46 |    50 |  92% |
 | string.comt               | index substr split join eq size print(+:str) +        |      78 |    97 |  80% |
+| global.comt               | global                                                |      17 |    18 |  94% |
+| local.comt                | local                                                 |      14 |    15 |  93% |
+| assignops.comt            | mod_assign mpy_assign add_assign sub_assign div_assi… |      33 |    53 |  62% |
+| attrlist.comt             | dot list(:attr) attrlist at size attrname attrval + - |      56 |    68 |  82% |
+| listat.comt               | at  list  size                                        |       — |     — |    — |
+| stackkey.comt             | at  list                                              |       — |     — |    — |
+| print.comt                | print                                                 |      24 |    35 |  69% |
+| parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
 | symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |
-| symboldrain.comt          | —                                                     |       — |     — |    — |
+| char.comt                 | char-constant ('x', '\xNN')  print(:str)  ==          |       — |     — |    — |
+| help.comt                 | help() help(:posteval) help(:top) help("op")          |      13 |    13 | 100% |
+| stream-literal.comt       | postfix() errmsg() index() next() list() each() size… |       — |     — |    — |
+| stream-info.comt          | —                                                     |       — |     — |    — |
+| stream-argcnt.comt        | —                                                     |       — |     — |    — |
+| matrixmult.comt           | sum() list() at() func() for() print() check_fail()   |       — |     — |    — |
+| deeptest.comt             | list attrlist at size attrname attrval + - . for whi… |       — |     — |    — |
+| bigbuf.comt               | + sum                                                 |       — |     — |    — |
+| funcarg.comt †              | func arg narg (positional args, keyword-as-variable,… |      18 |    26 |  69% |
+| funcclosure.comt †          | func local global (declaration-time capture, #310)    |      13 |    21 |  62% |
+| posteval.comt †             | func arg if (`:posteval` keyword)                     |      21 |    28 |  75% |
+| funcstream.comt           | func arg narg if while list local print               |       — |     — |    — |
+| nilcompare.comt           | func arg while list print                             |       — |     — |    — |
+| random.comt               | split index substr join eq size print + global while… |       — |     — |    — |
+| time.comt                 | time int srand help index                             |       — |     — |    — |
+| numstring.comt            | int long float double print                           |       — |     — |    — |
+| keyword_lineend.comt      | func arg run help print list                          |       — |     — |    — |
+| funchelp.comt †             | help func arg narg local global (`help(f)` on a bare… |      19 |    24 |  79% |
 | updown.comt               | shell()  socket()  remote()  remote(:nowait)  close(… |       — |     — |    — |
+| spread.comt               | spread stream print echo attrlist func narg list      |       — |     — |    — |
+| replay.comt               | %% replay optable(:insert) optable(:delete) postfix … |       — |     — |    — |
+| feed.comt                 | feed                                                  |      18 |    22 |  82% |
+| chunk.comt                | chunk feed list sum xpose istype print                |       — |     — |    — |
+| istype.comt               | istype isclass iscomm isfunc                          |      27 |    32 |  84% |
+| runfile.comt              | —                                                     |       — |     — |    — |
+| filter.comt               | —                                                     |       — |     — |    — |
+| optable.comt              | —                                                     |       — |     — |    — |
+| starnext.comt             | * (unary next) * (binary mpy) optable(:table) optabl… |       — |     — |    — |
+| symboldrain.comt          | —                                                     |       — |     — |    — |
+| bracket-brace-parity.comt | —                                                     |       — |     — |    — |
+| atop.comt                 | @ (at) at() attrname attrval postfix                  |       — |     — |    — |
 | wrapper.comt              | —                                                     |       — |     — |    — |
 
 † recorded here but not declared by the script itself.
 
-`random.comt` is absent from this table because `run_all.comt` on this branch
-does not run it -- it sat in the directory, listed here at 100%, invoked by
-nothing, so its slot-12 sampling never executed in the suite or in CI. It is
-being wired in alongside the seeding fix it depends on, and gets a row here
-once that lands.
+`random.comt` and `time.comt` are the two most recent additions to the runner.
+`random.comt` spent a long stretch in the directory listed at 100% and invoked
+by nothing, so its slot-12 sampling never executed in the suite or in CI; it is
+wired in now, alongside the seeding fix it depended on. Neither declares a
+coverage number yet, so both read `—` here.
 
 ### Planned coverage (ivtools-2.2)
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -300,10 +300,11 @@ not gaps in testing -- do not read `—` as untested.
 
 † recorded here but not declared by the script itself.
 
-`random.comt` is not in this table because `run_all.comt` does not run it --
-it is present in the directory, was previously listed here at 100%, and is
-invoked by nothing. Wiring it in would add a randomly-seeded script to CI, so
-that is a deliberate decision rather than an omission to quietly fix.
+`random.comt` is absent from this table because `run_all.comt` on this branch
+does not run it -- it sat in the directory, listed here at 100%, invoked by
+nothing, so its slot-12 sampling never executed in the suite or in CI. It is
+being wired in alongside the seeding fix it depends on, and gets a row here
+once that lands.
 
 ### Planned coverage (ivtools-2.2)
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "182d3d80"
+#define PATCH_KEY "f662f93a"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Documentation only -- no test or source changes.

## What was wrong

`TESTING.md` says each script carries a `// coverage: N/T (P%)` header and that the summary table reports it. Audited against the scripts, the table had drifted three ways.

**Five rows contradicted their own script.** The table is meant to follow the header; it disagreed with it:

| script | table said | script declares |
|---|---|---|
| attrlist.comt | 42/55 (76%) | **56/68 (82%)** |
| global.comt | 13/14 (93%) | **17/18 (94%)** |
| help.comt | 14/14 (100%) | **13/13 (100%)** |
| parser.comt | 28/38 (74%) | **29/39 (74%)** |
| print.comt | 22/35 (63%) | **24/35 (69%)** |

**Three scripts declare coverage but were never listed:** `feed.comt` 18/22 (82%), `istype.comt` 27/32 (84%), `local.comt` 14/15 (93%).

**The table showed 19 scripts; `run_all.comt` runs 43.** Two dozen were simply absent, which made the suite look a third of its actual size.

## What this changes

Every script `run_all.comt` runs is now listed, in run order, in one of three states:

- **declared** (13) -- the script has a header and the table repeats it
- **table-only** (4, marked †) -- a number recorded here that the script does not declare, so it cannot be verified until that script gets a header
- **untracked** (26, `—`) -- no coverage header anywhere

The distinction matters and the text now says so: a dash means *unscored*, not untested. Those 26 scripts run and assert; they have just never been scored against the slot taxonomy.

No coverage number is invented here. Where a script declares one it is copied; where none exists the cell is a dash. Scoring the 26 needs real slot analysis per function, which is its own piece of work.

## Found while auditing

**`random.comt` is not run by anything.** It sits in the directory, was listed in this table at 100%, and `run_all.comt` never invokes it -- so neither does CI. It is not in the new table, with a note saying why. Wiring it in would put a randomly-seeded script into CI, which is a call worth making deliberately rather than folding into a docs change.

Two consequences worth noting: its 100% was being counted toward a suite that never ran it, and the `time(:ms)` seeding change in #380 lands in a file nothing executes.

**Several declared headers are themselves now stale.** `attrlist.comt` says 56/68, but that predates tests 53-57 added in #367; `print.comt` and `feed.comt` likewise gained tests without header updates. Coverage is slot-based rather than test-count-based, so refreshing them means re-scoring, not arithmetic. Left alone rather than guessed at.