### PR TITLE
Return nil from int/long/float/double where the value has no numeric reading

### DIFF
--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1066,7 +1066,8 @@ IntFunc::IntFunc(ComTerp* comterp) : ComFunc(comterp) {}
    symbols.
 
    Streams are deliberately absent: a stream argument overdrives these
-   commands, so it is never converted whole -- int($$("1","2")) is {1,2}.
+   commands, so it is never converted whole -- int(("1" "2")) is {1,2}, while
+   the comma form int(("1","2")) is a list and lands here.
    Keywords likewise: :key in this position is read as a keyword to the
    command, not as a value to convert, so it never arrives here. */
 static boolean has_no_numeric_reading(ComValue& operand) {

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1055,6 +1055,24 @@ IntFunc::IntFunc(ComTerp* comterp) : ComFunc(comterp) {}
    counts as part of a number.  Returns nil unless the scan really produced
    one -- a non-numeric string lexes as a symbol, and its int_val() is the
    interned symbol id, a wrong answer that reads like a valid parse. */
+/* Kinds with no numeric reading at all.  int_val() answered them anyway: an
+   object gave something derived from its address, so int(date()) returned a
+   different number every call, and a list or a keyword gave 0 -- wrong answers
+   wearing the shape of right ones, the same fault as a symbol's interned id.
+
+   Report nil, and let it propagate: nil+1 is nil, where a 0 or -1 marker would
+   flow on through arithmetic as ordinary data.  An identity, if one is ever
+   wanted, belongs in a command that says so -- symid() already does that for
+   symbols.
+
+   Streams are deliberately absent: a stream argument overdrives these
+   commands, so it is never converted whole -- int($$("1","2")) is {1,2}.
+   Keywords likewise: :key in this position is read as a keyword to the
+   command, not as a value to convert, so it never arrives here. */
+static boolean has_no_numeric_reading(ComValue& operand) {
+    return operand.is_object() || operand.is_array();
+}
+
 static ComValue scan_number_string(const char* numstr) {
     const char* str = numstr;
     while (isspace((unsigned char)*str)) str++;
@@ -1080,6 +1098,7 @@ void IntFunc::execute() {
     reset_stack();
     if (operand.is_string())
       operand = scan_number_string(operand.symbol_ptr());
+    if (has_no_numeric_reading(operand)) operand = ComValue();
     ComValue result(operand.int_val(),  
 		    operand.is_nil() ? ComValue::UnknownType :
                     (uval_flag ? ComValue::UIntType : ComValue::IntType));
@@ -1095,6 +1114,7 @@ void LongFunc::execute() {
     reset_stack();
     if (operand.is_string())
       operand = scan_number_string(operand.symbol_ptr());
+    if (has_no_numeric_reading(operand)) operand = ComValue();
     if (operand.is_nil()) { push_stack(ComValue::nullval()); return; }
     ComValue result(operand.long_val());
     if(uval_flag) result.type(ComValue::ULongType);
@@ -1110,6 +1130,7 @@ void FloatFunc::execute() {
     reset_stack();
     if (operand.is_string())
       operand = scan_number_string(operand.symbol_ptr());
+    if (has_no_numeric_reading(operand)) operand = ComValue();
     if (operand.is_nil()) { push_stack(ComValue::nullval()); return; }
     ComValue result(operand.float_val());
     push_stack(result);
@@ -1123,6 +1144,7 @@ void DoubleFunc::execute() {
     reset_stack();
     if (operand.is_string())
       operand = scan_number_string(operand.symbol_ptr());
+    if (has_no_numeric_reading(operand)) operand = ComValue();
     if (operand.is_nil()) { push_stack(ComValue::nullval()); return; }
     ComValue result(operand.double_val());
     push_stack(result);

--- a/src/comterp_/tests/numstring.comt
+++ b/src/comterp_/tests/numstring.comt
@@ -95,9 +95,14 @@ ok=ok&&((int(date())*2)==nil)
 print("16 the nil propagates through arithmetic rather than becoming data (expect nil nil): %v %v\n" (int(date())+1) (int(date())*2))
 
 // a stream is untouched by this: it overdrives the command rather than being
-// converted whole, so it never reaches the guard
-ok=ok&&(list(int($$("1","2","3")))==(1,2,3))
-print("16b a stream still overdrives rather than converting whole (expect {1,2,3}): %v\n" list(int($$("1","2","3"))))
+// converted whole, so it never reaches the guard.  Spaces make a stream
+// literal, commas make a list -- the same parentheses, and the whole
+// difference in behavior between these two lines
+ok=ok&&(list(int(("1" "2" "3")))==(1,2,3))
+print("16b stream literal overdrives, one conversion per element (expect {1,2,3}): %v\n" list(int(("1" "2" "3"))))
+
+ok=ok&&(int(("1","2","3"))==nil)
+print("16c the comma form is a list, converted whole, and has no reading (expect nil): %v\n" int(("1","2","3")))
 
 // and nothing coercible was caught by this
 ok=ok&&(int(3.7)==3)

--- a/src/comterp_/tests/numstring.comt
+++ b/src/comterp_/tests/numstring.comt
@@ -1,7 +1,7 @@
 // src/comterp_/tests/numstring.comt -- int()/long()/float()/double() applied
-// to a string argument
+// to arguments that are not numbers: strings, and objects
 //
-// funcs: int long float double print
+// funcs: int long float double date attrlist func print
 //
 // These four are comterp's atoi/strtol, and they begin the way atoi does:
 // skip leading whitespace, take an explicit sign, then hand the rest to the
@@ -67,6 +67,43 @@ print("12 float(\" -2.5\") and float(\"x\") (expect -2.5 and nil): %v %v\n" floa
 ok=ok&&(double("+1.5")==1.5)
 ok=ok&&(double("x")==nil)
 print("13 double(\"+1.5\") and double(\"x\") (expect 1.5 and nil): %v %v\n" double("+1.5") double("x"))
+
+// --- 14-17: an object has no numeric reading.  int_val() on one returns
+// something derived from its address, so int(date()) used to answer a
+// different number on every call -- the same fault as a symbol's interned id,
+// a wrong answer wearing the shape of a right one. ---
+ok=ok&&(int(date())==nil)
+print("14 int(date()) on a DateObj (expect nil, not an address): %v\n" int(date()))
+
+// a list has none either -- it used to answer 0, which is a real number and
+// so indistinguishable from a successful conversion
+ok=ok&&(int(1,2,3)==nil)
+print("14b int(1,2,3) on a list (expect nil, not 0): %v\n" int(1,2,3))
+
+// every kind of object, and all four commands, agree
+ok=ok&&(int(attrlist(:a 1))==nil)
+ok=ok&&(int(func(arg(0)))==nil)
+ok=ok&&(long(date())==nil)
+ok=ok&&(float(date())==nil)
+ok=ok&&(double(date())==nil)
+print("15 attrlist, funcobj, and all four commands agree (expect nil): %v %v %v %v %v\n" int(attrlist(:a 1)) int(func(arg(0))) long(date()) float(date()) double(date()))
+
+// nil is out of band and stays that way -- this is why nil rather than 0 or
+// -1: an in-band marker would flow on through arithmetic as ordinary data
+ok=ok&&((int(date())+1)==nil)
+ok=ok&&((int(date())*2)==nil)
+print("16 the nil propagates through arithmetic rather than becoming data (expect nil nil): %v %v\n" (int(date())+1) (int(date())*2))
+
+// a stream is untouched by this: it overdrives the command rather than being
+// converted whole, so it never reaches the guard
+ok=ok&&(list(int($$("1","2","3")))==(1,2,3))
+print("16b a stream still overdrives rather than converting whole (expect {1,2,3}): %v\n" list(int($$("1","2","3"))))
+
+// and nothing coercible was caught by this
+ok=ok&&(int(3.7)==3)
+ok=ok&&(int('a')==97)
+ok=ok&&(int(true)==1)
+print("17 real coercions unaffected (expect 3 97 1): %v %v %v\n" int(3.7) int('a') int(true))
 
 print("numstring: %v\n" ok)
 ok

--- a/src/comterp_/tests/numstring.comt
+++ b/src/comterp_/tests/numstring.comt
@@ -1,5 +1,5 @@
 // src/comterp_/tests/numstring.comt -- int()/long()/float()/double() applied
-// to arguments that are not numbers: strings, and objects
+// to arguments that are not numbers: strings, objects, and lists
 //
 // funcs: int long float double date attrlist func print
 //

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "182d3d80"
+#define PATCH_KEY "e62a469d"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Follows the rule settled in discussion: return nil where a value has no other useful meaning.

## What it was doing

```
int(date())         = 45769984      <- derived from the object's address
int(date())         = 45770016      <- different on the next call
long(date())        = 4340737280L
int(attrlist(:a 1)) = -1962926240
int(1,2,3)          = 0             <- a list, answering a real number
```

An object has no numeric reading, so `int_val()` handed back something derived from its address -- a different answer every call, and negative about half the time. A list answered `0`, which is worse in one way: `0` is a perfectly good result, so nothing distinguishes it from a conversion that succeeded.

This is the same fault as `int("hello") -> 201` in #251: an internal representation returned as though it were the number asked for.

## nil, not 0 and not -1

Both alternatives are *in band* -- `0` and `-1` are values a real conversion can produce, so neither can be told apart from success. nil is out of band, and it stays that way:

```
nil+1   = nil        (-1)+1 = 0
nil*2   = nil        (-1)*2 = -2
nil>0   = nil
```

A marker of `-1` propagates as ordinary arithmetic and becomes believable data downstream; nil keeps being nil. C reaches for `-1` because it has no out-of-band return to reach for -- comterp does, so importing the convention would be importing a workaround for a constraint it does not have.

It is also already the established answer here: #251 made `int("hello")` nil.

## Scope

Covers **objects** and **lists**. Deliberately not:

- **symbols** -- `int(`foo)` already returns nil, since `is_string()` includes `SymbolType` and the scanner fails to read `foo` as a number. `symid()` remains the primitive that gives a symbol's id and says so in its name, which is where identity belongs.
- **streams** -- a stream overdrives these commands rather than being converted whole: `int($$("1","2","3"))` is `{1,2,3}`. Guarding it would break that.
- **keywords** -- `:key` in the argument position is read as a keyword to the command, not as a value to convert, so a `KeywordType` never arrives. I could not construct a case where it does, so there is no guard for it rather than a guard that looks like it handles something it never sees.

Nothing coercible changes: `int(3.7)` 3, `int('a')` 97, `int(true)` 1, `int("42")` 42.

## Test

`numstring.comt` tests 14-17, extended to cover objects and lists, that all four commands agree, that the nil propagates through arithmetic rather than becoming data, and that streams still overdrive. Suite 43/43.

Its header widened from "applied to a string argument" to "applied to arguments that are not numbers".