### PR TITLE
FrameKit: read the comt attribute, so drawserv -comt builds the pane

### DIFF
--- a/src/FrameUnidraw/framekit.c
+++ b/src/FrameUnidraw/framekit.c
@@ -195,7 +195,14 @@ void FrameKit::InitLayout(OverlayKit* kit, const char* name) {
 	  ed->body(menus);
 	  ed->GetKeyMap()->Execute(CODE_SELECT);
 	  topbox->append(ed);
-	  if (!bookgeom && inlineTextEditor) {
+	  /* the "comt" attribute as well as the compiled-in default, the way
+	     OverlayKit::InitLayout does it.  This override predates that
+	     attribute, so -comt set it and nothing down the FrameKit path --
+	     drawserv and flipbook both -- ever read it: the option was accepted,
+	     listed in -help, and silently did nothing. */
+	  const char* comt_string = unidraw->GetCatalog()->GetAttribute("comt");
+	  boolean comt_flag = comt_string ? strcmp(comt_string, "true")==0 : false;
+	  if (!bookgeom && (inlineTextEditor || comt_flag)) {
 	    boolean set_flag = kit->set_button_flag();
 	    boolean clr_flag = kit->clr_button_flag();
 	    EivTextEditor* texteditor = nil;

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "eca875d1"
+#define PATCH_KEY "bb39a856"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Follow-on to #444, which added `-comt` to drawserv but could not work: the option
sets the `comt` catalog attribute and nothing on drawserv's path reads it.

`DrawKit : FrameKit : OverlayKit`, and `FrameKit::InitLayout` overrides
`OverlayKit::InitLayout` with its own copy of the pane code -- an older copy.
OverlayKit's asks the attribute:

```c
const char* comt_string = catalog->GetAttribute("comt");
boolean comt_flag = comt_string ? strcmp(comt_string, "true")==0 : false;
if (ed->comterp() && (inlineTextEditor || comt_flag)) {
```

FrameKit's asks only the compiled-in global:

```c
if (!bookgeom && inlineTextEditor) {
```

So `-comt` was accepted, listed in `-help`, and did nothing -- for flipbook as
well as drawserv, both of which come down this path.

## Verified

Window height is no indicator (comdraw is 720x822 either way), but the pane adds
one X window, so the tree tells:

| | plain | `-comt` |
|---|---|---|
| comdraw (already worked) | 76 | 77 |
| drawserv (with this fix) | 76 | 77 |

Worth noting how #444 slipped through: I checked that a `-comt` node started
clean, served its comdraw port and still drew -- everything except the pane
actually appearing.