### PR TITLE
type(:all) lists every type symbol, and bare type() answers blank like class()

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -2651,6 +2651,33 @@ float(3.14)            // explicit conversion to FloatType
 double(3)              // explicit conversion to DoubleType
 ```
 
+`type(:all)` returns the whole set of type symbols, in enum order:
+
+```
+type(:all)             // UnknownType,CharType,UCharType,ShortType,UShortType,
+                       // IntType,UIntType,LongType,ULongType,FloatType,
+                       // DoubleType,StringType,SymbolType,ListType,StreamType,
+                       // CommandType,KeywordType,ObjectType,EofType,
+                       // BooleanType,OperatorType,BlankType
+size(type(:all))       // 22
+at(type(:all) 5)==type(1)  // true -- the listing and the per-value answer agree
+```
+
+That list is complete: every value in the language carries one of those 22
+types, and `ArrayType` is absent because it and `ListType` are one type under
+two names, registered as `ListType`.
+
+Asked with no value at all, both commands answer `blank` rather than `nil` --
+`nil` is the answer *about* a value, so it needs a value to be about:
+
+```
+class(3)               // nil   -- a value was named; it has no class
+class()                // blank -- no value was named at all
+type()                 // blank -- likewise
+type()==nil            // false -- the two stay distinguishable
+type()==blank()        // true
+```
+
 ### istype()/isclass()/iscomm()/isfunc() — inspecting a variable without firing it
 
 `type()` and `class()`, above, both evaluate their argument the ordinary

--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -1224,6 +1224,10 @@ boolean AttributeValue::isa(int id) {
 }
 
 int AttributeValue::type_symid() const {
+  return type_symid(type());
+}
+
+int AttributeValue::type_symid(ValueType type) {
   if (!_type_syms) {
     int i = 0;
     _type_syms = new int[((int)BlankType)+1];
@@ -1250,8 +1254,8 @@ int AttributeValue::type_symid() const {
     _type_syms[i++] = symbol_add("OperatorType");
     _type_syms[i++] = symbol_add("BlankType");
   }
-  if (type()>=UnknownType && type()<=BlankType)
-    return _type_syms[(int)type()];
+  if (type>=UnknownType && type<=BlankType)
+    return _type_syms[(int)type];
   else
     return -1;
 }

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -196,6 +196,8 @@ public:
     // return sizeof of value of given type.
     int type_symid() const;
     // return symbol id corresponding to type
+    static int type_symid(ValueType);
+    // return symbol id corresponding to given type
     const char* type_name() { return symbol_pntr(type_symid()); }
     // type name of value.
 

--- a/src/ComTerp/typefunc.c
+++ b/src/ComTerp/typefunc.c
@@ -43,10 +43,37 @@ TypeSymbolFunc::TypeSymbolFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void TypeSymbolFunc::execute() {
-  // return type symbol for each argumen
-  boolean noargs = !nargs() && !nkeys();
+  // return type symbol for each argument
+  static int all_symid = symbol_add("all");
+  boolean all_flag = stack_key(all_symid).is_true();
   int numargs = nargs();
-  if (!numargs) return;
+
+  if (all_flag) {
+    /* the whole closed set, in enum order -- every value in the language has
+       one of these, so unlike class() this list is complete by construction.
+       ListType and ArrayType are one type under two names; the symbol is
+       ListType, so ArrayType never appears. */
+    reset_stack();
+    AttributeValueList* avl = new AttributeValueList();
+    ComValue retval(avl);
+    for (int t=AttributeValue::UnknownType; t<=AttributeValue::BlankType; t++) {
+      ComValue* av = new ComValue
+	(AttributeValue::type_symid((AttributeValue::ValueType)t),
+	 AttributeValue::SymbolType);
+      av->bquote(1);
+      avl->Append(av);
+    }
+    push_stack(retval);
+    return;
+  }
+
+  if (!numargs) {
+    /* no value named at all -- blank, the "nothing was asked" answer, the same
+       distinction class() draws.  nil stays the answer about a named value. */
+    reset_stack();
+    push_stack(ComValue::blankval());
+    return;
+  }
   std::vector<int> type_syms(numargs);
   for (int i=0; i<numargs; i++) {
     ComValue& val = stack_arg(i);

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -33,14 +33,22 @@
 class ComTerp;
 
 //: command to return type symbols for values
-// sym|lst=type(val [val ...]) -- return type symbol(s) for value(s)
+// sym|lst=type(val [val ...] :all) -- return type symbol(s) for value(s),
+// or with :all the complete list of type symbols this language has.
 class TypeSymbolFunc : public ComFunc {
 public:
     TypeSymbolFunc(ComTerp*);
     virtual void execute();
 
     virtual const char* docstring() { 
-      return "sym|lst=%s(val [ ...]) -- return type symbol(s) for value(s)"; }
+      return "sym|lst=%s(val [ ...] :all) -- return type symbol(s) for value(s), blank for no value at all"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+	":all       return the complete list of type symbols, ignoring any value",
+	nil
+      };
+      return keys;
+    }
 };
 
 //: command to return class symbols for values of object type

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -190,5 +190,9 @@ if(run("./classblank.comt")
   :then print("pass: classblank\n")
   :else print("FAIL: classblank\n");topok=false)
 
+if(run("./typeall.comt")
+  :then print("pass: typeall\n")
+  :else print("FAIL: typeall\n");topok=false)
+
 print("\nrun_all: %v\n" topok)
 topok

--- a/src/comterp_/tests/typeall.comt
+++ b/src/comterp_/tests/typeall.comt
@@ -1,0 +1,111 @@
+// src/comterp_/tests/typeall.comt -- type(:all) hands back the complete list
+// of type symbols, and bare type() answers blank like class() does
+//
+// coverage: 12/15 (80%)
+// funcs: type size at blank
+// missing: type(stress-wrong-type) type(stress-nil) index(type-list) !type(:all value)
+//
+// The type symbols are a closed set: every value in the language carries one
+// of them, and the table that names them (AttributeValue::_type_syms) is built
+// in one shot, so :all can report the whole set with nothing left to discover.
+// class(:all) can never promise that -- a class symbol only exists once some
+// class asks for one, so the classes a binary can report are whatever it
+// linked.  Same keyword, different guarantee, and this test pins the strong
+// half.
+//
+// The list is in enum order, which makes at(lst n) positional and stable.
+// ListType and ArrayType are two names for one enum slot; the registered
+// symbol is ListType, so ArrayType never appears (test 6) -- that is the
+// same name type(1,2,3) already reports, not an omission.
+//
+// type() with no value now answers blank rather than falling through to
+// comterp's stack-shortfall backstop, matching class().  See classblank.comt
+// for why blank and nil have to stay distinguishable.
+//
+// Run from inside comterp, comdraw, or drawserv (cd to this dir first):
+//   run("./typeall.comt")
+
+run("./testlib.comt")
+ok=true
+
+// --- test 1: type(:all) returns a list ---
+lst=type(:all)
+r1=type(lst)
+ok=ok&&(r1==`ListType)
+print("1 type(type(:all)) (expect ListType): %v\n" r1)
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: and the list is the whole closed set, one entry per type ---
+r2=size(lst)
+ok=ok&&(r2==22)
+print("2 size(type(:all)) the closed set (expect 22): %v\n" r2)
+prev_ok=check_fail(:ok ok)
+
+// --- test 3: in enum order, so position is meaningful at both ends ---
+r3a=at(lst 0)
+r3b=at(lst 21)
+ok=ok&&(r3a==`UnknownType)&&(r3b==`BlankType)
+print("3 at(lst 0) at(lst 21) enum order (expect UnknownType BlankType): %v %v\n" r3a r3b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 4: every entry is a symbol, the same thing type(val) hands back ---
+r4=type(at(lst 5))
+ok=ok&&(r4==`SymbolType)
+print("4 type(at(lst 5)) entries are symbols (expect SymbolType): %v\n" r4)
+prev_ok=check_fail(:ok ok)
+
+// --- test 5: a real value's type is in the list -- the listing and the
+// per-value answer are the same symbols, not two parallel spellings ---
+r5=(type(1)==at(lst 5))
+ok=ok&&(r5==true)
+print("5 type(1)==at(lst 5) the listing agrees with the value (expect true): %v\n" r5)
+prev_ok=check_fail(:ok ok)
+
+// --- test 6: ListType and ArrayType share one slot, named ListType ---
+r6a=at(lst 13)
+r6b=type(1,2,3)
+ok=ok&&(r6a==`ListType)&&(r6b==`ListType)
+print("6 at(lst 13) and type(1,2,3) one slot one name (expect ListType ListType): %v %v\n" r6a r6b)
+prev_ok=check_fail(:ok ok)
+
+// --- test 7: :all is a listing request, so a named value does not narrow it ---
+r7=size(type(3 :all))
+ok=ok&&(r7==22)
+print("7 size(type(3 :all)) :all ignores the value (expect 22): %v\n" r7)
+prev_ok=check_fail(:ok ok)
+
+// --- test 8: bare type() names no value, so it answers blank ---
+r8=type(type())
+ok=ok&&(r8==`BlankType)
+print("8 type(type()) with no argument (expect BlankType): %v\n" r8)
+prev_ok=check_fail(:ok ok)
+
+// --- test 9: and it is the same blank blank() hands out ---
+r9=(type()==blank())
+ok=ok&&(r9==true)
+print("9 type()==blank() (expect true): %v\n" r9)
+prev_ok=check_fail(:ok ok)
+
+// --- test 10: an unrecognized keyword is ignored by design, so it names no
+// value either and answers blank rather than handing the keyword back ---
+r10=type(:foo)
+ok=ok&&(type(r10)==`BlankType)
+print("10 type(:foo) names no value either (expect BlankType): %v\n" type(r10))
+prev_ok=check_fail(:ok ok)
+
+// --- test 11: blank is not nil, so a caller can tell the two apart ---
+r11=(type()==nil)
+ok=ok&&(r11==false)
+print("11 type()==nil blank is not nil (expect false): %v\n" r11)
+prev_ok=check_fail(:ok ok)
+
+// --- test 12: the ordinary forms are untouched by any of this ---
+r12a=type(3)
+lst12=type(3 "a")
+r12b=size(lst12)
+ok=ok&&(r12a==`IntType)&&(r12b==2)
+print("12 type(3) and size(type(3 \"a\")) unchanged (expect IntType 2): %v %v\n" r12a r12b)
+prev_ok=check_fail(:ok ok)
+
+print("typeall: %v\n" ok)
+ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "52391288"
+#define PATCH_KEY "13492dd3"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Stacked on #413 — it references `classblank.comt` and mirrors its blank rule, so it wants that branch as its base.

## What

`type(:all)` returns the complete list of type symbols, and `type()` with no value answers `blank` instead of falling through to comterp's stack-shortfall backstop — the same two fixes #413 made for `class()`, applied to its twin.

```
type(:all)                  // UnknownType,CharType,...,OperatorType,BlankType
size(type(:all))            // 22
at(type(:all) 5)==type(1)   // true
type(3 :all)                // still the whole list
type()                      // blank -- no "failed to push a single value" warning
type(:foo)                  // blank -- not the caller's own keyword handed back
```

## Why `type` before `class`

Both commands want a listing, but they can't promise the same thing, and it's worth having the strong half land first so the shape of the answer is settled before the hard half has to argue about it.

The type symbols are a **closed set**. Every value in the language carries one of the 22, and `AttributeValue::_type_syms` is filled in a single shot on first use — so `:all` is complete by construction, with nothing left to discover. A future `class(:all)` can never say that: a class symbol only exists once some class asks for one (`CLASS_SYMID`'s `if (_symid<0) _symid=symbol_add(...)`), so the classes a binary can report are whatever it linked and then happened to touch. Same keyword, different guarantee.

## How

`AttributeValue::type_symid()` is split into a static `type_symid(ValueType)` so the table can be walked without an instance — exactly parallel to the `type_size()` / `type_size(ValueType)` pair sitting two lines above it in the header. `TypeSymbolFunc::execute()` then checks `:all` ahead of the arity test, so `:all` is a listing request that a named value doesn't narrow.

`ListType` and `ArrayType` remain one enum slot registered under the single name `ListType`, so `ArrayType` never appears in the list. That's not an omission — it's the same name `type(1,2,3)` already reports, and test 6 pins it so nobody "fixes" it later.

## Tests

`typeall.comt`, 12 tests: the listing and its type, the closed count, enum order at both ends, entries are symbols, the listing agrees with the per-value answer, the one-slot-one-name rule, `:all` winning over a named value, blank for the bare and keyword-only calls, blank ≠ nil, and the ordinary arities untouched. Registered in `run_all.comt`; full comterp suite 47/47 green locally.

`doc/LANGUAGE.md` picks up both the listing and the blank-vs-nil rule under *Symbols as type and class names* — that section had nothing about the empty-handed cases even after #413.

## Next in the sequence

1. **this PR** — `type()` blank + `type(:all)`
2. `CLASS_SYMID_DEF` — 13 of the 58 `_symid` definitions omit the `= -1` (`int StreamFunc::_symid;` and friends), so zero-init means `if (_symid<0)` never fires and `class_symid()` returns 0, which is the symbol `sym`. Harmless today because nothing calls those, fatal to a registry built on the macro. A `CLASS_SYMID_DEF(Foo)` that defines `_symid` *and* registers eagerly fixes them by construction. (Checked: the symbol table is zero-init POD with lazy allocation inside `symbol_add`, so a registrar running before `main()` is safe.)
3. `class(:all)` / `class(:comps)` on top, the latter fed by `CLASS_SYMID2`'s Unidraw `ClassId` rather than by substring-matching `"Comp"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
