### PR TITLE
Finish #395: migrate index() and ordering comparisons to cstr()

### DIFF
--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -504,8 +504,27 @@ void GreaterThanFunc::execute() {
 	result.boolean_ref() = operand1.double_val() > operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
+	   modified, so there's nothing for cstr() to narrow; operand2
+	   isn't provably a symbol here (a mixed comparison, `abc>s@0:3,
+	   still needs the slice-aware read, #395). */
+	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
-	const char* str2 = operand2.symbol_ptr();
+	const char* str2 = operand2.cstr(scratch2);
+	if (nval.is_unknown())
+	  result.boolean_ref() = strcmp(str1, str2)>0;
+	else
+	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())>0;
+	break;
+    }
+    case ComValue::StringType: {
+	/* StringType never handled here at all before -- a pre-existing
+	   gap, not something #395 broke, but the same cstr() migration
+	   applies once it's added: slice-aware for both operands, same
+	   pattern as EqualFunc's own StringType case. */
+	std::string scratch1, scratch2;
+	const char* str1 = operand1.cstr(scratch1);
+	const char* str2 = operand2.cstr(scratch2);
 	if (nval.is_unknown())
 	  result.boolean_ref() = strcmp(str1, str2)>0;
 	else
@@ -515,8 +534,8 @@ void GreaterThanFunc::execute() {
     case ComValue::BooleanType:
 	result.boolean_ref() = operand1.boolean_val() > operand2.boolean_val();
 	break;
-    case ComValue::ArrayType: 
-      result.boolean_ref() = operand2.type() == ComValue::ArrayType && 
+    case ComValue::ArrayType:
+      result.boolean_ref() = operand2.type() == ComValue::ArrayType &&
 	operand1.array_val() != operand2.array_val() &&
         operand1.array_val()->GreaterThan(operand2.array_val());
       break;
@@ -573,8 +592,27 @@ void GreaterThanOrEqualFunc::execute() {
 	result.boolean_ref() = operand1.double_val() >= operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
+	   modified, so there's nothing for cstr() to narrow; operand2
+	   isn't provably a symbol here (a mixed comparison, `abc>=s@0:3,
+	   still needs the slice-aware read, #395). */
+	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
-	const char* str2 = operand2.symbol_ptr();
+	const char* str2 = operand2.cstr(scratch2);
+	if (nval.is_unknown())
+	  result.boolean_ref() = strcmp(str1, str2)>=0;
+	else
+	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())>=0;
+	break;
+    }
+    case ComValue::StringType: {
+	/* StringType never handled here at all before -- a pre-existing
+	   gap, not something #395 broke, but the same cstr() migration
+	   applies once it's added: slice-aware for both operands, same
+	   pattern as EqualFunc's own StringType case. */
+	std::string scratch1, scratch2;
+	const char* str1 = operand1.cstr(scratch1);
+	const char* str2 = operand2.cstr(scratch2);
 	if (nval.is_unknown())
 	  result.boolean_ref() = strcmp(str1, str2)>=0;
 	else
@@ -637,8 +675,27 @@ void LessThanFunc::execute() {
 	result.boolean_ref() = operand1.double_val() < operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
+	   modified, so there's nothing for cstr() to narrow; operand2
+	   isn't provably a symbol here (a mixed comparison, `abc<s@0:3,
+	   still needs the slice-aware read, #395). */
+	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
-	const char* str2 = operand2.symbol_ptr();
+	const char* str2 = operand2.cstr(scratch2);
+	if (nval.is_unknown())
+	  result.boolean_ref() = strcmp(str1, str2)<0;
+	else
+	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())<0;
+	break;
+    }
+    case ComValue::StringType: {
+	/* StringType never handled here at all before -- a pre-existing
+	   gap, not something #395 broke, but the same cstr() migration
+	   applies once it's added: slice-aware for both operands, same
+	   pattern as EqualFunc's own StringType case. */
+	std::string scratch1, scratch2;
+	const char* str1 = operand1.cstr(scratch1);
+	const char* str2 = operand2.cstr(scratch2);
 	if (nval.is_unknown())
 	  result.boolean_ref() = strcmp(str1, str2)<0;
 	else
@@ -648,8 +705,8 @@ void LessThanFunc::execute() {
     case ComValue::BooleanType:
 	result.boolean_ref() = operand1.boolean_val() < operand2.boolean_val();
 	break;
-    case ComValue::ArrayType: 
-      result.boolean_ref() = operand2.type() == ComValue::ArrayType && 
+    case ComValue::ArrayType:
+      result.boolean_ref() = operand2.type() == ComValue::ArrayType &&
 	operand1.array_val() != operand2.array_val() &&
         operand1.array_val()->LesserThan(operand2.array_val());
       break;
@@ -706,8 +763,27 @@ void LessThanOrEqualFunc::execute() {
 	result.boolean_ref() = operand1.double_val() <= operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
+	   modified, so there's nothing for cstr() to narrow; operand2
+	   isn't provably a symbol here (a mixed comparison, `abc<=s@0:3,
+	   still needs the slice-aware read, #395). */
+	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
-	const char* str2 = operand2.symbol_ptr();
+	const char* str2 = operand2.cstr(scratch2);
+	if (nval.is_unknown())
+	  result.boolean_ref() = strcmp(str1, str2)<=0;
+	else
+	  result.boolean_ref() = strncmp(str1, str2, nval.int_val())<=0;
+	break;
+    }
+    case ComValue::StringType: {
+	/* StringType never handled here at all before -- a pre-existing
+	   gap, not something #395 broke, but the same cstr() migration
+	   applies once it's added: slice-aware for both operands, same
+	   pattern as EqualFunc's own StringType case. */
+	std::string scratch1, scratch2;
+	const char* str1 = operand1.cstr(scratch1);
+	const char* str2 = operand2.cstr(scratch2);
 	if (nval.is_unknown())
 	  result.boolean_ref() = strcmp(str1, str2)<=0;
 	else

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -504,6 +504,14 @@ void GreaterThanFunc::execute() {
 	result.boolean_ref() = operand1.double_val() > operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* Greptile, #445: operand1 matching this case says nothing about
+	   operand2 -- a mismatched operand2 (anything not string-like)
+	   would otherwise get read through cstr()/symbol_ptr() as if its
+	   raw union storage were a symid, either comparing against an
+	   unrelated interned symbol or handing strcmp() a null pointer.
+	   Bail to nil the same way the pre-#445 default case always did
+	   for a mismatch, rather than pass unrelated bits through. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc>s@0:3,
@@ -518,6 +526,9 @@ void GreaterThanFunc::execute() {
 	break;
     }
     case ComValue::StringType: {
+	/* same operand2 type guard as the SymbolType case above -- see
+	   its comment. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
 	   gap, not something #395 broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
@@ -592,6 +603,11 @@ void GreaterThanOrEqualFunc::execute() {
 	result.boolean_ref() = operand1.double_val() >= operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* Greptile, #445: see GreaterThanFunc's identical guard -- operand1
+	   matching this case says nothing about operand2, and a mismatched
+	   operand2 read through cstr()/symbol_ptr() would compare against
+	   unrelated union bits or crash strcmp() on a null pointer. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc>=s@0:3,
@@ -606,6 +622,9 @@ void GreaterThanOrEqualFunc::execute() {
 	break;
     }
     case ComValue::StringType: {
+	/* same operand2 type guard as the SymbolType case above -- see
+	   its comment. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
 	   gap, not something #395 broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
@@ -675,6 +694,11 @@ void LessThanFunc::execute() {
 	result.boolean_ref() = operand1.double_val() < operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* Greptile, #445: see GreaterThanFunc's identical guard -- operand1
+	   matching this case says nothing about operand2, and a mismatched
+	   operand2 read through cstr()/symbol_ptr() would compare against
+	   unrelated union bits or crash strcmp() on a null pointer. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc<s@0:3,
@@ -689,6 +713,9 @@ void LessThanFunc::execute() {
 	break;
     }
     case ComValue::StringType: {
+	/* same operand2 type guard as the SymbolType case above -- see
+	   its comment. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
 	   gap, not something #395 broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
@@ -763,6 +790,11 @@ void LessThanOrEqualFunc::execute() {
 	result.boolean_ref() = operand1.double_val() <= operand2.double_val();
 	break;
     case ComValue::SymbolType: {
+	/* Greptile, #445: see GreaterThanFunc's identical guard -- operand1
+	   matching this case says nothing about operand2, and a mismatched
+	   operand2 read through cstr()/symbol_ptr() would compare against
+	   unrelated union bits or crash strcmp() on a null pointer. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc<=s@0:3,
@@ -777,6 +809,9 @@ void LessThanOrEqualFunc::execute() {
 	break;
     }
     case ComValue::StringType: {
+	/* same operand2 type guard as the SymbolType case above -- see
+	   its comment. */
+	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
 	   gap, not something #395 broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -570,7 +570,13 @@ void ListIndexFunc::execute() {
 	  eqfunc.exec(2,0);
 	  match =  comterp()->pop_stack().is_true();
 	} else {
-	  match = strstr(testv->string_ptr(), valv.string_ptr()) != NULL;
+	  /* cstr(), not string_ptr() -- testv (a list element) or valv (the
+	     search value) can each independently be a slice (#395); a raw
+	     string_ptr() would search the whole shared parent instead of
+	     just testv's/valv's own window. */
+	  std::string tscratch, vscratch;
+	  ComValue testcv(*testv);
+	  match = strstr(testcv.cstr(tscratch), valv.cstr(vscratch)) != NULL;
 	}
 	if(match) {
 	  if (allflag)
@@ -590,9 +596,14 @@ void ListIndexFunc::execute() {
       };
       
   } else if (listorstrv.is_string()) {
+      /* cstr(), not string_ptr() -- listorstrv can be a slice (#395);
+	 the returned index stays relative to the slice's own window
+	 (position 0 of cstr()'s text), same convention split()/at()
+	 already use, not the shared parent's. */
+      std::string sscratch;
+      const char* string = listorstrv.cstr(sscratch);
 
       if (valv.is_char()) {
-          const char* string = listorstrv.string_ptr();
           int sz=strlen(string);
           int i= lastflag ? sz : 0;
           while(lastflag ? i>=0 : i<sz) {
@@ -608,13 +619,14 @@ void ListIndexFunc::execute() {
               i = i + (lastflag?-1:1);
           }
       } else if (valv.is_string()) {
-          const char* string = listorstrv.string_ptr();          
-          const char* foundstr = strstr(string, valv.symbol_ptr());
+          std::string nscratch;
+          const char* needle = valv.cstr(nscratch);
+          const char* foundstr = strstr(string, needle);
 	  const char* newfoundstr = foundstr;
           if((lastflag||allflag) && foundstr!=NULL) {
 	    do {
 	      foundstr = newfoundstr;
-	      newfoundstr = strstr(foundstr+strlen(valv.symbol_ptr()), valv.symbol_ptr());
+	      newfoundstr = strstr(foundstr+strlen(needle), needle);
               if(allflag) {
                 if(lastflag)
 		  nvl->Prepend(new AttributeValue((int)(foundstr-string), AttributeValue::IntType));

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
 //
-// funcs: colonlist at size print eq split string strcap +
+// funcs: colonlist at size print eq split string strcap + index gt lt ge le
 //
 // str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
 // own symid (its memory stays exactly where it was allocated, reachable at
@@ -186,6 +186,58 @@ sl16=buf@0:5
 r16=sl16+buf
 ok=ok&&(r16=="hi thhi there")
 print("16 overlapping append (sl16=buf@0:5, sl16+buf) (expect \"hi thhi there\"): %s\n" r16)
+
+// --- 17: index() char search on a sliced string reads only the
+//         slice's own window, and the returned position is relative
+//         to that window (0 = the slice's own start), not the parent's
+//         -- the same convention split()/at() already use.  s17@3:6 is
+//         "cde"; 'x' only appears outside the slice's window. ---
+s17="xxxcdexxx"
+sl17=s17@3:6
+ok=ok&&(index(sl17 'd')==1)
+ok=ok&&(index(sl17 'x')==nil)
+print("17 index() char search on a slice (expect 1 nil): %v %v\n" index(sl17 'd') index(sl17 'x'))
+
+// --- 18: index() substring search on a sliced string, same window
+//         convention, and the search value (needle) can independently
+//         be a slice too ---
+s18="xxxhelloworldxxx"
+sl18=s18@3:13
+ok=ok&&(index(sl18 "world")==5)
+ok=ok&&(index(sl18 "xxx")==nil)
+needle18=("__world__"@2:7)
+ok=ok&&(index(sl18 needle18)==5)
+print("18 index() substring search, sliced haystack and needle (expect 5 nil 5): %v %v %v\n" index(sl18 "world") index(sl18 "xxx") index(sl18 needle18))
+
+// --- 19: index(:all) on a sliced string -- every match position,
+//         still relative to the slice's own window ---
+s19="ababab"
+sl19=s19@0:6
+ok=ok&&(print(index(sl19 'a' :all) :str)=="{0,2,4}")
+print("19 index(:all) on a slice (expect {0,2,4}): %s\n" print(index(sl19 'a' :all) :str))
+
+// --- 20: ordering comparisons (>/</>=/<=, boolfunc.c) never handled
+//         StringType at all before -- a separate, pre-existing gap,
+//         not something #395 broke ("abc">"abd" always answered nil.
+//         Added a StringType case to all four, modeled directly on
+//         EqualFunc's own (cstr() for both operands, slice-aware). ---
+ok=ok&&(("abc">"abd")==false)
+ok=ok&&(("abd">"abc")==true)
+ok=ok&&(("abc"<"abd")==true)
+ok=ok&&(("abc">="abc")==true)
+ok=ok&&(("abc"<="abc")==true)
+print("20 plain-string ordering comparisons, previously always nil (expect false true true true true): %v %v %v %v %v\n" "abc">"abd" "abd">"abc" "abc"<"abd" "abc">="abc" "abc"<="abc")
+
+// --- 21: ordering comparisons read each operand's own slice window,
+//         not the parent's -- s21@3:6 is "abd", compared against the
+//         full parent string it came from would give a different
+//         (wrong) answer than comparing against just "abd" ---
+s21="xxxabdxxx"
+sl21=s21@3:6
+ok=ok&&((sl21>"abc")==true)
+ok=ok&&(("abc"<sl21)==true)
+ok=ok&&((sl21>s21)==false)
+print("21 sliced-string ordering comparisons (expect true true false): %v %v %v\n" sl21>"abc" "abc"<sl21 sl21>s21)
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -239,5 +239,19 @@ ok=ok&&(("abc"<sl21)==true)
 ok=ok&&((sl21>s21)==false)
 print("21 sliced-string ordering comparisons (expect true true false): %v %v %v\n" sl21>"abc" "abc"<sl21 sl21>s21)
 
+// --- 22: a string compared against a non-string operand answers nil,
+//         same as it always did (Greptile, #445) -- test 20 added a
+//         real StringType case to these four functions, but that case
+//         must not assume operand2 is also string-like just because
+//         operand1 is; comparing against a Float would otherwise read
+//         its union storage through cstr()/symbol_ptr() as if it were
+//         a symid, either a bogus interned-symbol comparison or a
+//         null pointer into strcmp(). ---
+ok=ok&&(("abc">3.14)==nil)
+ok=ok&&(("abc"<3.14)==nil)
+ok=ok&&(("abc">=3.14)==nil)
+ok=ok&&(("abc"<=3.14)==nil)
+print("22 string vs non-string ordering comparison (expect nil x4): %v %v %v %v\n" "abc">3.14 "abc"<3.14 "abc">=3.14 "abc"<=3.14)
+
 print("colonslice: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b64f0d2c"
+#define PATCH_KEY "3f9c8e17"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c92e47a0"
+#define PATCH_KEY "7e1a9d63"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

The last two `#395` leftovers from the epic's own tracking: `index()` and the ordering comparisons (`<`/`>`/`<=`/`>=`) weren't slice-aware yet.

- **`index()`** (`ListIndexFunc::execute()`, `listfunc.c`) had three separate `string_ptr()`/`symbol_ptr()` call sites, none slice-aware: the searched-in string, the search value/needle, and (in `:substr` array-search mode) both the list element under test and the search value again. Migrated all three to `cstr()`. A returned index stays relative to the slice's own window (0 = the slice's own start), matching how `split()`/`at()` already treat indices. The array mode's default (non-`:substr`) match path already goes through `EqualFunc`, migrated earlier in this epic — only `:substr`'s raw `strstr()` needed fixing.
- **Ordering comparisons** (`GreaterThanFunc`/`GreaterThanOrEqualFunc`/`LessThanFunc`/`LessThanOrEqualFunc`, `boolfunc.c`) never handled `StringType` at all — a separate, pre-existing gap, not something `#395` broke: `"abc">"abd"` always fell through to the default case and answered `nil`. Added a `StringType` case to all four, modeled directly on `EqualFunc`'s own (already migrated): `cstr()` for both operands, slice-aware. Also fixed each existing `SymbolType` case's operand2 read (was `symbol_ptr()`, now `cstr()`) for the same reason `EqualFunc`'s `SymbolType` case does — operand1 being confirmed a symbol says nothing about operand2, which could still be a slice in a mixed comparison (`` `abc>s@0:3 ``).

## Test plan

- [x] New tests 17-19 in `colonslice.comt`: `index()` char search, substring search (haystack and needle both independently sliced), `index(:all)`, all on sliced strings
- [x] New tests 20-21 in `colonslice.comt`: plain-string ordering comparisons now give real answers instead of `nil`; sliced-string comparisons read each operand's own window, not the parent's
- [x] Full `run_all.comt` suite green (0 failures)
- [x] Verified live: mixed-type comparisons (`"abc"==5`, `"abc">5`) don't crash, consistent with `EqualFunc`'s existing precedent for the same pattern

Note: a `list()`-of-sliced-elements case for `index(:substr)` was attempted in testing but hits a separate, already-known limitation (`#438`'s class of bug) — `AttributeValueList` only stores plain `AttributeValue`, no room for a `ComValue`-only `sliced()` flag, so an element's slice-ness doesn't survive comma-list construction. Not something to fix here; the `index()` fix itself is still correct and forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)