### PR TITLE
Drain a symbol's arglist where the symbol sits, not only where a statement ends

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -88,6 +88,11 @@
 
 #define TITLE "ComTerp"
 
+/* a symbol that carried an arglist -- "SYMBOL (args)", a call attempt on
+   something that wasn't a registered command when the token was converted */
+#define PENDING_CALL(v) \
+  ((v).is_type(ComValue::SymbolType) && ((v).narg() || (v).nkey()))
+
 extern int _detail_matched_delims;
 extern int _no_bracesplus;
 
@@ -963,6 +968,10 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	   the early exit that previously skipped the FuncObj check). */
 	if (val && !val->is_object(FuncObj::class_symid())) {
 	  ComValue newval(*val);
+	  /* a func-local plain value drains a pending arglist the same way
+	     the local/global case below does -- otherwise the args stay
+	     stranded under the result */
+	  decr_stack(sv.narg() + sv.nkey());
 	  push_stack(newval);
 	  return;
 	}
@@ -1073,13 +1082,22 @@ void ComTerp::load_sub_expr() {
        command (the next token) to read.  The RHS of a dot attribute should
        not look up a zero-arg funcobj. */
     boolean funcobj_top = stack_top().is_funcobj(this);
-    if (funcobj_top && _pfoff < _pfnum &&
+    /* Same break for a symbol carrying a pending arglist: "SYMBOL (args)"
+       is always a call attempt (LANGUAGE.md), so it has to be dispatched
+       here like a command -- eval_expr_internals is what fires a FuncObj
+       or drains a plain value's arglist.  Without the break the symbol
+       sits on the stack with its already-evaluated args stranded under
+       it, so the next operator reads those as its operands and one entry
+       leaks per evaluation. */
+    boolean pending_call_top = PENDING_CALL(stack_top());
+    if ((funcobj_top || pending_call_top) && _pfoff < _pfnum &&
 	_pfcomvals[_pfoff].is_type(ComValue::CommandType)) {
       static int dot_symid = symbol_add("dot");
-      if (_pfcomvals[_pfoff].command_symid() == dot_symid) funcobj_top = false;
+      if (_pfcomvals[_pfoff].command_symid() == dot_symid)
+	funcobj_top = pending_call_top = false;
     }
-    if ((stack_top().type() == ComValue::CommandType || funcobj_top) &&
-	!_pfcomvals[_pfoff-1].pedepth()) break;
+    if ((stack_top().type() == ComValue::CommandType || funcobj_top ||
+	 pending_call_top) && !_pfcomvals[_pfoff-1].pedepth()) break;
   }
   
 #if 0
@@ -1172,13 +1190,16 @@ int ComTerp::post_eval_expr(int tokcnt, int offtop, int pedepth
 	   that is the RHS of a dot is an attribute name, not a call (here in the
 	   post-eval path, e.g. inside && / if). */
 	boolean pe_funcobj_top = stack_top().is_funcobj(this);
-	if (pe_funcobj_top && offset < _pfnum &&
+	/* and the same pending-arglist break as the main push loop */
+	boolean pe_pending_call_top = PENDING_CALL(stack_top());
+	if ((pe_funcobj_top || pe_pending_call_top) && offset < _pfnum &&
 	    _pfcomvals[offset].is_type(ComValue::CommandType)) {
 	  static int dot_symid = symbol_add("dot");
-	  if (_pfcomvals[offset].command_symid() == dot_symid) pe_funcobj_top = false;
+	  if (_pfcomvals[offset].command_symid() == dot_symid)
+	    pe_funcobj_top = pe_pending_call_top = false;
 	}
-	if ((stack_top().is_type(ComValue::CommandType) || pe_funcobj_top)
-	    && stack_top().pedepth() == pedepth) break;
+	if ((stack_top().is_type(ComValue::CommandType) || pe_funcobj_top ||
+	     pe_pending_call_top) && stack_top().pedepth() == pedepth) break;
       }
 #ifdef POSTEVAL_EXPERIMENT 
       if (!(stack_top().is_symbol()&&numtok==1&&nolookup))

--- a/src/comterp_/tests/symboldrain.comt
+++ b/src/comterp_/tests/symboldrain.comt
@@ -82,5 +82,90 @@ ok=ok&&sameheight
 print("5 stackheight() delta is the same for 3 vs 5 drains (expect true): %v %v\n\n" d3 d5)
 check_fail(:ok ok)
 
+// --- tests 6-10: the drain has to happen where the symbol sits, mid
+// expression, not just when it lands at the top of a finished statement.
+// A drain inside a loop condition is where getting that wrong shows:
+// "while(i<lim (i=i+1))" glues the paren group onto lim (adjacency, above),
+// so while sees ONE argument -- the condition -- and no body at all, with
+// the increment riding inside the condition.  That is a legal, terminating
+// loop; whether a body-less while should say so is #398.  It used to run
+// exactly one iteration and print stack diagnostics: the symbol was left
+// on the stack unresolved with its already-evaluated arglist stranded
+// underneath, so "<" compared the arglist's value against the bare symbol,
+// and the leftover entry wrecked while's post-eval anchor on the next
+// pass.  It only ever looked right at the end of a statement, where the
+// enclosing command's reset_stack() swept the leftover away. ---
+
+// --- test 6: the glued forms -- one per comparison shape, since which
+// operand the paren lands against is what decides who gets drained ---
+lim=5
+i=0
+while(i<lim (i=i+1))
+a6=i
+i=0
+while(lim>i (i=i+1))
+b6=i
+i=0
+while(i!=lim (i=i+1))
+c6=i
+ok=ok&&(a6==5 && b6==5 && c6==5)
+print("6 glued cond runs to completion, i<lim / lim>i / i!=lim (expect 5 5 5): %v %v %v\n\n" a6 b6 c6)
+check_fail(:ok ok)
+
+// --- test 7: the contrasting forms that never glued, so the test fails if
+// the parse itself ever shifts.  A literal can't be called, so the parens
+// stay a body; a closing paren before them does the same; and a bare or
+// ";"-terminated body was never ambiguous ---
+i=0
+while(i<5 (i=i+1))
+a7=i
+i=0
+while((i<lim) (i=i+1))
+b7=i
+i=0
+while(i<lim i=i+1)
+c7=i
+i=0
+while(i<lim i=i+1;)
+d7=i
+ok=ok&&(a7==5 && b7==5 && c7==5 && d7==5)
+print("7 unglued forms unchanged, i<5 / (i<lim) / bare / semicolon (expect 5 5 5 5): %v %v %v %v\n\n" a7 b7 c7 d7)
+check_fail(:ok ok)
+
+// --- test 8: the leak signature, measured the way test 5 measures it --
+// a glued loop drains once per iteration, so a leak here compounds ---
+before2=stackheight()
+h2=(i=0; while(i<lim (i=i+1)); i=0; while(i<lim (i=i+1)); stackheight())
+before4=stackheight()
+h4=(i=0; while(i<lim (i=i+1)); i=0; while(i<lim (i=i+1)); i=0; while(i<lim (i=i+1)); i=0; while(i<lim (i=i+1)); stackheight())
+e2=h2-before2
+e4=h4-before4
+ok=ok&&(e2==e4)
+print("8 stackheight() delta is the same for 2 vs 4 glued loops (expect true): %v %v\n\n" e2 e4)
+check_fail(:ok ok)
+
+// --- test 9: the same drain as a plain mid-expression operand, away from
+// any loop -- the general case the loop symptom was a symptom of.  The
+// arglist runs once for its side effect and the symbol's own value is what
+// the operator gets ---
+x9=5
+cnt9=0
+r9=2+x9 (cnt9=cnt9+1)
+ok=ok&&(r9==7 && cnt9==1)
+print("9 2+x9 (side effect) drains mid-expression (expect r9=7 cnt9=1): %v %v\n\n" r9 cnt9)
+check_fail(:ok ok)
+
+// --- test 10: the same again for a symbol that resolves in func scope
+// rather than the local/global tables -- a keyword param is a plain value
+// too, so it drains the same way, in a loop condition inside a body.  lim
+// is deliberately the outer symbol from test 6: the keyword binding is
+// what each call reads, which is the func-scope path being covered ---
+g10=func(i=0; while(i<lim (i=i+1)); i)
+a10=g10(:lim 5)
+b10=g10(:lim 3)
+ok=ok&&(a10==5 && b10==3)
+print("10 glued cond on a func keyword param (expect 5 3): %v %v\n\n" a10 b10)
+check_fail(:ok ok)
+
 print("\nsymboldrain: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "9471d959"
+#define PATCH_KEY "a93f115b"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Reported as a `while()` loop that silently runs one iteration and prints
stack diagnostics when the body is parenthesized and the condition
compares two symbols:

```
lim=5
i=0
while(i<lim (i=i+1))
print("i=%d (expect 5)\n" i)
```

```
comterp: stack_arg_post_eval: offtop out of range (offtop=199 nkeys=0 argoff=208 _pfnum=9) -- ...
func "while" pushed more than a single value on stack (line 3)
i=1
```

## The parse is not the bug

`lim (i=i+1)` really is a call attempt on `lim` -- same-line adjacency to
a paren group always is (doc/LANGUAGE.md, "Symbol-then-parens is always a
call attempt"), and `symboldrain.comt` already covers it. So `while` sees
one argument and no body, with the increment riding inside the condition.
That is a legal, terminating loop. Substituting a literal
(`while(i<5 (i=i+1))`) or closing the condition first
(`while((i<lim) (i=i+1))`) leaves the parens a body, which is why only
some of the reported variants misbehaved.

## The bug

Both postfix push loops broke out to `eval_expr_internals` only on a
`CommandType`, or on a symbol resolving to a `FuncObj`. A symbol holding
a **plain value** never broke out, so the drain branch
`eval_expr_internals` already implements never ran. The symbol stayed on
the stack unresolved with its already-evaluated arglist stranded
underneath it. `trace(1)` shows the consequence directly:

```
4:  while: nargs=1 nkeys=0
4:      assign: nargs=2 nkeys=0
4:          add(i 1)
4:      lt(1 lim)          <-- arglist's value vs the bare symbol
```

`<` took the arglist's value and the unresolved symbol as its two
operands, and one entry leaked per evaluation.

This looked correct everywhere it had been exercised, because at the end
of a statement the enclosing command's `reset_stack()` swept the leftover
away -- so `symboldrain.comt` passed throughout. A loop condition gets no
such sweep: the stray entry clobbered `while`'s post-eval argoff anchor on
the second pass, hence `offtop out of range`, a nil condition, and one
iteration.

## The change

Break the push loops on a pending-arglist symbol as well, with the same
dot-RHS suppression the `FuncObj` case already carries, so
`eval_expr_internals` runs and does the drain it already knows how to do.
The func-scope early return needs the matching `decr_stack` -- a keyword
param is a plain value too. That line is load-bearing: removing it
reproduces the identical corruption for a symbol resolved out of `_alist`.

## Testing

`symboldrain.comt` gains tests 6-10, covering the reported failing forms
alongside the working ones: the three glued comparison shapes, the four
unglued forms that pin the parse, stack flatness across repeated glued
loops, the mid-expression operand case away from any loop, and the
func-scope case. Verified they fail on the parent commit (6, 9 and 10
give wrong values) and pass with the fix.

`run_all.comt` is 43/43, identical to the pre-change baseline.

A body-less `while` is left alone, tracked separately as #398.
