### PR TITLE
Migrate the tree to gnu++17, and move the standard off the ACE macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           set -e
           for t in sock_loopback reactor_loop acceptor_spawn log_fmt; do
             echo "=== ACE-lite: $t ==="
-            g++ -std=c++14 -Wall -I src -I src/include \
+            g++ -std=c++17 -Wall -I src -I src/include \
               src/ACE-lite/reactor.c src/ACE-lite/event_handler.c \
               src/ACE-lite/sock.c src/ACE-lite/log_msg.c \
               "src/ACE-lite/tests/$t.cc" -o "$RUNNER_TEMP/acelite_$t"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           set -e
           for t in sock_loopback reactor_loop acceptor_spawn log_fmt; do
             echo "=== ACE-lite: $t ==="
-            g++ -std=c++17 -Wall -I src -I src/include \
+            g++ -std=gnu++17 -Wall -I src -I src/include \
               src/ACE-lite/reactor.c src/ACE-lite/event_handler.c \
               src/ACE-lite/sock.c src/ACE-lite/log_msg.c \
               "src/ACE-lite/tests/$t.cc" -o "$RUNNER_TEMP/acelite_$t"

--- a/config/local.def
+++ b/config/local.def
@@ -45,9 +45,9 @@ XCOMM from <local.def>:
  */ 
 #undef LanguageCCDefines
 #if LibStdCPlusPlusV3
-#define LanguageCCDefines -Dcplusplus_2_1 -Wno-deprecated -DLEAKCHECK
+#define LanguageCCDefines -Dcplusplus_2_1 -std=c++17 -Wno-deprecated -DLEAKCHECK
 #else
-#define LanguageCCDefines -Dcplusplus_2_1
+#define LanguageCCDefines -Dcplusplus_2_1 -std=c++17
 #endif
 #include <gcc.def>
 

--- a/config/local.def
+++ b/config/local.def
@@ -44,10 +44,15 @@ XCOMM from <local.def>:
  * Assume the use of gcc-2.3.3 or greater
  */ 
 #undef LanguageCCDefines
+/* gnu++17, not c++17: strict ISO defines __STRICT_ANSI__, under which glibc
+   hides the BSD/POSIX names -- gettimeofday() and struct timezone in Time.c
+   among them.  Most directories carried no -std at all before and so were
+   already getting the compiler's gnu++ default; this keeps that dialect and
+   only moves the standard forward. */
 #if LibStdCPlusPlusV3
-#define LanguageCCDefines -Dcplusplus_2_1 -std=c++17 -Wno-deprecated -DLEAKCHECK
+#define LanguageCCDefines -Dcplusplus_2_1 -std=gnu++17 -Wno-deprecated -DLEAKCHECK
 #else
-#define LanguageCCDefines -Dcplusplus_2_1 -std=c++17
+#define LanguageCCDefines -Dcplusplus_2_1 -std=gnu++17
 #endif
 #include <gcc.def>
 

--- a/config/params.def
+++ b/config/params.def
@@ -467,8 +467,10 @@ config.guess config.sub configure configure.in MANIFEST.perceps MANIFEST.comterp
 
 #ifndef AceCCDefines
 /* ACE-lite (#147): HAVE_ACE is on for either backend -- the in-tree subset
-   (default) or external libACE (--with-ace).  Networking is always available. */
-#define AceCCDefines -DHAVE_ACE -std=c++14
+   (default) or external libACE (--with-ace).  Networking is always available.
+   The C++ standard is not set here -- it belongs to the whole tree, and lives
+   in LanguageCCDefines (config/local.def) where every directory picks it up. */
+#define AceCCDefines -DHAVE_ACE
 #endif
 
 #ifndef QtCCDefines

--- a/src/ACE-lite/Imakefile
+++ b/src/ACE-lite/Imakefile
@@ -10,7 +10,7 @@ PACKAGE = ACE-lite
 LIB = ACE-lite
 
 /* Compile with the same flags as the consumers: the library and its callers
-   must agree on the C++ standard (LanguageCCDefines carries -std=c++17 tree
+   must agree on the C++ standard (LanguageCCDefines carries -std=gnu++17 tree
    wide) so the std::map/std::set in ACE_Reactor have one ABI across the dylib
    boundary. */
 OTHER_CCDEFINES = $(ACE_CCDEFINES)

--- a/src/ACE-lite/Imakefile
+++ b/src/ACE-lite/Imakefile
@@ -9,9 +9,10 @@ PACKAGE = ACE-lite
 
 LIB = ACE-lite
 
-/* Compile with the same flags as the consumers (ACE_CCDEFINES carries
-   -std=c++14): the library and its callers must agree on the C++ standard so
-   the std::map/std::set in ACE_Reactor have one ABI across the dylib boundary. */
+/* Compile with the same flags as the consumers: the library and its callers
+   must agree on the C++ standard (LanguageCCDefines carries -std=c++17 tree
+   wide) so the std::map/std::set in ACE_Reactor have one ABI across the dylib
+   boundary. */
 OTHER_CCDEFINES = $(ACE_CCDEFINES)
 
 MakeLibrary($(LIB),$(VERSION))

--- a/src/Dispatch/iostreamb.c
+++ b/src/Dispatch/iostreamb.c
@@ -270,7 +270,7 @@ ostreamb::~ostreamb() {}
 // character that all the inserters insert after a formatted value.
 
 inline void ostreamb::fixwidth() {
-    register int w = width();
+    int w = width();
     if (w) {
 	width(w - 1);
     }

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "86effd6b"
+#define PATCH_KEY "3810991e"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "92fccbb1"
+#define PATCH_KEY "86effd6b"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Standalone. Unblocks a header-only class registry (a `static inline` registrar in `CLASS_SYMID` needs C++17 inline variables), but stands on its own regardless.

## The standard was never tree-wide

`-std=c++14` lived in `AceCCDefines`, because once upon a time ACE was what pinned it — the 2023 commit that set it says exactly that: *"update to use c++14 (same as ace)"*. But only **14 of the 46** directory Makefiles actually consume `ACE_CCDEFINES`; the rest compile at whatever the compiler defaults to. `Attribute` is not one of the 14. Neither is `GraphUnidraw` or `FrameUnidraw`.

So the macro named after ACE was setting the C++ standard for a third of the tree and silently leaving the rest to the compiler's default. This moves it to `LanguageCCDefines` in `config/local.def` — the tree-wide hook that already carries `-Dcplusplus_2_1` and reaches all 46 — and leaves `AceCCDefines` as plain `-DHAVE_ACE`.

With ACE-lite (#147) providing networking in-tree, there is no external library left to pin the standard to anyway.

After `make Makefiles`, every directory reads:

```
 LANGUAGE_CCDEFINES = -Dcplusplus_2_1 -std=gnu++17
      ACE_CCDEFINES = -DHAVE_ACE
```

## gnu++17, not c++17 — and CI is what taught me

The first push used strict `-std=c++17` and broke the Linux build:

```
src/Time/Time.c:64:25: error: aggregate 'inittimezone()::timezone tz' has incomplete type
src/Time/Time.c:65:9:  error: 'gettimeofday' was not declared in this scope
```

Strict ISO defines `__STRICT_ANSI__`, under which glibc hides the BSD/POSIX names. `gettimeofday()` and `struct timezone` are two of them. Since `src/Time` carried **no** `-std` flag before this change, it had been compiling as g++'s `gnu++17` default all along — moving it to strict ISO was the regression, not moving it to C++17.

Worth recording that a full clang build and a 560-file syntax sweep on macOS both came back clean: Apple's libc declares both regardless of `__STRICT_ANSI__`, so this is glibc-only and nothing local could have found it.

Most directories were already getting the compiler's `gnu++` default, so `gnu++17` keeps the dialect the tree has always had and moves only the standard.

## History, for the record

| when | who | change |
|---|---|---|
| 2023-03-04 | Rui Chen | `c++11` → `c++14`, *"same as ace"* |
| 2024-05-20 | Rui Chen | `c++14` → `c++17` |
| 2024-11-11 | Scott Johnston | `c++17` → `c++14` (bundled into "install imake and set c++ version for ace") |

The tree ran at C++17 for six months in 2024. The revert changed `config/params.def` but not `Makefile.orig`, which still reads `-std=c++17` today — the two have disagreed ever since.

## What breaks: one word

A sweep of all 560 sources found exactly one C++17 removal in the tree: `register int w = width();` at `src/Dispatch/iostreamb.c:273`. Every other `register` is in a C-compiled file (TIFF, imake), where it stays legal.

That file sits behind `#if BuildRPCClasses`, is built in no current configuration, and **already fails at C++14** with 20 errors from pre-standard `ios`/`streambuf`. Dropping the keyword clears the C++17-specific blocker without pretending to revive the RPC path.

No dynamic exception specifications, no `auto_ptr`, no `bind1st`/`mem_fun` anywhere in the tree.

## Testing

Clean `make -B` of the whole tree: **560 compile lines all carrying `-std=gnu++17`, zero errors, zero warnings.** (The 21 `-Wvla-cxx-extension` warnings the strict-ISO attempt produced are gone — VLAs are a documented GNU extension in this dialect.)

comterp suite 46/46 and comdraw suite 11/11 green against the rebuilt binaries.

`ci.yml`'s standalone ACE-lite unit builds move to `-std=gnu++17` too, so the fast gate keeps testing the same ABI as the tree build — which is what the ACE-lite Imakefile comment is about, and that comment named the wrong macro as the carrier; corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
