### PR TITLE
string(), strcap(), and a capacity-based at() bounds check (fixes #394)

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2113,6 +2113,8 @@ void ComTerp::add_defaults() {
     add_command("symvar", new SymVarFunc(this));
     add_command("symstr", new SymStrFunc(this));
     add_command("strref", new StrRefFunc(this));
+    add_command("string", new StringFunc(this));
+    add_command("cap", new CapFunc(this));
     add_command("global", new GlobalSymbolFunc(this));
     add_command("local", new LocalSymbolFunc(this));
     add_command("split", new SplitStrFunc(this));

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2114,7 +2114,7 @@ void ComTerp::add_defaults() {
     add_command("symstr", new SymStrFunc(this));
     add_command("strref", new StrRefFunc(this));
     add_command("string", new StringFunc(this));
-    add_command("cap", new CapFunc(this));
+    add_command("strcap", new StrCapFunc(this));
     add_command("global", new GlobalSymbolFunc(this));
     add_command("local", new LocalSymbolFunc(this));
     add_command("split", new SplitStrFunc(this));

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -272,9 +272,17 @@ void ListAtFunc::execute() {
     }
   } else if (listv.is_string()) {
     const char* str = listv.string_ptr();
-    int nvv = nv.is_nil() ? strlen(str)-1 : nv.int_val();
+    /* bounds-checked against capacity (symbol_len(), the allocation's own
+       byte count), not strlen() -- a strlen()-based bound made every byte
+       past the first NUL permanently unreachable the moment one landed
+       there (a fresh string(cap) buffer is all NUL, so index 0 was
+       "already past the end" before anything was ever written), even
+       though the underlying allocation still had the room.  nil still
+       means the last logical (strlen()-based) character, unchanged. */
+    int cap = symbol_len(listv.string_val());
+    int nvv = nv.is_nil() ? (int)strlen(str)-1 : nv.int_val();
     if(!setflag) {
-      if(strlen(str) > nv.int_val()) {
+      if(nvv>=0 && nvv<cap) {
         ComValue retval(*(str+nvv), ComValue::CharType);
         push_stack(retval);
         return;
@@ -284,7 +292,7 @@ void ListAtFunc::execute() {
 	 its identity: every value holding that symid names the same text, so
 	 a write here would edit the symbol out from under all of them (#393).
 	 Reads above stay open to both. */
-      if(nvv<strlen(str) && nvv>=0) {
+      if(nvv<cap && nvv>=0) {
 	*((char *)str+nvv) = setv.char_val();
 	ComValue retval(setv);
 	push_stack(retval);

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -290,10 +290,10 @@ void StringFunc::execute() {
 
 /*****************************************************************************/
 
-CapFunc::CapFunc(ComTerp* comterp) : ComFunc(comterp) {
+StrCapFunc::StrCapFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
-void CapFunc::execute() {
+void StrCapFunc::execute() {
   ComValue strv(stack_arg(0));
   reset_stack();
   if (strv.type()==ComValue::StringType) {

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -268,6 +268,43 @@ void StrRefFunc::execute() {
 
 /*****************************************************************************/
 
+StringFunc::StringFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void StringFunc::execute() {
+  ComValue capv(stack_arg(0));
+  static int spaces_symid = symbol_add("spaces");
+  ComValue spacesv(stack_key(spaces_symid));
+  boolean spacesflag = spacesv.is_true();
+  reset_stack();
+
+  int cap = capv.int_val();
+  int newid = cap>=0 ? symbol_new((unsigned)cap, spacesflag) : -1;
+  if (newid<0) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+  ComValue retval((unsigned int)newid, ComValue::StringType);
+  push_stack(retval);
+}
+
+/*****************************************************************************/
+
+CapFunc::CapFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void CapFunc::execute() {
+  ComValue strv(stack_arg(0));
+  reset_stack();
+  if (strv.type()==ComValue::StringType) {
+    ComValue retval(symbol_len(strv.symbol_val()), ComValue::IntType);
+    push_stack(retval);
+  } else
+    push_stack(ComValue::nullval());
+}
+
+/*****************************************************************************/
+
 SplitStrFunc::SplitStrFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 

--- a/src/ComTerp/symbolfunc.h
+++ b/src/ComTerp/symbolfunc.h
@@ -129,10 +129,10 @@ public:
 };
 
 //: return a string's usable capacity.
-// n=cap(str) -- capacity in bytes, not counting the guaranteed terminator.
-class CapFunc : public ComFunc {
+// n=strcap(str) -- capacity in bytes, not counting the guaranteed terminator.
+class StrCapFunc : public ComFunc {
 public:
-    CapFunc(ComTerp*);
+    StrCapFunc(ComTerp*);
     virtual void execute();
 
     virtual const char* docstring() {

--- a/src/ComTerp/symbolfunc.h
+++ b/src/ComTerp/symbolfunc.h
@@ -109,6 +109,36 @@ public:
       return "n=%s(str|symid) -- return string reference count"; }
 };
 
+//: create a fresh, writable, capacity-bearing string.
+// str=string(cap :spaces) -- cap bytes, NUL-filled (or space-filled with
+// :spaces), never deduplicated against an existing symbol.
+class StringFunc : public ComFunc {
+public:
+    StringFunc(ComTerp*);
+    virtual void execute();
+
+    virtual const char* docstring() {
+      return "str=%s(cap :spaces) -- cap bytes, NUL-filled (or space-filled with :spaces)"; }
+    virtual const char** dockeys() {
+      static const char* keys[] = {
+	":spaces    fill with spaces instead of NUL bytes",
+	nil
+      };
+      return keys;
+    }
+};
+
+//: return a string's usable capacity.
+// n=cap(str) -- capacity in bytes, not counting the guaranteed terminator.
+class CapFunc : public ComFunc {
+public:
+    CapFunc(ComTerp*);
+    virtual void execute();
+
+    virtual const char* docstring() {
+      return "n=%s(str) -- capacity in bytes, not counting the guaranteed terminator"; }
+};
+
 //: create symbol command for ComTerp.
 // symv|lst=symadd(sym|str [sym|str ...]) -- create symbol(s) and return without lookup
 class SymAddFunc : public ComFunc {

--- a/src/ComUtil/comutil.arg
+++ b/src/ComUtil/comutil.arg
@@ -9,6 +9,7 @@ void *mblock_pntr(int id);
 int mblock_sizes(int id,unsigned *nel,unsigned *size,unsigned long *nbytes);
 /* SYMBOLS.C */
 int symbol_add(const char *string);
+int symbol_new(unsigned cap, BOOLEAN blanks=false);
 int symbol_find(const char *string);
 int symbol_unref (int id);
 int symbol_reference (int id);

--- a/src/ComUtil/symbols.c
+++ b/src/ComUtil/symbols.c
@@ -93,6 +93,38 @@ char *strdup(const char *s) {
 
 /*=============*/
 
+/* find (or grow the table to make) an empty symid slot, shared by
+   symbol_add() and symbol_new(); returns its index, or -1 on OOM. */
+static int symbol_alloc_slot()
+{
+  int id, found;
+  symid* pntr;
+
+  if (symid_beg == NULL) {
+    symid_alloc_num = SYMID_ALLOC_NUM_HIGH;
+    if (dmm_calloc((void**)&symid_beg, (long) symid_alloc_num, sizeof(symid)) != 0)
+      return -1;
+    for (int i=0; i<symid_alloc_num; i++)
+      symid_beg[i].symstr = NULL;
+    symid_nrecs = symid_alloc_num;
+  }
+
+  for (id=found=0, pntr=symid_beg; id<symid_nrecs; id++,pntr++) {
+    if (pntr->symstr == NULL) { found = 1; break; }
+  }
+  if (!found) {
+    symid* symid_beg_after;
+    if (!(symid_beg_after = (symid*)realloc(symid_beg, (long) (symid_nrecs + symid_alloc_num) * sizeof(symid))))
+      return -1;
+    symid_beg = symid_beg_after;
+    id = symid_nrecs;
+    symid_nrecs += symid_alloc_num;
+    for (int i=id; i < symid_nrecs; i++)
+      symid_beg[i].symstr = NULL;
+  }
+  return id;
+}
+
 /*!
 
 symbol_add	Add a new symbol to the symbol table.
@@ -182,39 +214,11 @@ main()
   }
   else 	/* you have to add the symbol */
   {
-    int found;
     symbol_count++;
 
-    if (symid_beg == NULL)	/* if NULL, allocate some space for symbol table */
-    {
-      symid_alloc_num = SYMID_ALLOC_NUM_HIGH;
-      if ( dmm_calloc((void**)&symid_beg,(long) symid_alloc_num,sizeof(symid)) != 0)
-         goto error_return;	/* goto error return; INSUFFICIENT MEMORY */
-      for (int i=0; i<symid_alloc_num; i++) 
-        symid_beg[i].symstr = NULL;;  /* set unused */
-      symid_nrecs = symid_alloc_num;
-    }
+    if ((id = symbol_alloc_slot()) < 0)
+      goto error_return;
 
-    /* hunt for empty cell in symid array */
-    for (id=found=0, pntr=symid_beg; id<symid_nrecs; id++,pntr++)
-    {
-      if (pntr->symstr == NULL)	/* found one, break */
-      {
-	 found = 1;
-         break;
-      }
-    }
-    if (!found)		/* have to realloc some more symid table space */
-    {	/* realloc some more */
-      symid* symid_beg_after;
-      if(!(symid_beg_after = (symid*)realloc(symid_beg, (long) (symid_nrecs + symid_alloc_num) * sizeof(symid))))
-          goto error_return;
-      symid_beg = symid_beg_after;
-      id = symid_nrecs;	/* first new one allocated */
-      symid_nrecs += symid_alloc_num;
-      for (int i=id; i < symid_nrecs; i++)
-        symid_beg[i].symstr = NULL;  /* set unused */
-    }
     pntr = symid_beg + id;	/* index into entry of interest */
     pntr->nchars = n;		/* number of non-NULL characters */
     pntr->symstr = strdup(string);	/* make copy of string */
@@ -228,6 +232,72 @@ main()
   return id;
 error_return:		/* return an error code */
   return -1;
+}
+
+/*!
+
+symbol_new	Add a fresh, writable, non-deduplicating symbol.
+
+Summary:
+
+#include <ComUtil/comutil.h>
+*/
+
+int symbol_new (unsigned cap, BOOLEAN blanks)
+
+/*!
+Return Value:  >= 0 unique identifier for this symbol,
+               -1 if insufficient memory.
+
+Parameters:
+
+Type            Name          IO  Description
+------------    -----------   --  -----------                  */
+#ifdef DOC
+unsigned        cap        ;/*  I    usable byte capacity, not counting the
+                                      guaranteed terminator */
+BOOLEAN         blanks     ;/*  I    fill with spaces instead of NUL bytes */
+#endif
+
+#ifdef DOC
+/*!
+Description:
+
+Adds a `cap+1`-byte symbol -- `cap` bytes, all NUL (or all space if
+`blanks`), followed by one guaranteed terminating NUL -- and returns its
+id.  Unlike symbol_add(), never deduplicates by content and never looks
+existing entries up: every call allocates a genuinely fresh entry, on
+purpose, since this is a writable buffer's own storage, not a shared
+literal's.  For the same reason it is never added to the reverse index
+symbol_find() searches -- registering it there would let some unrelated
+later symbol_add() of matching text resolve onto (and corrupt) a buffer
+meant to be written through.
+
+See Also:  symbol_add(), symbol_unref()
+
+!*/
+#endif /* DOC */
+/*
+!*/
+
+{
+  int id;
+  symid* pntr;
+
+  if ((id = symbol_alloc_slot()) < 0)
+    return -1;
+
+  pntr = symid_beg + id;
+  pntr->symstr = (char*)malloc(cap + 1);
+  if (!pntr->symstr)
+    return -1;
+  memset(pntr->symstr, blanks ? ' ' : '\0', cap);
+  pntr->symstr[cap] = '\0';
+  pntr->nchars = cap;
+  pntr->instances = 1;
+  symbol_count++;
+
+  return id;
 }
 
 /*!

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -267,6 +267,7 @@ not gaps in testing -- do not read `—` as untested.
 | attrlist.comt             | dot list(:attr) attrlist at size attrname attrval + - |      56 |    68 |  82% |
 | listat.comt               | at  list  size                                        |       — |     — |    — |
 | stackkey.comt             | at  list                                              |       — |     — |    — |
+| string_cap.comt           | string cap size at @                                  |       — |     — |    — |
 | print.comt                | print                                                 |      24 |    35 |  69% |
 | parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
 | symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -267,7 +267,7 @@ not gaps in testing -- do not read `—` as untested.
 | attrlist.comt             | dot list(:attr) attrlist at size attrname attrval + - |      56 |    68 |  82% |
 | listat.comt               | at  list  size                                        |       — |     — |    — |
 | stackkey.comt             | at  list                                              |       — |     — |    — |
-| string_cap.comt           | string cap size at @                                  |       — |     — |    — |
+| string_cap.comt           | string strcap size at @                               |       — |     — |    — |
 | print.comt                | print                                                 |      24 |    35 |  69% |
 | parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
 | symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -45,6 +45,10 @@ if(run("./stackkey.comt")
   :then print("pass: stackkey\n")
   :else print("FAIL: stackkey\n");topok=false)
 
+if(run("./string_cap.comt")
+  :then print("pass: string_cap\n")
+  :else print("FAIL: string_cap\n");topok=false)
+
 if(run("./print.comt")
   :then print("pass: print\n")
   :else print("FAIL: print\n");topok=false)

--- a/src/comterp_/tests/string_cap.comt
+++ b/src/comterp_/tests/string_cap.comt
@@ -1,0 +1,78 @@
+// src/comterp_/tests/string_cap.comt -- string(), cap(), and @ into a
+// capacity-bearing buffer (#394)
+//
+// funcs: string cap size at @
+//
+// string(cap) creates a blank, writable buffer -- cap bytes of NUL, plus
+// one guaranteed terminator, none of it shared or deduplicated with any
+// other symbol.  This is the runtime fix for #394's original bug: at()'s
+// bounds check used to be strlen()-based, so a NUL written mid-buffer
+// (deliberately, via string(), or accidentally, via at(s n :set 0) on an
+// ordinary string) made every later byte permanently unwritable even
+// though the real allocation still had the room.  It's now checked
+// against cap() (the allocation's own byte count) instead, for both reads
+// and writes, on every string -- not just ones built by string().
+
+ok=true
+
+// --- 1: string(cap) starts out empty but at full capacity ---
+s=string(10)
+ok=ok&&(print(s :str)=="")
+ok=ok&&(size(s)==0)
+ok=ok&&(cap(s)==10)
+print("1 string(10) starts empty at full capacity (expect  0 10): %s %s %s\n" print(s :str) size(s) cap(s))
+
+// --- 2: @ writes into it like any other string ---
+s@0=(char(72))
+s@1=(char(73))
+ok=ok&&(print(s :str)=="HI")
+print("2 s@0='H' s@1='I' (expect HI): %s\n" print(s :str))
+
+// --- 3: writing past a gap, then writing a NUL in the middle, still
+//        leaves the far bytes in place -- a NUL terminates size()/print()
+//        without erasing anything after it, because the bound that
+//        governs @ is cap(), not the position of the first NUL ---
+s@5=(char(87))
+s@6=(char(88))
+s@9=(char(90))
+ok=ok&&(print(s :str)=="HI")
+ok=ok&&(size(s)==2)
+ok=ok&&(cap(s)==10)
+print("3 far writes don't move size()/print(), still HI/2/10: %s %s %s\n" print(s :str) size(s) cap(s))
+
+// --- 4: ...but the far bytes are still really there, individually
+//        readable past the terminating NUL ---
+ok=ok&&(s@5=='W')
+ok=ok&&(s@6=='X')
+ok=ok&&(s@9=='Z')
+print("4 s@5, s@6, s@9 read through the gap (expect W X Z): %s %s %s\n" s@5 s@6 s@9)
+
+// --- 5: out of bounds -- the index at cap() itself (the guaranteed
+//        terminator slot) and anything past it both answer nil, same as
+//        an ordinary string's own out-of-range indices ---
+ok=ok&&(s@10==nil)
+ok=ok&&(s@20==nil)
+print("5 s@10, s@20 are out of bounds (expect nil nil): %v %v\n" s@10 s@20)
+
+// --- 6: an out-of-bounds @ assignment is refused, not silently
+//        truncated or grown -- the buffer is unchanged afterward ---
+s@20=(char(35))
+ok=ok&&(print(s :str)=="HI")
+ok=ok&&(cap(s)==10)
+print("6 s@20=val refused, buffer unchanged (expect HI 10): %s %s\n" print(s :str) cap(s))
+
+// --- 7: #394's own original repro -- a NUL written into the MIDDLE of an
+//        ordinary (not string()-built) string used to make everything
+//        after it permanently unwritable.  cap() covers ordinary strings
+//        too, not just string()-built ones, so writing back over that
+//        position now works and the original content comes back. ---
+t="ABCDEF"
+at(t 2 :set 0)
+ok=ok&&(size(t)==2)
+ok=ok&&(cap(t)==6)
+at(t 2 :set 67)
+ok=ok&&(print(t :str)=="ABCDEF")
+print("7 #394 repro: at(t 2 :set 0) then :set 67 restores ABCDEF: %s\n" print(t :str))
+
+print("string_cap: %v\n" ok)
+ok

--- a/src/comterp_/tests/string_cap.comt
+++ b/src/comterp_/tests/string_cap.comt
@@ -74,5 +74,18 @@ at(t 2 :set 67)
 ok=ok&&(print(t :str)=="ABCDEF")
 print("7 #394 repro: at(t 2 :set 0) then :set 67 restores ABCDEF: %s\n" print(t :str))
 
+// string()'s own refcounting matches an ordinary literal's exactly -- not
+// asserted here as a test, since embedding two strref() reads inside one
+// comparison expression perturbs the count differently than reading each
+// independently (order-of-evaluation sensitive, not a stable thing to pin
+// in an automated check) -- but verified directly, twice, in isolation:
+// strref() reads the identical baseline (2: the table's own hold, plus
+// the read's own transient copy) right after creation, for both
+// u=string(10) and v="some literal".  Reassignment doesn't yet release
+// either one's reference (#434, a pre-existing gap in AssignFunc shared
+// by every string, not something string() introduces) -- string() is
+// exactly as well-behaved here as an ordinary string, no better and no
+// worse.
+
 print("string_cap: %v\n" ok)
 ok

--- a/src/comterp_/tests/string_cap.comt
+++ b/src/comterp_/tests/string_cap.comt
@@ -1,7 +1,7 @@
-// src/comterp_/tests/string_cap.comt -- string(), cap(), and @ into a
+// src/comterp_/tests/string_cap.comt -- string(), strcap(), and @ into a
 // capacity-bearing buffer (#394)
 //
-// funcs: string cap size at @
+// funcs: string strcap size at @
 //
 // string(cap) creates a blank, writable buffer -- cap bytes of NUL, plus
 // one guaranteed terminator, none of it shared or deduplicated with any
@@ -10,8 +10,8 @@
 // (deliberately, via string(), or accidentally, via at(s n :set 0) on an
 // ordinary string) made every later byte permanently unwritable even
 // though the real allocation still had the room.  It's now checked
-// against cap() (the allocation's own byte count) instead, for both reads
-// and writes, on every string -- not just ones built by string().
+// against strcap() (the allocation's own byte count) instead, for both
+// reads and writes, on every string -- not just ones built by string().
 
 ok=true
 
@@ -19,8 +19,8 @@ ok=true
 s=string(10)
 ok=ok&&(print(s :str)=="")
 ok=ok&&(size(s)==0)
-ok=ok&&(cap(s)==10)
-print("1 string(10) starts empty at full capacity (expect  0 10): %s %s %s\n" print(s :str) size(s) cap(s))
+ok=ok&&(strcap(s)==10)
+print("1 string(10) starts empty at full capacity (expect  0 10): %s %s %s\n" print(s :str) size(s) strcap(s))
 
 // --- 2: @ writes into it like any other string ---
 s@0=(char(72))
@@ -31,14 +31,14 @@ print("2 s@0='H' s@1='I' (expect HI): %s\n" print(s :str))
 // --- 3: writing past a gap, then writing a NUL in the middle, still
 //        leaves the far bytes in place -- a NUL terminates size()/print()
 //        without erasing anything after it, because the bound that
-//        governs @ is cap(), not the position of the first NUL ---
+//        governs @ is strcap(), not the position of the first NUL ---
 s@5=(char(87))
 s@6=(char(88))
 s@9=(char(90))
 ok=ok&&(print(s :str)=="HI")
 ok=ok&&(size(s)==2)
-ok=ok&&(cap(s)==10)
-print("3 far writes don't move size()/print(), still HI/2/10: %s %s %s\n" print(s :str) size(s) cap(s))
+ok=ok&&(strcap(s)==10)
+print("3 far writes don't move size()/print(), still HI/2/10: %s %s %s\n" print(s :str) size(s) strcap(s))
 
 // --- 4: ...but the far bytes are still really there, individually
 //        readable past the terminating NUL ---
@@ -47,7 +47,7 @@ ok=ok&&(s@6=='X')
 ok=ok&&(s@9=='Z')
 print("4 s@5, s@6, s@9 read through the gap (expect W X Z): %s %s %s\n" s@5 s@6 s@9)
 
-// --- 5: out of bounds -- the index at cap() itself (the guaranteed
+// --- 5: out of bounds -- the index at strcap() itself (the guaranteed
 //        terminator slot) and anything past it both answer nil, same as
 //        an ordinary string's own out-of-range indices ---
 ok=ok&&(s@10==nil)
@@ -58,18 +58,18 @@ print("5 s@10, s@20 are out of bounds (expect nil nil): %v %v\n" s@10 s@20)
 //        truncated or grown -- the buffer is unchanged afterward ---
 s@20=(char(35))
 ok=ok&&(print(s :str)=="HI")
-ok=ok&&(cap(s)==10)
-print("6 s@20=val refused, buffer unchanged (expect HI 10): %s %s\n" print(s :str) cap(s))
+ok=ok&&(strcap(s)==10)
+print("6 s@20=val refused, buffer unchanged (expect HI 10): %s %s\n" print(s :str) strcap(s))
 
 // --- 7: #394's own original repro -- a NUL written into the MIDDLE of an
 //        ordinary (not string()-built) string used to make everything
-//        after it permanently unwritable.  cap() covers ordinary strings
-//        too, not just string()-built ones, so writing back over that
-//        position now works and the original content comes back. ---
+//        after it permanently unwritable.  strcap() covers ordinary
+//        strings too, not just string()-built ones, so writing back over
+//        that position now works and the original content comes back. ---
 t="ABCDEF"
 at(t 2 :set 0)
 ok=ok&&(size(t)==2)
-ok=ok&&(cap(t)==6)
+ok=ok&&(strcap(t)==6)
 at(t 2 :set 67)
 ok=ok&&(print(t :str)=="ABCDEF")
 print("7 #394 repro: at(t 2 :set 0) then :set 67 restores ABCDEF: %s\n" print(t :str))

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "ee992d63"
+#define PATCH_KEY "33b1fa51"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -310,6 +310,10 @@ Print a usage summary of all the invocation modes above and exit.
 
 .SH STRING COMMANDS
 
+ str=string(cap :spaces) -- cap bytes, NUL-filled (or space-filled with :spaces)
+
+ n=strcap(str) -- capacity in bytes, not counting the guaranteed terminator
+
  lst=split(sym|str :tokstr [delim] :tokval [delim] :keep :reverse) -- split symbol or string into list of characters (or tokens).
 
  str=join(lst :sym) -- join list of characters into string


### PR DESCRIPTION
## Summary

Fixes #394. Independent of #423/#428/#429 -- this came up mid-conversation while designing the slice work's representation, but landed on being pure #394 scope with no dependency on the colon-list machinery at all, so it's based on `master`, not stacked on #429.

**The actual bug (#394's own repro):** `at()`'s bounds check on a string was `strlen()`-based. Writing a `\0` mid-buffer -- deliberately or accidentally -- made every byte after it permanently unreachable, even though the real allocation still had the room:
```
s="ABCDEF"
at(s 2 :set 0)      // now "AB\0DEF" in memory, but...
at(s 2 :set 67)      // nil -- "DEF" is unreachable for good
```

**The fix:** bounds-check against **capacity** (`symbol_len()`, the allocation's own stored byte count) instead of `strlen()`, for both reads and writes, on every string -- not just new ones. `size()` keeps meaning `strlen()` (deliberately -- that's still the right definition of "logical content length"); `strcap()` is new, and exposes the allocation size that governs what `at()`/`@` will actually let you touch. With the fix:
```
s="ABCDEF"
at(s 2 :set 0); size(s)==2; strcap(s)==6
at(s 2 :set 67)      // 67 -- succeeds
print(s :str)         // "ABCDEF" -- back
```

## What's added

- **`symbol_new(cap, blanks)`** (`symbols.c`) -- a fresh, non-deduplicating, capacity-bearing symbol-table entry: `cap` bytes (NUL- or space-filled) plus one guaranteed terminator. Unlike `symbol_add()`, never looks up or reuses an existing entry by content, and is never registered in the reverse/dedup index, so a later `symbol_add()` of matching text can't resolve onto (and corrupt) a buffer meant to be written through. `symbol_add()`'s own slot-finding/growth logic is factored into a shared `symbol_alloc_slot()` helper rather than duplicated.
- **`string(cap :spaces)`** -- builds the buffer. Deliberately takes no initial-content argument: filling one is `at()`'s job (or a future bulk-copy command), not `string()`'s -- so there's no aliasing or copy-vs-reuse question to answer at construction time; the new buffer starts independent and stays that way.
- **`strcap(str)`** -- the capacity `at()`/`@` now actually bounds-check against.

## A finding along the way, not a fix in this PR

Review turned up a question worth checking: does a `string()`-built buffer's symbol-table entry ever actually get freed? Traced it with lldb (conditional breakpoints on `symbol_reference`/`symbol_unref`, filtered to the specific id, across `x=string(10); x=7`). Two things came out of it:

- `string()`'s own construction is sound -- `strref()` reads the identical baseline right after creation for a `string()`-built buffer and an ordinary literal, in isolation. No extra leak of its own.
- `symbol_unref()` is never called at all when `AssignFunc` reassigns away from a string value -- confirmed for an ordinary literal too (`x="hello123"; x=7`), not specific to `string()`. Pre-existing, and bigger than this PR (affects every string, not just `string()`-built ones), so it's **#434**, not fixed here.

`string_cap.comt` documents the parity finding as a comment rather than an automated assertion -- embedding two `strref()` reads inside one comparison expression turned out to perturb the count differently than reading each independently, which isn't something worth pinning in a check that would then be flaky for reasons unrelated to what it's testing.

## Test plan

- [x] `src/comterp_/tests/string_cap.comt`, registered in `run_all.comt` -- covers `string()`/`strcap()`/`@` into a fresh buffer, out-of-bounds reads and writes (including at `strcap()` itself, the reserved terminator slot), a NUL mid-buffer not erasing what comes after it (individually re-readable via `@`), and #394's own original repro restoring cleanly
- [x] Full `run_all.comt` suite green (49/49)
- [x] Full rebuild (ComUtil through comterp_) clean, verified standalone against `master` (no dependency on #429)

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

