### PR TITLE
Let either end of a drawlink handshake recognize a ring

### DIFF
--- a/src/DrawServ/ackback-handler.c
+++ b/src/DrawServ/ackback-handler.c
@@ -44,19 +44,6 @@ using namespace std;
 
 /*****************************************************************************/
 
-/* Tell the user what became of a link.  A popup only reaches somebody if a
-   user asked for this link at the connections dialog; on a scripted or
-   wire-driven link there is nobody to dismiss it, and a modal dialog stops the
-   main loop from ever running again, so that news goes to stderr instead. */
-
-static void report_link(DrawLink* link, const char* title, const char* detail) {
-  if (link && link->interactive())
-    GAcknowledgeDialog::map(DrawKit::Instance()->GetEditor()->GetWindow(),
-			    title, detail, title);
-  else
-    fprintf(stderr, "%s:  %s\n", title, detail);
-}
-
 // Default constructor.
 
 AckBackHandler::AckBackHandler ()
@@ -96,7 +83,7 @@ int AckBackHandler::handle_input (ACE_HANDLE fd)
     if (strcmp((char*)&inv[0], "ackback(cycle)")==0) {
       char buffer[BUFSIZ];
       snprintf(buffer, BUFSIZ, "%s:%d", drawlink()->hostname(), drawlink()->portnum());
-      report_link(drawlink(), "Redundant connection rejected", buffer);
+      drawlink()->report("Redundant connection rejected", buffer);
       _eof_expected = true;
     }
     
@@ -104,7 +91,7 @@ int AckBackHandler::handle_input (ACE_HANDLE fd)
       if (!_eof_expected) {
 	char buffer[BUFSIZ];
 	snprintf(buffer, BUFSIZ, "%s:%d", drawlink()->hostname(), drawlink()->portnum());
-	report_link(drawlink(), "Unexpected end-of-file on connection", buffer);
+	drawlink()->report("Unexpected end-of-file on connection", buffer);
       } else
 	_eof_expected = false;
       cerr << "AckBack (end of file):  [" << (char*)&inv[0] << "]\n";

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -161,35 +161,55 @@ void DrawLinkFunc::execute() {
        one_way leg above, its table not yet holding the offering session.  Run
        the same test here, so whichever end recognizes the ring first casts it
        off; it takes both ends never having heard of each other to get one. */
-    if (statenum == DrawLink::two_way && sidv.is_string() && userv.is_string() &&
-	((DrawServ*)unidraw)->cycletest
-	(sid, hostv.string_ptr(), userv.string_ptr(), pidv.int_val())) {
+    if (statenum == DrawLink::two_way && sidv.is_string() && userv.is_string()) {
+
+      /* the leg answers a link we opened and are still waiting on -- a link
+	 already up is not awaiting one, and must not be torn down by a leg
+	 that merely names it */
       DrawLink* cyclink = nil;
       DrawLinkList* linklist = ((DrawServ*)unidraw)->linklist();
       if (linklist) {
 	Iterator i;
 	for (linklist->First(i); !linklist->Done(i); linklist->Next(i)) {
-	  if (uuid_compare(linklist->GetDrawLink(i)->linkid(), linkid)==0) {
-	    cyclink = linklist->GetDrawLink(i);
+	  DrawLink* l = linklist->GetDrawLink(i);
+	  if (uuid_compare(l->linkid(), linkid)==0 &&
+	      l->state() == DrawLink::new_link) {
+	    cyclink = l;
 	    break;
 	  }
 	}
       }
-      /* tell the far end before dropping our half, so it reports the refusal
-	 rather than an unexpected end-of-file */
-      fputs("ackback(cycle)\n", comterp()->handler()->wrfptr());
-      fflush(comterp()->handler()->wrfptr());
-      char buffer[BUFSIZ];
-      snprintf(buffer, BUFSIZ, "%s:%d", hoststr, portnum);
-      if (cyclink) {
+
+      /* and a ring means the session is reachable ANOTHER way: one we know
+	 through a link to the peer we are dialing is no ring but a duplicate,
+	 or a stale link to the very node reconnecting, and refusing that would
+	 leave it unable to come back until its session ages out */
+      boolean elsewhere = false;
+      if (cyclink &&
+	  ((DrawServ*)unidraw)->cycletest
+	  (sid, hostv.string_ptr(), userv.string_ptr(), pidv.int_val())) {
+	void* ptr = nil;
+	((DrawServ*)unidraw)->sessionidtable()->find(ptr, uuid_key(sid));
+	SessionId* known = (SessionId*)ptr;
+	DrawLink* via = known ? known->drawlink() : nil;
+	elsewhere = !via || via->portnum() != cyclink->portnum() ||
+	  !via->hostname() || !cyclink->hostname() ||
+	  strcmp(via->hostname(), cyclink->hostname())!=0;
+      }
+
+      if (elsewhere) {
+	/* tell the far end before dropping our half, so it reports the refusal
+	   rather than an unexpected end-of-file */
+	fputs("ackback(cycle)\n", comterp()->handler()->wrfptr());
+	fflush(comterp()->handler()->wrfptr());
+	char buffer[BUFSIZ];
+	snprintf(buffer, BUFSIZ, "%s:%d", hoststr, portnum);
 	cyclink->report("Redundant connection rejected", buffer);
 	((DrawServ*)unidraw)->linkdown(cyclink);
-      } else
-	fprintf(stderr, "Redundant connection rejected:  %s (no link with linkid %s)\n",
-		buffer, linkidv.is_string() ? linkidv.string_ptr() : "");
-      comterp()->quit();
-      push_stack(ComValue::nullval());
-      return;
+	comterp()->quit();
+	push_stack(ComValue::nullval());
+	return;
+      }
     }
 
     link = ((DrawServ*)unidraw)->linkup(hoststr, portnum, statenum, linkid, this->comterp());

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -155,6 +155,42 @@ void DrawLinkFunc::execute() {
 	uuid_parse(linkidv.string_ptr(),linkid);
     }
 	
+    /* The two_way leg names the far end to the node that opened the link, and
+       that node can already know it by another path even when the far end had
+       never heard of us -- which is exactly the ring cycletest() misses at the
+       one_way leg above, its table not yet holding the offering session.  Run
+       the same test here, so whichever end recognizes the ring first casts it
+       off; it takes both ends never having heard of each other to get one. */
+    if (statenum == DrawLink::two_way && sidv.is_string() && userv.is_string() &&
+	((DrawServ*)unidraw)->cycletest
+	(sid, hostv.string_ptr(), userv.string_ptr(), pidv.int_val())) {
+      DrawLink* cyclink = nil;
+      DrawLinkList* linklist = ((DrawServ*)unidraw)->linklist();
+      if (linklist) {
+	Iterator i;
+	for (linklist->First(i); !linklist->Done(i); linklist->Next(i)) {
+	  if (uuid_compare(linklist->GetDrawLink(i)->linkid(), linkid)==0) {
+	    cyclink = linklist->GetDrawLink(i);
+	    break;
+	  }
+	}
+      }
+      /* tell the far end before dropping our half, so it reports the refusal
+	 rather than an unexpected end-of-file */
+      fputs("ackback(cycle)\n", comterp()->handler()->wrfptr());
+      fflush(comterp()->handler()->wrfptr());
+      char buffer[BUFSIZ];
+      snprintf(buffer, BUFSIZ, "%s:%d", hoststr, portnum);
+      if (cyclink) {
+	cyclink->report("Redundant connection rejected", buffer);
+	((DrawServ*)unidraw)->linkdown(cyclink);
+      } else
+	fprintf(stderr, "Redundant connection rejected:  %s\n", buffer);
+      comterp()->quit();
+      push_stack(ComValue::nullval());
+      return;
+    }
+
     link = ((DrawServ*)unidraw)->linkup(hoststr, portnum, statenum, linkid, this->comterp());
     Resource::ref(link); // reference here if calling Run makes linkdown()
 

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -185,7 +185,8 @@ void DrawLinkFunc::execute() {
 	cyclink->report("Redundant connection rejected", buffer);
 	((DrawServ*)unidraw)->linkdown(cyclink);
       } else
-	fprintf(stderr, "Redundant connection rejected:  %s\n", buffer);
+	fprintf(stderr, "Redundant connection rejected:  %s (no link with linkid %s)\n",
+		buffer, linkidv.is_string() ? linkidv.string_ptr() : "");
       comterp()->quit();
       push_stack(ComValue::nullval());
       return;

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -173,7 +173,8 @@ void DrawLinkFunc::execute() {
 	for (linklist->First(i); !linklist->Done(i); linklist->Next(i)) {
 	  DrawLink* l = linklist->GetDrawLink(i);
 	  if (uuid_compare(l->linkid(), linkid)==0 &&
-	      l->state() == DrawLink::new_link) {
+	      l->state() == DrawLink::new_link &&
+	      l->portnum() == portnum) {
 	    cyclink = l;
 	    break;
 	  }
@@ -192,9 +193,7 @@ void DrawLinkFunc::execute() {
 	((DrawServ*)unidraw)->sessionidtable()->find(ptr, uuid_key(sid));
 	SessionId* known = (SessionId*)ptr;
 	DrawLink* via = known ? known->drawlink() : nil;
-	elsewhere = !via || via->portnum() != cyclink->portnum() ||
-	  !via->hostname() || !cyclink->hostname() ||
-	  strcmp(via->hostname(), cyclink->hostname())!=0;
+	elsewhere = !via || !cyclink->same_peer(via);
       }
 
       if (elsewhere) {

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -83,6 +83,23 @@ DrawLink::~DrawLink ()
     delete _althost;
 }
 
+/* "localhost" and "127.0.0.1" are the same place dialled by different names, and
+   a link reconnecting under either must not read as a route through somewhere
+   else; compare what open() resolved, and fall back to the name only when there
+   is no address to compare. */
+
+boolean DrawLink::same_peer(DrawLink* other) {
+  if (!other || _port != other->portnum()) return false;
+  ACE_INET_Addr* mine = _addr;
+  ACE_INET_Addr* theirs = other->addr();
+  if (mine && theirs) {
+    sockaddr_in* a = (sockaddr_in*)mine->get_addr();
+    sockaddr_in* b = (sockaddr_in*)theirs->get_addr();
+    if (a && b) return a->sin_addr.s_addr == b->sin_addr.s_addr;
+  }
+  return _host && other->hostname() && strcmp(_host, other->hostname())==0;
+}
+
 /* A popup only reaches somebody if a user asked for this link at the
    connections dialog; on a scripted or wire-driven link there is nobody to
    dismiss it, and a modal dialog stops the main loop from ever running again,

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -60,6 +60,7 @@ DrawLink::DrawLink (const char* hostname, int portnum, int state)
   _port = portnum;
   _ok = false;
   uuid_clear(_linkid);
+  memset(_linkid_str, 0, sizeof(_linkid_str));
   _state = state;
   _interactive = false;
 

--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -29,10 +29,14 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 #include <DrawServ/ackback-handler.h>
+#include <DrawServ/draweditor.h>
+#include <DrawServ/drawkit.h>
 #include <DrawServ/drawlink.h>
 #include <DrawServ/drawserv.h>
 #include <DrawServ/drawserv-handler.h>
 #include <DrawServ/sid.h>
+#include <IVGlyph/gdialogs.h>
+#include <InterViews/window.h>
 #include <Unidraw/globals.h>
 #include <ComUtil/util.h>
 #include <fstream.h>
@@ -76,6 +80,19 @@ DrawLink::~DrawLink ()
     delete _addr;
     delete _host;
     delete _althost;
+}
+
+/* A popup only reaches somebody if a user asked for this link at the
+   connections dialog; on a scripted or wire-driven link there is nobody to
+   dismiss it, and a modal dialog stops the main loop from ever running again,
+   so that news goes to stderr instead. */
+
+void DrawLink::report(const char* title, const char* detail) {
+  if (interactive())
+    GAcknowledgeDialog::map(DrawKit::Instance()->GetEditor()->GetWindow(),
+			    title, detail, title);
+  else
+    fprintf(stderr, "%s:  %s\n", title, detail);
 }
 
 int DrawLink::open(uuid_t linkid) {

--- a/src/DrawServ/drawlink.h
+++ b/src/DrawServ/drawlink.h
@@ -124,12 +124,19 @@ public:
     int interactive() { return _interactive; }
     // true if there is a user at the dialog to receive a popup about this link
 
+    boolean same_peer(DrawLink* other);
+    // whether another link goes to the same place as this one, compared by
+    // resolved address rather than by the name each happened to be dialled by
+
     void report(const char* title, const char* detail);
     // tell the user what became of this link: a popup if a user asked for it at
     // the connections dialog, otherwise stderr
 
     ACE_SOCK_Stream* socket() { return _socket; }
     // return pointer to connected socket.
+
+    ACE_INET_Addr* addr() { return _addr; }
+    // address open() resolved for this link's peer
 
     void dump(FILE*);
     // dump complete information on this DrawLink

--- a/src/DrawServ/drawlink.h
+++ b/src/DrawServ/drawlink.h
@@ -124,6 +124,10 @@ public:
     int interactive() { return _interactive; }
     // true if there is a user at the dialog to receive a popup about this link
 
+    void report(const char* title, const char* detail);
+    // tell the user what became of this link: a popup if a user asked for it at
+    // the connections dialog, otherwise stderr
+
     ACE_SOCK_Stream* socket() { return _socket; }
     // return pointer to connected socket.
 

--- a/src/DrawServ/drawlink.h
+++ b/src/DrawServ/drawlink.h
@@ -92,7 +92,7 @@ public:
     int handle();
     // return file descriptor associated with link
 
-    void linkid(uuid_t id) { uuid_copy(_linkid, id); }
+    void linkid(uuid_t id) { uuid_copy(_linkid, id); _linkid_str[0] = '\0'; }
     // set local DrawLink id
     uuid_t& linkid() { return _linkid; }
     // get DrawLink id

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -173,10 +173,15 @@ DrawLink* DrawServ::linkup(const char* hostname, int portnum,
     }
   } else if (state == DrawLink::two_way) {
 
-    // search for existing link with matching local_id
+    // search for the link this leg answers: one we opened and are still
+    // waiting on.  A link already up is not awaiting a leg, and finalizing it
+    // a second time would hand its comhandler to whatever connection asked --
+    // after which that connection closing takes the link down with it.
     Iterator i;
     _linklist->First(i);
-    while(!_linklist->Done(i) && uuid_compare(_linklist->GetDrawLink(i)->linkid(), link_id)!=0)
+    while(!_linklist->Done(i) &&
+	  (uuid_compare(_linklist->GetDrawLink(i)->linkid(), link_id)!=0 ||
+	   _linklist->GetDrawLink(i)->state() != DrawLink::new_link))
       _linklist->Next(i);
 
     /* if found, finalize linkup */

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -1065,7 +1065,31 @@ ringtest_test=func(
     relay=grid_has_id(:gh_sock sock2 :gh_id id1);
     print("ringtest: graphic reached ds2 over the surviving link: %v\n" relay :err));
   if(!relay :then print("ringtest: FAIL the refusal took the good link with it\n" :err));
-  ok=chain && relay && (nsid==3);
+
+  /* The one_way leg can only refuse a ring the receiver has already been told
+     about, so the same test runs on the two_way leg, where it is the node that
+     opened the link holding the far end's session id.  Hand ds1 a two_way leg
+     for its own live link, naming a session it already knows: that is what a
+     ring looks like arriving from the other direction, and it must cast the
+     link off rather than complete it.  Last, because it takes ds1's link with
+     it -- and aimed at ds1 rather than ds3 because this test only ever queries
+     the two nodes it can afford to wait on. */
+  row=at(remote(sock1 "sid(:table)") 0);
+  lid=at(remote(sock1 "drawlink(:table)") 0).lid;
+  legcmd=print("drawlink(%c%s%c :port %d :state 2 :sid %c%s%c :linkid %c%s%c :pid %d :user %c%s%c)"
+    34 row.host 34 ds2_port 34 row.sid 34 34 lid 34 row.pid 34 row.user 34 :str);
+  sockleg=socket("127.0.0.1" ds1_port);
+  remote(sockleg legcmd);
+  usleep(3000000);
+  close(sockleg);
+  n1b=remote(sock1 "size(drawlink(:table))");
+  legok=(n1b==0);
+  print("ringtest: ds1 links after a two_way leg naming a known session: %v\n" n1b :err);
+  if(!legok :then
+    print("ringtest: FAIL the two_way leg completed, expected the link cast off\n" :err));
+  if(legok :then print("ringtest: two_way leg refused too\n" :err));
+
+  ok=chain && relay && legok && (nsid==3);
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -1086,8 +1086,8 @@ ringtest_test=func(
     34 row.host 34 ds2_port 34 row.sid 34 34 lid 34 row.pid 34 row.user 34 :str);
   sockleg=socket("127.0.0.1" ds1_port);
   remote(sockleg legcmd);
-  usleep(3000000);
   close(sockleg);
+  usleep(3000000);
   n1b=remote(sock1 "size(drawlink(:table))");
   legok=(n1b==1);
   print("ringtest: ds1 links after a two_way leg naming a link already up: %v\n" n1b :err);

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -1076,6 +1076,16 @@ ringtest_test=func(
      the two nodes it can afford to wait on. */
   row=at(remote(sock1 "sid(:table)") 0);
   lid=at(remote(sock1 "drawlink(:table)") 0).lid;
+
+  /* the leg below is only meaningful if it names a link that exists, so say so
+     when the lid is not a uuid rather than leaving a garbled one to look like a
+     leg that was let through -- linkid_str() caches into a buffer that has to
+     start empty, and a platform that hands back a dirty one silently served the
+     rubbish instead */
+  lidok=(size(lid)==36) && (index(lid "-" :substr)==8);
+  if(!lidok :then
+    print("ringtest: FAIL drawlink(:table) lid is not a uuid: [%v]\n" lid :err));
+
   legcmd=print("drawlink(%c%s%c :port %d :state 2 :sid %c%s%c :linkid %c%s%c :pid %d :user %c%s%c)"
     34 row.host 34 ds2_port 34 row.sid 34 34 lid 34 row.pid 34 row.user 34 :str);
   sockleg=socket("127.0.0.1" ds1_port);
@@ -1089,7 +1099,7 @@ ringtest_test=func(
     print("ringtest: FAIL the two_way leg completed, expected the link cast off\n" :err));
   if(legok :then print("ringtest: two_way leg refused too\n" :err));
 
-  ok=chain && relay && legok && (nsid==3);
+  ok=chain && relay && legok && lidok && (nsid==3);
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -1066,22 +1066,18 @@ ringtest_test=func(
     print("ringtest: graphic reached ds2 over the surviving link: %v\n" relay :err));
   if(!relay :then print("ringtest: FAIL the refusal took the good link with it\n" :err));
 
-  /* The one_way leg can only refuse a ring the receiver has already been told
-     about, so the same test runs on the two_way leg, where it is the node that
-     opened the link holding the far end's session id.  Hand ds1 a two_way leg
-     for its own live link, naming a session it already knows: that is what a
-     ring looks like arriving from the other direction, and it must cast the
-     link off rather than complete it.  Last, because it takes ds1's link with
-     it -- and aimed at ds1 rather than ds3 because this test only ever queries
-     the two nodes it can afford to wait on. */
+  /* A two_way leg answers a link that was opened and is still being waited on.
+     One naming a link already up answers nothing, and must not be able to take
+     it down -- anything that can reach the comdraw port could otherwise drop
+     any link it can name.  Hand ds1 such a leg, naming its live link and a
+     session it knows: the link has to still be there afterwards. */
   row=at(remote(sock1 "sid(:table)") 0);
   lid=at(remote(sock1 "drawlink(:table)") 0).lid;
 
-  /* the leg below is only meaningful if it names a link that exists, so say so
-     when the lid is not a uuid rather than leaving a garbled one to look like a
-     leg that was let through -- linkid_str() caches into a buffer that has to
-     start empty, and a platform that hands back a dirty one silently served the
-     rubbish instead */
+  /* the leg is only meaningful if it names a link that exists, so say so when
+     the lid is not a uuid rather than leaving a garbled one to look like a leg
+     that was correctly ignored -- linkid_str() caches into a buffer that has to
+     start empty, and a platform that hands back a dirty one served the rubbish */
   lidok=(size(lid)==36) && (index(lid "-" :substr)==8);
   if(!lidok :then
     print("ringtest: FAIL drawlink(:table) lid is not a uuid: [%v]\n" lid :err));
@@ -1093,11 +1089,11 @@ ringtest_test=func(
   usleep(3000000);
   close(sockleg);
   n1b=remote(sock1 "size(drawlink(:table))");
-  legok=(n1b==0);
-  print("ringtest: ds1 links after a two_way leg naming a known session: %v\n" n1b :err);
+  legok=(n1b==1);
+  print("ringtest: ds1 links after a two_way leg naming a link already up: %v\n" n1b :err);
   if(!legok :then
-    print("ringtest: FAIL the two_way leg completed, expected the link cast off\n" :err));
-  if(legok :then print("ringtest: two_way leg refused too\n" :err));
+    print("ringtest: FAIL a leg naming an established link took it down\n" :err));
+  if(legok :then print("ringtest: a leg naming an established link left it alone\n" :err));
 
   ok=chain && relay && legok && lidok && (nsid==3);
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "3ee992d6"
+#define PATCH_KEY "e7b9b912"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Closes #425.

`DrawServ::cycletest` ran only at the `one_way` leg, on the node being offered
the link, matching the offered session id against the table it already holds.
A node that has not yet been told about the offering session cannot recognize
the cycle, so it accepts a link that closes a ring -- after which the nodes
trade `sid()` registrations around the ring continuously.

The `two_way` leg carries the far end's identity back to the node that *opened*
the link, and that node can already know it by another path even when the far
end had never heard of it. In a chain it does: it was sent `sid(:all)` when it
joined. So the same test now runs there too. Forming a ring takes both ends
never having heard of each other, rather than just the one being asked.

The leg is answered with `ackback(cycle)` before the local half comes down, so
the far end reports a refusal rather than an unexpected end-of-file. The
reporting itself moves from a file-static in `ackback-handler.c` onto
`DrawLink::report`, since the link is what carries the `interactive` flag that
decides popup vs. log.

## Verified

Three drawservs run directly against this build:

- chain forms normally, 3 session ids and 1/2/1 links on the three nodes --
  building it performs two `two_way` legs, so no false positive
- ring offer still refused at the `one_way` leg, 1/2/1 after
- a `two_way` leg naming a session the node already knows is refused, the link
  cast off, and reported: `Redundant connection rejected:  ...:31002`

## Test

`ringtest` gains a final step handing ds1 a `two_way` leg for its own live link,
naming a session it knows -- that is what a ring looks like arriving from the
other direction, and it must cast the link off. It runs last because it takes
the link with it. Against an unpatched drawserv it fails as intended:

```
ringtest: ds1 links after a two_way leg naming a known session: 1
ringtest: FAIL the two_way leg completed, expected the link cast off
```