### PR TITLE
drawserv -comt: the inline comterp pane comdraw already has

### DIFF
--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -240,6 +240,11 @@ static OptionDesc options[] = {
     { "-stdin_off", "*stdin_off", OptionValueImplicit, "true" },
     { "-import", "*import", OptionValueNext },
     { "-comdraw", "*comdraw", OptionValueNext },
+    /* the inline comterp pane OverlayKit builds off the "comt" attribute,
+       same as comdraw's -comt.  A drawserv run with -stdin_off has no
+       terminal REPL at all, which is exactly when a pane in the window is
+       the only way in. */
+    { "-comt", "*comt", OptionValueImplicit, "true" },
     { "-help", "*help", OptionValueImplicit, "true" },
     { "--help", "*help", OptionValueImplicit, "true" },
     { "-font", "*font", OptionValueNext },
@@ -273,6 +278,7 @@ Usage:  drawserv [file] [options]\n\n\
 -tile                       enable tiled page view\n\
 -twidth | -tw n             tile width in pixels\n\
 -zoomer_off | -zoff         disable zoomer\n\
+-comt                       inline comterp text-entry pane\n\
 -runfile file               run script file after startup\n\
 -runexpr cmdstr             run command string after startup\n\n\
 any idraw parameter is also accepted (see idraw man page)";

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c92e47a0"
+#define PATCH_KEY "eca875d1"
 
 #endif /* _patch_h */


### PR DESCRIPTION
`OverlayKit` builds the inline comterp text-entry pane from the `comt` catalog
attribute, and `DrawKit` derives from `OverlayKit` -- so the pane already worked
in drawserv, it just had no option to turn it on. This adds the one `OptionDesc`
line comdraw has, plus the usage text.

It matters more in drawserv than in comdraw: a node run with `-stdin_off` has no
terminal REPL, so without this the only way to ask it anything is to open a
socket to its comdraw port from somewhere else. With `-comt` you can type at the
node itself -- `grid(:table)`, `select(:all)`, whatever -- which is what you want
when four of them are on screen and one is behaving oddly.

Not included: comdraw's `-comt file` form, which runs `run(file)` in the pane at
startup. That needs `extract_comtfile()` and its plumbing; this is just the flag.

Verified: `-help` lists it, a `-comt -stdin_off` node starts clean, still serves
its comdraw port (`6*7` -> 42), and still draws.