### PR TITLE
Stop the distributed transform echoing forever, and export()'s attribute duplication

### DIFF
--- a/src/ComUnidraw/unifunc.c
+++ b/src/ComUnidraw/unifunc.c
@@ -598,10 +598,13 @@ void ExportFunc::compout(OverlayComp* comp, ostream* out) {
   OverlayScript* ovsv = (OverlayScript*) comp->Create(SCRIPT_VIEW);
   comp->Attach(ovsv);
   ovsv->Update();
+  /* Definition() already emitted this comp's attributes, inside the command's
+     own parens where the reader picks them up as ordinary keywords -- that is
+     how :grid and :sid survive a trip to another drawserv.  Appending them
+     again here put a second copy after the closing paren, so any graphic
+     carrying an attribute exported malformed and did not read back. */
   ovsv->Definition(*out);
   delete ovsv;
-  AttributeList* attrlist = comp->GetAttributeList();
-  *out << *attrlist;
   out->flush();
 }
 

--- a/src/DrawServ/ackback-handler.c
+++ b/src/DrawServ/ackback-handler.c
@@ -44,6 +44,19 @@ using namespace std;
 
 /*****************************************************************************/
 
+/* Tell the user what became of a link.  A popup only reaches somebody if a
+   user asked for this link at the connections dialog; on a scripted or
+   wire-driven link there is nobody to dismiss it, and a modal dialog stops the
+   main loop from ever running again, so that news goes to stderr instead. */
+
+static void report_link(DrawLink* link, const char* title, const char* detail) {
+  if (link && link->interactive())
+    GAcknowledgeDialog::map(DrawKit::Instance()->GetEditor()->GetWindow(),
+			    title, detail, title);
+  else
+    fprintf(stderr, "%s:  %s\n", title, detail);
+}
+
 // Default constructor.
 
 AckBackHandler::AckBackHandler ()
@@ -80,10 +93,10 @@ int AckBackHandler::handle_input (ACE_HANDLE fd)
 	inv.push_back(ch);
     inv.push_back('\0');
     
-    if (strcmp((char*)&inv[0], "ackback(cycle)\n")==0) {
+    if (strcmp((char*)&inv[0], "ackback(cycle)")==0) {
       char buffer[BUFSIZ];
       snprintf(buffer, BUFSIZ, "%s:%d", drawlink()->hostname(), drawlink()->portnum());
-      GAcknowledgeDialog::map(DrawKit::Instance()->GetEditor()->GetWindow(), "Redundant connection rejected", buffer, "Redundant connection rejected");
+      report_link(drawlink(), "Redundant connection rejected", buffer);
       _eof_expected = true;
     }
     
@@ -91,7 +104,7 @@ int AckBackHandler::handle_input (ACE_HANDLE fd)
       if (!_eof_expected) {
 	char buffer[BUFSIZ];
 	snprintf(buffer, BUFSIZ, "%s:%d", drawlink()->hostname(), drawlink()->portnum());
-	GAcknowledgeDialog::map(DrawKit::Instance()->GetEditor()->GetWindow(), "Unexpected end-of-file on connection", buffer, "Unexpected end-of-file on connection");
+	report_link(drawlink(), "Unexpected end-of-file on connection", buffer);
       } else
 	_eof_expected = false;
       cerr << "AckBack (end of file):  [" << (char*)&inv[0] << "]\n";

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -57,6 +57,7 @@ DrawLink::DrawLink (const char* hostname, int portnum, int state)
   _ok = false;
   uuid_clear(_linkid);
   _state = state;
+  _interactive = false;
 
   _addr = nil;
   _socket = nil;

--- a/src/DrawServ/drawlink.h
+++ b/src/DrawServ/drawlink.h
@@ -118,6 +118,12 @@ public:
     int state() { return _state; }
     // get state of DrawLink
 
+    void interactive(int val) { _interactive = val; }
+    // mark this link as one a user asked for at the connections dialog
+
+    int interactive() { return _interactive; }
+    // true if there is a user at the dialog to receive a popup about this link
+
     ACE_SOCK_Stream* socket() { return _socket; }
     // return pointer to connected socket.
 
@@ -146,6 +152,7 @@ protected:
     uuid_t _linkid;
     uuid_string_t _linkid_str;
     int _state;
+    int _interactive;
 
     ACE_INET_Addr* _addr;
     ACE_SOCK_Connector* _conn;

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -146,13 +146,15 @@ DrawServ::~DrawServ ()
 }
 
 DrawLink* DrawServ::linkup(const char* hostname, int portnum, 
-		     int state, uuid_t link_id,  ComTerp* comterp) {
+		     int state, uuid_t link_id,  ComTerp* comterp,
+		     int interactive) {
 
   if (comterp!=NULL) comterp->handler()->alt_fd(portnum);
   
   if (state == DrawLink::new_link || state == DrawLink::one_way) {
     
     DrawLink* link = new DrawLink(hostname, portnum, state);
+    link->interactive(interactive);
     if (state==DrawLink::one_way && comterp && comterp->handler()) {
       ((DrawServHandler*)comterp->handler())->drawlink(link);
       link->comhandler((DrawServHandler*)comterp->handler());

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -75,7 +75,8 @@ public:
   void Init();
   
   DrawLink* linkup(const char* hostname, int portnum, 
-		   int state, uuid_t link_id=NULL, ComTerp* comterp=nil);
+		   int state, uuid_t link_id=NULL, ComTerp* comterp=nil,
+		   int interactive=false);
   // Create new link to remote drawserv, return -1 if error
   // state: 0==new_link, 1==one_way, 2==two_way.
   

--- a/src/DrawServ/linkcmd.c
+++ b/src/DrawServ/linkcmd.c
@@ -152,7 +152,9 @@ const char* LinkTransformCmd::dist_script() {
     if (!drawserv->linklist() || drawserv->linklist()->Number() == 0)
         return _dist_script_buf.c_str();
 
-    /* the target rides in the clipboard, not the selection -- trans() named it */
+    /* trans() names its target, so the comp comes from the clipboard rather
+       than the selection -- but the OWNERSHIP still has to come from the grid,
+       for the same reason it does in the relays that read the selection. */
     Clipboard* cb = GetClipboard();
     if (!cb) return _dist_script_buf.c_str();
     Iterator i;
@@ -165,6 +167,27 @@ const char* LinkTransformCmd::dist_script() {
     drawserv->compidtable()->find(ptr, comp);
     GraphicId* grid = (GraphicId*)ptr;
     if (!grid) return _dist_script_buf.c_str();   /* not distributed yet */
+
+    /* Relay only what this node owns, or what a remote owner has unlocked
+       through it -- exactly the gate LinkBrushCmd applies.  Without it a node
+       that merely RECEIVED a transform re-emits it to every link including the
+       one it arrived on, and two drawservs bounce it forever: dist_script has
+       no idea it is looking at someone else's change.  A node that owns
+       nothing here now produces an empty script, which is what stops the echo. */
+    boolean locally_owned = (grid->selected() == LinkSelection::LocallySelected);
+    if (!locally_owned && !grid->unlocked())
+        return _dist_script_buf.c_str();
+
+    uint32_t owner_key = 0;
+    if (locally_owned) {
+        owner_key = drawserv->sessionidkey();
+        uuid_copy(_dist_owner_sid, drawserv->sessionid());
+    } else {
+        /* forward the owner's key rather than re-derive it, so the bracket
+           stays valid at the next hop -- see LinkBrushCmd for why */
+        owner_key = grid->selectorkey();
+        uuid_copy(_dist_owner_sid, grid->selector());
+    }
 
     /* dist_script runs before Execute, so the graphic still holds the
        transform this command is about to compose the delta onto.  Work out
@@ -180,13 +203,21 @@ const char* LinkTransformCmd::dist_script() {
     float a00, a01, a10, a11, a20, a21;
     result.matrix(a00, a01, a10, a11, a20, a21);
 
-    /* stamp this session so ExecuteCmd excludes the link back toward us */
-    uuid_copy(_dist_owner_sid, drawserv->sessionid());
+    char keystr[9];
+    snprintf(keystr, sizeof(keystr), "%08X", owner_key);
 
+    /* The select(:unlock)/select(:lock) bracket is not addressing -- trans()
+       already names its graphic.  It carries the OWNER to the far node, which
+       is what lets that node's own dist_script stamp the owner rather than
+       itself, and so exclude the link back toward here.  Leaving it out is
+       what let the transform echo between two nodes without end. */
     std::ostringstream sbuf;
-    sbuf << "trans(grid(\"" << grid->idstr() << "\") "
+    sbuf << "s=select();select(grid(\"" << grid->idstr() << "\")"
+	 << " :unlock \"" << keystr << "\")"
+	 << ";trans(grid(\"" << grid->idstr() << "\") "
 	 << a00 << "," << a01 << "," << a10 << ","
-	 << a11 << "," << a20 << "," << a21 << ")";
+	 << a11 << "," << a20 << "," << a21 << ")"
+	 << ";select(s :lock \"" << keystr << "\")";
     _dist_script_buf = sbuf.str();
 
     return _dist_script_buf.c_str();

--- a/src/DrawServ/rcdialog.c
+++ b/src/DrawServ/rcdialog.c
@@ -88,7 +88,7 @@ RemoteConnectAction::RemoteConnectAction(StrEditDialog* dialog) : Action() {
 void RemoteConnectAction::execute() {
 
   if (_dialog && _dialog->text()) 
-    ((DrawServ*)unidraw)->linkup(_dialog->text(), 99999/*20002*/, 0);
+    ((DrawServ*)unidraw)->linkup(_dialog->text(), 99999/*20002*/, 0, NULL, nil, true);
 
 }
 
@@ -252,7 +252,7 @@ void ConnectionsDialogImpl::connect() {
       return;
     }
 
-    if(((DrawServ*)unidraw)->linkup(hostbuf, portnum, 0)==nil) {
+    if(((DrawServ*)unidraw)->linkup(hostbuf, portnum, 0, NULL, nil, true)==nil) {
       char buffer[BUFSIZ];
       snprintf(buffer, BUFSIZ, "%s:%d", hostbuf, portnum);
       GAcknowledgeDialog::map(dialog_->GetEditor()->GetWindow(), "Connection refused", buffer, "Connection refused");

--- a/src/OverlayUnidraw/scriptview.c
+++ b/src/OverlayUnidraw/scriptview.c
@@ -986,8 +986,16 @@ void OverlayScript::StencilGS (ostream& out) {
 
 void OverlayScript::Attributes(ostream& out) {
     AttributeList* attrlist = GetOverlayComp()->GetAttributeList();
-    if( attrlist->Number() && (!unidraw || !((OverlayUnidraw*)unidraw)->PrintAttributeList(out, attrlist)))
+    if (!attrlist->Number()) return;
+    if (!unidraw || !((OverlayUnidraw*)unidraw)->PrintAttributeList(out, attrlist)) {
+      /* serialize() writes no leading space before its first attribute, so
+         without one here it runs onto the value before it -- ":transform
+         1,0,0,1,89,163" followed by ":myattr 7" came out as "163:myattr 7".
+         PrintAttributeList leads every attribute with a space of its own, so
+         the separator belongs on this branch only. */
+      out << " ";
       out << *attrlist;
+    }
 }
 
 Clipboard* OverlayScript::GetGSList() {

--- a/src/comdraw/tests/gsexim.comt
+++ b/src/comdraw/tests/gsexim.comt
@@ -157,34 +157,10 @@ ac=run(as1 :str)
 as2=export(ac :string :percomp)
 r10=eq(as1 as2)
 ok=ok&&r10
-ok=ok&&(index(as1 "163 :myattr" :substr)!=nil)
+ok=ok&&(index(as1 " :myattr" :substr)!=nil)
 print("10a attributed graphic exports as %s\n" as1)
 print("10b and re-creates from it identically (expect true): %v\n" r10)
-print("10c with the attributes separated from the transform (expect a position): %v\n\n" index(as1 "163 :myattr" :substr))
-
-// --- test 10: a graphic carrying its own attributes round-trips too.  Every
-//              case above uses graphic state; none carries an attribute, which
-//              is how the exporter got away with emitting the attribute list
-//              twice.  Attributes belong at the tail end of the command, after
-//              the graphic state and inside the parens, where the reader takes
-//              them as ordinary keywords -- that is how :grid and :sid survive
-//              a trip to another drawserv.  export() emitted them there AND
-//              again past the closing paren, where nothing reads them, so the
-//              export was no longer its own command.  The list also ran onto
-//              the value before it for want of a separator, coming out as
-//              ":transform 1,0,0,1,89,163:myattr 7". ---
-each(delete($$select(:all)))
-ab=rect(0,0,50,50 :myattr 7 :other "x")
-as1=export(ab :string :percomp)
-each(delete($$select(:all)))
-ac=run(as1 :str)
-as2=export(ac :string :percomp)
-r10=eq(as1 as2)
-ok=ok&&r10
-ok=ok&&(index(as1 "163 :myattr" :substr)!=nil)
-print("10a attributed graphic exports as %s\n" as1)
-print("10b and re-creates from it identically (expect true): %v\n" r10)
-print("10c with the attributes separated from the transform (expect a position): %v\n\n" index(as1 "163 :myattr" :substr))
+print("10c with a separator before the first attribute (expect a position): %v\n\n" index(as1 " :myattr" :substr))
 
 print("gsexim: %v\n" ok)
 ok

--- a/src/comdraw/tests/gsexim.comt
+++ b/src/comdraw/tests/gsexim.comt
@@ -140,5 +140,51 @@ r9=eq(q1 q2)
 ok=ok&&r9
 print("9 raster export re-creates and re-exports identically (expect true): %v\n\n" r9)
 
+// --- test 10: a graphic carrying its own attributes round-trips too.  Every
+//              case above uses graphic state; none carries an attribute, which
+//              is how the exporter got away with emitting the attribute list
+//              twice -- once inside the command's parens where the reader takes
+//              it as ordinary keywords, and again after the closing paren.  The
+//              second copy is not a format, it is a bug: nothing reads a
+//              trailing attribute, and its presence made the export unparseable
+//              as its own command.  The list also ran onto the preceding value
+//              for want of a separator, ":transform 1,0,0,1,89,163:myattr 7". ---
+each(delete($$select(:all)))
+ab=rect(0,0,50,50 :myattr 7 :other "x")
+as1=export(ab :string :percomp)
+each(delete($$select(:all)))
+ac=run(as1 :str)
+as2=export(ac :string :percomp)
+r10=eq(as1 as2)
+ok=ok&&r10
+ok=ok&&(index(as1 "163 :myattr" :substr)!=nil)
+print("10a attributed graphic exports as %s\n" as1)
+print("10b and re-creates from it identically (expect true): %v\n" r10)
+print("10c with the attributes separated from the transform (expect a position): %v\n\n" index(as1 "163 :myattr" :substr))
+
+// --- test 10: a graphic carrying its own attributes round-trips too.  Every
+//              case above uses graphic state; none carries an attribute, which
+//              is how the exporter got away with emitting the attribute list
+//              twice.  Attributes belong at the tail end of the command, after
+//              the graphic state and inside the parens, where the reader takes
+//              them as ordinary keywords -- that is how :grid and :sid survive
+//              a trip to another drawserv.  export() emitted them there AND
+//              again past the closing paren, where nothing reads them, so the
+//              export was no longer its own command.  The list also ran onto
+//              the value before it for want of a separator, coming out as
+//              ":transform 1,0,0,1,89,163:myattr 7". ---
+each(delete($$select(:all)))
+ab=rect(0,0,50,50 :myattr 7 :other "x")
+as1=export(ab :string :percomp)
+each(delete($$select(:all)))
+ac=run(as1 :str)
+as2=export(ac :string :percomp)
+r10=eq(as1 as2)
+ok=ok&&r10
+ok=ok&&(index(as1 "163 :myattr" :substr)!=nil)
+print("10a attributed graphic exports as %s\n" as1)
+print("10b and re-creates from it identically (expect true): %v\n" r10)
+print("10c with the attributes separated from the transform (expect a position): %v\n\n" index(as1 "163 :myattr" :substr))
+
 print("gsexim: %v\n" ok)
 ok

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,7 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
+# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,9 +10,9 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|gsexim|gsbrushA|gsbrushB]\n");
+    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|gsexim|gsbrushA|gsbrushB]\n");
     print("\t\t\ttests to run (comma-separated), returns -1 on error\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
@@ -139,6 +139,13 @@ if(tests_flag :then
         print("updown4B: pass\n" :err)
       :else
         print("updown4B: FAIL\n" :err);
+        ok=false));
+    if(t==`ringtest || t==`all :then
+      print("running ringtest\n" :err);
+      if(ringtest_test(:dummy 0) :then
+        print("ringtest: pass\n" :err)
+      :else
+        print("ringtest: FAIL\n" :err);
         ok=false));
     if(t==`gsexim || t==`all :then
       print("running gsexim test\n" :err);

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -354,6 +354,22 @@ gsbrushB_test=func(
   print("gsbrushB: patternmask scalar form reached ds2=%v ds3=%v\n" m2 m3 :err);
   if(!m2 :then print("gsbrushB: FAIL patternmask did not reach ds2 intact\n" :err));
   if(!m3 :then print("gsbrushB: FAIL patternmask did not reach ds3 intact\n" :err));
+
+  /* --- transform across the fork.  gsbrushA covers a transform down a chain;
+     this covers one fanning out from a hub, which is the other shape the relay
+     has to get right.  A relay that fails to exclude the link a command arrived
+     on does not show up as a wrong value here -- the transform is absolute, so
+     an echo re-applies the same matrix -- it shows up as the two nodes trading
+     it back and forth until the suite times out. --- */
+  xstr=":transform 2,0,0,2,30,40";
+  remote(sock1 print("trans(grid(%c%s%c) 2,0,0,2,30,40)" 34 id1 34 :str));
+  update(2000000);
+  t2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs xstr);
+  t3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs xstr);
+  print("gsbrushB: transform fanned out ds2=%v ds3=%v\n" t2 t3 :err);
+  if(!t2 :then print("gsbrushB: FAIL transform did not reach ds2 intact\n" :err));
+  if(!t3 :then print("gsbrushB: FAIL transform did not reach ds3 intact\n" :err));
+  ok=ok && t2 && t3;
   ok=ok && m2 && m3;
 
   /* --- tear all three down --- */

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -1027,10 +1027,10 @@ ringtest_test=func(
   update(5000000);
 
   /* ds1 is where the ring would have closed, so its count is the decisive
-     one: a ring gives it two links, a chain one.  ds3 is deliberately not
-     asked -- a node whose cycle-closing offer is refused has been seen to stop
-     answering its comdraw port, and remote() has no timeout to recover from
-     that, so this test neither queries ds3 nor waits on it to exit. */
+     one: a ring gives it two links, a chain one.  ds3 is not asked -- remote()
+     has no timeout, so a node that stopped serving its comdraw port would hang
+     the whole suite rather than fail it; its health is checked at teardown
+     instead, where the wait can be bounded. */
   n1=remote(sock1 "size(drawlink(:table))");
   n2=remote(sock2 "size(drawlink(:table))");
   print("ringtest: links held -- ds1=%v ds2=%v\n" n1 n2 :err);
@@ -1060,10 +1060,20 @@ ringtest_test=func(
   remote(sock2 "exit" :nowait);close(sock2);
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
   print("ringtest: ds2 shut down\n" :err);
-  close(sock3);
-  kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
+
+  /* ds3 had a link cast off under it, so its shutdown doubles as the liveness
+     check: exit is sent :nowait and the wait is bounded, and a node that never
+     processes it is one that stopped serving its port -- which is what a modal
+     dialog on the refusal path does to a drawserv nobody is sitting at */
+  remote(sock3 "exit" :nowait);close(sock3);
   cnt=0;
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 && cnt<50
     usleep(200000);cnt++);
-  print("ringtest: ds3 shut down\n" :err);
+  stuck=shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0;
+  if(stuck :then
+    print("ringtest: FAIL ds3 stopped serving its comdraw port after the refusal\n" :err);
+    kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import)
+  :else
+    print("ringtest: ds3 shut down\n" :err));
+  ok=ok && !stuck;
   ok)

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -1014,9 +1014,23 @@ ringtest_test=func(
 
   /* --- build the chain: ds1->ds2 (on ds1), then ds2->ds3 (on ds2) --- */
   print("ringtest: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
+  /* cycletest() compares the offered session id against the table the target
+     already holds, so ds1 can only recognize the cycle once ds3's session id
+     has reached it -- wait for each hop to reach ds1 before making the next,
+     rather than guessing at a settle.  update() is no help: it is
+     handle_events(), returning on the first event rather than after the
+     timeout, and a chain built with both links in flight at once has been seen
+     to leave ds1 permanently short of ds3's session id. */
   remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  cnt=0;
+  while(remote(sock1 "size(sid(:table))")<2 && cnt<50 usleep(200000);cnt++);
   remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
-  update(3000000);
+  cnt=0;
+  while(remote(sock1 "size(sid(:table))")<3 && cnt<50 usleep(200000);cnt++);
+  nsid=remote(sock1 "size(sid(:table))");
+  print("ringtest: ds1 knows %v of 3 sessions\n" nsid :err);
+  if(nsid!=3 :then
+    print("ringtest: FAIL session ids never propagated around the chain\n" :err));
 
   /* --- now try to close the ring.  cycletest() compares the offered session
      id, host, user and pid against the session table this node already knows,
@@ -1024,7 +1038,7 @@ ringtest_test=func(
      handshake answers ackback(cycle) and drops the connection. --- */
   print("ringtest: closing the ring, ds3(%d)->ds1(%d)\n" ds3_port ds1_port :err);
   remote(sock3 print("drawlink(\"127.0.0.1\" %d)" ds1_port :str));
-  update(5000000);
+  usleep(5000000);
 
   /* ds1 is where the ring would have closed, so its count is the decisive
      one: a ring gives it two links, a chain one.  ds3 is not asked -- remote()
@@ -1051,7 +1065,7 @@ ringtest_test=func(
     relay=grid_has_id(:gh_sock sock2 :gh_id id1);
     print("ringtest: graphic reached ds2 over the surviving link: %v\n" relay :err));
   if(!relay :then print("ringtest: FAIL the refusal took the good link with it\n" :err));
-  ok=chain && relay;
+  ok=chain && relay && (nsid==3);
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -935,3 +935,135 @@ updown4C_test=func(
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds4_port :str))==0 usleep(200000));
   print("updown4C: ds4 shut down\n" :err);
   ok)
+
+/* ringtest test -- RING refused: ds1 -> ds2, ds2 -> ds3, then ds3 -> ds1 to
+   close the loop.  drawserv detects the cycle during the one_way handshake and
+   casts the connection off, so the ring never forms and the topology stays a
+   chain.  Every relay depends on that: LinkBrushCmd and its four siblings break
+   loops by excluding the link toward the graphic's owner, which is sufficient
+   only because two non-owner nodes can never be linked to each other.  Nothing
+   tested the guarantee those relays lean on until this. */
+ringtest_test=func(
+
+  poll_usec=2000000;
+  timeout=60*1000000/poll_usec;
+  progress_interval=10*1000000/poll_usec;
+
+  /* --- launch ds1 (20002) --- */
+  ds1_port=find_open_port(:base_port 20002);
+  ds1_import=ds1_port-1;
+  global(drawserv_upring1)=false;
+  print("ringtest: launching ds1 on port %d\n" ds1_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upring1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upring1) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ringtest: still waiting for ds1 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upring1) :then
+    print("ringtest: FAIL timeout waiting for ds1 callback\n" :err);
+    kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds1_import);
+    return(false));
+  print("ringtest: ds1 up on %d\n" ds1_port :err);
+
+  /* --- launch ds2 (30002) --- */
+  ds2_port=find_open_port(:base_port 30002);
+  ds2_import=ds2_port-1;
+  global(drawserv_upring2)=false;
+  print("ringtest: launching ds2 on port %d\n" ds2_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upring2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upring2) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ringtest: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upring2) :then
+    print("ringtest: FAIL timeout waiting for ds2 callback\n" :err);
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
+    return(false));
+  print("ringtest: ds2 up on %d\n" ds2_port :err);
+
+  /* --- launch ds3 (40002) --- */
+  ds3_port=find_open_port(:base_port 40002);
+  ds3_import=ds3_port-1;
+  global(drawserv_upring3)=false;
+  print("ringtest: launching ds3 on port %d\n" ds3_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upring3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
+  shell(cmdstr);
+  cnt=0;
+  while(!global(drawserv_upring3) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ringtest: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
+  if(!global(drawserv_upring3) :then
+    print("ringtest: FAIL timeout waiting for ds3 callback\n" :err);
+    s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
+    s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+    while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+    kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
+    return(false));
+  print("ringtest: ds3 up on %d\n" ds3_port :err);
+
+  /* --- connect to all three --- */
+  sock1=socket("127.0.0.1" ds1_port);
+  sock2=socket("127.0.0.1" ds2_port);
+  sock3=socket("127.0.0.1" ds3_port);
+  if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
+    print("ringtest: FAIL could not connect to all three drawservs\n" :err);
+    kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
+    return(false));
+
+  /* --- build the chain: ds1->ds2 (on ds1), then ds2->ds3 (on ds2) --- */
+  print("ringtest: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
+  remote(sock1 print("drawlink(\"127.0.0.1\" %d)" ds2_port :str));
+  remote(sock2 print("drawlink(\"127.0.0.1\" %d)" ds3_port :str));
+  update(3000000);
+
+  /* --- now try to close the ring.  cycletest() compares the offered session
+     id, host, user and pid against the session table this node already knows,
+     and a match means the far end is already reachable another way -- so the
+     handshake answers ackback(cycle) and drops the connection. --- */
+  print("ringtest: closing the ring, ds3(%d)->ds1(%d)\n" ds3_port ds1_port :err);
+  remote(sock3 print("drawlink(\"127.0.0.1\" %d)" ds1_port :str));
+  update(5000000);
+
+  /* ds1 is where the ring would have closed, so its count is the decisive
+     one: a ring gives it two links, a chain one.  ds3 is deliberately not
+     asked -- a node whose cycle-closing offer is refused has been seen to stop
+     answering its comdraw port, and remote() has no timeout to recover from
+     that, so this test neither queries ds3 nor waits on it to exit. */
+  n1=remote(sock1 "size(drawlink(:table))");
+  n2=remote(sock2 "size(drawlink(:table))");
+  print("ringtest: links held -- ds1=%v ds2=%v\n" n1 n2 :err);
+  chain=(n1==1) && (n2==2);
+  if(!chain :then print("ringtest: FAIL the ring formed -- expected 1,2 links\n" :err));
+  if(chain :then print("ringtest: ring refused, topology stayed a chain\n" :err));
+
+  /* the counts alone would also read 1,2 if that third drawlink had failed for
+     some reason of its own, so make the refusal prove itself: casting off the
+     offending link must leave the good one relaying */
+  remote(sock1 "ellipse(100,100,40,40)");
+  update(2000000);
+  id1=remote(sock1 "at(grid(:table)).grid");
+  if(type(id1)!=`StringType :then
+    print("ringtest: FAIL could not read grid id from ds1 (got %v)\n" id1 :err);
+    relay=false
+  :else
+    relay=grid_has_id(:gh_sock sock2 :gh_id id1);
+    print("ringtest: graphic reached ds2 over the surviving link: %v\n" relay :err));
+  if(!relay :then print("ringtest: FAIL the refusal took the good link with it\n" :err));
+  ok=chain && relay;
+
+  /* --- tear all three down --- */
+  remote(sock1 "exit" :nowait);close(sock1);
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
+  print("ringtest: ds1 shut down\n" :err);
+  remote(sock2 "exit" :nowait);close(sock2);
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
+  print("ringtest: ds2 shut down\n" :err);
+  close(sock3);
+  kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
+  cnt=0;
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0 && cnt<50
+    usleep(200000);cnt++);
+  print("ringtest: ds3 shut down\n" :err);
+  ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c36132af"
+#define PATCH_KEY "3ee992d6"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Fixes an infinite relay loop introduced by #402. Two linked drawservs, a rect, and one `trans()` traded the same transform **24,000 times in ten seconds**.

## What was wrong

`LinkTransformCmd::dist_script` did two things the other relays do not.

**It stamped its own session as the owner:**

```c
/* stamp this session so ExecuteCmd excludes the link back toward us */
uuid_copy(_dist_owner_sid, drawserv->sessionid());
```

That comment has the mechanism backwards. `ExecuteCmd` excludes `linkget(sid)`, and there is no link to *yourself* -- so `linkget(self)` is nil and `DistributeCmdString` sends to every link, including the one the command just arrived on.

**And it had no ownership gate.** `LinkBrushCmd` relays only comps this node owns or that a remote owner has unlocked through it:

```c
if (grid && (grid->selected() == LinkSelection::LocallySelected ||
             grid->unlocked())) {
```

A node that merely *received* a change owns nothing, so its script comes back empty and the echo stops. `LinkTransformCmd` relayed anything in its clipboard, unconditionally.

The root mistake was this comment:

```c
/* the target rides in the clipboard, not the selection -- trans() named it */
```

The `select(grid(...) :unlock KEY)` bracket is not addressing. It is what carries the **owner** to the receiving node, so that node stamps the owner rather than itself and excludes the link back. Dropping it as redundant dropped the loop prevention with it.

## The fix

`LinkTransformCmd` now does exactly what brush, colour, pattern and font do: gate on `LocallySelected || unlocked()`, stamp `grid->selector()` when relaying rather than self, and emit the same bracket. The one deviation is forced by the signature -- brush applies to the selection so its script is just `brush(...)`, while `trans()` takes an explicit compview, so the command inside the bracket is `trans(grid("uuid") ...)`. The bracket is identical.

## Measured

Two drawservs launched directly (not through drawmo's `shell()`, so they load the build under test rather than the installed libraries), linked, one rect, one transform, ten seconds:

| | ds1 | ds2 |
|---|---|---|
| before | 24091 | 24134 |
| after | 3 | 1 |

The transform arrives correctly either way -- `{1,0,0,1,10,20}` on both nodes in both runs.

## Why the existing test did not catch this

`gsbrushA` already asserted a transform reaching two hops, and it passed in CI throughout. **A loop is invisible in state**: the transform is absolute, so every extra copy sets the same value. The assertion checks arrival, and an echoing relay still delivers -- it just keeps delivering until teardown.

That is also why loop-freedom cannot be tested by watching values, and why the gate must never be "did this change anything" -- setting a transform to the value it already holds is a legitimate no-op that still has to relay.

This PR adds the transform check to `gsbrushB` so the fork topology is covered alongside the chain, which is regression coverage for the relay rather than for the loop.
