### PR TITLE
class() with no value named answers blank, not nothing

### DIFF
--- a/src/ComTerp/typefunc.c
+++ b/src/ComTerp/typefunc.c
@@ -84,10 +84,15 @@ ClassSymbolFunc::ClassSymbolFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void ClassSymbolFunc::execute() {
-  // return type symbol for each argumen
-  boolean noargs = !nargs() && !nkeys();
+  // return class symbol for each argument
   int numargs = nargs();
-  if (!numargs) return;
+  if (!numargs) {
+    /* no value named at all -- blank, the "nothing was asked" answer.  nil is
+       reserved for the value that was named but has no class to report. */
+    reset_stack();
+    push_stack(ComValue::blankval());
+    return;
+  }
   std::vector<int> class_syms(numargs);
   for (int i=0; i<numargs; i++) {
     ComValue val = stack_arg(i);

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -51,7 +51,7 @@ public:
     virtual void execute();
 
     virtual const char* docstring() {
-      return "sym|lst=%s(val [ ...]) -- return class symbol(s) for value(s) of object type"; }
+      return "sym|lst=%s(val [ ...]) -- return class symbol(s) for value(s) of object type, nil for a value with no class, blank for no value at all"; }
 };
 
 //: command to test a variable's type without ever evaluating it.

--- a/src/comterp_/tests/classblank.comt
+++ b/src/comterp_/tests/classblank.comt
@@ -1,0 +1,106 @@
+// src/comterp_/tests/classblank.comt -- class() with no argument answers
+// blank, not nil: the two "no answer" values say different things
+//
+// coverage: 10/12 (83%)
+// funcs: class blank empty type
+// missing: blank(arg) empty(arg) over-arity forms
+//
+// class(val) has two ways to come back empty-handed, and they are not the
+// same question:
+//
+//   class(3)   ->  nil     a value was named; it has no class to report
+//   class()    ->  blank   no value was named at all
+//
+// nil is an answer about the argument, so it needs an argument to be about.
+// With nothing named there is nothing to answer for, and blank -- the
+// value ComTerp already uses for "no value here", the one empty() leaves
+// behind -- is what that costs.  Reserving nil for the named-but-classless
+// case keeps the answer readable: a caller feeding class() a value it did
+// not build itself can tell "you handed me something with no class" from
+// "you handed me nothing", which a single shared nil cannot express.
+//
+// The distinction survives comparison -- blank==nil is false (test 5, 6) --
+// so a caller can branch on which of the two it got.  Both are falsy in a
+// condition (test 8), so neither one silently takes a :then branch.
+//
+// class() takes no keywords, so a keyword-only call names no value either
+// and answers blank the same way (test 10).
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./classblank.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: class() with no argument answers blank ---
+r1=type(class())
+ok=ok&&(r1==`BlankType)
+print("1 type(class()) with no argument (expect BlankType): %v\n" r1)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: and it is the same blank blank() hands out ---
+r2=(class()==blank())
+ok=ok&&(r2==true)
+print("2 class()==blank() (expect true): %v\n" r2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: empty() is the partner -- the empty statement leaves the same
+// value behind, so class() with nothing to look at reads the same way ---
+r3a=type(empty())
+r3b=(class()==empty())
+ok=ok&&(r3a==`BlankType)&&(r3b==true)
+print("3 empty() leaves the same blank (expect BlankType true): %v %v\n" r3a r3b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: a value that was named but has no class still answers nil ---
+r4=class(3)
+ok=ok&&(r4==nil)&&(type(r4)==`UnknownType)
+print("4 class(3) names a classless value (expect nil UnknownType): %v %v\n" r4 type(r4))
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: the two answers are distinguishable -- this is the whole point ---
+r5=(class()==class(3))
+ok=ok&&(r5==false)
+print("5 class()==class(3) blank is not nil (expect false): %v\n" r5)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: stated the other way, against nil directly ---
+r6a=(class()==nil)
+r6b=(class(3)==nil)
+ok=ok&&(r6a==false)&&(r6b==true)
+print("6 blank==nil vs nil==nil (expect false true): %v %v\n" r6a r6b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: a real object still reports its class, unchanged ---
+al7=attrlist(:x 1)
+r7=class(al7)
+ok=ok&&(r7==`AttributeList)&&(type(r7)==`SymbolType)
+print("7 class(attrlist(:x 1)) (expect AttributeList SymbolType): %v %v\n" r7 type(r7))
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: both no-answer values are falsy, so neither takes a :then ---
+r8a=if(class() :then "true-branch" :else "false-branch")
+r8b=if(class(3) :then "true-branch" :else "false-branch")
+ok=ok&&(r8a=="false-branch")&&(r8b=="false-branch")
+print("8 blank and nil are both falsy (expect false-branch false-branch): %v %v\n" r8a r8b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: multi-argument class() is untouched -- with arguments to be
+// about, every classless one is still its own nil in the returned list ---
+lst9=class(1 2)
+n9=size(lst9)
+a9=at(lst9 0)
+b9=at(lst9 1)
+ok=ok&&(n9==2)&&(a9==nil)&&(b9==nil)
+print("9 class(1 2) one nil per argument (expect 2 nil nil): %v %v %v\n" n9 a9 b9)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: class() takes no keywords, so a keyword-only call still names
+// no value -- blank, not the keyword's own value handed back ---
+r10=class(:foo)
+ok=ok&&(type(r10)==`BlankType)
+print("10 class(:foo) names no value either (expect BlankType): %v\n" type(r10))
+prev_ok=check_fail(:ok ok)
+
+print("classblank: %v\n" ok)
+ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -186,5 +186,9 @@ if(run("./wrapper.comt")
   :then print("pass: wrapper\n")
   :else print("FAIL: wrapper\n");topok=false)
 
+if(run("./classblank.comt")
+  :then print("pass: classblank\n")
+  :else print("FAIL: classblank\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a5e9aa7d"
+#define PATCH_KEY "52391288"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## What

`class(val)` has two ways to come back empty-handed, and they were not
distinguishable:

```
class(3)   ->  nil     a value was named; it has no class to report
class()    ->  ???
```

`nil` is an answer *about the argument*, so it needs an argument to be about.
With nothing named there is nothing to answer for, and blank — the value
ComTerp already uses for "no value here", the one `empty()` leaves behind — is
what that costs. This makes `class()` return it deliberately.

## Why it wasn't already that

The no-args path was `if (!numargs) return;` — an outright return that never
touched the stack. Two things followed from that:

- **No args at all.** `ComTerp::eval_expr_internals` noticed the shortfall,
  printed `func "class" failed to push a single value on stack` to stderr, and
  backfilled `blankval()` behind it. So the *value* was already blank, by
  accident of a backstop meant for genuinely broken commands, with a
  diagnostic on every call.

- **Keyword-only call.** `class(:foo)` has `nargs()==0` but `nkeys()==1`, and
  the early return skipped `reset_stack()` too — so the unconsumed keyword was
  still sitting there. That made the stack look balanced, the backstop never
  fired, and the caller got its own `:foo` handed back as the return value:

  ```
  before:  type(class(:foo))  ->  KeywordType
  after:   type(class(:foo))  ->  BlankType
  ```

The fix is the same one line either way: `reset_stack()` then push
`blankval()` explicitly, and return.

Also drops a dead `boolean noargs` local, fixes the copy-pasted `// return
type symbol` comment (this is `class`, not `type`), and extends the docstring
to name both empty-handed cases.

## Behavior

```
class()             ->  blank        (was: blank, plus a stderr complaint)
class(:foo)         ->  blank        (was: `foo, the caller's own keyword)
class(3)            ->  nil          unchanged
class(attrlist(:x 1)) -> `AttributeList   unchanged
class(1 2)          ->  {nil,nil}    unchanged
```

The two answers stay distinguishable — `class()==class(3)` is `false`,
`class()==nil` is `false` — so a caller feeding `class()` a value it did not
build itself can tell "you handed me something with no class" from "you handed
me nothing". Both are falsy in a condition, so neither silently takes a
`:then` branch.

`class() == blank() == empty()`.

## Tests

New `src/comterp_/tests/classblank.comt` (10 tests, registered in
`run_all.comt`): blank-vs-nil across `==`, `if()`, and identity with
`blank()`/`empty()`; the real-object and multi-arg paths held unchanged.

Test 10 (`class(:foo)`) is the one that actually fails on `master` — the
others pass there too, since the backstop was already manufacturing the blank.
They are here to pin the contract, not to catch the old code.

Full `run_all.comt` green locally (46/46) on macOS.

## Not in this PR

`TypeSymbolFunc::execute()` (`type()`) is the same function shape a few lines
up and has the identical `if (!numargs) return;`, so bare `type()` still
prints the stack-shortfall complaint on stderr before getting its blank
backfilled. It has no nil case of its own — `type_symid()` always answers — so
the blank-vs-nil argument doesn't apply to it, only the spurious diagnostic
does. Left alone rather than widened into silently; say the word and it's a
one-line follow-up.
