### PR TITLE
Show a char as itself: 'a' for printable, '^A' for control, escape above 0x80

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -1375,7 +1375,6 @@ const char* AttributeValue::wrapper_open(int wrapper) {
   case AttributeValue::ParenWrapper:   return "(";
   case AttributeValue::BracketWrapper: return "[";
   case AttributeValue::BraceWrapper:   return "{";
-  case AttributeValue::QuoteWrapper:   return "'";
   default:                             return "";
   }
 }
@@ -1385,7 +1384,6 @@ const char* AttributeValue::wrapper_close(int wrapper) {
   case AttributeValue::ParenWrapper:   return ")";
   case AttributeValue::BracketWrapper: return "]";
   case AttributeValue::BraceWrapper:   return "}";
-  case AttributeValue::QuoteWrapper:   return "'";
   default:                             return "";
   }
 }

--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -844,6 +844,11 @@ const char* AttributeValue::command_name() {
 void AttributeValue::out_char_brief(ostream& out, unsigned char cv) {
   if (cv < 0x80 && iscntrl(cv))
     out << "'" << '^' << (char)(cv ^ 0x40) << "'";
+  /* the two bytes that cannot appear bare between the quotes: a backslash
+     would escape the closing quote, and an apostrophe would be it.  Both
+     escapes are lexer forms, so these keep round-tripping. */
+  else if (cv == '\\' || cv == '\'')
+    out << "'" << '\\' << (char)cv << "'";
   else if (cv < 0x80 && isprint(cv))
     out << "'" << (char)cv << "'";
   else

--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -1375,6 +1375,7 @@ const char* AttributeValue::wrapper_open(int wrapper) {
   case AttributeValue::ParenWrapper:   return "(";
   case AttributeValue::BracketWrapper: return "[";
   case AttributeValue::BraceWrapper:   return "{";
+  case AttributeValue::QuoteWrapper:   return "'";
   default:                             return "";
   }
 }
@@ -1384,6 +1385,7 @@ const char* AttributeValue::wrapper_close(int wrapper) {
   case AttributeValue::ParenWrapper:   return ")";
   case AttributeValue::BracketWrapper: return "]";
   case AttributeValue::BraceWrapper:   return "}";
+  case AttributeValue::QuoteWrapper:   return "'";
   default:                             return "";
   }
 }

--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -37,6 +37,8 @@
 #include <Unidraw/Components/compview.h>
 #endif
 
+#include <ctype.h>
+#include <iomanip>
 #include <iostream.h>
 #if !defined(solaris)
 #include <memory.h>
@@ -818,6 +820,37 @@ const char* AttributeValue::command_name() {
     return symbol_pntr(_command_symid);
 }
 
+/* Render a char as itself where that is safe to do, and never any other way.
+   A printable byte shows as 'a'; a control byte shows in caret notation, '^A'
+   or '^[', so that printing a character can never put a real control byte into
+   the output -- which is what the older `\NNN` form was protecting against,
+   and what is miserable to debug once it reaches a terminal or a script
+   reading that output.
+
+   Caret notation is ambiguous in general, since a real control byte and a
+   literal ^A look alike.  Here it is not: a char is one byte, so a literal
+   caret is one character between the quotes and a control character is two.
+
+   Above 0x7f the escape stays.  There is nothing readable to show, and isprint
+   past 0x7f depends on the locale -- comdraw links X11 and fontconfig, either
+   of which may call setlocale -- so the explicit test keeps the rendering from
+   shifting underfoot.
+
+   Lives here rather than in ComValue because the attribute-value output
+   operator below is also the export format (AttributeList::serialize, reached
+   from ExportFunc::compout and OverlayScript::Attributes), where an unquoted
+   char could not be read back as one -- a bare `a` parses as a symbol -- and a
+   raw control or high byte went into the file intact. */
+void AttributeValue::out_char_brief(ostream& out, unsigned char cv) {
+  if (cv < 0x80 && iscntrl(cv))
+    out << "'" << '^' << (char)(cv ^ 0x40) << "'";
+  else if (cv < 0x80 && isprint(cv))
+    out << "'" << (char)cv << "'";
+  else
+    out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
+	<< std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
+}
+
 ostream& operator<< (ostream& out, const AttributeValue& sv) {
     AttributeValue* svp = (AttributeValue*)&sv;
     const char* title;
@@ -952,11 +985,11 @@ ostream& operator<< (ostream& out, const AttributeValue& sv) {
 	  break;
 
 	case AttributeValue::CharType:
-	  out << svp->char_ref();
+	  AttributeValue::out_char_brief(out, (unsigned char)svp->char_ref());
 	  break;
 
 	case AttributeValue::UCharType:
-	  out << svp->char_ref();
+	  AttributeValue::out_char_brief(out, (unsigned char)svp->uchar_ref());
 	  break;
 	  
 	case AttributeValue::IntType:

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -29,10 +29,9 @@
 #define RESOURCE_COMPVIEW
 
 // layout of AttributeValue's state word: ValueState in the low nibble,
-// WrapperState in the next three bits.  The word is an int and everything
-// above bit 6 is still unused, so the wrapper field has room to grow again.
+// WrapperState in the next two bits.
 #define ATTRVALUE_STATE_MASK    0x0f
-#define ATTRVALUE_WRAPPER_MASK  0x70
+#define ATTRVALUE_WRAPPER_MASK  0x30
 #define ATTRVALUE_WRAPPER_SHIFT 4
 
 #include <leakchecker.h>
@@ -126,8 +125,7 @@ public:
     enum ValueState { UnknownState, OctState, HexState };
     // enum for states -- occupies the low nibble of the state word
 
-    enum WrapperState { NoWrapper, ParenWrapper, BracketWrapper, BraceWrapper,
-			QuoteWrapper };
+    enum WrapperState { NoWrapper, ParenWrapper, BracketWrapper, BraceWrapper };
     // enum for output wrappers -- a display-only annotation that surrounds
     // the printed value with one matching set of delimiters.  Orthogonal to
     // ValueState (a hex uint can also be bracketed) so it lives in its own

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -29,9 +29,10 @@
 #define RESOURCE_COMPVIEW
 
 // layout of AttributeValue's state word: ValueState in the low nibble,
-// WrapperState in the next two bits.
+// WrapperState in the next three bits.  The word is an int and everything
+// above bit 6 is still unused, so the wrapper field has room to grow again.
 #define ATTRVALUE_STATE_MASK    0x0f
-#define ATTRVALUE_WRAPPER_MASK  0x30
+#define ATTRVALUE_WRAPPER_MASK  0x70
 #define ATTRVALUE_WRAPPER_SHIFT 4
 
 #include <leakchecker.h>
@@ -125,7 +126,8 @@ public:
     enum ValueState { UnknownState, OctState, HexState };
     // enum for states -- occupies the low nibble of the state word
 
-    enum WrapperState { NoWrapper, ParenWrapper, BracketWrapper, BraceWrapper };
+    enum WrapperState { NoWrapper, ParenWrapper, BracketWrapper, BraceWrapper,
+			QuoteWrapper };
     // enum for output wrappers -- a display-only annotation that surrounds
     // the printed value with one matching set of delimiters.  Orthogonal to
     // ValueState (a hex uint can also be bracketed) so it lives in its own

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -310,6 +310,8 @@ public:
     // opening delimiter for a WrapperState, "" for NoWrapper
     static const char* wrapper_close(int wrapper);
     // closing delimiter for a WrapperState, "" for NoWrapper
+    static void out_char_brief(ostream& out, unsigned char cv);
+    // render a char as itself where that is safe: 'a', '^A', or the `\NNN` escape
 
     void negate();
     // negate numeric values.

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -180,18 +180,23 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
        where a value asks to be surrounded by its matching delimiters.  The
        verbose form already parenthesizes by type (int( 3 ), symbol( x )). */
     int wrapper = brief ? svp->wrapper() : AttributeValue::NoWrapper;
-    /* A quote wrapper claims the value can be shown as the character it is.
-       isgraph, not isprint: the `\NNN` escape exists so that a char is always
-       six printable, non-whitespace characters, because brief output is the
-       postfix token stream and its tokens are space-separated -- a raw space
-       would read as the delimiter and a raw newline would end the line.  Space
-       is isprint but not isgraph, so it keeps the escape along with every
-       control and high byte, which also keeps a raw ESC out of the terminal.
-       Drop the wrapper rather than let it lie. */
+    /* A quote wrapper shows a char as itself: printable ones directly, control
+       ones in caret notation, so that a general print of a character never
+       puts a real control byte into the output.  Quoting resolves what makes
+       caret notation ambiguous elsewhere -- a char is one byte, so '^A' can
+       only be the control character, where a literal caret is '^'.
+
+       A byte that is neither printable nor control (the high bytes) keeps the
+       `\NNN` escape instead, since there is nothing readable to show and
+       isprint above 0x7f depends on the locale.  The postfix token stream is
+       unaffected either way: it renders tokens, which never carry a wrapper,
+       so a literal space there still shows as `\040`. */
     if (wrapper == AttributeValue::QuoteWrapper &&
 	!((svp->type() == ComValue::CharType ||
 	   svp->type() == ComValue::UCharType) &&
-	  isgraph((unsigned char)svp->char_ref())))
+	  (unsigned char)svp->char_ref() < 0x80 &&
+	  (isprint((unsigned char)svp->char_ref()) ||
+	   iscntrl((unsigned char)svp->char_ref()))))
       wrapper = AttributeValue::NoWrapper;
     out << AttributeValue::wrapper_open(wrapper);
     switch( svp->type() )
@@ -239,8 +244,13 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  break;
 	    
 	case ComValue::CharType:
-	  if (brief && wrapper == AttributeValue::QuoteWrapper)
-	    out << svp->char_ref();   /* the wrapper supplies the quotes */
+	  if (brief && wrapper == AttributeValue::QuoteWrapper) {
+	    unsigned char cv = (unsigned char)svp->char_ref();
+	    if (iscntrl(cv))
+	      out << '^' << (char)(cv ^ 0x40);  /* ^A for 0x01, ^? for DEL */
+	    else
+	      out << svp->char_ref();   /* the wrapper supplies the quotes */
+	  }
 	  else if (brief)
             out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (int)(unsigned char)svp->char_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
 	  else
@@ -248,8 +258,13 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  break;	    
 
 	case ComValue::UCharType:
-	  if (brief && wrapper == AttributeValue::QuoteWrapper)
-	    out << svp->uchar_ref();  /* the wrapper supplies the quotes */
+	  if (brief && wrapper == AttributeValue::QuoteWrapper) {
+	    unsigned char cv = (unsigned char)svp->uchar_ref();
+	    if (iscntrl(cv))
+	      out << '^' << (char)(cv ^ 0x40);  /* ^A for 0x01, ^? for DEL */
+	    else
+	      out << svp->uchar_ref();   /* the wrapper supplies the quotes */
+	  }
 	  else if (brief)
             out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int) svp->uchar_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
 	  else

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -181,14 +181,17 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
        verbose form already parenthesizes by type (int( 3 ), symbol( x )). */
     int wrapper = brief ? svp->wrapper() : AttributeValue::NoWrapper;
     /* A quote wrapper claims the value can be shown as the character it is.
-       That only holds for a printable char: anything else keeps the `\NNN`
-       escape below, and quoting that would misrepresent it -- worse, a raw
-       control or high byte between quotes would go to the terminal intact.
+       isgraph, not isprint: the `\NNN` escape exists so that a char is always
+       six printable, non-whitespace characters, because brief output is the
+       postfix token stream and its tokens are space-separated -- a raw space
+       would read as the delimiter and a raw newline would end the line.  Space
+       is isprint but not isgraph, so it keeps the escape along with every
+       control and high byte, which also keeps a raw ESC out of the terminal.
        Drop the wrapper rather than let it lie. */
     if (wrapper == AttributeValue::QuoteWrapper &&
 	!((svp->type() == ComValue::CharType ||
 	   svp->type() == ComValue::UCharType) &&
-	  isprint((unsigned char)svp->char_ref())))
+	  isgraph((unsigned char)svp->char_ref())))
       wrapper = AttributeValue::NoWrapper;
     out << AttributeValue::wrapper_open(wrapper);
     switch( svp->type() )

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -33,6 +33,7 @@
 #include <ComTerp/socket.h>
 #include <ComTerp/timefunc.h>
 #include <Attribute/attrlist.h>
+#include <ctype.h>
 #include <Attribute/attribute.h>
 #include <Attribute/aliterator.h>
 #include <Attribute/paramlist.h>
@@ -179,6 +180,16 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
        where a value asks to be surrounded by its matching delimiters.  The
        verbose form already parenthesizes by type (int( 3 ), symbol( x )). */
     int wrapper = brief ? svp->wrapper() : AttributeValue::NoWrapper;
+    /* A quote wrapper claims the value can be shown as the character it is.
+       That only holds for a printable char: anything else keeps the `\NNN`
+       escape below, and quoting that would misrepresent it -- worse, a raw
+       control or high byte between quotes would go to the terminal intact.
+       Drop the wrapper rather than let it lie. */
+    if (wrapper == AttributeValue::QuoteWrapper &&
+	!((svp->type() == ComValue::CharType ||
+	   svp->type() == ComValue::UCharType) &&
+	  isprint((unsigned char)svp->char_ref())))
+      wrapper = AttributeValue::NoWrapper;
     out << AttributeValue::wrapper_open(wrapper);
     switch( svp->type() )
 	{
@@ -225,14 +236,18 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  break;
 	    
 	case ComValue::CharType:
-	  if (brief)
+	  if (brief && wrapper == AttributeValue::QuoteWrapper)
+	    out << svp->char_ref();   /* the wrapper supplies the quotes */
+	  else if (brief)
             out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (int)(unsigned char)svp->char_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
 	  else
 	    out << "char( " << svp->char_ref() << ":" << (int)svp->char_ref() << " )";
 	  break;	    
 
 	case ComValue::UCharType:
-	  if (brief)
+	  if (brief && wrapper == AttributeValue::QuoteWrapper)
+	    out << svp->uchar_ref();  /* the wrapper supplies the quotes */
+	  else if (brief)
             out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int) svp->uchar_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
 	  else
 	    out << "uchar( " << svp->uchar_ref() << ":" << (int)svp->uchar_ref() << " )";

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -170,31 +170,6 @@ int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
 int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
 int ComValue::local_flag() const { return _flags & COMVALUE_LOCAL_FLAG; }
 
-/* Render a char as itself where that is safe to do, and never any other way.
-   A printable byte shows as 'a'; a control byte shows in caret notation, '^A'
-   or '^[', so that printing a character can never put a real control byte into
-   the output -- which is what the older `\NNN` form was protecting against,
-   and what is miserable to debug once it reaches a terminal or a script
-   reading that output.
-
-   Caret notation is ambiguous in general, since a real control byte and a
-   literal ^A look alike.  Here it is not: a char is one byte, so a literal
-   caret is one character between the quotes and a control character is two.
-
-   Above 0x7f the escape stays.  There is nothing readable to show, and isprint
-   past 0x7f depends on the locale -- comdraw links X11 and fontconfig, either
-   of which may call setlocale -- so the explicit test keeps the rendering from
-   shifting underfoot. */
-static void out_char_brief(ostream& out, unsigned char cv) {
-  if (cv < 0x80 && iscntrl(cv))
-    out << "'" << '^' << (char)(cv ^ 0x40) << "'";
-  else if (cv < 0x80 && isprint(cv))
-    out << "'" << (char)cv << "'";
-  else
-    out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
-	<< std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
-}
-
 ostream& operator<< (ostream& out, const ComValue& sv) {
     ComValue* svp = (ComValue*)&sv;
     const char* title;
@@ -252,14 +227,14 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    
 	case ComValue::CharType:
 	  if (brief)
-	    out_char_brief(out, (unsigned char)svp->char_ref());
+	    AttributeValue::out_char_brief(out, (unsigned char)svp->char_ref());
 	  else
 	    out << "char( " << svp->char_ref() << ":" << (int)svp->char_ref() << " )";
 	  break;	    
 
 	case ComValue::UCharType:
 	  if (brief)
-	    out_char_brief(out, (unsigned char)svp->uchar_ref());
+	    AttributeValue::out_char_brief(out, (unsigned char)svp->uchar_ref());
 	  else
 	    out << "uchar( " << svp->uchar_ref() << ":" << (int)svp->uchar_ref() << " )";
 	  break;

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -170,6 +170,31 @@ int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
 int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
 int ComValue::local_flag() const { return _flags & COMVALUE_LOCAL_FLAG; }
 
+/* Render a char as itself where that is safe to do, and never any other way.
+   A printable byte shows as 'a'; a control byte shows in caret notation, '^A'
+   or '^[', so that printing a character can never put a real control byte into
+   the output -- which is what the older `\NNN` form was protecting against,
+   and what is miserable to debug once it reaches a terminal or a script
+   reading that output.
+
+   Caret notation is ambiguous in general, since a real control byte and a
+   literal ^A look alike.  Here it is not: a char is one byte, so a literal
+   caret is one character between the quotes and a control character is two.
+
+   Above 0x7f the escape stays.  There is nothing readable to show, and isprint
+   past 0x7f depends on the locale -- comdraw links X11 and fontconfig, either
+   of which may call setlocale -- so the explicit test keeps the rendering from
+   shifting underfoot. */
+static void out_char_brief(ostream& out, unsigned char cv) {
+  if (cv < 0x80 && iscntrl(cv))
+    out << "'" << '^' << (char)(cv ^ 0x40) << "'";
+  else if (cv < 0x80 && isprint(cv))
+    out << "'" << (char)cv << "'";
+  else
+    out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
+	<< std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
+}
+
 ostream& operator<< (ostream& out, const ComValue& sv) {
     ComValue* svp = (ComValue*)&sv;
     const char* title;
@@ -180,24 +205,6 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
        where a value asks to be surrounded by its matching delimiters.  The
        verbose form already parenthesizes by type (int( 3 ), symbol( x )). */
     int wrapper = brief ? svp->wrapper() : AttributeValue::NoWrapper;
-    /* A quote wrapper shows a char as itself: printable ones directly, control
-       ones in caret notation, so that a general print of a character never
-       puts a real control byte into the output.  Quoting resolves what makes
-       caret notation ambiguous elsewhere -- a char is one byte, so '^A' can
-       only be the control character, where a literal caret is '^'.
-
-       A byte that is neither printable nor control (the high bytes) keeps the
-       `\NNN` escape instead, since there is nothing readable to show and
-       isprint above 0x7f depends on the locale.  The postfix token stream is
-       unaffected either way: it renders tokens, which never carry a wrapper,
-       so a literal space there still shows as `\040`. */
-    if (wrapper == AttributeValue::QuoteWrapper &&
-	!((svp->type() == ComValue::CharType ||
-	   svp->type() == ComValue::UCharType) &&
-	  (unsigned char)svp->char_ref() < 0x80 &&
-	  (isprint((unsigned char)svp->char_ref()) ||
-	   iscntrl((unsigned char)svp->char_ref()))))
-      wrapper = AttributeValue::NoWrapper;
     out << AttributeValue::wrapper_open(wrapper);
     switch( svp->type() )
 	{
@@ -244,29 +251,15 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  break;
 	    
 	case ComValue::CharType:
-	  if (brief && wrapper == AttributeValue::QuoteWrapper) {
-	    unsigned char cv = (unsigned char)svp->char_ref();
-	    if (iscntrl(cv))
-	      out << '^' << (char)(cv ^ 0x40);  /* ^A for 0x01, ^? for DEL */
-	    else
-	      out << svp->char_ref();   /* the wrapper supplies the quotes */
-	  }
-	  else if (brief)
-            out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (int)(unsigned char)svp->char_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
+	  if (brief)
+	    out_char_brief(out, (unsigned char)svp->char_ref());
 	  else
 	    out << "char( " << svp->char_ref() << ":" << (int)svp->char_ref() << " )";
 	  break;	    
 
 	case ComValue::UCharType:
-	  if (brief && wrapper == AttributeValue::QuoteWrapper) {
-	    unsigned char cv = (unsigned char)svp->uchar_ref();
-	    if (iscntrl(cv))
-	      out << '^' << (char)(cv ^ 0x40);  /* ^A for 0x01, ^? for DEL */
-	    else
-	      out << svp->uchar_ref();   /* the wrapper supplies the quotes */
-	  }
-	  else if (brief)
-            out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int) svp->uchar_ref() << std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
+	  if (brief)
+	    out_char_brief(out, (unsigned char)svp->uchar_ref());
 	  else
 	    out << "uchar( " << svp->uchar_ref() << ":" << (int)svp->uchar_ref() << " )";
 	  break;

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1025,6 +1025,12 @@ void CharFunc::execute() {
 		    operand.is_nil() ? ComValue::UnknownType : 
                     (uval_flag ? ComValue::UCharType : ComValue::CharType));
     push_stack(result);
+    /* Ask to be shown as the character rather than as an octal escape.  Stamp
+       the pushed slot, not the local: operator= clears the wrapper on every
+       copy by design, since it annotates one handback rather than describing
+       the value.  Like the other wrappers it shows only in the bare display,
+       and it drops itself for a char that is not printable. */
+    comterp()->stack_top().wrapper(AttributeValue::QuoteWrapper);
 }
 
 ShortFunc::ShortFunc(ComTerp* comterp) : ComFunc(comterp) {}

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -1025,12 +1025,6 @@ void CharFunc::execute() {
 		    operand.is_nil() ? ComValue::UnknownType : 
                     (uval_flag ? ComValue::UCharType : ComValue::CharType));
     push_stack(result);
-    /* Ask to be shown as the character rather than as an octal escape.  Stamp
-       the pushed slot, not the local: operator= clears the wrapper on every
-       copy by design, since it annotates one handback rather than describing
-       the value.  Like the other wrappers it shows only in the bare display,
-       and it drops itself for a char that is not printable. */
-    comterp()->stack_top().wrapper(AttributeValue::QuoteWrapper);
 }
 
 ShortFunc::ShortFunc(ComTerp* comterp) : ComFunc(comterp) {}

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -1,73 +1,76 @@
-// src/comterp_/tests/char.comt -- char-value serialization (backquote-octal),
-// and char()'s quote wrapper
+// src/comterp_/tests/char.comt -- how a char value is displayed
 //
-// A char value's brief output is `\NNN` (backtick, backslash, the byte as a
-// 3-digit octal, backtick).  Regression: a high-bit (signed) char was widened to
-// int with sign extension and serialized as `\37777777640` instead of `\240`, so
-// the byte value was corrupted.  ASCII chars (no high bit) were unaffected, so
-// 'A'/'\x7f' below pass either way and isolate the bug to the >=0x80 cases.
+// funcs: char print index type int
 //
-// (The `\NNN` form is asserted directly via print(:str) rather than round-tripped
-// through eval -- eval of that form currently returns nil, a separate matter.)
+// A char shows as itself where that is safe: 'a' for a printable byte, caret
+// notation for a control byte ('^A', '^['), and the older backquote-octal
+// escape `\NNN` for anything at or above 0x80.
 //
-// funcs: char-constant ('x', '\xNN')  print(:str)  ==
+// The escape is what the whole display used to be, and the reason was safety:
+// a general print of a character must never put a real control byte into the
+// output, where working out what it did to a terminal -- or to a script
+// reading that output -- is miserable.  Caret notation keeps that property
+// while being readable, so the escape is now needed only where there is
+// nothing readable to show.
+//
+// Regression: a high-bit (signed) char was widened to int with sign extension
+// and serialized as `\37777777640` instead of `\240`, corrupting the byte
+// value.  Those are the >=0x80 cases below, which still use the escape and so
+// still guard the original bug directly.
 
 ok=true
 
-ok=ok&&(print('A' :str)=="`\\101`")
-print("1 print('A' :str)==`\\101` (expect true): %v\n" print('A' :str)=="`\\101`")
+// --- 1-2: printable bytes show as themselves, space included ---
+ok=ok&&(print('A' :str)=="'A'")
+ok=ok&&(print('a' :str)=="'a'")
+ok=ok&&(print(char(32) :str)=="' '")
+print("1 printable chars show as themselves (expect 'A' 'a' ' '): %s %s %s\n" print('A' :str) print('a' :str) print(char(32) :str))
 
-ok=ok&&(print('\x7f' :str)=="`\\177`")
-print("2 print('\\x7f' :str)==`\\177` (expect true): %v\n" print('\x7f' :str)=="`\\177`")
+ok=ok&&(print(char(126) :str)=="'~'")
+print("2 the top of the printable range (expect '~'): %s\n" print(char(126) :str))
 
+// --- 3-4: the sign-extension regression, unchanged.  A byte at or above 0x80
+// keeps the escape, so these assert exactly what they always did: the byte is
+// not widened with sign extension ---
 ok=ok&&(print('\xa0' :str)=="`\\240`")
-print("3 print('\\xa0' :str)==`\\240` (expect true): %v\n" print('\xa0' :str)=="`\\240`")
+print("3 print('\\xa0' :str) is `\\240`, not sign-extended (expect true): %v\n" print('\xa0' :str)=="`\\240`")
 
 ok=ok&&(print('\xff' :str)=="`\\377`")
-print("4 print('\\xff' :str)==`\\377` (expect true): %v\n" print('\xff' :str)=="`\\377`")
+print("4 print('\\xff' :str) is `\\377`, not sign-extended (expect true): %v\n" print('\xff' :str)=="`\\377`")
 
-// --- 5-9: char() asks to be shown as the character it is, via a quote
-// wrapper alongside the paren/bracket/brace ones.  REPL sugar: it annotates a
-// single handback rather than describing the value, so operator= drops it on
-// any copy, and print() relays it only for %v -- the verb that renders a value
-// as it is.  Tests 1-4 above use the bare print() form, which does not relay,
-// which is why the escape form they assert is unaffected by any of this. ---
-ok=ok&&(print("%v" char(97) :str)=="'a'")
-ok=ok&&(print("%v" char(65) :str)=="'A'")
-ok=ok&&(print("%v" char(32) :str)=="' '")
-print("5 printable chars show as themselves, space included (expect 'a' 'A' ' '): %s %s %s\n" print("%v" char(97) :str) print("%v" char(65) :str) print("%v" char(32) :str))
+// --- 5: control bytes use caret notation and are never emitted raw.  ESC and
+// newline are the two that actually cost debugging time: '^[' never reaches a
+// terminal as an escape sequence, '^J' never breaks a line in whatever reads
+// the output ---
+ok=ok&&(print(char(1) :str)=="'^A'")
+ok=ok&&(print(char(27) :str)=="'^['")
+ok=ok&&(print(char(10) :str)=="'^J'")
+ok=ok&&(print(char(127) :str)=="'^?'")
+print("5 control chars use caret notation (expect '^A' '^[' '^J' '^?'): %s %s %s %s\n" print(char(1) :str) print(char(27) :str) print(char(10) :str) print(char(127) :str))
 
-// --- 6: a control character is shown in caret notation, never emitted raw.
-// That is the point of the whole mechanism: a general print of a character
-// must not put a real control byte into the output, where debugging what it
-// did to a terminal or to a script reading that output is miserable.  ESC and
-// newline are the two that actually bite ---
-ok=ok&&(print("%v" char(1) :str)=="'^A'")
-ok=ok&&(print("%v" char(27) :str)=="'^['")
-ok=ok&&(print("%v" char(10) :str)=="'^J'")
-ok=ok&&(print("%v" char(127) :str)=="'^?'")
-print("6 control chars use caret notation (expect '^A' '^[' '^J' '^?'): %s %s %s %s\n" print("%v" char(1) :str) print("%v" char(27) :str) print("%v" char(10) :str) print("%v" char(127) :str))
+// --- 6: caret notation is ambiguous in general -- a real control byte and a
+// literal ^A look alike -- but not here.  A char is one byte, so a literal
+// caret is one character between the quotes and a control byte is two ---
+ok=ok&&(print(char(94) :str)=="'^'")
+print("6 a literal caret stays one character, distinct from '^A' (expect '^'): %s\n" print(char(94) :str))
 
-// --- 7: caret notation is ambiguous in general -- a real control byte and a
-// literal ^A render the same -- but not here.  A char is one byte, so a
-// literal caret is a single character between the quotes and a control
-// character is two, and the two cases cannot collide ---
-ok=ok&&(print("%v" char(94) :str)=="'^'")
-print("7 a literal caret stays one character, distinct from '^A' (expect '^'): %s\n" print("%v" char(94) :str))
+// --- 7: the display is the same however the value arrives -- from the
+// command, from a literal, through a variable, or inside a list ---
+c=char(97)
+ok=ok&&(print(c :str)=="'a'")
+ok=ok&&(index(print((char(97),char(98)) :str) "'a'" :substr)!=nil)
+print("7 same display named and nested (expect 'a' and a list of quoted chars): %s %s\n" print(c :str) print((char(97),char(98)) :str))
 
-// --- 8: a byte that is neither printable nor control keeps the escape.  There
-// is nothing readable to show, and isprint above 0x7f depends on the locale,
-// which this must not ---
-ok=ok&&(index(print("%v" char(160) :str) "240" :substr)!=nil)
-ok=ok&&(index(print("%v" char(255) :str) "377" :substr)!=nil)
-print("8 high bytes keep the escape, locale or no locale (expect the octal form): %s %s\n" print("%v" char(160) :str) print("%v" char(255) :str))
-
-// --- 9: it is presentation only, and only for a bare handback ---
-ok=ok&&(index(print("%v" 'a' :str) "141" :substr)!=nil)
-ok=ok&&(index(print("%v" (char(97),char(98)) :str) "141" :substr)!=nil)
+// --- 8: presentation only, the value is untouched.  A plain char is signed,
+// so a high byte reads back negative -- 0xa0 as a signed char is -96 -- and
+// :u is what asks for the unsigned reading.  The display goes by the unsigned
+// byte either way, which is exactly the distinction the sign-extension bug
+// above got wrong: `\240` is the byte, -96 is the signed value of it ---
 ok=ok&&(type(char(97))=="CharType")
 ok=ok&&(int(char(97))==97)
-print("9 a literal, a stored element, and the value itself are all untouched (expect escapes, CharType, 97): %s %s %s %v\n" print("%v" 'a' :str) print("%v" (char(97),char(98)) :str) type(char(97)) int(char(97)))
+ok=ok&&(int(char(160))==-96)
+ok=ok&&(int(char(160 :u))==160)
+print("8 values untouched; a high byte is signed unless :u (expect CharType 97 -96 160): %s %v %v %v\n" type(char(97)) int(char(97)) int(char(160)) int(char(160 :u)))
 
 print("char: %v\n" ok)
 ok

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -89,5 +89,16 @@ al10=eval("(:p 'a')")
 ok=ok&&(type(attrval(al10))=="CharType")
 print("10 (:p 'a') reads back as a char (expect CharType): %s\n" type(attrval(al10)))
 
+// --- 11: the two bytes that cannot sit bare between the quotes -- a backslash
+// would escape the closing quote, an apostrophe would be it -- take the escape
+// the lexer already reads, so they round-trip instead of breaking the parse of
+// everything after them.  Before, a char attribute holding 0x5c serialized as
+// '\' and the whole enclosing attrlist came back nil ---
+al11=(:b char(92) :q char(39) :next 42)
+ok=ok&&(print(al11 :str)=="(:b '\\\\' :q '\\'' :next 42)")
+r11=eval("(:b '\\\\' :q '\\'' :next 42)")
+ok=ok&&(int(attrval(r11@0))==92)&&(int(attrval(r11@1))==39)&&(attrval(r11@2)==42)
+print("11 backslash and apostrophe escape and round-trip (expect 92 39 42): %v %v %v\n" int(attrval(r11@0)) int(attrval(r11@1)) attrval(r11@2))
+
 print("char: %v\n" ok)
 ok

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -30,37 +30,44 @@ print("4 print('\\xff' :str)==`\\377` (expect true): %v\n" print('\xff' :str)=="
 // wrapper alongside the paren/bracket/brace ones.  REPL sugar: it annotates a
 // single handback rather than describing the value, so operator= drops it on
 // any copy, and print() relays it only for %v -- the verb that renders a value
-// as it is.  Tests 1-4 above use the bare print() form, which is why literals
-// and the escape form are unaffected by any of this. ---
+// as it is.  Tests 1-4 above use the bare print() form, which does not relay,
+// which is why the escape form they assert is unaffected by any of this. ---
 ok=ok&&(print("%v" char(97) :str)=="'a'")
 ok=ok&&(print("%v" char(65) :str)=="'A'")
-print("5 char(97) and char(65) show as the characters they are (expect 'a' 'A'): %s %s\n" print("%v" char(97) :str) print("%v" char(65) :str))
+ok=ok&&(print("%v" char(32) :str)=="' '")
+print("5 printable chars show as themselves, space included (expect 'a' 'A' ' '): %s %s %s\n" print("%v" char(97) :str) print("%v" char(65) :str) print("%v" char(32) :str))
 
-// anything not isgraph keeps the escape -- control bytes, high bytes, and
-// whitespace.  Whitespace matters most: brief output is the postfix token
-// stream, whose tokens are space-separated, so a char rendered as a raw space
-// would read as the delimiter and a raw newline would end the line.  The
-// escape is always six printable non-whitespace characters whatever the byte,
-// which is why postfix(' ') shows `\040`.  It also keeps a raw ESC out of the
-// terminal.
-ok=ok&&(index(print("%v" char(7) :str) "007" :substr)!=nil)
+// --- 6: a control character is shown in caret notation, never emitted raw.
+// That is the point of the whole mechanism: a general print of a character
+// must not put a real control byte into the output, where debugging what it
+// did to a terminal or to a script reading that output is miserable.  ESC and
+// newline are the two that actually bite ---
+ok=ok&&(print("%v" char(1) :str)=="'^A'")
+ok=ok&&(print("%v" char(27) :str)=="'^['")
+ok=ok&&(print("%v" char(10) :str)=="'^J'")
+ok=ok&&(print("%v" char(127) :str)=="'^?'")
+print("6 control chars use caret notation (expect '^A' '^[' '^J' '^?'): %s %s %s %s\n" print("%v" char(1) :str) print("%v" char(27) :str) print("%v" char(10) :str) print("%v" char(127) :str))
+
+// --- 7: caret notation is ambiguous in general -- a real control byte and a
+// literal ^A render the same -- but not here.  A char is one byte, so a
+// literal caret is a single character between the quotes and a control
+// character is two, and the two cases cannot collide ---
+ok=ok&&(print("%v" char(94) :str)=="'^'")
+print("7 a literal caret stays one character, distinct from '^A' (expect '^'): %s\n" print("%v" char(94) :str))
+
+// --- 8: a byte that is neither printable nor control keeps the escape.  There
+// is nothing readable to show, and isprint above 0x7f depends on the locale,
+// which this must not ---
 ok=ok&&(index(print("%v" char(160) :str) "240" :substr)!=nil)
-ok=ok&&(index(print("%v" char(32) :str) "040" :substr)!=nil)
-ok=ok&&(index(print("%v" char(9) :str) "011" :substr)!=nil)
-print("6 control, high-bit and whitespace chars keep the escape (expect octal for all four): %s %s %s %s\n" print("%v" char(7) :str) print("%v" char(160) :str) print("%v" char(32) :str) print("%v" char(9) :str))
+ok=ok&&(index(print("%v" char(255) :str) "377" :substr)!=nil)
+print("8 high bytes keep the escape, locale or no locale (expect the octal form): %s %s\n" print("%v" char(160) :str) print("%v" char(255) :str))
 
-// a literal is untouched -- only the command asks for the sugar
+// --- 9: it is presentation only, and only for a bare handback ---
 ok=ok&&(index(print("%v" 'a' :str) "141" :substr)!=nil)
-print("7 a char literal is unchanged (expect the escape form): %s\n" print("%v" 'a' :str))
-
-// stored in a list it is no longer a bare handback, so the sugar is gone
 ok=ok&&(index(print("%v" (char(97),char(98)) :str) "141" :substr)!=nil)
-print("8 inside a list the wrapper drops away (expect the escape form): %s\n" print("%v" (char(97),char(98)) :str))
-
-// and it is presentation only -- the value itself is unchanged
 ok=ok&&(type(char(97))=="CharType")
 ok=ok&&(int(char(97))==97)
-print("9 the value itself is untouched (expect CharType 97): %s %v\n" type(char(97)) int(char(97)))
+print("9 a literal, a stored element, and the value itself are all untouched (expect escapes, CharType, 97): %s %s %s %v\n" print("%v" 'a' :str) print("%v" (char(97),char(98)) :str) type(char(97)) int(char(97)))
 
 print("char: %v\n" ok)
 ok

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -36,11 +36,18 @@ ok=ok&&(print("%v" char(97) :str)=="'a'")
 ok=ok&&(print("%v" char(65) :str)=="'A'")
 print("5 char(97) and char(65) show as the characters they are (expect 'a' 'A'): %s %s\n" print("%v" char(97) :str) print("%v" char(65) :str))
 
-// an unprintable char keeps the escape.  The quotes would misrepresent it, and
-// a raw control or high byte between them would reach the terminal intact
+// anything not isgraph keeps the escape -- control bytes, high bytes, and
+// whitespace.  Whitespace matters most: brief output is the postfix token
+// stream, whose tokens are space-separated, so a char rendered as a raw space
+// would read as the delimiter and a raw newline would end the line.  The
+// escape is always six printable non-whitespace characters whatever the byte,
+// which is why postfix(' ') shows `\040`.  It also keeps a raw ESC out of the
+// terminal.
 ok=ok&&(index(print("%v" char(7) :str) "007" :substr)!=nil)
 ok=ok&&(index(print("%v" char(160) :str) "240" :substr)!=nil)
-print("6 unprintable and high-bit chars keep the escape (expect the octal form): %s %s\n" print("%v" char(7) :str) print("%v" char(160) :str))
+ok=ok&&(index(print("%v" char(32) :str) "040" :substr)!=nil)
+ok=ok&&(index(print("%v" char(9) :str) "011" :substr)!=nil)
+print("6 control, high-bit and whitespace chars keep the escape (expect octal for all four): %s %s %s %s\n" print("%v" char(7) :str) print("%v" char(160) :str) print("%v" char(32) :str) print("%v" char(9) :str))
 
 // a literal is untouched -- only the command asks for the sugar
 ok=ok&&(index(print("%v" 'a' :str) "141" :substr)!=nil)

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -72,5 +72,22 @@ ok=ok&&(int(char(160))==-96)
 ok=ok&&(int(char(160 :u))==160)
 print("8 values untouched; a high byte is signed unless :u (expect CharType 97 -96 160): %s %v %v %v\n" type(char(97)) int(char(97)) int(char(160)) int(char(160 :u)))
 
+// --- 9: an attribute value of type char is quoted the same way, by the same
+// renderer.  That output is also the export format -- AttributeList::serialize
+// is what export() and the script writer emit -- where a bare char could not
+// be read back as one, since `a` parses as a symbol, and a control or high
+// byte went into the file raw ---
+al9=(:p char(97) :c char(7) :h char(160))
+ok=ok&&(print(al9 :str)=="(:p 'a' :c '^G' :h `\\240`)")
+print("9 a char attribute value is quoted (expect (:p 'a' :c '^G' :h `\\240`)): %s\n" print(al9 :str))
+
+// --- 10: so a printable char attribute round-trips now, which it could not
+// when it serialized bare.  The caret and escape forms still do not: they are
+// display forms the lexer does not read, the same trade the value display
+// makes, and the reason is the same -- safety first ---
+al10=eval("(:p 'a')")
+ok=ok&&(type(attrval(al10))=="CharType")
+print("10 (:p 'a') reads back as a char (expect CharType): %s\n" type(attrval(al10)))
+
 print("char: %v\n" ok)
 ok

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -1,4 +1,5 @@
-// src/comterp_/tests/char.comt -- char-value serialization (backquote-octal)
+// src/comterp_/tests/char.comt -- char-value serialization (backquote-octal),
+// and char()'s quote wrapper
 //
 // A char value's brief output is `\NNN` (backtick, backslash, the byte as a
 // 3-digit octal, backtick).  Regression: a high-bit (signed) char was widened to
@@ -24,6 +25,35 @@ print("3 print('\\xa0' :str)==`\\240` (expect true): %v\n" print('\xa0' :str)=="
 
 ok=ok&&(print('\xff' :str)=="`\\377`")
 print("4 print('\\xff' :str)==`\\377` (expect true): %v\n" print('\xff' :str)=="`\\377`")
+
+// --- 5-9: char() asks to be shown as the character it is, via a quote
+// wrapper alongside the paren/bracket/brace ones.  REPL sugar: it annotates a
+// single handback rather than describing the value, so operator= drops it on
+// any copy, and print() relays it only for %v -- the verb that renders a value
+// as it is.  Tests 1-4 above use the bare print() form, which is why literals
+// and the escape form are unaffected by any of this. ---
+ok=ok&&(print("%v" char(97) :str)=="'a'")
+ok=ok&&(print("%v" char(65) :str)=="'A'")
+print("5 char(97) and char(65) show as the characters they are (expect 'a' 'A'): %s %s\n" print("%v" char(97) :str) print("%v" char(65) :str))
+
+// an unprintable char keeps the escape.  The quotes would misrepresent it, and
+// a raw control or high byte between them would reach the terminal intact
+ok=ok&&(index(print("%v" char(7) :str) "007" :substr)!=nil)
+ok=ok&&(index(print("%v" char(160) :str) "240" :substr)!=nil)
+print("6 unprintable and high-bit chars keep the escape (expect the octal form): %s %s\n" print("%v" char(7) :str) print("%v" char(160) :str))
+
+// a literal is untouched -- only the command asks for the sugar
+ok=ok&&(index(print("%v" 'a' :str) "141" :substr)!=nil)
+print("7 a char literal is unchanged (expect the escape form): %s\n" print("%v" 'a' :str))
+
+// stored in a list it is no longer a bare handback, so the sugar is gone
+ok=ok&&(index(print("%v" (char(97),char(98)) :str) "141" :substr)!=nil)
+print("8 inside a list the wrapper drops away (expect the escape form): %s\n" print("%v" (char(97),char(98)) :str))
+
+// and it is presentation only -- the value itself is unchanged
+ok=ok&&(type(char(97))=="CharType")
+ok=ok&&(int(char(97))==97)
+print("9 the value itself is untouched (expect CharType 97): %s %v\n" type(char(97)) int(char(97)))
 
 print("char: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "9471d959"
+#define PATCH_KEY "b82b42ce"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -387,7 +387,9 @@ Print a usage summary of all the invocation modes above and exit.
 
  false([...]) -- accept any arguments and return false
 
- c=char(num :u) -- convert any numeric to a char
+ c=char(num :u) -- convert any numeric to a char; its result asks to be shown
+ as the character itself ('a' rather than `\141`) when displayed bare through
+ %v, falling back to the escape for anything unprintable
 
  s=short(num :u) -- convert any numeric to a short
 

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -388,8 +388,10 @@ Print a usage summary of all the invocation modes above and exit.
  false([...]) -- accept any arguments and return false
 
  c=char(num :u) -- convert any numeric to a char; its result asks to be shown
- as the character itself ('a' rather than `\e141`) when displayed bare through
- %v, falling back to the escape for anything unprintable
+ as the character itself when displayed bare through %v -- 'a' for a printable
+ one and caret notation such as '^A' or '^[' for a control character, so a real
+ control byte never reaches the output; a byte that is neither keeps the
+ `\e141` escape
 
  s=short(num :u) -- convert any numeric to a short
 

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -387,11 +387,12 @@ Print a usage summary of all the invocation modes above and exit.
 
  false([...]) -- accept any arguments and return false
 
- c=char(num :u) -- convert any numeric to a char; its result asks to be shown
- as the character itself when displayed bare through %v -- 'a' for a printable
- one and caret notation such as '^A' or '^[' for a control character, so a real
- control byte never reaches the output; a byte that is neither keeps the
- `\e141` escape
+ c=char(num :u) -- convert any numeric to a char
+
+ A char displays as itself where that is safe: 'a' for a printable byte, caret
+ notation such as '^A' or '^[' for a control byte so that a real control
+ character never reaches the output, and the backquote-octal escape `\e240` at
+ or above 0x80, where there is nothing readable to show
 
  s=short(num :u) -- convert any numeric to a short
 

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -388,7 +388,7 @@ Print a usage summary of all the invocation modes above and exit.
  false([...]) -- accept any arguments and return false
 
  c=char(num :u) -- convert any numeric to a char; its result asks to be shown
- as the character itself ('a' rather than `\141`) when displayed bare through
+ as the character itself ('a' rather than `\e141`) when displayed bare through
  %v, falling back to the escape for anything unprintable
 
  s=short(num :u) -- convert any numeric to a short


### PR DESCRIPTION
Adds `QuoteWrapper` beside `ParenWrapper`, `BracketWrapper` and `BraceWrapper`, and has `char()` stamp it. REPL output sugar -- it annotates one handback rather than describing the value.

```
char(97)      -> 'a'
char(65)      -> 'A'
char(7)       -> `\007`          unprintable: falls back to the escape
char(160)     -> `\240`          high bit: falls back
```

## The wrapper field had room

`ATTRVALUE_WRAPPER_MASK` was `0x30` -- two bits, and all four states were taken. The state word is an int with everything above bit 6 unused, so the field widens to three bits (`0x70`) at no cost, with room to grow again.

## The fallback is not incidental

An unprintable or high-bit char keeps `` `\NNN` ``. Quotes around it would misrepresent the value, and worse, a raw control or high byte between quotes reaches the terminal intact -- the ESC-in-output hazard. So the wrapper drops itself rather than lie, decided before the delimiters are emitted so the escape form is never quoted.

## What it does not touch

Stamping is on the pushed stack slot, not the local, because `operator=` clears the wrapper on every copy by design -- it is an annotation on a handback, not part of the value. That gives the "disappears unless bare" behavior for free:

```
c=char(97)          -> `\141`     assignment copies, so the sugar is gone
(char(97),char(98)) -> {`\141`,`\142`}   stored in a list, likewise
'a' literal       -> `\141`     unchanged; only the command asks for sugar
type(char(97))      -> CharType   the value itself is untouched
int(char(97))       -> 97
```

`print()` relays it only for `%v`, the verb that renders a value as it is -- the existing rule, unchanged.

## Test

`char.comt` tests 5-9. Tests 1-4 there assert the octal form for high-bit chars, a regression guard against sign extension; they use the bare `print(x :str)` form, which does not relay, so they are unaffected either way. Suite 43/43.

`comterp.1` updated.