### PR TITLE
Supply the missing -1 sentinel on 13 class symbol id definitions

### DIFF
--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -646,8 +646,8 @@ reliable way to isolate a parse error for assertion.
 ### CLASS_SYMID and _symid
 
 If the new command class uses `CLASS_SYMID("MyCmd")` in its header,
-add the static initializer in the `.c` file alongside the other `_symid`
-definitions:
+add the static initializer in the `.c` file (set to -1) alongside the
+other `_symid` definitions:
 
 ```cpp
 int LinkColorCmd::_symid = -1;

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -315,7 +315,7 @@ void ListSizeFunc::execute() {
 
 /*****************************************************************************/
 
-int TupleFunc::_symid;
+int TupleFunc::_symid = -1;
 
 TupleFunc::TupleFunc(ComTerp* comterp) : ComFunc(comterp) {
 }

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -73,7 +73,7 @@ boolean StrmFunc::is_delimiter(ComValue& val) {
 
 /*****************************************************************************/
 
-int StreamFunc::_symid;
+int StreamFunc::_symid = -1;
 
 StreamFunc::StreamFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -288,7 +288,7 @@ void StreamFunc::execute_literal() {
 
 /*****************************************************************************/
 
-int SpreadFunc::_symid;
+int SpreadFunc::_symid = -1;
 
 SpreadFunc::SpreadFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -397,7 +397,7 @@ void EchoFunc::execute() {
 
 /*****************************************************************************/
 
-int StreamNextFunc::_symid;
+int StreamNextFunc::_symid = -1;
 
 StreamNextFunc::StreamNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -456,7 +456,7 @@ void StreamNextFunc::execute() {
 
 /*****************************************************************************/
 
-int ConcatFunc::_symid;
+int ConcatFunc::_symid = -1;
 
 ConcatFunc::ConcatFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -483,7 +483,7 @@ void ConcatFunc::execute() {
 
 /*****************************************************************************/
 
-int ConcatNextFunc::_symid;
+int ConcatNextFunc::_symid = -1;
 
 ConcatNextFunc::ConcatNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -1005,7 +1005,7 @@ void EachFunc::execute() {
 
 /*****************************************************************************/
 
-int FilterFunc::_symid;
+int FilterFunc::_symid = -1;
 
 FilterFunc::FilterFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -1032,7 +1032,7 @@ void FilterFunc::execute() {
 
 /*****************************************************************************/
 
-int FilterNextFunc::_symid;
+int FilterNextFunc::_symid = -1;
 
 FilterNextFunc::FilterNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }
@@ -1329,7 +1329,7 @@ void InfoFunc::execute() {
 
 /*****************************************************************************/
 
-int FeedFunc::_symid;
+int FeedFunc::_symid = -1;
 
 FeedFunc::FeedFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
@@ -1531,7 +1531,7 @@ void ChunkNextFunc::execute() {
 
 /*****************************************************************************/
 
-int FeedNextFunc::_symid;
+int FeedNextFunc::_symid = -1;
 
 FeedNextFunc::FeedNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }

--- a/src/ComUnidraw/grstrmfunc.c
+++ b/src/ComUnidraw/grstrmfunc.c
@@ -32,7 +32,7 @@
 
 /*****************************************************************************/
 
-int GrStreamFunc::_symid;
+int GrStreamFunc::_symid = -1;
 
 GrStreamFunc::GrStreamFunc(ComTerp* comterp) : StreamFunc(comterp) {
 }
@@ -144,7 +144,7 @@ void GrStreamFunc::execute() {
 
 /*****************************************************************************/
 
-int GrDepthFunc::_symid;
+int GrDepthFunc::_symid = -1;
 
 GrDepthFunc::GrDepthFunc(ComTerp* comterp) : StreamFunc(comterp) {
 }
@@ -187,7 +187,7 @@ void GrDepthFunc::execute() {
 
 /*****************************************************************************/
 
-int GrDepthNextFunc::_symid;
+int GrDepthNextFunc::_symid = -1;
 
 GrDepthNextFunc::GrDepthNextFunc(ComTerp* comterp) : StrmFunc(comterp) {
 }

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "9471d959"
+#define PATCH_KEY "7d0f8357"
 
 #endif /* _patch_h */


### PR DESCRIPTION
`CLASS_SYMID`/`CLASS_SYMID2` declare `static int _symid;` and each class writes its own storage definition in a `.c` file. 58 of them. **13 omit the `= -1`:**

```c
int StreamFunc::_symid;        // <-- zero-initialized
int RectOvComp::_symid = -1;   // <-- correct
```

Zero-init leaves `_symid` at 0, so the macro's `if (_symid<0)` guard never fires, `symbol_add()` is never reached, and `class_symid()`/`classid()` report **symbol 0** for the life of the process. Symbol 0 is a real symbol — it's `sym` — so there's no error, just a wrong answer that looks like an answer.

The thirteen: `StreamFunc`, `SpreadFunc`, `StreamNextFunc`, `ConcatFunc`, `ConcatNextFunc`, `FilterFunc`, `FilterNextFunc`, `FeedFunc`, `FeedNextFunc`, `TupleFunc`, `GrStreamFunc`, `GrDepthFunc`, `GrDepthNextFunc`.

Nothing calls their `class_symid()` today, which is why a wrong answer rather than a crash went unnoticed. The one live path is `ComFunc::push_funcstate()` (`comfunc.c:610`), which falls back to `classid()` when no command symid is supplied — an error label from one of those thirteen would read `sym`. Cosmetic, and evidently never hit.

It matters ahead of a `class(:all)` listing (#415 is the `type()` half): a registry hung off `CLASS_SYMID`'s intern point would enroll all thirteen under symbol 0.

## Testing

No script-visible behavior changes, so there's nothing new to pin — the guard is that nothing moved. Rebuilt Attribute, ComTerp, ComUnidraw, OverlayUnidraw, GraphUnidraw, FrameUnidraw, DrawServ, comterp and comdraw clean; comterp suite 46/46 and comdraw suite 11/11 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
