### PR TITLE
kidmo: four fourth graders at a table, and a drawmo mode that tests them

### DIFF
--- a/src/drawserv_/examples/kid.comt
+++ b/src/drawserv_/examples/kid.comt
@@ -78,14 +78,14 @@ kid=(
 /* only when there is nothing here yet: with -comt kid.comt the pane loads this
    at startup, and kidmo loads it again over its own connection to drive from --
    two loads, and without this, two welcome creatures */
-if(size(children())==0 :then kid.animal(:x 300 :y 220 :c kid.colour))
+if(size(children())==0 && nowelcome!=true :then kid.animal(:x 300 :y 220 :c kid.colour))
 
 if(quiet!=true :then
   print("\n===============================================\n");
   print("   YOU ARE A FOURTH GRADER WITH A DRAWSERV\n");
-  print("   That grey creature is kid.animal() -- and\n");
-  print("   anything you draw goes to everyone you are\n");
-  print("   linked to.  Try typing:\n");
+  print("   That grey creature was created by kid.animal()\n");
+  print("   -- and anything you draw goes to everyone you\n");
+  print("   are linked to.  Try typing:\n");
   print("       kid.play(:n 3)\n");
   print("       kid.colour=\"#DD3333\"\n");
   print("       kid.adventurer(:x 200 :y 120 :c kid.colour)\n");

--- a/src/drawserv_/examples/kid.comt
+++ b/src/drawserv_/examples/kid.comt
@@ -41,10 +41,13 @@ kid=(
   )
 
   // kid.play(:n 6) -- draw n things, pausing between them.  The pause is the
-  // point: a fourth grader draws at mouse speed, not at socket speed.
+  // point: a fourth grader draws at mouse speed, not at socket speed.  Bare
+  // kid.play() draws one: an omitted keyword formal is nil, and i<nil is nil
+  // rather than true, so the loop would not run a single pass.
   :play func(
+    cnt=if(n==nil :then 1 :else n);
     i=0;
-    while(i<n
+    while(i<cnt
       xx=60+int(rand(0,520));
       yy=50+int(rand(0,300));
       pick=int(rand(0,2.99));

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -28,7 +28,13 @@
 /* kid.comt sits beside this script, so find it from arg(0) rather than from
    wherever you happened to be standing when you typed kidmo.  The kids need
    this too, and more than kidmo does: they are handed the path over a socket
-   and resolve it against their own working directory. */
+   and resolve it against their own working directory.
+
+   The shell resolves PATH before execve, so even a bare "kidmo" reaches us as
+   an absolute path.  substr() keeps everything up to but not including the
+   last slash, and the "%s/kid.comt" below supplies the separator:
+     /opt/ivtools/src/drawserv_/examples/kidmo -> /opt/.../examples/kid.comt
+     ./kidmo                                   -> ./kid.comt */
 kidmo_slash=index(arg(0) "/" :last)
 kidmo_dir=if(kidmo_slash!=nil :then substr(arg(0) kidmo_slash) :else ".")
 kid_file=print("%s/kid.comt" kidmo_dir :str)
@@ -242,7 +248,8 @@ print("kidmo: hub holds %v links, everyone knows %v sessions\n" remote(e1 "size(
 kid1=(
   :name "Todd" :colour "#DD3333" :socket k1
   :draw func( global(kid1_done)=false;
-    remote(kid1.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid1_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid1.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid1_done)=true%c)" cnt 34 34 callback_port 34 34 :str)); cnt)
   :one func( global(nrect)=global(nrect)+1;
     remote(kid1.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
     global(nrect))
@@ -250,7 +257,8 @@ kid1=(
 kid2=(
   :name "Mia" :colour "#3366DD" :socket k2
   :draw func( global(kid2_done)=false;
-    remote(kid2.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid2_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid2.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid2_done)=true%c)" cnt 34 34 callback_port 34 34 :str)); cnt)
   :one func( global(nrect)=global(nrect)+1;
     remote(kid2.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
     global(nrect))
@@ -258,7 +266,8 @@ kid2=(
 kid3=(
   :name "Sam" :colour "#22AA55" :socket k3
   :draw func( global(kid3_done)=false;
-    remote(kid3.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid3_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid3.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid3_done)=true%c)" cnt 34 34 callback_port 34 34 :str)); cnt)
   :one func( global(nrect)=global(nrect)+1;
     remote(kid3.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
     global(nrect))
@@ -266,7 +275,8 @@ kid3=(
 kid4=(
   :name "Ana" :colour "#CC7722" :socket k4
   :draw func( global(kid4_done)=false;
-    remote(kid4.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid4_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid4.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid4_done)=true%c)" cnt 34 34 callback_port 34 34 :str)); cnt)
   :one func( global(nrect)=global(nrect)+1;
     remote(kid4.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
     global(nrect))
@@ -284,11 +294,12 @@ mia=kid2
 sam=kid3
 ana=kid4
 
-all=func( kid1.draw(:n n);
-  if(nkids>1 :then kid2.draw(:n n));
-  if(nkids>2 :then kid3.draw(:n n));
-  if(nkids>3 :then kid4.draw(:n n));
-  n)
+all=func( cnt=if(n==nil :then 1 :else n);
+  kid1.draw(:n cnt);
+  if(nkids>1 :then kid2.draw(:n cnt));
+  if(nkids>2 :then kid3.draw(:n cnt));
+  if(nkids>3 :then kid4.draw(:n cnt));
+  cnt)
 
 wait_all=func(
   cnt=0;

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -1,0 +1,335 @@
+#! /usr/bin/env comterp_listen
+#
+# kidmo -- sit four fourth graders round a table, each with a drawserv of their
+# own, all linked, and leave you at the prompt to play with them.
+#
+//   kidmo                     // then, at the (comt) prompt it leaves you at:
+//   todd.draw()               // Todd draws something he likes
+//   mia.draw(:n 3)            // Mia draws three things she likes
+//   all(:n 2)                 // everyone draws two
+//   wait_all()                // block until they have all reported done
+//   look()                    // what each table holds
+//   bye()                     // send them home
+//
+// Two sockets per kid, both opened once and kept.  The kids were written to
+// with :nowait once, so that all four drew at once rather than taking turns.
+// That was wrong: :nowait skips reading the answer, which is only safe when
+// something else is reading that socket, and nothing was -- a comterp socket()
+// is a bare stream with no handler, so every reply piled up unread.  They are
+// asked for their answers now, which costs the simultaneity and is the honest
+// version until there is a handler to give it back.  :nowait is left only on
+// exit, which sends no reply for anyone to read.
+//
+// The kids report back the way drawserv's own AckBackHandler does -- over a
+// separate path -- which here is the listen port comterp_listen gives us, so a
+// kid finishing sets a global we can wait on.  Questions that are about the
+// node rather than the connection (the canvas) go down a throwaway socket.
+
+/* kid.comt sits beside this script, so find it from arg(0) rather than from
+   wherever you happened to be standing when you typed kidmo.  The kids need
+   this too, and more than kidmo does: they are handed the path over a socket
+   and resolve it against their own working directory. */
+kidmo_slash=index(arg(0) "/" :last)
+kidmo_dir=if(kidmo_slash!=nil :then substr(arg(0) kidmo_slash) :else ".")
+kid_file=print("%s/kid.comt" kidmo_dir :str)
+if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
+  arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
+    print("kidmo  four fourth graders at a table, each with a drawserv\n\n");
+    print("Usage:  kidmo [--kids n] [--draw n] [--help]\n");
+    print("  Run it from anywhere -- it reads the kid.comt beside it.  It brings\n");
+    print("  drawservs up, pulls three chairs to the one at the head of the table,\n");
+    print("  hands each of them the script and a crayon, and leaves you at the\n");
+    print("  comterp prompt with a model of each kid:\n\n");
+    print("    todd.draw()          Todd draws something he likes\n");
+    print("      (todd is kid1, mia kid2, sam kid3, ana kid4 -- a kid who is\n");
+    print("       not at the table is nil)\n");
+    print("    todd.one()           Todd draws one plain rectangle\n");
+    print("    mia.draw(:n 3)       Mia draws three things she likes\n");
+    print("    all(:n 2)            everyone draws two\n");
+    print("    wait_all()           until they have all reported done\n");
+    print("    look()               what each table is holding\n");
+    print("    bye()                send them home\n\n");
+    print("--kids [n]\t\thow many sit down (1-4, default 4)\n");
+    print("--draw [n]\t\thow many things each draws before the prompt\n");
+    print("\t\t\t(default 3; 0 for an empty canvas, welcome and all)\n");
+    print("--help\t\t\tprint this help message\n\n");
+    print("  What a hero or an animal looks like is the kid's own business, in\n");
+    print("  kid.comt on their machine -- kidmo only ever asks for something\n");
+    print("  they like.\n");
+    exit(0))
+
+callback_port=int(arg(1))
+
+/* --kids and --draw dial the table down to a case small enough to reason about
+   and then back up: two kids drawing one thing each is four graphics and one
+   link, where the default is four kids, three links and a creature's worth of
+   shapes before you have typed anything.  --draw also takes the welcome creature
+   off, so the canvas holds exactly what was asked for and nothing else. */
+nkids=4
+ndraw=-1
+global(nrect)=0
+for(i=2 i<narg() i++
+  switch(substr(arg(i) 2 :after)
+    :kids if(i+1>=narg() || substr(arg(i+1) 2)=="--" :then continue);i++;nkids=int(arg(i))
+    :draw if(i+1>=narg() || substr(arg(i+1) 2)=="--" :then continue);i++;ndraw=int(arg(i))
+    :default print("kidmo:  Unknown argument %s\n" arg(i) :err)))
+if(nkids<1 :then nkids=1)
+if(nkids>4 :then nkids=4)
+/* Ports the way drawmo finds them -- probe, and step up by ten until both the
+   comdraw port and the import port below it are free -- so a second kidmo, a
+   drawmo run, or yesterday's drawserv that never quite died cannot wedge the
+   demo before it starts.  The ones actually chosen get printed below, since a
+   demo you want to poke at from another window has to say where the kids are. */
+have_lsof=shell("which lsof > /dev/null 2>&1")==0;
+have_nc=shell("which nc > /dev/null 2>&1")==0;
+port_probe=if(have_lsof :then
+  "lsof -i :%d > /dev/null 2>&1"
+:else if(have_nc :then
+  "nc -z 127.0.0.1 %d > /dev/null 2>&1"
+:else
+  "false"));
+
+find_open_port=func(
+  port=base_port;
+  while(shell(print(port_probe port :str))==0 ||
+        shell(print(port_probe port-1 :str))==0
+    port=port+10);
+  port)
+
+kill_port=func(
+  if(have_lsof :then
+    shell(print("kill $(lsof -ti :%d) > /dev/null 2>&1" kill_port_num :str))
+  :else
+    shell(print("fuser -k %d/tcp > /dev/null 2>&1" kill_port_num :str))))
+
+p1=find_open_port(:base_port 21002)
+p2=find_open_port(:base_port 31002)
+p3=find_open_port(:base_port 41002)
+p4=find_open_port(:base_port 51002)
+kid_ports=(p1,p2,p3,p4)
+kid_cols=("#DD3333","#3366DD","#22AA55","#CC7722")
+
+/* Launch, each kid calling back when it is up -- no guessing at a settle.
+   -comt gives every kid an inline comterp pane in their own window: with
+   -stdin_off there is no terminal REPL, so that pane is the only way to ask a
+   kid something at the kid, rather than over a socket from here.  Type
+   grid(:table) or select(:all) straight into the window of whichever one is
+   behaving oddly.
+
+   Asked for only if this drawserv has it: an older one does not merely ignore
+   the option, it comes up and then exits, and four kids that die at birth look
+   exactly like four kids taking their time. */
+have_comt=shell("drawserv -help 2>&1 | grep -q '^-comt'")==0
+/* dots rather than \[file\]: a backslash does not survive comterp's string
+   parser into the shell, and the bracket then reads as a character class that
+   matches nothing here -- which quietly reported no file support at all */
+/* each kid's drawserv used to go to /dev/null, which is a poor place to keep
+   the grant traffic when the question is why a graphic will not select.  One
+   file per kid, named by the port so two kidmos do not write to the same one. */
+log_dir="/tmp"
+
+have_comtfile=shell("drawserv -help 2>&1 | grep -q '^-comt .file.'")==0
+/* --draw 0 wants an empty canvas, and the welcome creature cannot be talked out
+   of it from this end: the pane loads kid.comt in its own interpreter, which
+   never sees a nowelcome set on the driving connection, one connection not
+   being able to see another's variables.  Nor can it be cleared afterwards --
+   each kid holds its own creature and a select() from one node is refused the
+   rest.  So the pane loads a two-line wrapper instead, which sets the flag and
+   then runs kid.comt: the greeting still prints and kid.play is still there to
+   call, only the creature is missing, which is what was asked for. */
+pane_file=kid_file
+if(ndraw==0 :then
+  pane_file=print("%s/kidmo-nowelcome.comt" log_dir :str);
+  shell(print("echo 'nowelcome=true' > %s" pane_file :str));
+  shell(print("echo 'run(%c%s%c)' >> %s" 34 kid_file 34 pane_file :str)))
+
+comt_flag=if(have_comtfile :then print("-comt %s" pane_file :str)
+         :else if(have_comt :then "-comt" :else ""))
+if(!have_comt :then
+  print("kidmo: this drawserv has no -comt, so the kids get no pane\n" :err)
+:else if(!have_comtfile :then
+  print("kidmo: this drawserv takes -comt but not a file after it, so the pane\n" :err);
+  print("       comes up empty -- type run(\"kid.comt\") in it yourself\n" :err)))
+/* one by one rather than in the loop: global() wants a symbol, and
+   global(print("kid%d_up" ...)) assigns to nothing at all -- silently, bar a
+   warning, so the four of these were never being cleared */
+global(kid1_up)=false
+global(kid2_up)=false
+global(kid3_up)=false
+global(kid4_up)=false
+
+/* a chair nobody sat in is up and done, so every four-way wait below reads
+   correctly without knowing how many kids there are */
+if(nkids<4 :then global(kid4_up)=true;global(kid4_done)=true)
+if(nkids<3 :then global(kid3_up)=true;global(kid3_done)=true)
+if(nkids<2 :then global(kid2_up)=true;global(kid2_done)=true)
+
+j=0
+while(j<nkids
+  p=at(kid_ports j);
+  shell(print("drawserv -comdraw %d -import %d -stdin_off %s -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(kid%d_up)=true\\\")\" > %s/kidmo-%d.log 2>&1 &" p p-1 comt_flag callback_port j+1 log_dir p :str));
+  j=j+1)
+print("kidmo: %d drawserv(s) starting, logs in %s/kidmo-<port>.log\n" nkids log_dir :err)
+
+cnt=0
+while((!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up)) && cnt<120
+  update(500000);cnt++)
+if(!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up) :then
+  print("kidmo: FAILED -- not every kid came up.  Is drawserv on PATH, and does\n" :err);
+  print("       it accept the options above?  An option it does not know makes\n" :err);
+  print("       it exit at startup.\n" :err);
+  exit(1))
+print("kidmo: all %d answered\n" nkids :err)
+
+/* Two connections per kid, both opened once and kept.  The kids are written to
+   and asked for their answer, so nothing accumulates on either.  The eyes never
+   learn the kid -- one connection cannot see another's definitions -- but they
+   do not need to: they
+   only ask about the canvas, which belongs to the node rather than to any
+   connection.  look() is a snapshot, so a kid's shapes may still be in flight
+   to the others when it is called. */
+k1=socket("127.0.0.1" at(kid_ports 0))
+k2=if(nkids>1 :then socket("127.0.0.1" at(kid_ports 1)) :else nil)
+k3=if(nkids>2 :then socket("127.0.0.1" at(kid_ports 2)) :else nil)
+k4=if(nkids>3 :then socket("127.0.0.1" at(kid_ports 3)) :else nil)
+kids=(k1,k2,k3,k4)
+e1=socket("127.0.0.1" at(kid_ports 0))
+e2=if(nkids>1 :then socket("127.0.0.1" at(kid_ports 1)) :else nil)
+e3=if(nkids>2 :then socket("127.0.0.1" at(kid_ports 2)) :else nil)
+e4=if(nkids>3 :then socket("127.0.0.1" at(kid_ports 3)) :else nil)
+eyes=(e1,e2,e3,e4)
+
+/* the other chairs pull up to the one at the head of the table */
+j=1
+while(j<nkids
+  remote(at(eyes j) print("drawlink(%c127.0.0.1%c %d)" 34 34 at(kid_ports 0) :str));
+  usleep(3000000);
+  j=j+1)
+
+/* Each kid is taught down the connection that will later be told to play, and
+   that connection is then kept for good.  -runfile looks like it should do this
+   at startup and does not: the names load, but funcs defined in the startup
+   interpreter draw nothing when called from a connection.  Connections cannot
+   see each other's definitions either, so the eyes know nothing of kid -- which
+   is fine, they only ever ask about the canvas, which belongs to the node. */
+j=0
+while(j<nkids
+  /* quiet: this connection loads the kid to drive it, not to read it.  The
+     greeting is printed plainly so it reaches the pane, and plain output over a
+     socket lands in the reply stream, putting every later question one behind */
+  remote(at(kids j) "quiet=true");
+  if(ndraw>=0 :then remote(at(kids j) "nowelcome=true"));
+  remote(at(kids j) print("run(%c%s%c)" 34 kid_file 34 :str));
+  remote(at(kids j) print("kid.colour=%c%s%c" 34 at(kid_cols j) 34 :str));
+  remote(at(kids j) print("srand(%d)" 11+j*7 :str));
+  j=j+1)
+print("kidmo: hub holds %v links, everyone knows %v sessions\n" remote(e1 "size(drawlink(:table))") remote(e1 "size(sid(:table))") :err)
+
+/* A model of each kid: name, crayon, the socket he is on, and the things we
+   can ask of him.  The funcs are defined inline because naming a func fires
+   it niladically -- (:draw todd_draw) would store the nil that calling it
+   returned -- and each refers to its own object by name, the way zoomap's
+   zoo.flash() does from inside zoo. */
+
+kid1=(
+  :name "Todd" :colour "#DD3333" :socket k1
+  :draw func( global(kid1_done)=false;
+    remote(kid1.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid1_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid1.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+kid2=(
+  :name "Mia" :colour "#3366DD" :socket k2
+  :draw func( global(kid2_done)=false;
+    remote(kid2.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid2_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid2.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+kid3=(
+  :name "Sam" :colour "#22AA55" :socket k3
+  :draw func( global(kid3_done)=false;
+    remote(kid3.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid3_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid3.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+kid4=(
+  :name "Ana" :colour "#CC7722" :socket k4
+  :draw func( global(kid4_done)=false;
+    remote(kid4.socket print("kid.play(:n %d);remote(%c127.0.0.1%c %d %cglobal(kid4_done)=true%c)" n 34 34 callback_port 34 34 :str)); n)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid4.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+
+/* The kids are numbered kid1..kid<n>; the names are what you call them by.  A
+   chair nobody sat in is nil rather than a model with a dead socket in it, so
+   asking after a kid who is not at the table says so rather than hanging on a
+   connection that was never made. */
+if(nkids<2 :then kid2=nil)
+if(nkids<3 :then kid3=nil)
+if(nkids<4 :then kid4=nil)
+todd=kid1
+mia=kid2
+sam=kid3
+ana=kid4
+
+all=func( kid1.draw(:n n);
+  if(nkids>1 :then kid2.draw(:n n));
+  if(nkids>2 :then kid3.draw(:n n));
+  if(nkids>3 :then kid4.draw(:n n));
+  n)
+
+wait_all=func(
+  cnt=0;
+  while((!global(kid1_done) || !global(kid2_done) || !global(kid3_done) || !global(kid4_done)) && cnt<120
+    update(500000);cnt++);
+  cnt)
+
+look=func(
+  j=0;
+  while(j<nkids
+    print("  %v canvas=%v held=%v\n" at(kid_cols j)
+      remote(at(eyes j) "size(children())") remote(at(eyes j) "size(select())") :err);
+    j=j+1);
+  0)
+
+/* ask them to go home, then insist: a kid mid-something may never get to it */
+bye=func(
+  remote(k1 "exit" :nowait);
+  if(nkids>1 :then remote(k2 "exit" :nowait));
+  if(nkids>2 :then remote(k3 "exit" :nowait));
+  if(nkids>3 :then remote(k4 "exit" :nowait));
+  usleep(2000000);
+  j=0;
+  while(j<nkids
+    p=at(kid_ports j);
+    /* the process, not the port: a port sits in TIME_WAIT after the drawserv
+       on it has already gone, and probing that reports a kid still at the
+       table who left a second ago */
+    if(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" p :str))==0 :then
+      print("kidmo: kid %d would not go home, sending them\n" j+1 :err);
+      kill_port(:kill_port_num p);kill_port(:kill_port_num p-1));
+    j=j+1);
+  0)
+
+/* a nametag apiece, so you can tell whose window is whose -- and since
+   everything distributes, every table ends up showing the whole class */
+nametag=func(
+  remote(at(kids who) print("text(%d,20 %c%s%c)" 60+who*150 34 nm 34 :str));
+  remote(at(kids who) print("colorsrgb(%c%s%c %c#FFFFFF%c)" 34 at(kid_cols who) 34 34 34 :str));
+  nm)
+nametag(:who 0 :nm "Todd")
+if(nkids>1 :then nametag(:who 1 :nm "Mia"))
+if(nkids>2 :then nametag(:who 2 :nm "Sam"))
+if(nkids>3 :then nametag(:who 3 :nm "Ana"))
+
+print("kidmo: Todd %v, Mia %v, Sam %v, Ana %v\n" p1 p2 p3 p4 :err)
+print("kidmo: ready -- todd.draw()  mia.draw(:n 3)  all(:n 2)  wait_all()  look()  bye()\n" :err)
+
+/* what they draw before you get the prompt.  --draw 0 leaves the canvas empty
+   -- with the welcome creature already off, that is a table of kids who have
+   drawn nothing, which is where to start when something is going wrong. */
+if(ndraw<0 :then all(:n 3) :else if(ndraw>0 :then all(:n ndraw)))

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -38,6 +38,24 @@
 kidmo_slash=index(arg(0) "/" :last)
 kidmo_dir=if(kidmo_slash!=nil :then substr(arg(0) kidmo_slash) :else ".")
 kid_file=print("%s/kid.comt" kidmo_dir :str)
+
+/* That path crosses two parsers on its way to a kid: a shell command line, and
+   a comterp string literal inside the run() we send down the socket.  A quote
+   or a backslash survives neither -- and a single quote pasted into a shell
+   command is an injection rather than merely a breakage, running as whoever
+   started kidmo.  Escaping cleanly through both parsers is more machinery than
+   an example wants to carry, so refuse the path and say which character. */
+badchar=nil
+if(index(kid_file print("%c" 39 :str))!=nil :then badchar="a single quote")
+if(index(kid_file print("%c" 34 :str))!=nil :then badchar="a double quote")
+if(index(kid_file print("%c" 92 :str))!=nil :then badchar="a backslash")
+if(badchar!=nil :then
+  print("kidmo: the path to this script contains %s:\n" badchar :err);
+  print("         %s\n" kid_file :err);
+  print("       it reaches the kids through a shell command and a comterp\n" :err);
+  print("       string literal, and survives neither.  Put the examples\n" :err);
+  print("       somewhere without quotes in the name.\n" :err);
+  exit(1))
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("kidmo  four fourth graders at a table, each with a drawserv\n\n");
@@ -173,7 +191,7 @@ if(nkids<2 :then global(kid2_up)=true;global(kid2_done)=true)
 j=0
 while(j<nkids
   p=at(kid_ports j);
-  shell(print("drawserv -comdraw %d -import %d -stdin_off %s -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(kid%d_up)=true\\\")\" > %s/kidmo-%d.log 2>&1 &" p p-1 comt_flag callback_port j+1 log_dir p :str));
+  shell(print("drawserv -comdraw %d -import %d -stdin_off %s -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(kid%d_up)=true\\\")\" > %s/kidmo-%d.log 2>&1 & echo $! > %s/kidmo-%d.pid" p p-1 comt_flag callback_port j+1 log_dir p log_dir p :str));
   j=j+1)
 print("kidmo: %d drawserv(s) starting, logs in %s/kidmo-<port>.log\n" nkids log_dir :err)
 
@@ -186,11 +204,15 @@ if(!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up) 
   print("       it exit at startup.\n" :err);
   /* and take down the ones that did: leaving them holding ports means the next
      attempt steps past those ports and the desk fills with drawservs nobody
-     asked for */
+     asked for.  By pid rather than by port -- a kid that died before binding
+     holds no port to find it by, and a port we probed as free a moment ago may
+     since have been taken by somebody who is not ours.  The pid came from $!
+     at launch; check it is still a drawserv before killing it, in case the
+     number has been recycled. */
   j=0;
   while(j<nkids
-    kill_port(:kill_port_num at(kid_ports j));
-    kill_port(:kill_port_num at(kid_ports j)-1);
+    shell(print("pid=$(cat %s/kidmo-%d.pid 2>/dev/null); [ -n \"$pid\" ] && ps -p $pid -o comm= 2>/dev/null | grep -q drawserv && kill $pid > /dev/null 2>&1; rm -f %s/kidmo-%d.pid"
+      log_dir at(kid_ports j) log_dir at(kid_ports j) :str));
     j=j+1);
   exit(1))
 print("kidmo: all %d answered\n" nkids :err)

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -140,10 +140,10 @@ have_comtfile=shell("drawserv -help 2>&1 | grep -q '^-comt .file.'")==0
 pane_file=kid_file
 if(ndraw==0 :then
   pane_file=print("%s/kidmo-nowelcome.comt" log_dir :str);
-  shell(print("echo 'nowelcome=true' > %s" pane_file :str));
-  shell(print("echo 'run(%c%s%c)' >> %s" 34 kid_file 34 pane_file :str)))
+  shell(print("echo 'nowelcome=true' > '%s'" pane_file :str));
+  shell(print("echo 'run(%c%s%c)' >> '%s'" 34 kid_file 34 pane_file :str)))
 
-comt_flag=if(have_comtfile :then print("-comt %s" pane_file :str)
+comt_flag=if(have_comtfile :then print("-comt '%s'" pane_file :str)
          :else if(have_comt :then "-comt" :else ""))
 if(!have_comt :then
   print("kidmo: this drawserv has no -comt, so the kids get no pane\n" :err)
@@ -178,6 +178,14 @@ if(!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up) 
   print("kidmo: FAILED -- not every kid came up.  Is drawserv on PATH, and does\n" :err);
   print("       it accept the options above?  An option it does not know makes\n" :err);
   print("       it exit at startup.\n" :err);
+  /* and take down the ones that did: leaving them holding ports means the next
+     attempt steps past those ports and the desk fills with drawservs nobody
+     asked for */
+  j=0;
+  while(j<nkids
+    kill_port(:kill_port_num at(kid_ports j));
+    kill_port(:kill_port_num at(kid_ports j)-1);
+    j=j+1);
   exit(1))
 print("kidmo: all %d answered\n" nkids :err)
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "89ea67dc"
+#define PATCH_KEY "f1cf24a8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
`src/drawserv_/examples/` is new -- comdraw and comterp_ have examples
directories, drawserv did not.

**`kid.comt`** teaches one drawserv to draw animals, adventurers and trees
wherever its dice land. The verbs ride inline on one object the way zoomap's
`zoo=(...)` does, because naming a func fires it niladically -- `(:animal
kid_animal)` would store the nil that calling it returned.

**`kidmo`** brings four up, pulls three chairs to the one at the head, hands each
the script and a crayon, and leaves you at the prompt with a model of each kid:

```
todd.draw()          // Todd draws something he likes
mia.draw(:n 3)       // Mia draws three things she likes
all(:n 2)  wait_all()  look()  bye()
```

It asks for intent, never for drawings -- what a hero looks like stays in
`kid.comt` on the kid's machine.

Two things it does deliberately:

- the kid sockets are written with `:nowait` so all four draw at once, and are
  never read: an undrained reply puts every later read on that socket an answer
  behind. Reporting comes back over the listen port `comterp_listen` provides --
  the same separation a drawlink gets from its `AckBackHandler` -- so a kid
  finishing sets a global `wait_all()` can block on.
- teaching goes down the connection that will later be told to play. Every
  connection has an interpreter of its own, so loading the script anywhere else
  leaves the playing socket knowing nothing about it. The canvas belongs to the
  node, so `look()` can use a throwaway socket.

**`drawmo --tests kidmo`** covers the example the way `src/comdraw/tests/spirograph.comt`
covers its demo -- the real script, not a stand-in. Four-node star, `run("../examples/kid.comt")`
on each, each asked for something it likes, and every table required to hold the
same drawing:

```
kidmo: all four have crayons
kidmo: canvases 22 22 22 22
kidmo: every table holds the same drawing
kidmo: pass
```