### PR TITLE
Implement str@lo:hi string slicing (#395)

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1618,6 +1618,19 @@ ComValue& ComTerp::fire_if_funcobj(ComValue& val) {
   return *slot;
 }
 
+/* sliceoff()/slicelen() (comvalue.h) write straight through to _narg/_nkey
+   -- fine on a StringType, which never needs them for anything else, but
+   catastrophic on any other type, where those same fields carry a command
+   call's own argument/keyword counts.  Restricted to StringType so a
+   lookup_symval() carry-over (below) can't clobber that bookkeeping for
+   every other symbol resolution in the interpreter. */
+static void carry_slice(ComValue& dst, ComValue& src) {
+  if (src.type() != ComValue::StringType) return;
+  dst.sliced(src.sliced());
+  dst.sliceoff(src.sliceoff());
+  dst.slicelen(src.slicelen());
+}
+
 ComValue& ComTerp::lookup_symval(ComValue& comval) {
     if (comval.bquote()) {
         return comval;
@@ -1656,10 +1669,12 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	if (!comval.global_flag() && localtable()->find(vptr, comval.symbol_val()) ) {
 	  comval.assignval(*(ComValue*)vptr);
 	  comval.coloned(((ComValue*)vptr)->coloned());
+	  carry_slice(comval, *(ComValue*)vptr);
 	  return comval;
 	} else if (globaltable()->find(vptr, comval.symbol_val())) {
 	  comval.assignval(*(ComValue*)vptr);
 	  comval.coloned(((ComValue*)vptr)->coloned());
+	  carry_slice(comval, *(ComValue*)vptr);
 	  return comval;
 	} else
 	  return ComValue::nullval();

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <iostream.h>
 #include <strstream>
+#include <string>
 using namespace std;
 
 ComValue ComValue::_nullval(ComValue::UnknownType);
@@ -163,13 +164,23 @@ ComValue& ComValue::operator= (const ComValue& sv) {
     return *this;
 }
     
-int ComValue::narg() const { return _narg; }
-int ComValue::nkey() const { return _nkey; }
+int ComValue::narg() const { return type()==ComValue::StringType ? 0 : _narg; }
+int ComValue::nkey() const { return type()==ComValue::StringType ? 0 : _nkey; }
 int ComValue::nids() const { return _nids; }
 int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
 int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
 int ComValue::local_flag() const { return _flags & COMVALUE_LOCAL_FLAG; }
 int ComValue::coloned() const { return _flags & COMVALUE_COLONED_FLAG; }
+int ComValue::sliced() const { return _flags & COMVALUE_SLICED_FLAG; }
+int ComValue::sliceoff() const { return _narg; }
+int ComValue::slicelen() const { return _nkey; }
+
+const char* ComValue::slice_cstr(std::string& scratch) {
+  const char* full = string_ptr();
+  if (!sliced()) return full;
+  scratch.assign(full + sliceoff(), slicelen());
+  return scratch.c_str();
+}
 
 ostream& operator<< (ostream& out, const ComValue& sv) {
     ComValue* svp = (ComValue*)&sv;
@@ -209,15 +220,18 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  }
 	  break;
 	    
-	case ComValue::StringType:
+	case ComValue::StringType: {
+	  std::string scratch;
+	  const char* strp = svp->slice_cstr(scratch);
 	  if (brief)
-	    ParamList::output_text(out, svp->string_ptr());
+	    ParamList::output_text(out, strp);
 	  else {
 	    out << "string(";
-	    ParamList::output_text(out, svp->string_ptr());
+	    ParamList::output_text(out, strp);
 	    out << ")";
 	  }
 	  break;
+	}
 	    
 	case ComValue::BooleanType:
 	  if (brief)

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -33,6 +33,7 @@
 #include <ComTerp/_comterp.h>
 #include <Attribute/attrvalue.h>
 #include <Unidraw/Components/compview.h>
+#include <string>
 
 class ComFunc;
 class ComTerp;
@@ -47,6 +48,7 @@ class ComTerp;
 #define COMVALUE_LHS_ASSIGN_FLAG 0x02  // set by AssignFunc on global() or local() ComValue in lhs context
 #define COMVALUE_LOCAL_FLAG      0x04  // set by local() on its lvalue symbol -- write the default symbol table, skipping any func frame
 #define COMVALUE_COLONED_FLAG    0x08  // set by ColonListFunc -- an ArrayType built by ':', not ','
+#define COMVALUE_SLICED_FLAG     0x10  // set on a StringType sliced from another string (#395) -- sliceoff()/slicelen() hold the window, narg()/nkey() read 0
 
 class ComValue : public AttributeValue {
 public:
@@ -111,9 +113,13 @@ public:
     // return true if ObjectType matches or compid is superclass
 
     int narg() const;
-    // number of arguments associated with this command or keyword.
+    // number of arguments associated with this command or keyword; always 0
+    // for a StringType, whose storage doubles as a slice's offset (#395) --
+    // use sliceoff() to read that.
     int nkey() const;
-    // number of keywords associated with this command.
+    // number of keywords associated with this command; always 0 for a
+    // StringType, whose storage doubles as a slice's length (#395) -- use
+    // slicelen() to read that.
     int nids() const;
     // number of subordinate identifiers associated with this identifier (not used).
     void narg(int n) {_narg = n; }
@@ -139,6 +145,28 @@ public:
     // return flag that marks an ArrayType as built by ':' rather than ','.
     void coloned(int flag) { if(flag) _flags |= COMVALUE_COLONED_FLAG; else _flags &= ~COMVALUE_COLONED_FLAG; }
     // set flag that marks an ArrayType as built by ':' rather than ','.
+
+    int sliced() const;
+    // return flag that marks a StringType value as a slice of another
+    // string, sharing its symid rather than owning a copy (#395).
+    void sliced(int flag) { if(flag) _flags |= COMVALUE_SLICED_FLAG; else _flags &= ~COMVALUE_SLICED_FLAG; }
+    // set flag that marks a StringType value as a slice.
+    int sliceoff() const;
+    // offset of a slice's window into its symid string; valid only when sliced().
+    void sliceoff(int off) { _narg = off; }
+    // set a slice's window offset.
+    int slicelen() const;
+    // length of a slice's window into its symid string; valid only when sliced().
+    void slicelen(int len) { _nkey = len; }
+    // set a slice's window length.
+
+    const char* slice_cstr(std::string& scratch);
+    // NUL-terminated text of a StringType value -- string_ptr() narrowed to
+    // [sliceoff(), sliceoff()+slicelen()) when sliced() (#395), otherwise
+    // string_ptr() itself.  Takes a caller-owned std::string rather than a
+    // ComValue member: _stack (comterp.c) grows via dmm_realloc, a raw
+    // realloc of the whole ComValue array, so ComValue must stay a plain,
+    // trivially-relocatable union -- no non-POD member survives that move.
 
     int& pedepth() { return _pedepth; }
     // set/get depth of nesting in post-evaluated blocks of control commands.

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -39,6 +39,7 @@
 #include <fstream.h>
 #endif
 #include <streambuf>
+#include <string>
 #include <unistd.h>
 
 #define TITLE "IoFunc"
@@ -162,8 +163,9 @@ void PrintFunc::execute() {
   int narg = nargsfixed();
   if (narg==1) {
 
+    std::string scratch;
     if (formatstr.is_string() && !prefixv.is_string()) {
-      out << formatstr.symbol_ptr();
+      out << formatstr.slice_cstr(scratch);
       out.flush();
     }
     else {
@@ -171,8 +173,8 @@ void PrintFunc::execute() {
       if (!formatstr.is_string())
 	out << formatstr;  // which could be arbitrary ComValue
       else
-	out << formatstr.string_ptr();
-	    
+	out << formatstr.slice_cstr(scratch);
+
       if (prefixv.is_string()) out << "\n";
       out.flush();
     }
@@ -309,9 +311,11 @@ void PrintFunc::execute() {
       switch( printval.type() )
       {
       case ComValue::SymbolType:
-      case ComValue::StringType:
-	out_form(out, fbuf, symbol_pntr( printval.symbol_ref()));
+      case ComValue::StringType: {
+	std::string scratch;
+	out_form(out, fbuf, printval.slice_cstr(scratch));
 	break;
+      }
 
       case ComValue::BooleanType:
 	out_form(out, fbuf, printval.boolean_ref());

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -133,6 +133,50 @@ void ListAtFunc::execute() {
      either way. */
   (void)rawflag;
 
+  /* str@lo:hi (#395): a coloned 2-element index into a string builds a
+     slice -- a StringType ComValue sharing str's own symid (so its memory
+     stays exactly as allocated, reachable at that symid) with an offset/
+     length window recorded via sliceoff()/slicelen() (comvalue.h) instead
+     of a copy.  lo/hi may have arrived as unresolved symbols (ColonListFunc
+     captures bare identifiers rather than looking them up), so each is run
+     through lookup_symval() here.  hi is exclusive, Go-style -- length is
+     hi-lo, and hi==cap is in bounds (an empty slice at the far end, same
+     as Go's s[len(s):len(s)]).  Not yet supported: writing through a slice
+     (:set/:ins/:del, or the #318 lhs_assign peek below) or slicing a plain
+     list/array -- both fall through to nil for now. */
+  if (listv.is_only_string() && nv.is_type(ComValue::ArrayType) && nv.coloned()) {
+    AttributeValueList* range = nv.array_val();
+    boolean forwrite = comterp()->stack_top(nkeys()+1).lhs_assign();
+    ComValue retval(ComValue::nullval());
+    if (!forwrite && range && range->Number()==2) {
+      ComValue loval(*range->Get(0));
+      ComValue hival(*range->Get(1));
+      loval = comterp()->lookup_symval(loval);
+      hival = comterp()->lookup_symval(hival);
+      if (loval.type()==ComValue::IntType && hival.type()==ComValue::IntType) {
+        int lo = loval.int_val();
+        int hi = hival.int_val();
+        int cap = symbol_len(listv.string_val());
+        if (lo>=0 && hi>=lo && hi<=cap) {
+          retval = ComValue(listv.string_val(), ComValue::StringType);
+          /* the (unsigned int, ValueType) ctor doesn't ref -- unlike the
+             (int, ValueType) one, it has no "used as a StringType
+             constructor" case (attrvalue.c).  Without this, listv's own
+             destructor unrefs the symid this slice still points at when
+             ListAtFunc::execute() returns, and a later allocation can
+             reuse that freed memory out from under the still-live slice. */
+          retval.ref_as_needed();
+          retval.sliceoff(lo);
+          retval.slicelen(hi-lo);
+          retval.sliced(1);
+        }
+      }
+    }
+    reset_stack();
+    push_stack(retval);
+    return;
+  }
+
   /* a list has no position in it, and int_val() answers 0 for one -- so a
      list-valued index used to read as index 0 and hand back the first item,
      a wrong answer wearing a right one's clothes.  A stream of indices does
@@ -279,18 +323,31 @@ void ListAtFunc::execute() {
     }
   } else if (listv.is_string()) {
     const char* str = listv.string_ptr();
-    /* bounds-checked against capacity (symbol_len(), the allocation's own
-       byte count), not strlen() -- a strlen()-based bound made every byte
-       past the first NUL permanently unreachable the moment one landed
-       there (a fresh string(cap) buffer is all NUL, so index 0 was
-       "already past the end" before anything was ever written), even
-       though the underlying allocation still had the room.  nil still
-       means the last logical (strlen()-based) character, unchanged. */
-    int cap = symbol_len(listv.string_val());
-    int nvv = nv.is_nil() ? (int)strlen(str)-1 : nv.int_val();
+    /* a sliced listv (#395) indexes relative to its own window into the
+       shared parent buffer -- base offsets every read/write into it, and
+       cap is the slice's own length rather than the parent's capacity, so
+       indexing a slice can't read or write past its own bound into the
+       parent's neighboring bytes.  Reading or writing still goes through
+       the same shared storage as the parent (str+base), so a write here
+       stays visible through any other slice or the parent itself, same as
+       test 4 (colonslice.comt).  For an ordinary, unsliced string, this is
+       exactly the pre-#395 behavior: bounds-checked against capacity
+       (symbol_len(), the allocation's own byte count), not strlen() -- a
+       strlen()-based bound made every byte past the first NUL permanently
+       unreachable the moment one landed there (a fresh string(cap) buffer
+       is all NUL, so index 0 was "already past the end" before anything
+       was ever written), even though the underlying allocation still had
+       the room. */
+    boolean isslice = listv.sliced();
+    int base = isslice ? listv.sliceoff() : 0;
+    int cap = isslice ? listv.slicelen() : symbol_len(listv.string_val());
+    /* nil means the last logical character -- the slice's own last index
+       when sliced (its length is exact, not NUL-delimited), otherwise the
+       parent's strlen()-based last character, unchanged. */
+    int nvv = nv.is_nil() ? (isslice ? cap-1 : (int)strlen(str)-1) : nv.int_val();
     if(!setflag) {
       if(nvv>=0 && nvv<cap) {
-        ComValue retval(*(str+nvv), ComValue::CharType);
+        ComValue retval(*(str+base+nvv), ComValue::CharType);
         push_stack(retval);
         return;
       }
@@ -300,7 +357,7 @@ void ListAtFunc::execute() {
 	 a write here would edit the symbol out from under all of them (#393).
 	 Reads above stay open to both. */
       if(nvv<cap && nvv>=0) {
-	*((char *)str+nvv) = setv.char_val();
+	*((char *)str+base+nvv) = setv.char_val();
 	ComValue retval(setv);
 	push_stack(retval);
 	return;
@@ -340,7 +397,11 @@ void ListSizeFunc::execute() {
       return;			  
     }
   } else if (listv.is_string() || listv.is_symbol()) {
-    ComValue retval((int)strlen(listv.symbol_ptr()), ComValue::IntType);
+    /* a slice's own length (#395), not its shared parent's -- strlen()
+       would run past the slice's window into whatever the parent holds
+       beyond it. */
+    int len = listv.sliced() ? listv.slicelen() : (int)strlen(listv.symbol_ptr());
+    ComValue retval(len, ComValue::IntType);
     push_stack(retval);
     return;
   } else if (listv.is_object(FuncObj::class_symid())) {

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -156,7 +156,14 @@ void ListAtFunc::execute() {
       if (loval.type()==ComValue::IntType && hival.type()==ComValue::IntType) {
         int lo = loval.int_val();
         int hi = hival.int_val();
-        int cap = symbol_len(listv.string_val());
+        /* slicing a slice (nesting): bound against listv's own window, not
+           the full backing allocation, and compose the new offset onto
+           listv's own -- otherwise a re-slice both exposes whatever the
+           parent holds past listv's own end and reads from the wrong
+           place entirely (sl@0:1 read the parent's own index 0 instead of
+           listv's). */
+        int base = listv.sliced() ? listv.sliceoff() : 0;
+        int cap = listv.sliced() ? listv.slicelen() : symbol_len(listv.string_val());
         if (lo>=0 && hi>=lo && hi<=cap) {
           retval = ComValue(listv.string_val(), ComValue::StringType);
           /* the (unsigned int, ValueType) ctor doesn't ref -- unlike the
@@ -166,7 +173,7 @@ void ListAtFunc::execute() {
              ListAtFunc::execute() returns, and a later allocation can
              reuse that freed memory out from under the still-live slice. */
           retval.ref_as_needed();
-          retval.sliceoff(lo);
+          retval.sliceoff(base+lo);
           retval.slicelen(hi-lo);
           retval.sliced(1);
         }

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -269,6 +269,7 @@ not gaps in testing -- do not read `—` as untested.
 | stackkey.comt             | at  list                                              |       — |     — |    — |
 | colonlist.comt            | colonlist at size                                     |       — |     — |    — |
 | string_cap.comt           | string strcap size at @                               |       — |     — |    — |
+| colonslice.comt           | colonlist at size print                               |       — |     — |    — |
 | print.comt                | print                                                 |      24 |    35 |  69% |
 | parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
 | symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,0 +1,75 @@
+// src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
+//
+// funcs: colonlist at size print
+//
+// str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
+// own symid (its memory stays exactly where it was allocated, reachable at
+// that symid -- no copy, no new storage) with an offset/length window
+// recorded on the ComValue itself via sliceoff()/slicelen() (comvalue.h),
+// borrowing the narg/nkey storage a StringType never otherwise needs (see
+// comvalue.h's narg()/nkey() doc -- both read 0 for a StringType, guarding
+// sliced code that repurposes the same fields for offset/length). hi is
+// exclusive, Go-style -- length is hi-lo, and hi==cap is in bounds (an
+// empty slice at the far end, same as Go's s[len(s):len(s)]).
+//
+// Only literal-bound ranges are covered here (s@0:3, not s@lo:hi) -- a bare
+// identifier as the ':' operator's own right-hand operand is always
+// tokenized as a keyword lexeme by the lexer (":hi" reads as a stray
+// keyword, "Unexpected keyword" from the parser) regardless of spacing,
+// the same underlying scanner ambiguity #423 already flagged for a
+// leading colon ("Dec:25"), just showing up on the trailing side too.
+// colonlist(lo hi) -- a plain command call, not the ':' lexeme -- sidesteps
+// it and still captures lo/hi unevaluated the same way (see colonlist.comt
+// test 6/7), so s@colonlist(lo hi) works today for variable bounds; that's
+// left as a documented workaround here rather than a test, since fixing
+// the lexer itself is out of scope for this file.
+//
+// Known gaps, not yet attempted: :set/:ins/:del through a slice (listfunc.c
+// falls back to nil for any coloned index in an lhs_assign context); slicing
+// a plain list/array (only listv.is_only_string() triggers slice logic);
+// slice==string / slice==slice (both fall back to a generic, symid-based
+// comparison today, which is wrong for a slice -- print(x :str) is used
+// below to get a real, comparable, unsliced string out first instead).
+
+ok=true
+
+// --- 1: hi is exclusive, Go-style -- length is hi-lo ---
+ok=ok&&(print("abcdefg"@0:3 :str)=="abc")
+print("1 lo:hi is exclusive of hi (expect abc): %s\n" print("abcdefg"@0:3 :str))
+
+// --- 2: unparenthesized binds tighter than @, no parens needed ---
+s="abcdefg"
+sl=s@2:5
+ok=ok&&(print(sl :str)=="cde")
+print("2 unparenthesized s@2:5 (expect cde): %s\n" print(sl :str))
+
+// --- 3: size() reports the slice's own length, not the parent's ---
+ok=ok&&(size(sl)==3)
+print("3 size of the slice (expect 3): %s\n" size(sl))
+
+// --- 4: the slice shares the parent's backing -- a write through the
+//        parent is visible through a slice taken before the write ---
+s2="wxyzabc"
+sl2=s2@0:3
+at(s2 1 :set 90)
+ok=ok&&(print(sl2 :str)=="wZy")
+print("4 slice sees a write through its parent (expect wZy): %s\n" print(sl2 :str))
+
+// --- 5: hi==cap (the string's own capacity) is in bounds -- an empty
+//        slice at the far end, same as Go's s[len(s):len(s)]; hi>cap
+//        answers nil, same as at()'s own bounds checks ---
+ok=ok&&(size("abc"@3:3)==0)
+ok=ok&&(("abc"@0:5)==nil)
+print("5 hi==cap is an empty slice, hi>cap is nil (expect 0 nil): %s %s\n" size("abc"@3:3) "abc"@0:5)
+
+// --- 6: a slice assigned to a variable keeps its sliced-ness across the
+//        symbol-table round trip -- lookup_symval() (comterp.c) has to
+//        carry sliced()/sliceoff()/slicelen() over explicitly, the same
+//        way it already does for coloned() (#429/Greptile), since
+//        assignval() only ever copies AttributeValue's base fields ---
+v=s@2:5
+ok=ok&&(size(v)==3 && print(v :str)=="cde")
+print("6 a sliced variable keeps its window (expect 3 cde): %s %s\n" size(v) print(v :str))
+
+print("colonslice: %v\n" ok)
+ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -29,7 +29,12 @@
 // a plain list/array (only listv.is_only_string() triggers slice logic);
 // slice==string / slice==slice (both fall back to a generic, symid-based
 // comparison today, which is wrong for a slice -- print(x :str) is used
-// below to get a real, comparable, unsliced string out first instead).
+// below to get a real, comparable, unsliced string out first instead); a
+// slice passed as a function keyword arg or captured free variable loses
+// its sliced()/sliceoff()/slicelen() the same way a colon-list's coloned()
+// does (Greptile, #437) -- AttributeList only ever stores a plain
+// AttributeValue (#438), which has no room for either.  Not independently
+// fixable here; test 7 pins it as a documented gap rather than a silent one.
 
 ok=true
 
@@ -70,6 +75,26 @@ print("5 hi==cap is an empty slice, hi>cap is nil (expect 0 nil): %s %s\n" size(
 v=s@2:5
 ok=ok&&(size(v)==3 && print(v :str)=="cde")
 print("6 a sliced variable keeps its window (expect 3 cde): %s %s\n" size(v) print(v :str))
+
+// --- 7: nesting -- a colon range applied to an existing slice bounds
+//        against the slice's own window, not the full backing allocation,
+//        and composes onto the slice's own offset (Greptile, #437) --
+//        sl@0:1 used to read the parent's own index 0 ("a") instead of
+//        the slice's index 0 ("c") ---
+s3="abcdef"
+sl3=s3@2:5
+ok=ok&&(print(sl3@0:1 :str)=="c")
+ok=ok&&(print(sl3@1:3 :str)=="de")
+ok=ok&&((sl3@0:10)==nil)
+print("7 nesting: sl3@0:1, sl3@1:3, sl3@0:10 (expect c de nil): %s %s %s\n" print(sl3@0:1 :str) print(sl3@1:3 :str) sl3@0:10)
+
+// --- 8: KNOWN GAP, pinned so a future #438 fix is a deliberate change
+//        here too, not a silent one -- a slice passed as a function
+//        keyword arg loses its sliced()-ness (see the file header) and
+//        reads back as the whole parent string, not its own window ---
+f8=func(print(x :str))
+ok=ok&&(f8(:x s3@2:5)=="abcdef")
+print("8 KNOWN GAP: a sliced :x arg reads as the whole parent (expect abcdef, not cde): %s\n" f8(:x s3@2:5))
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -53,6 +53,10 @@ if(run("./string_cap.comt")
   :then print("pass: string_cap\n")
   :else print("FAIL: string_cap\n");topok=false)
 
+if(run("./colonslice.comt")
+  :then print("pass: colonslice\n")
+  :else print("FAIL: colonslice\n");topok=false)
+
 if(run("./print.comt")
   :then print("pass: print\n")
   :else print("FAIL: print\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "4019ad04"
+#define PATCH_KEY "60cf95f8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

First working cut of #395 -- Go-style string slicing via the `:` operator (`str@lo:hi`).

- A coloned 2-element index into a string builds a slice: an ordinary `StringType` `ComValue` sharing the parent's own symid (no copy, no new storage type), with an offset/length window recorded via new `sliceoff()`/`slicelen()` accessors on `ComValue`. These repurpose the `narg`/`nkey` fields, which a plain `StringType` value never otherwise needs -- both now read 0 for `StringType`, so existing command-dispatch bookkeeping elsewhere is unaffected.
- `hi` is exclusive (Go-style): `"abcdefg"@0:3` gives `"abc"`.
- `size()`, `print()`, and scalar `@` indexing (reads and writes) all respect a slice's own window rather than its parent's full extent. A write through a slice lands in the shared parent buffer, so it's visible through the parent or any other overlapping slice.
- `lookup_symval()` (comterp.c) carries the slice fields across a variable's symbol-table round trip, the same way it already carries `coloned()` -- guarded strictly to `StringType`, since an early, more general version of this clobbered every symbol lookup's own `narg`/`nkey` argument-count bookkeeping (`_stack` grows via a raw `dmm_realloc`, so `ComValue` also has to stay a plain, trivially-relocatable type -- ruled out a `std::string` scratch member on `ComValue` itself for the same reason).

Depends on #429 (`colonlist-command`, still open) for the `:` operator / `coloned()` infrastructure this builds on -- based off that branch rather than master.

## Known gaps (documented in colonslice.comt)

- `s@lo:hi` with bare-identifier bounds isn't reachable through the `:` operator itself yet -- `:hi` lexes as a stray keyword token regardless of spacing, the same #423 scanner ambiguity already flagged for a leading colon (`Dec:25`). `s@colonlist(lo hi)` works today as a command-call workaround.
- `:set`/`:ins`/`:del` through a slice (falls back to nil).
- Slicing a plain list/array (only strings trigger slice logic).
- `slice==string` / `slice==slice` (falls back to a generic, symid-based comparison).

Filed #436 for a related follow-up: string-from-stream should eventually read directly from a slice's window instead of copying.

## Test plan

- [x] Full `run_all.comt` suite green (0 regressions, including a caught-and-fixed stack-imbalance regression from an earlier, over-broad `lookup_symval()` change)
- [x] New `colonslice.comt` (6 tests) covering inclusive/exclusive bounds, `size()`, write-through-parent visibility, out-of-bounds/`hi==cap`, and slice-ness surviving variable assignment
- [x] Manual verification of scalar `@` indexing into an already-sliced string (read, write, `nil`-for-last-char, out-of-window bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
