### PR TITLE
Note why parsetest can read a socket it sent :nowait on

### DIFF
--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -176,7 +176,10 @@ parsetest_test=func(
   remote(sock "1+1");
   remote(sockb "1+1");
 
-  /* a leaves a list open across lines, b parses in the gap, a closes it */
+  /* a leaves a list open across lines, b parses in the gap, a closes it.  Note
+     what makes it safe to keep reading sock after a :nowait: an incomplete
+     expression sends nothing back, so there is no undrained reply to put every
+     later read one answer behind. */
   remote(sock "x=(10,20,30," :nowait);
   usleep(1000000);
   b=remote(sockb "1+1");

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "4019ad04"
+#define PATCH_KEY "f3ccbdb5"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Comment only, plus the PATCH_KEY bump the checks require.

`:nowait` declines the reply but the far end still sends it. An undrained reply
puts every later `remote()` on that socket one answer behind -- silently, with no
error, handing back the previous question's result.

Every `:nowait` in the suite is `remote(sock "exit" :nowait)` at teardown, where
the socket is closed straight after, and `optabletest` never reads its socket
again after the two it sends. `parsetest` is the one place that keeps reading,
and it is safe only because the line it declines is an *incomplete expression*,
which sends nothing back.

CI proves that rather than assuming it: a stray reply would shift `size(x)` onto
the completing line's answer, making `n` the list `{10,20,30,40,50}` instead of
`5`, and the test would fail. It reports 5.

The note is there because the pattern is easy to copy to a `:nowait` line that
does answer, and the failure then looks like the far end misbehaving.