### PR TITLE
Give every interpreter its own parse state

### DIFF
--- a/src/ComTerp/parser.c
+++ b/src/ComTerp/parser.c
@@ -236,6 +236,14 @@ void Parser::check_parser_client(boolean restore) {
       NextLinenum = _NextLinenum;
       for (int i=0; i<OPTYPE_NUM; i++)
 	NextOp_ids[i] = _NextOp_ids[i];
+    }
+    /* The operator table is the one thing here that is legitimately shared --
+       every parser wants the same operators, and a saved copy is only ever a
+       copy of the one global.  Restoring a snapshot on a parser's FIRST parse
+       would undo an optable(:insert) made since that parser was constructed
+       (%% is defined that way at runtime), so this keeps the guard the parse
+       state above no longer needs. */
+    if (_linenum != 0) {
       opr_tbl_ptr_set(_opr_tbl_ptr);
       opr_tbl_numop_set(_opr_tbl_numop);
       opr_tbl_maxop_set(_opr_tbl_maxop);

--- a/src/ComTerp/parser.c
+++ b/src/ComTerp/parser.c
@@ -77,6 +77,37 @@ void Parser::init() {
     __angle_brackets = 0;
     __token_state_save = TOK_WHITESPACE;
     __ignore_numerics = 0;
+
+    /* And the backup copies of the parse state proper, which nothing set
+       before: check_parser_client() installs these when this parser takes the
+       globals over, so leaving them indeterminate meant the first parse ran on
+       whatever the previous client had left there -- and save_parser_client()
+       then copied that client's ParenStack POINTER in here, aliasing two
+       interpreters onto one stack of argument and keyword counts.  A NULL stack
+       makes parser() allocate one belonging to this parser alone. */
+    _expecting = 0;
+    _ParenStack = NULL;
+    _TopOfParenStack = -1;
+    _SizeOfParenStack = 0;
+    _OperStack = NULL;
+    _TopOfOperStack = -1;
+    _SizeOfOperStack = 0;
+    _NextBufptr = 0;
+    _NextToken = NULL;
+    _NextToklen = 0;
+    _NextToktype = 0;
+    _NextTokstart = 0;
+    _NextLinenum = 0;
+    for (int i=0; i<OPTYPE_NUM; i++)
+      _NextOp_ids[i] = 0;
+
+    /* the operator table is legitimately shared -- every parser wants the same
+       operators -- so take the current values rather than emptying them */
+    _opr_tbl_ptr = opr_tbl_ptr_get();
+    _opr_tbl_numop = opr_tbl_numop_get();
+    _opr_tbl_maxop = opr_tbl_maxop_get();
+    _opr_tbl_maxpri = opr_tbl_maxpri_get();
+    _opr_tbl_lastop = opr_tbl_lastop_get();
 }
 
 
@@ -189,7 +220,7 @@ void Parser::check_parser_client(boolean restore) {
     _ignore_numerics = __ignore_numerics;
     _angle_brackets = __angle_brackets ;
     _token_state_save = __token_state_save;
-    if (_linenum != 0) {
+    {
       expecting = _expecting;
       ParenStack = _ParenStack;
       TopOfParenStack = _TopOfParenStack;

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -507,6 +507,9 @@ void CreateTextFunc::execute() {
        not survive being exported and re-created, nor reach a far node intact.
 
        They are told apart by whether a text argument was supplied at all. */
+    /* the serialized form supplies no text argument, so nothing string-like
+       is sitting in argument 1.  (nargs() does not distinguish the two: it
+       reports 2 either way.) */
     boolean serialized_form = !txtv.is_string();
 
     const char* txt = nil;

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,7 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
+# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,9 +10,9 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|gsexim|gsbrushA|gsbrushB]\n");
+    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|gsexim|gsbrushA|gsbrushB]\n");
     print("\t\t\ttests to run (comma-separated), returns -1 on error\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
@@ -146,6 +146,13 @@ if(tests_flag :then
         print("ringtest: pass\n" :err)
       :else
         print("ringtest: FAIL\n" :err);
+        ok=false));
+    if(t==`parsetest || t==`all :then
+      print("running parsetest\n" :err);
+      if(parsetest_test(:dummy 0) :then
+        print("parsetest: pass\n" :err)
+      :else
+        print("parsetest: FAIL\n" :err);
         ok=false));
     if(t==`gsexim || t==`all :then
       print("running gsexim test\n" :err);

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -71,7 +71,7 @@ grid_has_id=func(
     n=size(t);
     for(j=0 j<n j++
       if(at(t j).grid==gh_id :then found=true));
-    if(!found :then update(poll_usec);cnt++));
+    if(!found :then usleep(poll_usec);cnt++));
   found)
 
 /* The test functions live in two grouped files, loaded here.  Order matters: a

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,7 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
+# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,9 +10,9 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|gsexim|gsbrushA|gsbrushB]\n");
+    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|gsexim|gsbrushA|gsbrushB]\n");
     print("\t\t\ttests to run (comma-separated), returns -1 on error\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
@@ -153,6 +153,13 @@ if(tests_flag :then
         print("parsetest: pass\n" :err)
       :else
         print("parsetest: FAIL\n" :err);
+        ok=false));
+    if(t==`optabletest || t==`all :then
+      print("running optabletest\n" :err);
+      if(optabletest_test(:dummy 0) :then
+        print("optabletest: pass\n" :err)
+      :else
+        print("optabletest: FAIL\n" :err);
         ok=false));
     if(t==`gsexim || t==`all :then
       print("running gsexim test\n" :err);

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -213,6 +213,43 @@ gsbrushA_test=func(
     if(!c3 :then print("gsbrushA: FAIL text content did not propagate to ds3\n" :err));
     ok=ok && f2 && f3 && c2 && c3);
 
+  /* --- every shape, not just the rect and the text above.  comdraw's
+     shapes.comt proves each one re-creates from the form DrawServ sends; this
+     is the same nine actually making the trip.  Which row of the far node's
+     table each landed in is not knowable in advance, so scan for the component
+     class rather than assume an order -- the grid table carries it already. --- */
+  shapecmds=("rect(200,200,240,240)","line(200,250,240,290)","ellipse(300,200,20,10)",
+             "text(300,250 \"x\")","multiline(350,200,370,220,390,200)",
+             "polygon(350,250,370,270,390,250)","openspline(400,200,420,220,440,200)",
+             "closedspline(400,250,420,270,440,250)","raster(450,200,458,208)");
+  shapeclasses=("RectComp","ArrowLineComp","EllipseComp","TextComp","ArrowMultiLineComp",
+                "PolygonComp","ArrowSplineComp","ClosedSplineComp","RasterComp");
+
+  k=0;
+  while(k<9 remote(sock1 at(shapecmds k)); k=k+1);
+  update(3000000);
+
+  n1=remote(sock1 "size(grid(:table))");
+  n2=remote(sock2 "size(grid(:table))");
+  print("gsbrushA: ds1 holds %v graphics, ds2 holds %v\n" n1 n2 :err);
+  shapesok=(type(n1)==`IntType && type(n2)==`IntType && n1==n2);
+  if(!shapesok :then print("gsbrushA: FAIL not every graphic reached ds2\n" :err));
+
+  if(type(n2)==`IntType :then
+    k=0;
+    while(k<9
+      want=at(shapeclasses k);
+      found=false;
+      j=0;
+      while(!found && j<n2
+        cls=remote(sock2 print("at(grid(:table) %d).comptype" j :str));
+        if(type(cls)==`StringType && index(cls want :substr)!=nil :then found=true);
+        j=j+1);
+      if(!found :then (print("gsbrushA: FAIL %s did not reach ds2\n" want :err); shapesok=false));
+      k=k+1));
+  print("gsbrushA: all nine shapes reached ds2 = %v\n" shapesok :err);
+  ok=ok && shapesok;
+
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -22,7 +22,7 @@ gs_on_node=func(
   while(!found && cnt<timeout
     e=remote(bn_sock expr);
     if(type(e)==`StringType && index(e bn_gs)!=nil :then found=true);
-    if(!found :then update(poll_usec);cnt++));
+    if(!found :then usleep(poll_usec);cnt++));
   found)
 
 /* gsbrushA test -- graphic-state BRUSH propagation, CHAIN topology ds1->ds2->ds3.
@@ -117,7 +117,8 @@ gsbrushA_test=func(
   remote(sock1 "pattern(5)");
   /* one reasoned settle (see updown3A): command distribution is fire-and-forget;
      give the create+brush+pattern a head start before polling the far nodes. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("gsbrushA: created rect+brush on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -153,7 +154,6 @@ gsbrushA_test=func(
      rather than merely proving something arrived. --- */
   maskstr=":pattern 0x0011,0x0022,0x0044,0x0088";
   remote(sock1 "patternmask(0x11,0x22,0x44,0x88,0x11,0x22,0x44,0x88,0x11,0x22,0x44,0x88,0x11,0x22,0x44,0x88)");
-  update(2000000);
   m2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs maskstr);
   m3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs maskstr);
   print("gsbrushA: patternmask 16-element form reached ds2=%v ds3=%v\n" m2 m3 :err);
@@ -170,7 +170,6 @@ gsbrushA_test=func(
      is the transform having propagated. --- */
   transtr=":transform 2,0,0,2,30,40";
   remote(sock1 print("trans(grid(%c%s%c) 2,0,0,2,30,40)" 34 id1 34 :str));
-  update(2000000);
   x2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs transtr);
   x3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs transtr);
   print("gsbrushA: transform reached ds2=%v ds3=%v\n" x2 x3 :err);
@@ -186,7 +185,8 @@ gsbrushA_test=func(
   fontstr="courier-bold";
   remote(sock1 "t=text(30,30 \"gs\")");
   remote(sock1 "font(3)");
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<2 && cnt<200 usleep(100000);cnt++);
   /* pick the entry that is not the rect rather than trusting table order */
   ida=remote(sock1 "at(grid(:table) 0).grid");
   idb=remote(sock1 "at(grid(:table) 1).grid");
@@ -227,9 +227,9 @@ gsbrushA_test=func(
 
   k=0;
   while(k<9 remote(sock1 at(shapecmds k)); k=k+1);
-  update(3000000);
-
   n1=remote(sock1 "size(grid(:table))");
+  cnt=0;
+  while(remote(sock2 "size(grid(:table))")<n1 && cnt<200 usleep(100000);cnt++);
   n2=remote(sock2 "size(grid(:table))");
   print("gsbrushA: ds1 holds %v graphics, ds2 holds %v\n" n1 n2 :err);
   shapesok=(type(n1)==`IntType && type(n2)==`IntType && n1==n2);
@@ -347,7 +347,8 @@ gsbrushB_test=func(
   remote(sock1 "brush(65520,2)");
   remote(sock1 "pattern(5)");
   /* one reasoned settle (see updown3B): fire-and-forget distribution. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("gsbrushB: created rect+brush on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -385,7 +386,6 @@ gsbrushB_test=func(
      see gsbrushA. --- */
   maskstr=":graypat -1";
   remote(sock1 "patternmask(255)");
-  update(2000000);
   m2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs maskstr);
   m3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs maskstr);
   print("gsbrushB: patternmask scalar form reached ds2=%v ds3=%v\n" m2 m3 :err);
@@ -400,7 +400,6 @@ gsbrushB_test=func(
      it back and forth until the suite times out. --- */
   xstr=":transform 2,0,0,2,30,40";
   remote(sock1 print("trans(grid(%c%s%c) 2,0,0,2,30,40)" 34 id1 34 :str));
-  update(2000000);
   t2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs xstr);
   t3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs xstr);
   print("gsbrushB: transform fanned out ds2=%v ds3=%v\n" t2 t3 :err);

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -253,26 +253,38 @@ optabletest_test=func(
   remote(sock "1+1");
   remote(sockb "1+1");
 
-  ins=remote(sock "optable(\"@@\" \"size\" :insert :pri 100 :prefix)");
-  usleep(500000);
-  u1=remote(sock "@@ \"abcd\"");
+  /* a starts the insert and leaves it unclosed, b parses in the gap, a closes
+     it.  Nothing waits on a: without the parse-state fix a stops answering
+     after its parse is interrupted, and a test that read from it would hang the
+     suite rather than fail it -- so the operator is used from b, which stays
+     healthy either way, and a is torn down on a bounded wait below. */
+  remote(sock "optable(\"@@\" \"size\" :insert :pri 100" :nowait);
+  usleep(1000000);
   b=remote(sockb "1+1");
   usleep(500000);
-  u2=remote(sock "@@ \"abcd\"");
-  u3=remote(sockb "@@ \"abcd\"");
-  print("optabletest: insert=%v use before=%v after=%v other connection=%v\n" ins u1 u2 u3 :err);
-  ok=(u1==4) && (b==2) && (u2==4) && (u3==4);
+  remote(sock ":prefix)" :nowait);
+  usleep(2000000);
+  useb=remote(sockb "@@ \"abcd\"");
+  print("optabletest: b answered %v in the gap; the operator, from b, gives %v\n" b useb :err);
+  ok=(b==2) && (useb==4);
   if(!ok :then
-    print("optabletest: FAIL the operator did not survive (want 4, 2, 4, 4)\n" :err));
-  if(ok :then print("optabletest: operator survived a parse on the other connection\n" :err));
+    print("optabletest: FAIL the interrupted insert did not take (want 2 and 4)\n" :err));
+  if(ok :then print("optabletest: the insert survived being interrupted mid-parse\n" :err));
   close(sockb);
 
   remote(sock "exit" :nowait);
   close(sock);
-  /* wait for the drawserv PROCESS to be gone (see updown_test) */
-  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
-    usleep(200000));
-  print("optabletest: drawserv shut down\n" :err);
+  /* bounded, then killed: a drawserv whose parse was interrupted may never
+     process the exit, and this test has to fail rather than hang on it */
+  cnt=0;
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0 && cnt<50
+    usleep(200000);cnt++);
+  stuck=shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0;
+  if(stuck :then
+    print("optabletest: drawserv never processed exit, killing it\n" :err);
+    kill_port(:kill_port_num ds_port);kill_port(:kill_port_num ds_import)
+  :else
+    print("optabletest: drawserv shut down\n" :err));
   ok)
 
 /* updown2 test -- launch two drawservs, link ds1->ds2, verify the link is

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -392,7 +392,8 @@ updown3A_test=func(
      installed (see history-count issue) -- then we poll the count
      instead of sleeping. drawlink settles were removed: drawlink
      already blocks until two_way via its own spin-loop. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("updown3A: created ellipse on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -512,7 +513,8 @@ updown3B_test=func(
      installed (see history-count issue) -- then we poll the count
      instead of sleeping. drawlink settles were removed: drawlink
      already blocks until two_way via its own spin-loop. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("updown3B: created ellipse on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -655,7 +657,8 @@ updown4A_test=func(
      installed (see history-count issue) -- then we poll the count
      instead of sleeping. drawlink settles were removed: drawlink
      already blocks until two_way via its own spin-loop. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("updown4A: created ellipse on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -811,7 +814,8 @@ updown4B_test=func(
      installed (see history-count issue) -- then we poll the count
      instead of sleeping. drawlink settles were removed: drawlink
      already blocks until two_way via its own spin-loop. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("updown4B: created ellipse on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -967,7 +971,8 @@ updown4C_test=func(
      installed (see history-count issue) -- then we poll the count
      instead of sleeping. drawlink settles were removed: drawlink
      already blocks until two_way via its own spin-loop. */
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   print("updown4C: created ellipse on ds1, grid id=%v\n" id1 :err);
   if(type(id1)!=`StringType :then
@@ -1134,7 +1139,8 @@ ringtest_test=func(
      some reason of its own, so make the refusal prove itself: casting off the
      offending link must leave the good one relaying */
   remote(sock1 "ellipse(100,100,40,40)");
-  update(2000000);
+  cnt=0;
+  while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   if(type(id1)!=`StringType :then
     print("ringtest: FAIL could not read grid id from ds1 (got %v)\n" id1 :err);

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -199,6 +199,82 @@ parsetest_test=func(
   print("parsetest: drawserv shut down\n" :err);
   ok)
 
+/* optabletest test -- the operator table is the one piece of parse state that is
+   meant to be shared: every interpreter wants the same operators, and
+   optable(:insert) edits it while a drawserv is running (%% is defined that
+   way).  A command's execution is atomic unless it deliberately re-enters the
+   interpreter, as drawlink's handshake wait does with a nested Run, and
+   OptableFunc::execute does nothing of the sort -- so an insert cannot be
+   caught half-done by another connection.  Same two-connection shape as
+   parsetest: edit on one, parse on the other in the gap, then use the new
+   operator from both.  Unlike parsetest this is a property test, not a
+   regression test: it passes with or without the parse-state fix. */
+optabletest_test=func(
+
+  ds_port=find_open_port(:base_port 21002);
+  ds_import=ds_port-1;
+  global(drawserv_upoptable)=false;
+  print("optabletest: launching drawserv on port %d\n" ds_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upoptable)=true\\\")\" &" ds_port ds_import callback_port :str);
+  print("optabletest: cmdstr=[%s]\n" cmdstr :err);
+  shell(cmdstr);
+  print("optabletest: waiting for drawserv callback on port %d\n" callback_port :err);
+
+  poll_usec=2000000;
+  timeout_secs=60;
+  timeout=timeout_secs*1000000/poll_usec;
+  progress_interval=10*1000000/poll_usec;
+  cnt=0;
+  while(!global(drawserv_upoptable) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("optabletest: still waiting after %d secs (Waiting for X11 to launch?)\n" cnt*poll_usec/1000000 :err)));
+
+  if(!global(drawserv_upoptable) :then
+    print("optabletest: FAIL timeout waiting for drawserv callback\n" :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  print("optabletest: drawserv callback received after %d polls\n" cnt :err);
+  sock=socket("127.0.0.1" ds_port);
+  if(type(sock)==`UnknownType :then
+    print("optabletest: FAIL could not connect to drawserv on port %d\n" ds_port :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  sockb=socket("127.0.0.1" ds_port);
+  if(type(sockb)==`UnknownType :then
+    print("optabletest: FAIL could not open a second connection on port %d\n" ds_port :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  /* both interpreters parse once, before the table is touched */
+  remote(sock "1+1");
+  remote(sockb "1+1");
+
+  ins=remote(sock "optable(\"@@\" \"size\" :insert :pri 100 :prefix)");
+  usleep(500000);
+  u1=remote(sock "@@ \"abcd\"");
+  b=remote(sockb "1+1");
+  usleep(500000);
+  u2=remote(sock "@@ \"abcd\"");
+  u3=remote(sockb "@@ \"abcd\"");
+  print("optabletest: insert=%v use before=%v after=%v other connection=%v\n" ins u1 u2 u3 :err);
+  ok=(u1==4) && (b==2) && (u2==4) && (u3==4);
+  if(!ok :then
+    print("optabletest: FAIL the operator did not survive (want 4, 2, 4, 4)\n" :err));
+  if(ok :then print("optabletest: operator survived a parse on the other connection\n" :err));
+  close(sockb);
+
+  remote(sock "exit" :nowait);
+  close(sock);
+  /* wait for the drawserv PROCESS to be gone (see updown_test) */
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
+    usleep(200000));
+  print("optabletest: drawserv shut down\n" :err);
+  ok)
+
 /* updown2 test -- launch two drawservs, link ds1->ds2, verify the link is
    visible in the drawlink table on both ends, shut both down.
    reuses the canonical port pair (20002/30002); find_open_port only steps

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -121,6 +121,84 @@ updown1_test=func(
   print("updown1: drawserv shut down\n" :err);
   ok)
 
+/* parsetest test -- one drawserv, TWO connections to it.  Each connection is
+   served by an interpreter of its own, but the parser keeps the stack that
+   counts a call's arguments and keywords in a file static, so a client's saved
+   copy has to be installed when it takes the globals over.  Nothing initialized
+   those copies, so a parser's first parse ran on the previous client's and then
+   kept its ParenStack POINTER, and the two counted into one array from then on.
+   Start a list across two lines on one connection, parse something on the other
+   in the gap, and finish the list: it has to still be the list that was started.
+   A raster is what met this in the wild, its serialized form running to some
+   thirty lines with a line read per dispatch, but nothing about it needs a
+   raster or any timing at all. */
+parsetest_test=func(
+
+  ds_port=find_open_port(:base_port 21002);
+  ds_import=ds_port-1;
+  global(drawserv_upparse)=false;
+  print("parsetest: launching drawserv on port %d\n" ds_port :err);
+  cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upparse)=true\\\")\" &" ds_port ds_import callback_port :str);
+  print("parsetest: cmdstr=[%s]\n" cmdstr :err);
+  shell(cmdstr);
+  print("parsetest: waiting for drawserv callback on port %d\n" callback_port :err);
+
+  poll_usec=2000000;
+  timeout_secs=60;
+  timeout=timeout_secs*1000000/poll_usec;
+  progress_interval=10*1000000/poll_usec;
+  cnt=0;
+  while(!global(drawserv_upparse) && cnt<timeout
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("parsetest: still waiting after %d secs (Waiting for X11 to launch?)\n" cnt*poll_usec/1000000 :err)));
+
+  if(!global(drawserv_upparse) :then
+    print("parsetest: FAIL timeout waiting for drawserv callback\n" :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  print("parsetest: drawserv callback received after %d polls\n" cnt :err);
+  sock=socket("127.0.0.1" ds_port);
+  if(type(sock)==`UnknownType :then
+    print("parsetest: FAIL could not connect to drawserv on port %d\n" ds_port :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  sockb=socket("127.0.0.1" ds_port);
+  if(type(sockb)==`UnknownType :then
+    print("parsetest: FAIL could not open a second connection on port %d\n" ds_port :err);
+    kill_port(:kill_port_num ds_port);
+    kill_port(:kill_port_num ds_import);
+    return(false));
+
+  /* both interpreters parse once, so each has a saved copy to install */
+  remote(sock "1+1");
+  remote(sockb "1+1");
+
+  /* a leaves a list open across lines, b parses in the gap, a closes it */
+  remote(sock "x=(10,20,30," :nowait);
+  usleep(1000000);
+  b=remote(sockb "1+1");
+  usleep(500000);
+  remote(sock "40,50)");
+  usleep(500000);
+  n=remote(sock "size(x)");
+  print("parsetest: b answered %v in the gap; the interrupted list is size %v\n" b n :err);
+  ok=(b==2) && (n==5);
+  if(!ok :then
+    print("parsetest: FAIL the list did not survive a parse on the other connection (want 2 and 5)\n" :err));
+  if(ok :then print("parsetest: the interrupted list survived intact\n" :err));
+  close(sockb);
+
+  remote(sock "exit" :nowait);
+  close(sock);
+  /* wait for the drawserv PROCESS to be gone (see updown_test) */
+  while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds_port :str))==0
+    usleep(200000));
+  print("parsetest: drawserv shut down\n" :err);
+  ok)
+
 /* updown2 test -- launch two drawservs, link ds1->ds2, verify the link is
    visible in the drawlink table on both ends, shut both down.
    reuses the canonical port pair (20002/30002); find_open_port only steps

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "07db7277"
+#define PATCH_KEY "1d5df8e3"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "1d5df8e3"
+#define PATCH_KEY "862db197"
 
 #endif /* _patch_h */


### PR DESCRIPTION
The parser keeps `expecting`, the operator stack, and the paren stack -- where a
call's argument and keyword counts accumulate -- in file statics, and
`Parser::check_parser_client()` swaps a client's saved copy into them when the
client changes. But `Parser::init()` never initialized those copies, so the swap
was gated on `_linenum != 0` to avoid installing indeterminate values. A parser's
**first** parse therefore ran on whatever the previous client had left in the
globals, and `save_parser_client()` then copied that client's `ParenStack`
*pointer* into it -- after which the two shared one array permanently.

drawserv accepts each connection with an interpreter of its own, and
`handle_input` reads one line per reactor dispatch. A raster's serialized form
runs to some thirty lines, so it sits mid-expression across many dispatches with
its paren frame live. A command arriving on another connection in that window
counted its arguments into the raster's frame:

```
TEMPDIAG fd=7 cmd="size" nargs=8 nkeys=6 top_before=12 posteval=0
func "size" pushed more than a single value on stack (line 33)
stack_base -2, stack_top 0
```

`size(grid(:table))` takes one argument; `nargs=8 nkeys=6` is the raster's shape.
It consumed twelve operands where fourteen were claimed, left that interpreter's
stack at -2, and the node answered nothing further.

## The fix

Initialize the saved copies to an empty state in `init()` -- a NULL stack has
`parser()` allocate one belonging to that parser alone -- and install them on the
first parse like any other, so the `_linenum != 0` gate comes out.

## Verified

- three-node repro, nine graphics created back-to-back over a link then polled:
  4/4 clean, the far node reaching all nine on the first poll. Before: failed
  2 runs in 3, with twenty seconds of polling returning nil.
- full comterp suite: `run_all: true`, zero `FAIL`.
- re-entrancy was measured and ruled out first -- a probe counted zero nested
  `handle_input` calls in every failing run, so this is interleaving between
  connections through shared state, not recursion.

#414 depends on this: its nine-shape test is what exposed the bug, and it is
stacked on this branch until this lands.