### PR TITLE
Implement str@lo:hi string slicing (#395), extensively re-reviewed

### DIFF
--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -252,8 +252,11 @@ public:
     const char* class_name();         // class name of object.
 
 
-    const char* string_ptr();
-    // lookup and return pointer to string associated with string.
+    virtual const char* string_ptr();
+    // lookup and return pointer to string associated with string.  Virtual
+    // so ComValue (comvalue.h) can override it to narrow a sliced
+    // StringType's window (#395) -- every existing caller keeps calling
+    // string_ptr() exactly as before and gets the right text for free.
     const char* symbol_ptr();
     boolean global_flag();
     // return true if a symbol and the global flag is set.

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -252,11 +252,21 @@ public:
     const char* class_name();         // class name of object.
 
 
-    virtual const char* string_ptr();
-    // lookup and return pointer to string associated with string.  Virtual
-    // so ComValue (comvalue.h) can override it to narrow a sliced
-    // StringType's window (#395) -- every existing caller keeps calling
-    // string_ptr() exactly as before and gets the right text for free.
+    const char* string_ptr();
+    // lookup and return pointer to string associated with string.  Not
+    // slice-aware -- a sliced StringType (#395, ComValue::cstr(),
+    // comvalue.h) returns its whole shared backing string here, not just
+    // its own window.  Tried making this virtual so ComValue could
+    // override it and every existing caller would get slice-correct text
+    // automatically; reverted (#440 review) once it turned out the more
+    // common pattern in this codebase -- ComValue& x = stack_arg(n), a
+    // raw reference rather than a genuinely-constructed local copy --
+    // isn't safe to call a virtual method on at all (comterp.c's _stack
+    // grows via raw dmm_realloc, so a raw element's vtable pointer isn't
+    // reliably ComValue's own; confirmed live, wrong answer, no crash).
+    // One always-correct mechanism (cstr(), explicit at every call site)
+    // beats two mechanisms with a subtle, easy-to-miss safety line
+    // between them.
     const char* symbol_ptr();
     boolean global_flag();
     // return true if a symbol and the global flag is set.

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -291,8 +291,12 @@ void EqualFunc::execute() {
 	if (nval.is_unknown() && operand2.type()==ComValue::SymbolType)
 	  result.boolean_ref() = operand1.symbol_val() == operand2.symbol_val();
 	else {
-	  std::string scratch1, scratch2;
-	  const char* str1 = operand1.slice_cstr(scratch1);
+	  /* operand1.symbol_ptr(), not slice_cstr() -- a symbol can't be
+	     sliced or modified, so there's nothing for slice_cstr() to
+	     narrow; operand2 isn't provably a symbol here (a mixed
+	     comparison, `abc==s@0:3, still needs the slice-aware read). */
+	  std::string scratch2;
+	  const char* str1 = operand1.symbol_ptr();
 	  const char* str2 = operand2.slice_cstr(scratch2);
 	  result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)==0
 	                                            : strncmp(str1, str2, nval.int_val())==0;
@@ -402,8 +406,10 @@ void NotEqualFunc::execute() {
       if (nval.is_unknown() && operand2.type()==ComValue::SymbolType)
 	result.boolean_ref() = operand1.symbol_val() != operand2.symbol_val();
       else {
-	std::string scratch1, scratch2;
-	const char* str1 = operand1.slice_cstr(scratch1);
+	/* operand1.symbol_ptr(), not slice_cstr() -- a symbol can't be
+	   sliced or modified; operand2 isn't provably a symbol here. */
+	std::string scratch2;
+	const char* str1 = operand1.symbol_ptr();
 	const char* str2 = operand2.slice_cstr(scratch2);
 	result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)!=0
 	                                          : strncmp(str1, str2, nval.int_val())!=0;

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -284,16 +284,36 @@ void EqualFunc::execute() {
       case ComValue::DoubleType:
 	result.boolean_ref() = operand1.double_val() == operand2.double_val();
 	break;
-      case ComValue::StringType:
       case ComValue::SymbolType:
-	if (nval.is_unknown()) 
+	/* identity via symbol_val() is a valid AND fast stand-in for text
+	   equality only when both sides are genuinely symbols -- but only
+	   when operand2 is too; operand1's type alone picked this case. */
+	if (nval.is_unknown() && operand2.type()==ComValue::SymbolType)
 	  result.boolean_ref() = operand1.symbol_val() == operand2.symbol_val();
 	else {
-	  const char* str1 = operand1.symbol_ptr();
-	  const char* str2 = operand2.symbol_ptr();
-	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())==0;
+	  std::string scratch1, scratch2;
+	  const char* str1 = operand1.slice_cstr(scratch1);
+	  const char* str2 = operand2.slice_cstr(scratch2);
+	  result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)==0
+	                                            : strncmp(str1, str2, nval.int_val())==0;
 	}
 	break;
+      case ComValue::StringType: {
+	/* always a text comparison, never symbol_val() identity -- interning
+	   dedups an ordinary string by content, so identity happened to work
+	   there, but a slice (#395) shares its PARENT's symid, unrelated to
+	   its own effective text (sl=="cde" compared false this way even
+	   though sl prints as "cde", confirmed live).  slice_cstr(), not
+	   string_ptr() -- operand1/operand2 are ComValue& straight off
+	   stack_arg(), not locals, so string_ptr()'s virtual dispatch isn't
+	   reliable here (see its own doc comment, comvalue.h). */
+	std::string scratch1, scratch2;
+	const char* str1 = operand1.slice_cstr(scratch1);
+	const char* str2 = operand2.slice_cstr(scratch2);
+	result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)==0
+	                                          : strncmp(str1, str2, nval.int_val())==0;
+	break;
+      }
       case ComValue::ArrayType: 
 	result.boolean_ref() = operand2.type() == ComValue::ArrayType && 
           (operand1.array_val() == operand2.array_val() ||
@@ -376,16 +396,32 @@ void NotEqualFunc::execute() {
     case ComValue::DoubleType:
 	result.boolean_ref() = operand1.double_val() != operand2.double_val();
 	break;
-    case ComValue::StringType:
     case ComValue::SymbolType:
-      if (nval.is_unknown()) 
+      /* identity via symbol_val() only when operand2 is also genuinely
+	 a symbol -- operand1's type alone picked this case. */
+      if (nval.is_unknown() && operand2.type()==ComValue::SymbolType)
 	result.boolean_ref() = operand1.symbol_val() != operand2.symbol_val();
       else {
-	const char* str1 = operand1.symbol_ptr();
-	const char* str2 = operand2.symbol_ptr();
-	result.boolean_ref() = strncmp(str1, str2, nval.int_val())!=0;
+	std::string scratch1, scratch2;
+	const char* str1 = operand1.slice_cstr(scratch1);
+	const char* str2 = operand2.slice_cstr(scratch2);
+	result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)!=0
+	                                          : strncmp(str1, str2, nval.int_val())!=0;
       }
       break;
+    case ComValue::StringType: {
+      /* always a text comparison, never symbol_val() identity -- a slice
+	 (#395) shares its parent's symid, unrelated to its own text.
+	 slice_cstr(), not string_ptr(): operand1/operand2 are raw
+	 stack_arg() references, not locals (see EqualFunc for the full
+	 reasoning, boolfunc.c above). */
+      std::string scratch1, scratch2;
+      const char* str1 = operand1.slice_cstr(scratch1);
+      const char* str2 = operand2.slice_cstr(scratch2);
+      result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)!=0
+	                                        : strncmp(str1, str2, nval.int_val())!=0;
+      break;
+    }
     case ComValue::ArrayType: 
       result.boolean_ref() = operand2.type() != ComValue::ArrayType || 
 	operand1.array_val() != operand2.array_val() &&

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -291,13 +291,13 @@ void EqualFunc::execute() {
 	if (nval.is_unknown() && operand2.type()==ComValue::SymbolType)
 	  result.boolean_ref() = operand1.symbol_val() == operand2.symbol_val();
 	else {
-	  /* operand1.symbol_ptr(), not slice_cstr() -- a symbol can't be
-	     sliced or modified, so there's nothing for slice_cstr() to
+	  /* operand1.symbol_ptr(), not cstr() -- a symbol can't be
+	     sliced or modified, so there's nothing for cstr() to
 	     narrow; operand2 isn't provably a symbol here (a mixed
 	     comparison, `abc==s@0:3, still needs the slice-aware read). */
 	  std::string scratch2;
 	  const char* str1 = operand1.symbol_ptr();
-	  const char* str2 = operand2.slice_cstr(scratch2);
+	  const char* str2 = operand2.cstr(scratch2);
 	  result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)==0
 	                                            : strncmp(str1, str2, nval.int_val())==0;
 	}
@@ -307,13 +307,13 @@ void EqualFunc::execute() {
 	   dedups an ordinary string by content, so identity happened to work
 	   there, but a slice (#395) shares its PARENT's symid, unrelated to
 	   its own effective text (sl=="cde" compared false this way even
-	   though sl prints as "cde", confirmed live).  slice_cstr(), not
+	   though sl prints as "cde", confirmed live).  cstr(), not
 	   string_ptr() -- operand1/operand2 are ComValue& straight off
 	   stack_arg(), not locals, so string_ptr()'s virtual dispatch isn't
 	   reliable here (see its own doc comment, comvalue.h). */
 	std::string scratch1, scratch2;
-	const char* str1 = operand1.slice_cstr(scratch1);
-	const char* str2 = operand2.slice_cstr(scratch2);
+	const char* str1 = operand1.cstr(scratch1);
+	const char* str2 = operand2.cstr(scratch2);
 	result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)==0
 	                                          : strncmp(str1, str2, nval.int_val())==0;
 	break;
@@ -406,11 +406,11 @@ void NotEqualFunc::execute() {
       if (nval.is_unknown() && operand2.type()==ComValue::SymbolType)
 	result.boolean_ref() = operand1.symbol_val() != operand2.symbol_val();
       else {
-	/* operand1.symbol_ptr(), not slice_cstr() -- a symbol can't be
+	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be
 	   sliced or modified; operand2 isn't provably a symbol here. */
 	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
-	const char* str2 = operand2.slice_cstr(scratch2);
+	const char* str2 = operand2.cstr(scratch2);
 	result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)!=0
 	                                          : strncmp(str1, str2, nval.int_val())!=0;
       }
@@ -418,12 +418,12 @@ void NotEqualFunc::execute() {
     case ComValue::StringType: {
       /* always a text comparison, never symbol_val() identity -- a slice
 	 (#395) shares its parent's symid, unrelated to its own text.
-	 slice_cstr(), not string_ptr(): operand1/operand2 are raw
+	 cstr(), not string_ptr(): operand1/operand2 are raw
 	 stack_arg() references, not locals (see EqualFunc for the full
 	 reasoning, boolfunc.c above). */
       std::string scratch1, scratch2;
-      const char* str1 = operand1.slice_cstr(scratch1);
-      const char* str2 = operand2.slice_cstr(scratch2);
+      const char* str1 = operand1.cstr(scratch1);
+      const char* str2 = operand2.cstr(scratch2);
       result.boolean_ref() = nval.is_unknown() ? strcmp(str1, str2)!=0
 	                                        : strncmp(str1, str2, nval.int_val())!=0;
       break;

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -308,9 +308,9 @@ void EqualFunc::execute() {
 	   there, but a slice (#395) shares its PARENT's symid, unrelated to
 	   its own effective text (sl=="cde" compared false this way even
 	   though sl prints as "cde", confirmed live).  cstr(), not
-	   string_ptr() -- operand1/operand2 are ComValue& straight off
-	   stack_arg(), not locals, so string_ptr()'s virtual dispatch isn't
-	   reliable here (see its own doc comment, comvalue.h). */
+	   string_ptr() -- string_ptr() isn't slice-aware at all (comvalue.h,
+	   attrvalue.h), so it would just read the whole shared parent
+	   string here regardless. */
 	std::string scratch1, scratch2;
 	const char* str1 = operand1.cstr(scratch1);
 	const char* str2 = operand2.cstr(scratch2);
@@ -418,9 +418,8 @@ void NotEqualFunc::execute() {
     case ComValue::StringType: {
       /* always a text comparison, never symbol_val() identity -- a slice
 	 (#395) shares its parent's symid, unrelated to its own text.
-	 cstr(), not string_ptr(): operand1/operand2 are raw
-	 stack_arg() references, not locals (see EqualFunc for the full
-	 reasoning, boolfunc.c above). */
+	 cstr(), not string_ptr(): string_ptr() isn't slice-aware at all
+	 (see EqualFunc above for the full reasoning). */
       std::string scratch1, scratch2;
       const char* str1 = operand1.cstr(scratch1);
       const char* str2 = operand2.cstr(scratch2);

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1629,6 +1629,7 @@ static void carry_slice(ComValue& dst, ComValue& src) {
   dst.sliced(src.sliced());
   dst.sliceoff(src.sliceoff());
   dst.slicelen(src.slicelen());
+  dst.blocksz(src.blocksz());
 }
 
 ComValue& ComTerp::lookup_symval(ComValue& comval) {

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1618,6 +1618,19 @@ ComValue& ComTerp::fire_if_funcobj(ComValue& val) {
   return *slot;
 }
 
+/* sliceoff()/slicelen() (comvalue.h) write straight through to _narg/_nkey
+   -- fine on a StringType, which never needs them for anything else, but
+   catastrophic on any other type, where those same fields carry a command
+   call's own argument/keyword counts.  Restricted to StringType so a
+   lookup_symval() carry-over (below) can't clobber that bookkeeping for
+   every other symbol resolution in the interpreter. */
+static void carry_slice(ComValue& dst, ComValue& src) {
+  if (src.type() != ComValue::StringType) return;
+  dst.sliced(src.sliced());
+  dst.sliceoff(src.sliceoff());
+  dst.slicelen(src.slicelen());
+}
+
 ComValue& ComTerp::lookup_symval(ComValue& comval) {
     if (comval.bquote()) {
         return comval;
@@ -1656,10 +1669,12 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	if (!comval.global_flag() && localtable()->find(vptr, comval.symbol_val()) ) {
 	  comval.assignval(*(ComValue*)vptr);
 	  comval.coloned(((ComValue*)vptr)->coloned());
+	  carry_slice(comval, *(ComValue*)vptr);
 	  return comval;
 	} else if (globaltable()->find(vptr, comval.symbol_val())) {
 	  comval.assignval(*(ComValue*)vptr);
 	  comval.coloned(((ComValue*)vptr)->coloned());
+	  carry_slice(comval, *(ComValue*)vptr);
 	  return comval;
 	} else
 	  return ComValue::nullval();

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -175,8 +175,39 @@ int ComValue::sliced() const { return _flags & COMVALUE_SLICED_FLAG; }
 int ComValue::sliceoff() const { return _narg; }
 int ComValue::slicelen() const { return _nkey; }
 
+const char* ComValue::string_ptr() {
+  if (!sliced()) return AttributeValue::string_ptr();
+  /* a small rotating pool, not a ComValue member -- see the comvalue.h
+     doc comment for why a member can't survive _stack's dmm_realloc.
+     Rotating (rather than one shared buffer) covers the ordinary case of
+     two sliced operands read in the same expression before either is
+     consumed (e.g. a string comparison or concatenation of two slices) --
+     each gets its own slot instead of the second overwriting the first's
+     still-needed text.  Still not safe across more simultaneous live
+     reads than the pool has slots, or across anything that holds onto the
+     pointer past the next few string_ptr() calls -- copy the text out
+     (or use %v/print's own :str, which does) if it needs to outlive that. */
+  static std::string pool[8];
+  static int next = 0;
+  std::string& scratch = pool[next];
+  next = (next + 1) % 8;
+  const char* full = AttributeValue::string_ptr();
+  scratch.assign(full + sliceoff(), slicelen());
+  return scratch.c_str();
+}
+
 const char* ComValue::slice_cstr(std::string& scratch) {
-  const char* full = string_ptr();
+  /* non-virtual, and calls AttributeValue::string_ptr() explicitly rather
+     than the virtual string_ptr() above -- safe to call on ANY ComValue&,
+     including a raw element of _stack (comterp.c) read directly rather
+     than copied to a genuine local first.  Such an element's own vtable
+     pointer isn't reliably ComValue's own (confirmed: print_stack_top(
+     ostream&) below reads one whose vtable resolves to plain
+     AttributeValue, so a virtual call on it silently runs the base
+     class's method instead of this override -- wrong, not a crash), but
+     sliced()/sliceoff()/slicelen() are plain field reads, unaffected
+     either way. */
+  const char* full = AttributeValue::string_ptr();
   if (!sliced()) return full;
   scratch.assign(full + sliceoff(), slicelen());
   return scratch.c_str();
@@ -221,6 +252,10 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  break;
 	    
 	case ComValue::StringType: {
+	  /* slice_cstr(), not string_ptr() -- svp may be a raw _stack element
+	     (print_stack_top(ostream&), comterp.c), and string_ptr()'s virtual
+	     dispatch isn't reliable on one of those (see slice_cstr()'s own
+	     doc comment, comvalue.h). */
 	  std::string scratch;
 	  const char* strp = svp->slice_cstr(scratch);
 	  if (brief)

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <iostream.h>
 #include <strstream>
+#include <string>
 using namespace std;
 
 ComValue ComValue::_nullval(ComValue::UnknownType);
@@ -163,13 +164,23 @@ ComValue& ComValue::operator= (const ComValue& sv) {
     return *this;
 }
     
-int ComValue::narg() const { return _narg; }
-int ComValue::nkey() const { return _nkey; }
+int ComValue::narg() const { return type()==ComValue::StringType ? 0 : _narg; }
+int ComValue::nkey() const { return type()==ComValue::StringType ? 0 : _nkey; }
 int ComValue::nids() const { return _nids; }
 int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
 int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
 int ComValue::local_flag() const { return _flags & COMVALUE_LOCAL_FLAG; }
 int ComValue::coloned() const { return _flags & COMVALUE_COLONED_FLAG; }
+int ComValue::sliced() const { return _flags & COMVALUE_SLICED_FLAG; }
+int ComValue::sliceoff() const { return _narg; }
+int ComValue::slicelen() const { return _nkey; }
+
+const char* ComValue::slice_cstr(std::string& scratch) {
+  const char* full = string_ptr();
+  if (!sliced()) return full;
+  scratch.assign(full + sliceoff(), slicelen());
+  return scratch.c_str();
+}
 
 ostream& operator<< (ostream& out, const ComValue& sv) {
     ComValue* svp = (ComValue*)&sv;
@@ -209,15 +220,18 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  }
 	  break;
 	    
-	case ComValue::StringType:
+	case ComValue::StringType: {
+	  std::string scratch;
+	  const char* strp = svp->slice_cstr(scratch);
 	  if (brief)
-	    ParamList::output_text(out, svp->string_ptr());
+	    ParamList::output_text(out, strp);
 	  else {
 	    out << "string(";
-	    ParamList::output_text(out, svp->string_ptr());
+	    ParamList::output_text(out, strp);
 	    out << ")";
 	  }
 	  break;
+	}
 	    
 	case ComValue::BooleanType:
 	  if (brief)

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -166,7 +166,7 @@ ComValue& ComValue::operator= (const ComValue& sv) {
     
 int ComValue::narg() const { return type()==ComValue::StringType ? 0 : _narg; }
 int ComValue::nkey() const { return type()==ComValue::StringType ? 0 : _nkey; }
-int ComValue::nids() const { return _nids; }
+int ComValue::nids() const { return type()==ComValue::StringType ? 0 : _nids; }
 int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
 int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
 int ComValue::local_flag() const { return _flags & COMVALUE_LOCAL_FLAG; }
@@ -174,6 +174,7 @@ int ComValue::coloned() const { return _flags & COMVALUE_COLONED_FLAG; }
 int ComValue::sliced() const { return _flags & COMVALUE_SLICED_FLAG; }
 int ComValue::sliceoff() const { return _narg; }
 int ComValue::slicelen() const { return _nkey; }
+int ComValue::blocksz() const { return _nids; }
 
 const char* ComValue::string_ptr() {
   if (!sliced()) return AttributeValue::string_ptr();

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -197,7 +197,7 @@ const char* ComValue::string_ptr() {
   return scratch.c_str();
 }
 
-const char* ComValue::slice_cstr(std::string& scratch) {
+const char* ComValue::cstr(std::string& scratch) {
   /* non-virtual, and calls AttributeValue::string_ptr() explicitly rather
      than the virtual string_ptr() above -- safe to call on ANY ComValue&,
      including a raw element of _stack (comterp.c) read directly rather
@@ -253,12 +253,12 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	  break;
 	    
 	case ComValue::StringType: {
-	  /* slice_cstr(), not string_ptr() -- svp may be a raw _stack element
+	  /* cstr(), not string_ptr() -- svp may be a raw _stack element
 	     (print_stack_top(ostream&), comterp.c), and string_ptr()'s virtual
-	     dispatch isn't reliable on one of those (see slice_cstr()'s own
+	     dispatch isn't reliable on one of those (see cstr()'s own
 	     doc comment, comvalue.h). */
 	  std::string scratch;
-	  const char* strp = svp->slice_cstr(scratch);
+	  const char* strp = svp->cstr(scratch);
 	  if (brief)
 	    ParamList::output_text(out, strp);
 	  else {

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -176,36 +176,15 @@ int ComValue::sliceoff() const { return _narg; }
 int ComValue::slicelen() const { return _nkey; }
 int ComValue::blocksz() const { return _nids; }
 
-const char* ComValue::string_ptr() {
-  if (!sliced()) return AttributeValue::string_ptr();
-  /* a small rotating pool, not a ComValue member -- see the comvalue.h
-     doc comment for why a member can't survive _stack's dmm_realloc.
-     Rotating (rather than one shared buffer) covers the ordinary case of
-     two sliced operands read in the same expression before either is
-     consumed (e.g. a string comparison or concatenation of two slices) --
-     each gets its own slot instead of the second overwriting the first's
-     still-needed text.  Still not safe across more simultaneous live
-     reads than the pool has slots, or across anything that holds onto the
-     pointer past the next few string_ptr() calls -- copy the text out
-     (or use %v/print's own :str, which does) if it needs to outlive that. */
-  static std::string pool[8];
-  static int next = 0;
-  std::string& scratch = pool[next];
-  next = (next + 1) % 8;
-  const char* full = AttributeValue::string_ptr();
-  scratch.assign(full + sliceoff(), slicelen());
-  return scratch.c_str();
-}
-
 const char* ComValue::cstr(std::string& scratch) {
-  /* non-virtual, and calls AttributeValue::string_ptr() explicitly rather
-     than the virtual string_ptr() above -- safe to call on ANY ComValue&,
-     including a raw element of _stack (comterp.c) read directly rather
-     than copied to a genuine local first.  Such an element's own vtable
-     pointer isn't reliably ComValue's own (confirmed: print_stack_top(
-     ostream&) below reads one whose vtable resolves to plain
-     AttributeValue, so a virtual call on it silently runs the base
-     class's method instead of this override -- wrong, not a crash), but
+  /* string_ptr() itself was tried as this mechanism (made virtual,
+     overridden here) and reverted -- see its own doc comment,
+     attrvalue.h.  Calling AttributeValue::string_ptr() explicitly (base-
+     qualified, never virtual) is what makes this safe to call on ANY
+     ComValue&, including a raw element of _stack (comterp.c) read
+     directly rather than copied to a genuine local first -- such an
+     element's own vtable pointer isn't reliably ComValue's own
+     (confirmed live: one resolved to plain AttributeValue's), but
      sliced()/sliceoff()/slicelen() are plain field reads, unaffected
      either way. */
   const char* full = AttributeValue::string_ptr();

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -121,13 +121,19 @@ public:
     // StringType, whose storage doubles as a slice's length (#395) -- use
     // slicelen() to read that.
     int nids() const;
-    // number of subordinate identifiers associated with this identifier (not used).
+    // for a SymbolType, -1 for a bare identifier or the matched-paren-
+    // delimiter kind following it otherwise (TOK_RPAREN/TOK_RBRACKET/...,
+    // comterp.c -- also how DotFunc, dotfunc.c, tells a bare field
+    // reference apart from an empty-parenthesized method call); when a
+    // language needs separate input/output arglists it counts those too.
+    // Always 0 for a StringType, whose storage doubles as a slice's chunk
+    // size (#395) -- use blocksz() to read that.
     void narg(int n) {_narg = n; }
     // set number of arguments associated with this command or keyword.
     void nkey(int n) {_nkey = n; }
     // set number of keywords associated with this command.
     void nids(int n) {_nids = n; }
-    // set number of subordinate identifiers associated with this identifier (not used).
+    // set the matched-paren-delimiter kind following a SymbolType.
     int bquote() const;
     // get flag that says this SymbolType has been backquoted
     void bquote(int flag) { if(flag) _flags |= COMVALUE_BQUOTE_FLAG; else _flags &= ~COMVALUE_BQUOTE_FLAG; }
@@ -159,6 +165,15 @@ public:
     // length of a slice's window into its symid string; valid only when sliced().
     void slicelen(int len) { _nkey = len; }
     // set a slice's window length.
+    int blocksz() const;
+    // chunk size of a slice, in bytes -- 0 (the default) means an ordinary
+    // byte-granular slice, same as today; a future consumer reading a
+    // nonzero value would treat sliceoff()/slicelen() as counts of
+    // blocksz()-byte chunks rather than raw bytes, so a string slice can
+    // describe more than chars, Go-style (#395).  Not consumed anywhere
+    // yet -- this is the storage, not the feature.
+    void blocksz(int sz) { _nids = sz; }
+    // set a slice's chunk size.
 
     virtual const char* string_ptr();
     // overrides AttributeValue::string_ptr() (attrvalue.h) -- when sliced()

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -160,13 +160,40 @@ public:
     void slicelen(int len) { _nkey = len; }
     // set a slice's window length.
 
+    virtual const char* string_ptr();
+    // overrides AttributeValue::string_ptr() (attrvalue.h) -- when sliced()
+    // (#395), narrows the text to [sliceoff(), sliceoff()+slicelen())
+    // instead of the whole shared backing string, so every existing
+    // string_ptr() caller (comparisons, concatenation, split, print, ...)
+    // gets the right text with no change of its own.  Not sliced(): calls
+    // straight through to AttributeValue::string_ptr(), no copy.  The
+    // narrowed case does need a real copy -- a mid-buffer slice's own end
+    // isn't a real '\0' in the shared backing string, and writing one
+    // there would be exactly #394's original bug -- backed by a small
+    // static scratch-buffer pool (comvalue.c), not a ComValue member:
+    // _stack (comterp.c) grows via dmm_realloc, a raw realloc of the whole
+    // ComValue array, so ComValue itself must stay a plain, trivially-
+    // relocatable type -- no member with real construction/destruction
+    // (like std::string) survives that move (confirmed by an actual
+    // crash on the very first string assignment when tried).
+    //
+    // ONLY safe on a genuinely-constructed ComValue (e.g. a local copy via
+    // ComValue x(stack_arg(n)) -- the standard idiom throughout ComFunc::
+    // execute()), because it's virtual: dispatch depends on the object's
+    // own vtable pointer, and a raw element of _stack read directly
+    // (rather than copied first) doesn't reliably carry ComValue's own
+    // vtable -- confirmed live: print_stack_top(ostream&) below reads one
+    // whose vtable resolves to plain AttributeValue's, so calling this
+    // virtually on it silently ran the base class's method instead.  Use
+    // slice_cstr() instead anywhere a value might still be a raw _stack
+    // reference.
     const char* slice_cstr(std::string& scratch);
-    // NUL-terminated text of a StringType value -- string_ptr() narrowed to
-    // [sliceoff(), sliceoff()+slicelen()) when sliced() (#395), otherwise
-    // string_ptr() itself.  Takes a caller-owned std::string rather than a
-    // ComValue member: _stack (comterp.c) grows via dmm_realloc, a raw
-    // realloc of the whole ComValue array, so ComValue must stay a plain,
-    // trivially-relocatable union -- no non-POD member survives that move.
+    // non-virtual counterpart to string_ptr() -- reads the same
+    // sliced()/sliceoff()/slicelen() (plain field accessors, unaffected by
+    // vtable state) and calls AttributeValue::string_ptr() explicitly, so
+    // it's correct regardless of the object's own vtable pointer.  Use
+    // this instead of string_ptr() at any call site that isn't provably
+    // working from a genuinely-constructed local copy.
 
     int& pedepth() { return _pedepth; }
     // set/get depth of nesting in post-evaluated blocks of control commands.

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -175,43 +175,25 @@ public:
     void blocksz(int sz) { _nids = sz; }
     // set a slice's chunk size.
 
-    virtual const char* string_ptr();
-    // overrides AttributeValue::string_ptr() (attrvalue.h) -- when sliced()
-    // (#395), narrows the text to [sliceoff(), sliceoff()+slicelen())
-    // instead of the whole shared backing string, so every existing
-    // string_ptr() caller (comparisons, concatenation, split, print, ...)
-    // gets the right text with no change of its own.  Not sliced(): calls
-    // straight through to AttributeValue::string_ptr(), no copy.  The
-    // narrowed case does need a real copy -- a mid-buffer slice's own end
-    // isn't a real '\0' in the shared backing string, and writing one
-    // there would be exactly #394's original bug -- backed by a small
-    // static scratch-buffer pool (comvalue.c), not a ComValue member:
-    // _stack (comterp.c) grows via dmm_realloc, a raw realloc of the whole
-    // ComValue array, so ComValue itself must stay a plain, trivially-
-    // relocatable type -- no member with real construction/destruction
-    // (like std::string) survives that move (confirmed by an actual
-    // crash on the very first string assignment when tried).
-    //
-    // ONLY safe on a genuinely-constructed ComValue (e.g. a local copy via
-    // ComValue x(stack_arg(n)) -- the standard idiom throughout ComFunc::
-    // execute()), because it's virtual: dispatch depends on the object's
-    // own vtable pointer, and a raw element of _stack read directly
-    // (rather than copied first) doesn't reliably carry ComValue's own
-    // vtable -- confirmed live: print_stack_top(ostream&) below reads one
-    // whose vtable resolves to plain AttributeValue's, so calling this
-    // virtually on it silently ran the base class's method instead.  Use
-    // cstr() instead anywhere a value might still be a raw _stack
-    // reference.
     const char* cstr(std::string& scratch);
-    // non-virtual counterpart to string_ptr() -- reads the same
-    // sliced()/sliceoff()/slicelen() (plain field accessors, unaffected by
-    // vtable state) and calls AttributeValue::string_ptr() explicitly, so
-    // it's correct regardless of the object's own vtable pointer.  Use
-    // this instead of string_ptr() at any call site that isn't provably
-    // working from a genuinely-constructed local copy.  Named plainly,
-    // not slice_cstr() -- whether the value happens to be a slice is an
-    // implementation detail with no meaning to a caller that just wants
-    // its text.
+    // the slice-aware way to get a StringType value's text (#395) --
+    // narrows to [sliceoff(), sliceoff()+slicelen()) when sliced() instead
+    // of AttributeValue::string_ptr()'s whole shared backing string;
+    // string_ptr() itself was tried as the mechanism for this (made
+    // virtual, overridden here) and reverted -- see its own doc comment,
+    // attrvalue.h, for why.  Named plainly, not slice_cstr() -- whether
+    // the value happens to be a slice is an implementation detail with no
+    // meaning to a caller that just wants its text.  Takes a caller-owned
+    // std::string rather than storing the copy on the ComValue itself:
+    // _stack (comterp.c) grows via dmm_realloc, a raw realloc of the
+    // whole ComValue array, so ComValue itself must stay a plain,
+    // trivially-relocatable type -- no member with real construction/
+    // destruction (like std::string) survives that move (confirmed by an
+    // actual crash on the very first string assignment when tried).  A
+    // real copy is unavoidable in the sliced case regardless of mechanism
+    // -- a mid-buffer slice's own end isn't a real '\0' in the shared
+    // backing string, and writing one there would be exactly #394's
+    // original bug.
 
     int& pedepth() { return _pedepth; }
     // set/get depth of nesting in post-evaluated blocks of control commands.

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -33,6 +33,7 @@
 #include <ComTerp/_comterp.h>
 #include <Attribute/attrvalue.h>
 #include <Unidraw/Components/compview.h>
+#include <string>
 
 class ComFunc;
 class ComTerp;
@@ -47,6 +48,7 @@ class ComTerp;
 #define COMVALUE_LHS_ASSIGN_FLAG 0x02  // set by AssignFunc on global() or local() ComValue in lhs context
 #define COMVALUE_LOCAL_FLAG      0x04  // set by local() on its lvalue symbol -- write the default symbol table, skipping any func frame
 #define COMVALUE_COLONED_FLAG    0x08  // set by ColonListFunc -- an ArrayType built by ':', not ','
+#define COMVALUE_SLICED_FLAG     0x10  // set on a StringType sliced from another string (#395) -- sliceoff()/slicelen() hold the window, narg()/nkey() read 0
 
 class ComValue : public AttributeValue {
 public:
@@ -111,9 +113,13 @@ public:
     // return true if ObjectType matches or compid is superclass
 
     int narg() const;
-    // number of arguments associated with this command or keyword.
+    // number of arguments associated with this command or keyword; always 0
+    // for a StringType, whose storage doubles as a slice's offset (#395) --
+    // use sliceoff() to read that.
     int nkey() const;
-    // number of keywords associated with this command.
+    // number of keywords associated with this command; always 0 for a
+    // StringType, whose storage doubles as a slice's length (#395) -- use
+    // slicelen() to read that.
     int nids() const;
     // number of subordinate identifiers associated with this identifier (not used).
     void narg(int n) {_narg = n; }
@@ -139,6 +145,28 @@ public:
     // return flag that marks an ArrayType as built by ':' rather than ','.
     void coloned(int flag) { if(flag) _flags |= COMVALUE_COLONED_FLAG; else _flags &= ~COMVALUE_COLONED_FLAG; }
     // set flag that marks an ArrayType as built by ':' rather than ','.
+
+    int sliced() const;
+    // return flag that marks a StringType value as a slice of another
+    // string, sharing its symid rather than owning a copy (#395).
+    void sliced(int flag) { if(flag) _flags |= COMVALUE_SLICED_FLAG; else _flags &= ~COMVALUE_SLICED_FLAG; }
+    // set flag that marks a StringType value as a slice.
+    int sliceoff() const;
+    // offset of a slice's window into its symid string; valid only when sliced().
+    void sliceoff(int off) { _narg = off; }
+    // set a slice's window offset.
+    int slicelen() const;
+    // length of a slice's window into its symid string; valid only when sliced().
+    void slicelen(int len) { _nkey = len; }
+    // set a slice's window length.
+
+    const char* slice_cstr(std::string& scratch);
+    // NUL-terminated text of a StringType value -- string_ptr() narrowed to
+    // [sliceoff(), sliceoff()+slicelen()) when sliced() (#395), otherwise
+    // string_ptr() itself.  Takes a caller-owned std::string rather than a
+    // ComValue member: _stack (comterp.c) grows via dmm_realloc, a raw
+    // realloc of the whole ComValue array, so ComValue must stay a plain,
+    // trivially-relocatable union -- no non-POD member survives that move.
 
     int& pedepth() { return _pedepth; }
     // set/get depth of nesting in post-evaluated blocks of control commands.

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -200,15 +200,18 @@ public:
     // vtable -- confirmed live: print_stack_top(ostream&) below reads one
     // whose vtable resolves to plain AttributeValue's, so calling this
     // virtually on it silently ran the base class's method instead.  Use
-    // slice_cstr() instead anywhere a value might still be a raw _stack
+    // cstr() instead anywhere a value might still be a raw _stack
     // reference.
-    const char* slice_cstr(std::string& scratch);
+    const char* cstr(std::string& scratch);
     // non-virtual counterpart to string_ptr() -- reads the same
     // sliced()/sliceoff()/slicelen() (plain field accessors, unaffected by
     // vtable state) and calls AttributeValue::string_ptr() explicitly, so
     // it's correct regardless of the object's own vtable pointer.  Use
     // this instead of string_ptr() at any call site that isn't provably
-    // working from a genuinely-constructed local copy.
+    // working from a genuinely-constructed local copy.  Named plainly,
+    // not slice_cstr() -- whether the value happens to be a slice is an
+    // implementation detail with no meaning to a caller that just wants
+    // its text.
 
     int& pedepth() { return _pedepth; }
     // set/get depth of nesting in post-evaluated blocks of control commands.

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -39,6 +39,7 @@
 #include <fstream.h>
 #endif
 #include <streambuf>
+#include <string>
 #include <unistd.h>
 
 #define TITLE "IoFunc"
@@ -162,8 +163,9 @@ void PrintFunc::execute() {
   int narg = nargsfixed();
   if (narg==1) {
 
+    std::string scratch;
     if (formatstr.is_string() && !prefixv.is_string()) {
-      out << formatstr.symbol_ptr();
+      out << formatstr.slice_cstr(scratch);
       out.flush();
     }
     else {
@@ -171,8 +173,8 @@ void PrintFunc::execute() {
       if (!formatstr.is_string())
 	out << formatstr;  // which could be arbitrary ComValue
       else
-	out << formatstr.string_ptr();
-	    
+	out << formatstr.slice_cstr(scratch);
+
       if (prefixv.is_string()) out << "\n";
       out.flush();
     }
@@ -309,9 +311,11 @@ void PrintFunc::execute() {
       switch( printval.type() )
       {
       case ComValue::SymbolType:
-      case ComValue::StringType:
-	out_form(out, fbuf, symbol_pntr( printval.symbol_ref()));
+      case ComValue::StringType: {
+	std::string scratch;
+	out_form(out, fbuf, printval.slice_cstr(scratch));
 	break;
+      }
 
       case ComValue::BooleanType:
 	out_form(out, fbuf, printval.boolean_ref());

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -125,7 +125,12 @@ void PrintFunc::execute() {
   static int prefix_symid = symbol_add("prefix");
   ComValue prefixv(stack_key(prefix_symid));
 
-  const char* fstr = formatstr.is_string() ? formatstr.string_ptr() : "nil";
+  /* cstr(), not string_ptr() -- formatstr can itself be a sliced string
+     (#395), and fstr backs fstrptr's scan through the whole multi-value
+     format string below (narg>1 branch); string_ptr() would read the
+     shared parent's full text instead of just the slice's own window. */
+  std::string fscratch;
+  const char* fstr = formatstr.is_string() ? formatstr.cstr(fscratch) : "nil";
   ComValue::comterp(comterp());
 
   streambuf* strmbuf = nil;

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -39,7 +39,6 @@
 #include <fstream.h>
 #endif
 #include <streambuf>
-#include <string>
 #include <unistd.h>
 
 #define TITLE "IoFunc"
@@ -163,9 +162,8 @@ void PrintFunc::execute() {
   int narg = nargsfixed();
   if (narg==1) {
 
-    std::string scratch;
     if (formatstr.is_string() && !prefixv.is_string()) {
-      out << formatstr.slice_cstr(scratch);
+      out << formatstr.string_ptr();
       out.flush();
     }
     else {
@@ -173,7 +171,7 @@ void PrintFunc::execute() {
       if (!formatstr.is_string())
 	out << formatstr;  // which could be arbitrary ComValue
       else
-	out << formatstr.slice_cstr(scratch);
+	out << formatstr.string_ptr();
 
       if (prefixv.is_string()) out << "\n";
       out.flush();
@@ -311,11 +309,9 @@ void PrintFunc::execute() {
       switch( printval.type() )
       {
       case ComValue::SymbolType:
-      case ComValue::StringType: {
-	std::string scratch;
-	out_form(out, fbuf, printval.slice_cstr(scratch));
+      case ComValue::StringType:
+	out_form(out, fbuf, printval.string_ptr());
 	break;
-      }
 
       case ComValue::BooleanType:
 	out_form(out, fbuf, printval.boolean_ref());

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -162,8 +162,9 @@ void PrintFunc::execute() {
   int narg = nargsfixed();
   if (narg==1) {
 
+    std::string scratch;
     if (formatstr.is_string() && !prefixv.is_string()) {
-      out << formatstr.string_ptr();
+      out << formatstr.cstr(scratch);
       out.flush();
     }
     else {
@@ -171,7 +172,7 @@ void PrintFunc::execute() {
       if (!formatstr.is_string())
 	out << formatstr;  // which could be arbitrary ComValue
       else
-	out << formatstr.string_ptr();
+	out << formatstr.cstr(scratch);
 
       if (prefixv.is_string()) out << "\n";
       out.flush();
@@ -309,9 +310,11 @@ void PrintFunc::execute() {
       switch( printval.type() )
       {
       case ComValue::SymbolType:
-      case ComValue::StringType:
-	out_form(out, fbuf, printval.string_ptr());
+      case ComValue::StringType: {
+	std::string scratch;
+	out_form(out, fbuf, printval.cstr(scratch));
 	break;
+      }
 
       case ComValue::BooleanType:
 	out_form(out, fbuf, printval.boolean_ref());

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -133,6 +133,50 @@ void ListAtFunc::execute() {
      either way. */
   (void)rawflag;
 
+  /* str@lo:hi (#395): a coloned 2-element index into a string builds a
+     slice -- a StringType ComValue sharing str's own symid (so its memory
+     stays exactly as allocated, reachable at that symid) with an offset/
+     length window recorded via sliceoff()/slicelen() (comvalue.h) instead
+     of a copy.  lo/hi may have arrived as unresolved symbols (ColonListFunc
+     captures bare identifiers rather than looking them up), so each is run
+     through lookup_symval() here.  hi is exclusive, Go-style -- length is
+     hi-lo, and hi==cap is in bounds (an empty slice at the far end, same
+     as Go's s[len(s):len(s)]).  Not yet supported: writing through a slice
+     (:set/:ins/:del, or the #318 lhs_assign peek below) or slicing a plain
+     list/array -- both fall through to nil for now. */
+  if (listv.is_only_string() && nv.is_type(ComValue::ArrayType) && nv.coloned()) {
+    AttributeValueList* range = nv.array_val();
+    boolean forwrite = comterp()->stack_top(nkeys()+1).lhs_assign();
+    ComValue retval(ComValue::nullval());
+    if (!forwrite && range && range->Number()==2) {
+      ComValue loval(*range->Get(0));
+      ComValue hival(*range->Get(1));
+      loval = comterp()->lookup_symval(loval);
+      hival = comterp()->lookup_symval(hival);
+      if (loval.type()==ComValue::IntType && hival.type()==ComValue::IntType) {
+        int lo = loval.int_val();
+        int hi = hival.int_val();
+        int cap = symbol_len(listv.string_val());
+        if (lo>=0 && hi>=lo && hi<=cap) {
+          retval = ComValue(listv.string_val(), ComValue::StringType);
+          /* the (unsigned int, ValueType) ctor doesn't ref -- unlike the
+             (int, ValueType) one, it has no "used as a StringType
+             constructor" case (attrvalue.c).  Without this, listv's own
+             destructor unrefs the symid this slice still points at when
+             ListAtFunc::execute() returns, and a later allocation can
+             reuse that freed memory out from under the still-live slice. */
+          retval.ref_as_needed();
+          retval.sliceoff(lo);
+          retval.slicelen(hi-lo);
+          retval.sliced(1);
+        }
+      }
+    }
+    reset_stack();
+    push_stack(retval);
+    return;
+  }
+
   /* a list has no position in it, and int_val() answers 0 for one -- so a
      list-valued index used to read as index 0 and hand back the first item,
      a wrong answer wearing a right one's clothes.  A stream of indices does
@@ -279,18 +323,31 @@ void ListAtFunc::execute() {
     }
   } else if (listv.is_string()) {
     const char* str = listv.string_ptr();
-    /* bounds-checked against capacity (symbol_len(), the allocation's own
-       byte count), not strlen() -- a strlen()-based bound made every byte
-       past the first NUL permanently unreachable the moment one landed
-       there (a fresh string(cap) buffer is all NUL, so index 0 was
-       "already past the end" before anything was ever written), even
-       though the underlying allocation still had the room.  nil still
-       means the last logical (strlen()-based) character, unchanged. */
-    int cap = symbol_len(listv.string_val());
-    int nvv = nv.is_nil() ? (int)strlen(str)-1 : nv.int_val();
+    /* a sliced listv (#395) indexes relative to its own window into the
+       shared parent buffer -- base offsets every read/write into it, and
+       cap is the slice's own length rather than the parent's capacity, so
+       indexing a slice can't read or write past its own bound into the
+       parent's neighboring bytes.  Reading or writing still goes through
+       the same shared storage as the parent (str+base), so a write here
+       stays visible through any other slice or the parent itself, same as
+       test 4 (colonslice.comt).  For an ordinary, unsliced string, this is
+       exactly the pre-#395 behavior: bounds-checked against capacity
+       (symbol_len(), the allocation's own byte count), not strlen() -- a
+       strlen()-based bound made every byte past the first NUL permanently
+       unreachable the moment one landed there (a fresh string(cap) buffer
+       is all NUL, so index 0 was "already past the end" before anything
+       was ever written), even though the underlying allocation still had
+       the room. */
+    boolean isslice = listv.sliced();
+    int base = isslice ? listv.sliceoff() : 0;
+    int cap = isslice ? listv.slicelen() : symbol_len(listv.string_val());
+    /* nil means the last logical character -- the slice's own last index
+       when sliced (its length is exact, not NUL-delimited), otherwise the
+       parent's strlen()-based last character, unchanged. */
+    int nvv = nv.is_nil() ? (isslice ? cap-1 : (int)strlen(str)-1) : nv.int_val();
     if(!setflag) {
       if(nvv>=0 && nvv<cap) {
-        ComValue retval(*(str+nvv), ComValue::CharType);
+        ComValue retval(*(str+base+nvv), ComValue::CharType);
         push_stack(retval);
         return;
       }
@@ -300,7 +357,7 @@ void ListAtFunc::execute() {
 	 a write here would edit the symbol out from under all of them (#393).
 	 Reads above stay open to both. */
       if(nvv<cap && nvv>=0) {
-	*((char *)str+nvv) = setv.char_val();
+	*((char *)str+base+nvv) = setv.char_val();
 	ComValue retval(setv);
 	push_stack(retval);
 	return;
@@ -340,7 +397,11 @@ void ListSizeFunc::execute() {
       return;			  
     }
   } else if (listv.is_string() || listv.is_symbol()) {
-    ComValue retval((int)strlen(listv.symbol_ptr()), ComValue::IntType);
+    /* a slice's own length (#395), not its shared parent's -- strlen()
+       would run past the slice's window into whatever the parent holds
+       beyond it. */
+    int len = listv.sliced() ? listv.slicelen() : (int)strlen(listv.symbol_ptr());
+    ComValue retval(len, ComValue::IntType);
     push_stack(retval);
     return;
   } else if (listv.is_object(FuncObj::class_symid())) {

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -156,7 +156,14 @@ void ListAtFunc::execute() {
       if (loval.type()==ComValue::IntType && hival.type()==ComValue::IntType) {
         int lo = loval.int_val();
         int hi = hival.int_val();
-        int cap = symbol_len(listv.string_val());
+        /* slicing a slice (nesting): bound against listv's own window, not
+           the full backing allocation, and compose the new offset onto
+           listv's own -- otherwise a re-slice both exposes whatever the
+           parent holds past listv's own end and reads from the wrong
+           place entirely (sl@0:1 read the parent's own index 0 instead of
+           listv's). */
+        int base = listv.sliced() ? listv.sliceoff() : 0;
+        int cap = listv.sliced() ? listv.slicelen() : symbol_len(listv.string_val());
         if (lo>=0 && hi>=lo && hi<=cap) {
           retval = ComValue(listv.string_val(), ComValue::StringType);
           /* the (unsigned int, ValueType) ctor doesn't ref -- unlike the
@@ -166,7 +173,7 @@ void ListAtFunc::execute() {
              ListAtFunc::execute() returns, and a later allocation can
              reuse that freed memory out from under the still-live slice. */
           retval.ref_as_needed();
-          retval.sliceoff(lo);
+          retval.sliceoff(base+lo);
           retval.slicelen(hi-lo);
           retval.sliced(1);
         }

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -249,24 +249,87 @@ void AddFunc::execute() {
     case ComValue::StringType:
     case ComValue::SymbolType:
         { // braces are work-around for gcc-2.8.1 bug in stack mgmt.
+          /* Go-style append (#396): b's bytes go straight into operand1's
+             own backing symid, in place, when there's room -- no copy at
+             all.  operand1 must be_only_string() (StringType, never
+             SymbolType): a symbol's characters are its identity, shared by
+             every value holding that symid (#393), so writing through one
+             would corrupt everyone else's view.  An ordinary interned
+             string literal is excluded too, with no extra check needed --
+             its symid was sized to hold exactly its own text
+             (symbol_len()==strlen()), zero spare capacity, so the in-place
+             branch below never finds room and falls through to copy on its
+             own.  The in-place result is handed back as a slice
+             (sliceoff()/slicelen(), #395) over operand1's own symid, so a
+             caller holding operand1 at a nonzero sliceoff() doesn't have
+             its result misread from the front of the shared buffer.
+
+             The fallback copy path intentionally still goes through
+             symbol_add() (dedup/intern by content), exactly like the
+             pre-#396 concatenation it replaces -- NOT symbol_new()'s
+             fresh, non-deduping, unfindable-by-text buffer.  Tried
+             symbol_new() with amortized (2x) headroom first, matching
+             #396's memory design note; it broke symadd()/global()'s
+             existing assumption that a StringType's own symid already
+             names a searchable symbol (symadd(global(p1)+global(p2)) --
+             global.comt test 11), since a symbol_new() id is deliberately
+             absent from symbol_find()'s reverse index (see symbol_new()'s
+             own doc comment, symbols.c).  So a plain concat -- not
+             starting from an already-over-allocated string()/strcap()
+             buffer -- gets no free growth headroom and must copy again on
+             its own next append, same as it always did; only appending
+             onto a deliberately over-provisioned string() buffer gets the
+             true zero-copy path above. */
+          std::string scratch1, scratch2;
+          const char* s1 = operand1.cstr(scratch1);
+          int len1 = operand1.sliced() ? operand1.slicelen() : (int)strlen(s1);
+          int base1 = operand1.sliced() ? operand1.sliceoff() : 0;
+          int end1 = base1 + len1;
+          boolean growable = operand1.is_only_string();
+          int cap1 = growable ? symbol_len(operand1.symbol_val()) : 0;
+
           if (operand2.is_string()) {
-            int len1 = strlen(operand1.string_ptr()); 
-            int len2 = strlen(operand2.string_ptr()); 
-            std::vector<char> buffer(len1+len2+1);
-            strcpy(&buffer[0], operand1.string_ptr());
-            strcpy(&buffer[0]+len1, operand2.string_ptr());
-            result.string_ref()  = symbol_add(&buffer[0]);
-	    result.ref_as_needed();
-            // symbol_reference(result.string_val());
+            const char* s2 = operand2.cstr(scratch2);
+            int len2 = operand2.sliced() ? operand2.slicelen() : (int)strlen(s2);
+            if (growable && end1+len2 < cap1) {
+              char* buf = (char*)symbol_pntr(operand1.symbol_val());
+              memcpy(buf+end1, s2, len2);
+              buf[end1+len2] = '\0';
+              result.string_ref() = operand1.symbol_val();
+              result.ref_as_needed();
+              result.sliceoff(base1);
+              result.slicelen(len1+len2);
+              result.sliced(1);
+            } else {
+              int newlen = len1+len2;
+              std::vector<char> vbuf(newlen+1);
+              memcpy(&vbuf[0], s1, len1);
+              memcpy(&vbuf[0]+len1, s2, len2);
+              vbuf[newlen] = '\0';
+              result.string_ref() = symbol_add(&vbuf[0]);
+              result.ref_as_needed();
+              result.sliced(0);
+            }
           } else {
-            int len1 = strlen(operand1.string_ptr()); 
-            std::vector<char> buffer(len1+2);
-            strcpy(&buffer[0], operand1.string_ptr());
-            buffer[len1] = operand2.char_val();
-            buffer[len1+1] = '\0';
-            result.string_ref()  = symbol_add(&buffer[0]);
-	    result.ref_as_needed();
-            // symbol_reference(result.string_val());
+            if (growable && end1+1 < cap1) {
+              char* buf = (char*)symbol_pntr(operand1.symbol_val());
+              buf[end1] = operand2.char_val();
+              buf[end1+1] = '\0';
+              result.string_ref() = operand1.symbol_val();
+              result.ref_as_needed();
+              result.sliceoff(base1);
+              result.slicelen(len1+1);
+              result.sliced(1);
+            } else {
+              int newlen = len1+1;
+              std::vector<char> vbuf(newlen+1);
+              memcpy(&vbuf[0], s1, len1);
+              vbuf[len1] = operand2.char_val();
+              vbuf[newlen] = '\0';
+              result.string_ref() = symbol_add(&vbuf[0]);
+              result.ref_as_needed();
+              result.sliced(0);
+            }
           }
 	}
 	break;

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -293,7 +293,13 @@ void AddFunc::execute() {
             int len2 = operand2.sliced() ? operand2.slicelen() : (int)strlen(s2);
             if (growable && end1+len2 < cap1) {
               char* buf = (char*)symbol_pntr(operand1.symbol_val());
-              memcpy(buf+end1, s2, len2);
+              /* memmove, not memcpy (Greptile, #440): operand2 can share
+                 operand1's own backing symid -- e.g. appending an unsliced
+                 buf onto a nonzero-offset slice of that same buf -- in
+                 which case s2 (read via cstr() above) points into this
+                 very buffer and the [s2,s2+len2) source range can overlap
+                 [buf+end1,buf+end1+len2), which memcpy doesn't allow. */
+              memmove(buf+end1, s2, len2);
               buf[end1+len2] = '\0';
               result.string_ref() = operand1.symbol_val();
               result.ref_as_needed();

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -334,7 +334,13 @@ void SplitStrFunc::execute() {
   if (symvalv.is_string()) {
     AttributeValueList* avl = new AttributeValueList();
     ComValue retval(avl);
-    const char* str = symvalv.symbol_ptr();
+    /* cstr(), not symbol_ptr() -- symvalv can be a slice (#395), and
+       everything below reads the input purely through this one str
+       pointer, walked forward, so this is the only place that needs to
+       change for the whole function to split just the slice's own text
+       instead of its parent's. */
+    std::string scratch;
+    const char* str = symvalv.cstr(scratch);
     const char* strbase = str;
     int len = strlen(str);
     char delim = tokstrv.char_val();

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -269,7 +269,7 @@ not gaps in testing -- do not read `—` as untested.
 | stackkey.comt             | at  list                                              |       — |     — |    — |
 | colonlist.comt            | colonlist at size                                     |       — |     — |    — |
 | string_cap.comt           | string strcap size at @                               |       — |     — |    — |
-| colonslice.comt           | colonlist at size print                               |       — |     — |    — |
+| colonslice.comt           | colonlist at size print eq split                      |       — |     — |    — |
 | print.comt                | print                                                 |      24 |    35 |  69% |
 | parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
 | symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -269,6 +269,7 @@ not gaps in testing -- do not read `—` as untested.
 | stackkey.comt             | at  list                                              |       — |     — |    — |
 | colonlist.comt            | colonlist at size                                     |       — |     — |    — |
 | string_cap.comt           | string strcap size at @                               |       — |     — |    — |
+| colonslice.comt           | colonlist at size print                               |       — |     — |    — |
 | print.comt                | print                                                 |      24 |    35 |  69% |
 | parser.comt               | attrlist(:literal) errmsg postfix class type          |      29 |    39 |  74% |
 | symbol.comt               | ` symadd symid symbol symstr symval symvar strref     |      36 |    42 |  86% |

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -175,5 +175,17 @@ ok=ok&&(b15=="hi there this is a much longer tail that will not fit in the remai
 ok=ok&&(a14=="hi there")
 print("15 grow-path append leaves the original untouched (expect true true): %v %v\n" b15=="hi there this is a much longer tail that will not fit in the remaining capacity" a14=="hi there")
 
+// --- 16: in-place append when operand2 shares operand1's own backing
+//         buffer and the source/destination ranges overlap (Greptile,
+//         #440) -- sl16=buf@0:5 ("hi th") appended with buf itself
+//         ("hi there") writes into buf's own trailing capacity while
+//         reading from buf's own front, an overlapping copy that needs
+//         memmove, not memcpy, to come out correct rather than
+//         corrupted ---
+sl16=buf@0:5
+r16=sl16+buf
+ok=ok&&(r16=="hi thhi there")
+print("16 overlapping append (sl16=buf@0:5, sl16+buf) (expect \"hi thhi there\"): %s\n" r16)
+
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
 //
-// funcs: colonlist at size print eq
+// funcs: colonlist at size print eq split
 //
 // str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
 // own symid (its memory stays exactly where it was allocated, reachable at
@@ -111,6 +111,16 @@ ok=ok&&(sl=="cde")
 ok=ok&&(sl!="abcdefg")
 ok=ok&&(!(sl=="abcdefg"))
 print("9 sl==\"cde\", sl!=\"abcdefg\" (expect true true): %v %v\n" sl=="cde" sl!="abcdefg")
+
+// --- 10: split() reads only the slice's own text, not the parent's --
+//         split(sl) (char mode) and split(:tokstr) (whitespace mode)
+//         both walk the input through a single cstr()-backed pointer,
+//         so one fix (SplitStrFunc, symbolfunc.c) covers both ---
+s4="foo bar baz"
+sl4=s4@4:11
+r10=split(sl4 :tokstr)
+ok=ok&&(size(r10)==2 && r10@0=="bar" && r10@1=="baz")
+print("10 split(sl4 :tokstr), sl4=s4@4:11 (expect {bar,baz}): %v\n" r10)
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -122,5 +122,20 @@ r10=split(sl4 :tokstr)
 ok=ok&&(size(r10)==2 && r10@0=="bar" && r10@1=="baz")
 print("10 split(sl4 :tokstr), sl4=s4@4:11 (expect {bar,baz}): %v\n" r10)
 
+// --- 11: print()'s multi-value format path reads the format string
+//         itself through the slice-aware fstr (Greptile, #440) -- fstr
+//         used to come from string_ptr() (never slice-aware), so a
+//         sliced format string leaked whatever text followed the slice's
+//         own end in the shared parent buffer.  fmt's full text is
+//         "%s!EXTRA" -- fmtsl@0:2 is just "%s", so a correct read of
+//         fmtsl produces "hi" with nothing appended; the pre-fix bug
+//         would have read the parent's full text and appended "!EXTRA"
+//         after substituting %s, giving "hi!EXTRA" instead ---
+fmt="%s!EXTRA"
+fmtsl=fmt@0:2
+r11=print(fmtsl "hi" :str)
+ok=ok&&(r11=="hi")
+print("11 sliced format string, fmtsl=fmt@0:2 (expect hi, not hi!EXTRA): %s\n" print(fmtsl "hi" :str))
+
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,0 +1,75 @@
+// src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
+//
+// funcs: colonlist at size print
+//
+// str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
+// own symid (its memory stays exactly where it was allocated, reachable at
+// that symid -- no copy, no new storage) with an offset/length window
+// recorded on the ComValue itself via sliceoff()/slicelen() (comvalue.h),
+// borrowing the narg/nkey storage a StringType never otherwise needs (see
+// comvalue.h's narg()/nkey() doc -- both read 0 for a StringType, guarding
+// sliced code that repurposes the same fields for offset/length). hi is
+// exclusive, Go-style -- length is hi-lo, and hi==cap is in bounds (an
+// empty slice at the far end, same as Go's s[len(s):len(s)]).
+//
+// Only literal-bound ranges are covered here (s@0:3, not s@lo:hi) -- a bare
+// identifier as the ':' operator's own right-hand operand is always
+// tokenized as a keyword lexeme by the lexer (":hi" reads as a stray
+// keyword, "Unexpected keyword" from the parser) regardless of spacing,
+// the same underlying scanner ambiguity #423 already flagged for a
+// leading colon ("Dec:25"), just showing up on the trailing side too.
+// colonlist(lo hi) -- a plain command call, not the ':' lexeme -- sidesteps
+// it and still captures lo/hi unevaluated the same way (see colonlist.comt
+// test 6/7), so s@colonlist(lo hi) works today for variable bounds; that's
+// left as a documented workaround here rather than a test, since fixing
+// the lexer itself is out of scope for this file.
+//
+// Known gaps, not yet attempted: :set/:ins/:del through a slice (listfunc.c
+// falls back to nil for any coloned index in an lhs_assign context); slicing
+// a plain list/array (only listv.is_only_string() triggers slice logic);
+// slice==string / slice==slice (both fall back to a generic, symid-based
+// comparison today, which is wrong for a slice -- print(x :str) is used
+// below to get a real, comparable, unsliced string out first instead).
+
+ok=true
+
+// --- 1: hi is exclusive, Go-style -- length is hi-lo ---
+ok=ok&&(print("abcdefg"@0:3 :str)=="abc")
+print("1 lo:hi is exclusive of hi (expect abc): %s\n" print("abcdefg"@0:3 :str))
+
+// --- 2: unparenthesized binds tighter than @, no parens needed ---
+s="abcdefg"
+sl=s@2:5
+ok=ok&&(print(sl :str)=="cde")
+print("2 unparenthesized s@2:5 (expect cde): %s\n" print(sl :str))
+
+// --- 3: size() reports the slice's own length, not the parent's ---
+ok=ok&&(size(sl)==3)
+print("3 size of the slice (expect 3): %s\n" size(sl))
+
+// --- 4: the slice shares the parent's backing -- a write through the
+//        parent is visible through a slice taken before the write ---
+s2="wxyzabc"
+sl2=s2@0:3
+at(s2 1 :set 90)
+ok=ok&&(print(sl2 :str)=="wZy")
+print("4 slice sees a write through its parent (expect wZy): %s\n" print(sl2 :str))
+
+// --- 5: hi==cap (the string's own capacity) is in bounds -- an empty
+//        slice at the far end, same as Go's s[len(s):len(s)]; hi>cap
+//        answers nil, same as at()'s own bounds checks ---
+ok=ok&&(size("abc"@3:3)==0)
+ok=ok&&(("abc"@0:5)==nil)
+print("5 hi==cap is an empty slice, hi>cap is nil (expect 0 nil): %s %s\n" size("abc"@3:3) "abc"@0:5)
+
+// --- 6: a slice assigned to a variable keeps its sliced-ness across the
+//        symbol-table round trip -- lookup_symval() (comterp.c) has to
+//        carry sliced()/sliceoff()/slicelen() over explicitly, the same
+//        way it already does for coloned() (#429/Greptile), since
+//        assignval() only ever copies AttributeValue's base fields ---
+v=s@2:5
+ok=ok&&(size(v)==3 && print(v :str)=="cde")
+print("6 a sliced variable keeps its window (expect 3 cde): %s %s\n" size(v) print(v :str))
+
+print("colonslice: %v\n" ok)
+ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -34,7 +34,7 @@
 // fixable here; test 8 pins it as a documented gap rather than a silent one.
 //
 // slice==string DOES work (test 9) -- EqualFunc/NotEqualFunc (boolfunc.c)
-// were fixed to compare text via slice_cstr() for any StringType operand,
+// were fixed to compare text via cstr() for any StringType operand,
 // rather than symbol_val() identity, which only ever stood in correctly
 // for two genuine symbols (interning dedups an ordinary string by content,
 // so identity happened to double as text equality there, but a slice

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
 //
-// funcs: colonlist at size print
+// funcs: colonlist at size print eq
 //
 // str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
 // own symid (its memory stays exactly where it was allocated, reachable at
@@ -26,15 +26,21 @@
 //
 // Known gaps, not yet attempted: :set/:ins/:del through a slice (listfunc.c
 // falls back to nil for any coloned index in an lhs_assign context); slicing
-// a plain list/array (only listv.is_only_string() triggers slice logic);
-// slice==string / slice==slice (both fall back to a generic, symid-based
-// comparison today, which is wrong for a slice -- print(x :str) is used
-// below to get a real, comparable, unsliced string out first instead); a
+// a plain list/array (only listv.is_only_string() triggers slice logic); a
 // slice passed as a function keyword arg or captured free variable loses
 // its sliced()/sliceoff()/slicelen() the same way a colon-list's coloned()
 // does (Greptile, #437) -- AttributeList only ever stores a plain
 // AttributeValue (#438), which has no room for either.  Not independently
-// fixable here; test 7 pins it as a documented gap rather than a silent one.
+// fixable here; test 8 pins it as a documented gap rather than a silent one.
+//
+// slice==string DOES work (test 9) -- EqualFunc/NotEqualFunc (boolfunc.c)
+// were fixed to compare text via slice_cstr() for any StringType operand,
+// rather than symbol_val() identity, which only ever stood in correctly
+// for two genuine symbols (interning dedups an ordinary string by content,
+// so identity happened to double as text equality there, but a slice
+// shares its PARENT's symid, unrelated to its own text).  print(x :str) is
+// still used in most tests below anyway, since that's testing print/
+// string_ptr()'s own correctness, a separate concern from equality's.
 
 ok=true
 
@@ -95,6 +101,16 @@ print("7 nesting: sl3@0:1, sl3@1:3, sl3@0:10 (expect c de nil): %s %s %s\n" prin
 f8=func(print(x :str))
 ok=ok&&(f8(:x s3@2:5)=="abcdef")
 print("8 KNOWN GAP: a sliced :x arg reads as the whole parent (expect abcdef, not cde): %s\n" f8(:x s3@2:5))
+
+// --- 9: slice==string compares the slice's own text, not the parent's,
+//        and not by symid identity (which would always be false -- a
+//        slice's symid is its parent's, never a dedicated one of its own,
+//        even when the slice's text happens to match some other interned
+//        string) ---
+ok=ok&&(sl=="cde")
+ok=ok&&(sl!="abcdefg")
+ok=ok&&(!(sl=="abcdefg"))
+print("9 sl==\"cde\", sl!=\"abcdefg\" (expect true true): %v %v\n" sl=="cde" sl!="abcdefg")
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
 //
-// funcs: colonlist at size print eq split
+// funcs: colonlist at size print eq split string strcap +
 //
 // str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
 // own symid (its memory stays exactly where it was allocated, reachable at
@@ -136,6 +136,44 @@ fmtsl=fmt@0:2
 r11=print(fmtsl "hi" :str)
 ok=ok&&(r11=="hi")
 print("11 sliced format string, fmtsl=fmt@0:2 (expect hi, not hi!EXTRA): %s\n" print(fmtsl "hi" :str))
+
+// --- 12: '+' concatenates a slice's own text, not its parent's, on
+//         either side, and slice+slice too (#396, AddFunc/numfunc.c) --
+//         cstr() reads each operand's own window, so sl+"XYZ" and
+//         "XYZ"+sl only ever see "cde", never "abcdefg" ---
+ok=ok&&(sl+"XYZ"=="cdeXYZ")
+ok=ok&&("XYZ"+sl=="XYZcde")
+ok=ok&&(sl+sl=="cdecde")
+print("12 sl+\"XYZ\", \"XYZ\"+sl, sl+sl (expect cdeXYZ XYZcde cdecde): %s %s %s\n" sl+"XYZ" "XYZ"+sl sl+sl)
+
+// --- 13: '+' with a CharType right operand appends one character,
+//         still reading operand1 through its own slice window ---
+ok=ok&&(sl+'!'=="cde!")
+print("13 sl+'!' char append (expect cde!): %s\n" sl+'!')
+
+// --- 14: appending into a string()/strcap() buffer with spare trailing
+//         capacity writes in place, no copy at all (#396) -- strcap()
+//         stays unchanged (same backing allocation, just more of it
+//         used), and the growth is visible through the ORIGINAL
+//         variable too, since it's the same shared memory -- the same
+//         aliasing tradeoff Go's own append() has when two slices share
+//         a backing array (accepted by design, not a bug) ---
+buf=string(20)
+at(buf 0 :set 'h')
+at(buf 1 :set 'i')
+a14=buf+" there"
+ok=ok&&(a14=="hi there" && strcap(a14)==20 && buf=="hi there")
+print("14 in-place append into string(20) (expect \"hi there\" 20 \"hi there\"): %s %s %s\n" a14 strcap(a14) buf)
+
+// --- 15: once the buffer's spare capacity can't hold the addition,
+//         '+' falls back to copy-and-grow instead of writing past the
+//         end -- the result is correct, and (unlike test 14) the
+//         original is left untouched, since nothing was written
+//         through it ---
+b15=a14+" this is a much longer tail that will not fit in the remaining capacity"
+ok=ok&&(b15=="hi there this is a much longer tail that will not fit in the remaining capacity")
+ok=ok&&(a14=="hi there")
+print("15 grow-path append leaves the original untouched (expect true true): %v %v\n" b15=="hi there this is a much longer tail that will not fit in the remaining capacity" a14=="hi there")
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -40,7 +40,7 @@
 // so identity happened to double as text equality there, but a slice
 // shares its PARENT's symid, unrelated to its own text).  print(x :str) is
 // still used in most tests below anyway, since that's testing print/
-// string_ptr()'s own correctness, a separate concern from equality's.
+// cstr()'s own correctness, a separate concern from equality's.
 
 ok=true
 

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -29,7 +29,12 @@
 // a plain list/array (only listv.is_only_string() triggers slice logic);
 // slice==string / slice==slice (both fall back to a generic, symid-based
 // comparison today, which is wrong for a slice -- print(x :str) is used
-// below to get a real, comparable, unsliced string out first instead).
+// below to get a real, comparable, unsliced string out first instead); a
+// slice passed as a function keyword arg or captured free variable loses
+// its sliced()/sliceoff()/slicelen() the same way a colon-list's coloned()
+// does (Greptile, #437) -- AttributeList only ever stores a plain
+// AttributeValue (#438), which has no room for either.  Not independently
+// fixable here; test 7 pins it as a documented gap rather than a silent one.
 
 ok=true
 
@@ -70,6 +75,26 @@ print("5 hi==cap is an empty slice, hi>cap is nil (expect 0 nil): %s %s\n" size(
 v=s@2:5
 ok=ok&&(size(v)==3 && print(v :str)=="cde")
 print("6 a sliced variable keeps its window (expect 3 cde): %s %s\n" size(v) print(v :str))
+
+// --- 7: nesting -- a colon range applied to an existing slice bounds
+//        against the slice's own window, not the full backing allocation,
+//        and composes onto the slice's own offset (Greptile, #437) --
+//        sl@0:1 used to read the parent's own index 0 ("a") instead of
+//        the slice's index 0 ("c") ---
+s3="abcdef"
+sl3=s3@2:5
+ok=ok&&(print(sl3@0:1 :str)=="c")
+ok=ok&&(print(sl3@1:3 :str)=="de")
+ok=ok&&((sl3@0:10)==nil)
+print("7 nesting: sl3@0:1, sl3@1:3, sl3@0:10 (expect c de nil): %s %s %s\n" print(sl3@0:1 :str) print(sl3@1:3 :str) sl3@0:10)
+
+// --- 8: KNOWN GAP, pinned so a future #438 fix is a deliberate change
+//        here too, not a silent one -- a slice passed as a function
+//        keyword arg loses its sliced()-ness (see the file header) and
+//        reads back as the whole parent string, not its own window ---
+f8=func(print(x :str))
+ok=ok&&(f8(:x s3@2:5)=="abcdef")
+print("8 KNOWN GAP: a sliced :x arg reads as the whole parent (expect abcdef, not cde): %s\n" f8(:x s3@2:5))
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -53,6 +53,10 @@ if(run("./string_cap.comt")
   :then print("pass: string_cap\n")
   :else print("FAIL: string_cap\n");topok=false)
 
+if(run("./colonslice.comt")
+  :then print("pass: colonslice\n")
+  :else print("FAIL: colonslice\n");topok=false)
+
 if(run("./print.comt")
   :then print("pass: print\n")
   :else print("FAIL: print\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "4019ad04"
+#define PATCH_KEY "60cf95f8"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -124,6 +124,7 @@ Print a usage summary of all the invocation modes above and exit.
     ..         iterate        90          L-to-R      binary
     **         repeat         80          L-to-R      binary
     %%         replay         79          L-to-R      binary
+    :          colonlist      78          L-to-R      binary
     @          at             77          L-to-R      binary
     ,,         concat         75          L-to-R      binary
     *          next           71          R-to-L      unary-prefix
@@ -231,11 +232,13 @@ Print a usage summary of all the invocation modes above and exit.
  
  lst=list([lst|strm|val|fileobj|pipeobj) :strmlst :attr :size n) -- create list, copy list, or convert stream
 
- val=at(lst|attrlst|str n :set val :ins val :del) -- return (or set, insert after, or delete) nth item in a list or string
+ val=at(lst|attrlst|str n|lo:hi :set val :ins val :del :raw) -- return (or set, insert after, or delete) nth item in a list or string
    (a nil n means the last item, reading or writing)
    (binary @: lst@n is at(lst n); lst@n=val writes through to a plain list or a string)
+   (str@lo:hi is a string slice: shares str's own storage, hi exclusive, writable through the parent; :set/:ins/:del not yet supported through a slice)
+   (:raw currently a no-op, reserved for a coloned lo:hi index)
 
- num=size(lst|attrlst|str) -- return size of a list (or string)
+ num=size(lst|attrlst|str) -- return size of a list (or string, or a slice's own length)
 
  val=index(lst|str val|char|str :last :all :substr) -- return index of value (or char or string) in list (or string), nil if not found.
 


### PR DESCRIPTION
## What this PR is

`str@lo:hi` string slicing (#395) -- the core feature of this fork's driving goal, Go-style slices in comterp. This is *not* a small delta anymore: what started as "bring #437's already-reviewed commits into master" (#437's base was `colonlist-command`, which had already merged to master via #429 by the time #437 landed, so its two commits never made it there) turned into a second, much more thorough review pass, since Greptile kept finding real problems in the original design and each fix needed its own verification. 13 commits total; the history is worth reading in order if you want the reasoning, not just the diff.

## The feature

A coloned 2-element index into a string (`str@lo:hi`, via #429's `:` operator) builds a slice: an ordinary `StringType` `ComValue` sharing the parent's own symid -- no copy, no new storage type -- with an offset/length window recorded via `sliceoff()`/`slicelen()`, which repurpose the `narg`/`nkey` fields a `StringType` value never otherwise needs. `hi` is exclusive, Go-style. A third field, `blocksz()` (repurposing `_nids`), is pure storage for a future non-byte-granular slice -- no consumer yet.

## What Greptile actually caught, and what changed as a result

- **`coloned()` (the `:` operator's own tag, #429) didn't survive every code path that reads a variable** -- `lookup_symval`'s `_alist` (function-frame) and attached-attribute branches lost it, the same way `sliced()` would later. Fixing that first pass introduced a real memory-safety bug (casting a plain `AttributeValue*` to `ComValue*` and reading past the real object's allocation) -- caught, traced, fixed properly (no cast, since there's nothing valid to recover on those paths; #438 tracks the actual fix).
- **Nested slices had broken bounds** -- `sl@0:1` on an already-sliced `sl` read the *parent's* index 0, not the slice's own, because the bounds check and offset math didn't account for `sl` itself being a window rather than a full string. Fixed by composing offsets and bounding against the slice's own length when nesting.
- **`==`/`!=` on a sliced string compared wrong** -- `sl=="cde"` was `false` even though `sl` printed as `"cde"`, because string equality shortcut to `symbol_val()` (symid) identity, which is only valid for two genuine symbols or two ordinary (interned, deduped-by-content) strings -- a slice shares its *parent's* symid, unrelated to its own text. Fixed in `EqualFunc`/`NotEqualFunc`.
- **A `string_ptr()`-virtual-dispatch experiment was tried and reverted.** Made `AttributeValue::string_ptr()` virtual so `ComValue`'s slice-aware override would apply to every existing caller automatically. Turned out the *common* pattern in this codebase -- `ComValue& x = stack_arg(n)`, a raw reference into `_stack`, not a genuinely-constructed local copy -- is exactly the case where that's unsafe (`_stack` grows via a raw `dmm_realloc`, and a raw element's vtable pointer doesn't reliably resolve to `ComValue`'s own; confirmed live via lldb, wrong answer, no crash). Reverted to plain/non-virtual; `ComValue::cstr(std::string& scratch)` is now the one explicit, always-correct accessor, migrated into call sites one at a time as they're found to need it (`print()`, `==`/`!=`, `split()`, and print's own format-string scan, each verified live before moving to the next).
- **`split()` and `print()`'s format-string handling both read through the whole parent string, ignoring the slice window** -- both fixed via `cstr()`; `substr()` deliberately left untouched (it's a proto-slice already -- makes a copy that gives you a portion of the input, the same shape this feature generalizes into a zero-copy view -- not meant to become slice-view-aware itself).

## Known, deliberately-scoped-out gaps (pinned by tests, not silently missing)

- `:set`/`:ins`/`:del` through a slice
- Slicing a plain list/array (only strings trigger slice logic)
- A slice passed as a function keyword arg or captured free variable loses its `sliced()`-ness (#438 -- `AttributeList` only ever stores a plain `AttributeValue`, no room for any `ComValue`-only field; needs `AttributeList` itself widened, out of scope here)
- String concatenation (`+`), `index()`, and ordering comparisons (`<`/`>`/`<=`/`>=`) still read via the non-slice-aware path -- same `cstr()` migration, not yet done
- Variable-bound ranges (`s@lo:hi` with bare identifiers) aren't reachable through the `:` operator itself yet -- `:hi` always tokenizes as a keyword lexeme regardless of spacing (#423); `s@colonlist(lo hi)` works today as a command-call workaround

## Test plan

- [x] `colonslice.comt`, 11 tests, covering inclusive/exclusive bounds, `size()`, write-through-parent visibility, out-of-bounds/`hi==cap`, slice-ness surviving variable assignment, nesting, `==`/`!=`, `split()`, and the sliced-format-string case
- [x] Full `run_all.comt` suite green throughout, re-verified after every fix in this history (including two real regressions this PR itself introduced and then caught before landing: a stack-imbalance bug from an early, over-broad `lookup_symval` change, and the `string_ptr()`-virtual-dispatch issue above)
- [x] `comterp.1` updated: `:` operator added to the OPERATOR TABLE, `at()`/`@`'s entry documents `:raw` and `str@lo:hi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
