### PR TITLE
Widen AttributeValue to carry ComValue's arity/flag block (#437, #438)

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -332,6 +332,7 @@ void AttributeValue::clear() {
     unsigned char* buf = (unsigned char*)(void*)&_v;
     for (int i=0; i<sizeof(_v); i++) buf[i] = '\0';
     _state = 0;
+    _ext1 = _ext2 = _ext3 = 0;
 }
 
 AttributeValue& AttributeValue::operator= (const AttributeValue& sv) {
@@ -342,6 +343,9 @@ AttributeValue& AttributeValue::operator= (const AttributeValue& sv) {
     memcpy(v1, v2, sizeof(_v));
     _type = sv._type;
     _command_symid = sv._command_symid;
+    _ext1 = sv._ext1;
+    _ext2 = sv._ext2;
+    _ext3 = sv._ext3;
     /* the output wrapper is an annotation on one particular value as it is
        handed back, not part of what the value IS -- so it never rides along
        on a copy.  Every consumer (arithmetic seeding a result from an
@@ -1207,6 +1211,9 @@ void AttributeValue::assignval (const AttributeValue& av) {
     memcpy(v1, v2, sizeof(_v));
     _type = av._type;
     _command_symid = av._command_symid;
+    _ext1 = av._ext1;
+    _ext2 = av._ext2;
+    _ext3 = av._ext3;
     wrapper(AttributeValue::NoWrapper);   /* never copies -- see operator= */
     if (!preserve_flag) ref_as_needed();
 }
@@ -1393,7 +1400,7 @@ int AttributeValue::stream_mode() {
    constructors preset to -1 on values that are not commands at all.  Read
    that -1 as "nothing set here", not as a state word of all ones -- without
    this every ordinary literal reports a wrapper of 3 (BraceWrapper). */
-int AttributeValue::state_word() {
+int AttributeValue::state_word() const {
   return _state == -1 ? 0 : _state;
 }
 

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -310,7 +310,7 @@ public:
     void stream_list(AttributeValueList* list); 
     // set pointer to AttributeValueList associated with stream object
 
-    int state_word();
+    int state_word() const;
     // raw state word with the -1 (_command_symid "no command") initializer read as 0
     int state();
     // get generic state value useful for any type other than CommandType, ObjectType, or StreamType
@@ -458,12 +458,25 @@ protected:
 
     ValueType _type;
     attr_value _v;
-    union { 
+    union {
       int _command_symid; // used for CommandType.
       boolean _object_compview; // used for ObjectType.
       int _stream_mode; // used for StreamType
-      int _state; // useful for any type other than CommandType, ObjectType, or StreamType
+      int _state; // useful for any type other than CommandType, ObjectType, or
+                  // StreamType
     };
+    /* Three more ints, widening the block above to a full 128 bits -- give
+       every AttributeValue the storage weight of a ComValue's command arity
+       (narg/nkey/nids) or a StringType slice window (sliceoff/slicelen),
+       without AttributeValue itself knowing which. ComValue (comvalue.h) is
+       the only class that interprets them; here they are just bytes that
+       get stored and copied.  ComValue's bquote/lhs_assign/local/coloned/
+       sliced flag bits live in _ext3 too, above nids()'s own low byte --
+       NOT in _state/_command_symid above: a real command_symid is an
+       unbounded symbol-table index (comvalue.h has the story of the
+       collision that ruled that out), so nothing sharing its word can use
+       small fixed bits safely, unlike _ext3's bounded low byte. */
+    int _ext1, _ext2, _ext3;
     static int* _type_syms;
 
 #ifdef LEAKCHECK

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1677,13 +1677,17 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	       (attrvalue.h), so coloned()/sliced()/etc. DO survive into aval
 	       when the original value had them set (#438) -- reading them via
 	       ((ComValue*)aval)->coloned() is exactly the intended, now-real
-	       recovery, not undefined behavior.  bquote() is the one flag that
-	       must NOT survive regardless: see restore_call_arity()'s comment
-	       for why carrying it through breaks a stored bquoted value's
-	       falsiness on read. */
+	       recovery, not undefined behavior.  narg()/nkey()/nids() and
+	       bquote() need the same restore_call_arity() treatment as the
+	       localtable/globaltable branches below, for the same reason: a
+	       func-local variable read (e.g. invoking a FuncObj received
+	       through a keyword arg or captured free variable) must keep its
+	       own call-site arity, not inherit the stored value's -- Greptile,
+	       #450. */
+	    int saved_narg = comval.narg(), saved_nkey = comval.nkey(), saved_nids = comval.nids();
 	    ComValue newval(*aval);
 	    *&comval = newval;
-	    comval.bquote(0);
+	    restore_call_arity(comval, newval, saved_narg, saved_nkey, saved_nids);
 	    return comval;
 	  }
 	}

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1618,18 +1618,43 @@ ComValue& ComTerp::fire_if_funcobj(ComValue& val) {
   return *slot;
 }
 
-/* sliceoff()/slicelen() (comvalue.h) write straight through to _narg/_nkey
-   -- fine on a StringType, which never needs them for anything else, but
-   catastrophic on any other type, where those same fields carry a command
-   call's own argument/keyword counts.  Restricted to StringType so a
-   lookup_symval() carry-over (below) can't clobber that bookkeeping for
-   every other symbol resolution in the interpreter. */
-static void carry_slice(ComValue& dst, ComValue& src) {
-  if (src.type() != ComValue::StringType) return;
-  dst.sliced(src.sliced());
-  dst.sliceoff(src.sliceoff());
-  dst.slicelen(src.slicelen());
-  dst.blocksz(src.blocksz());
+/* comval's own narg()/nkey()/nids() (comvalue.h) encode THIS identifier's
+   call-site shape, not the value it resolves to -- check_fail(:ok ok)
+   needs nkey()==1 to survive resolution so fire_funcobj() (below) knows
+   to pop a keyword marker+value for it.  assignval() (AttributeValue)
+   now copies a resolved value's own narg/nkey/nids over comval's
+   unconditionally, because that same storage doubles as a StringType's
+   slice window (#395) and a sliced variable's window must win here.  For
+   every other resolved type those fields are either unused (0) or, for a
+   FuncObj, irrelevant to this call, so restore comval's pre-lookup
+   values instead of letting a stale 0 clobber real call-site arity --
+   the inverse of the StringType case.  (Before AttributeValue grew this
+   storage, assignval() couldn't reach these ComValue-only fields at
+   all, and a StringType's window needed its own explicit carry instead;
+   now the same widening that lets a slice survive assignval() is what
+   needs undoing here for every non-StringType resolution.)
+
+   bquote() gets the opposite treatment, and unconditionally: it must
+   NEVER survive a resolution, in every type, StringType included.  A
+   stored value's bquote() records that *it* was written as a literal
+   backquoted expression (`EOS) -- it says nothing about how a *later*
+   read of the variable holding it should behave.  Carrying it through
+   is actively wrong: lookup_symval()'s own entry check
+   (`if (comval.bquote()) return comval;`) would then short-circuit a
+   second resolution attempt that's supposed to run and legitimately
+   fail -- e.g. a variable holding `EOS is itself an ordinary (non-
+   bquoted) SymbolType read, and resolving *that* symbol ("EOS") as if
+   it were a variable name correctly finds nothing and degrades to
+   nullval() (UnknownType, falsy) -- the actual mechanism nilcompare.comt
+   depends on for "a bquoted symbol is falsy" (test 7), broken by
+   assignval() carrying bquote() through until this reset. */
+static void restore_call_arity(ComValue& comval, ComValue& resolved,
+                                int saved_narg, int saved_nkey, int saved_nids) {
+  comval.bquote(0);
+  if (resolved.type() == ComValue::StringType) return;
+  comval.narg(saved_narg);
+  comval.nkey(saved_nkey);
+  comval.nids(saved_nids);
 }
 
 ComValue& ComTerp::lookup_symval(ComValue& comval) {
@@ -1644,53 +1669,52 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	  int id = comval.symbol_val();
 	  AttributeValue* aval = peek_alist_pending(_alist, id, _alist->find(id));
 	  if (aval) {
-	    /* coloned() can't be recovered here at all, and must not be
-	       guessed at: _alist (a func's keyword-bound locals, fire_funcobj()
-	       comterp.c) is populated via AttributeList::add_attr(int,
-	       AttributeValue&) (attrlist.c), same as attrlist() itself, which
-	       constructs a plain `new AttributeValue(value)` -- a strictly
-	       smaller type with no _flags field, not a ComValue.  aval is
-	       therefore genuinely only ever an AttributeValue* here, never a
-	       ComValue* despite how it looks; ((ComValue*)aval)->coloned()
-	       would read _flags out of memory past the real object's own
-	       allocation -- undefined behavior, not a recovered flag (#438
-	       tracks the actual fix: AttributeList would need to store
-	       ComValue, not AttributeValue). */
+	    /* _alist (a func's keyword-bound locals, fire_funcobj() comterp.c)
+	       is populated via AttributeList::add_attr(int, AttributeValue&)
+	       (attrlist.c), same as attrlist() itself, which constructs a
+	       plain `new AttributeValue(value)` -- still not a ComValue, but
+	       AttributeValue itself now carries the narg/nkey/nids/flags block
+	       (attrvalue.h), so coloned()/sliced()/etc. DO survive into aval
+	       when the original value had them set (#438) -- reading them via
+	       ((ComValue*)aval)->coloned() is exactly the intended, now-real
+	       recovery, not undefined behavior.  bquote() is the one flag that
+	       must NOT survive regardless: see restore_call_arity()'s comment
+	       for why carrying it through breaks a stored bquoted value's
+	       falsiness on read. */
 	    ComValue newval(*aval);
 	    *&comval = newval;
+	    comval.bquote(0);
 	    return comval;
 	  }
 	}
 
-	/* assignval() takes an AttributeValue&, so it only ever copies the
-	   base class's fields -- ComValue's own coloned() (comvalue.h)
-	   isn't one of them, and comval keeps whatever it already had (the
-	   identifier token's own, not the stored value's) unless carried
-	   over explicitly here. */
+	/* assignval() (AttributeValue) copies coloned() and every other flag
+	   bit packed into the shared _ext3 word along with narg/nkey/nids --
+	   see restore_call_arity()'s comment for why the latter need undoing
+	   again right after for a non-StringType resolution. */
 	if (!comval.global_flag() && localtable()->find(vptr, comval.symbol_val()) ) {
+	  int saved_narg = comval.narg(), saved_nkey = comval.nkey(), saved_nids = comval.nids();
 	  comval.assignval(*(ComValue*)vptr);
-	  comval.coloned(((ComValue*)vptr)->coloned());
-	  carry_slice(comval, *(ComValue*)vptr);
+	  restore_call_arity(comval, *(ComValue*)vptr, saved_narg, saved_nkey, saved_nids);
 	  return comval;
 	} else if (globaltable()->find(vptr, comval.symbol_val())) {
+	  int saved_narg = comval.narg(), saved_nkey = comval.nkey(), saved_nids = comval.nids();
 	  comval.assignval(*(ComValue*)vptr);
-	  comval.coloned(((ComValue*)vptr)->coloned());
-	  carry_slice(comval, *(ComValue*)vptr);
+	  restore_call_arity(comval, *(ComValue*)vptr, saved_narg, saved_nkey, saved_nids);
 	  return comval;
 	} else
 	  return ComValue::nullval();
 
     } else if (comval.is_object(Attribute::class_symid())) {
-      /* coloned() can't be recovered here, and reading it via a ComValue*
-	 cast on attrvalp would be undefined behavior, not a recovered flag --
-	 same reasoning as the _alist branch above.  Attribute::Value()
-	 returns whatever AttributeList::add_attr() (attrlist.c) stored, which
-	 is always a plain `new AttributeValue(value)`, never a ComValue --
-	 there's no _flags field to read past the end of.  #438 tracks the
-	 actual fix (AttributeList would need to store ComValue, not
-	 AttributeValue). */
+      /* Attribute::Value() returns whatever AttributeList::add_attr()
+	 (attrlist.c) stored -- a plain `new AttributeValue(value)`, never a
+	 ComValue, but AttributeValue's own narg/nkey/nids/flags block
+	 (attrvalue.h) now survives into it regardless (#438), same as the
+	 _alist branch above.  bquote() must not survive this read either,
+	 same reasoning as restore_call_arity()'s comment. */
       ComValue attrval = *((Attribute*)comval.obj_val())->Value();
       comval.assignval(attrval);
+      comval.bquote(0);
     }
     return comval;
 }

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -73,8 +73,14 @@ ComValue::ComValue(ComValue* sv) {
 }
 
 ComValue::ComValue(AttributeValue& sv) {
+    /* narg/nkey/nids and the flag bits (sliced() among them, #395) now live
+       in AttributeValue's own storage, so the assignment above already
+       carries them over when sv was itself a boxed ComValue -- zero_vals()
+       must not stomp them back to 0 here, unlike before this storage moved
+       up from ComValue.  _pedepth has no AttributeValue-level counterpart
+       to inherit, so it alone still needs an explicit reset. */
     *(AttributeValue*)this = sv;
-    zero_vals();
+    _pedepth = 0;
 }
 
 ComValue::ComValue() {
@@ -140,23 +146,21 @@ ComValue::ComValue(postfix_token* token) {
     case TOK_BLANK:   type(BlankType); break;
     default:          type(UnknownType); break;
     }
-    _narg = token->narg;
-    _nkey = token->nkey;
-    _nids = token->nids;  // nids not always used for number-of-ids
+    _ext1 = token->narg;
+    _ext2 = token->nkey;
+    _ext3 = token->nids & 0xff;  // nids not always used for number-of-ids;
+                                  // low byte only -- see nids(int) (comvalue.h)
     _linenum = token->ln;
 
     _command_symid = -1;
     _pedepth = 0;
-    _flags = 0;
 }
 
 ComValue& ComValue::operator= (const ComValue& sv) {
+    // narg/nkey/nids and the flag bits are inherited storage --
+    // assignval() (AttributeValue) already copies them.
     assignval(sv);
-    _narg = sv._narg;
-    _nkey = sv._nkey;
-    _nids = sv._nids;
     _pedepth = sv._pedepth;
-    _flags = sv._flags;
     _linenum = sv._linenum;
     #if 0  // duplicated ref_as_needed call in assignval()
     ref_as_needed();
@@ -164,17 +168,23 @@ ComValue& ComValue::operator= (const ComValue& sv) {
     return *this;
 }
     
-int ComValue::narg() const { return type()==ComValue::StringType ? 0 : _narg; }
-int ComValue::nkey() const { return type()==ComValue::StringType ? 0 : _nkey; }
-int ComValue::nids() const { return type()==ComValue::StringType ? 0 : _nids; }
-int ComValue::bquote() const { return _flags & COMVALUE_BQUOTE_FLAG; }
-int ComValue::lhs_assign() const { return _flags & COMVALUE_LHS_ASSIGN_FLAG; }
-int ComValue::local_flag() const { return _flags & COMVALUE_LOCAL_FLAG; }
-int ComValue::coloned() const { return _flags & COMVALUE_COLONED_FLAG; }
-int ComValue::sliced() const { return _flags & COMVALUE_SLICED_FLAG; }
-int ComValue::sliceoff() const { return _narg; }
-int ComValue::slicelen() const { return _nkey; }
-int ComValue::blocksz() const { return _nids; }
+int ComValue::narg() const { return type()==ComValue::StringType ? 0 : _ext1; }
+int ComValue::nkey() const { return type()==ComValue::StringType ? 0 : _ext2; }
+int ComValue::nids() const {
+  if (type()==ComValue::StringType) return 0;
+  /* sign-extend the low byte -- nids()'s own "bare identifier" sentinel is
+     -1, stored as 0xff there so it never sets any of the flag bits sharing
+     this word (comvalue.h, COMVALUE_*_FLAG start at 0x100). */
+  int lo = _ext3 & 0xff;
+  return (lo & 0x80) ? (lo | ~0xff) : lo;
+}
+int ComValue::bquote() const { return _ext3 & COMVALUE_BQUOTE_FLAG; }
+int ComValue::lhs_assign() const { return _ext3 & COMVALUE_LHS_ASSIGN_FLAG; }
+int ComValue::local_flag() const { return _ext3 & COMVALUE_LOCAL_FLAG; }
+int ComValue::coloned() const { return _ext3 & COMVALUE_COLONED_FLAG; }
+int ComValue::sliced() const { return _ext3 & COMVALUE_SLICED_FLAG; }
+int ComValue::sliceoff() const { return _ext1; }
+int ComValue::slicelen() const { return _ext2; }
 
 const char* ComValue::cstr(std::string& scratch) {
   /* string_ptr() itself was tried as this mechanism (made virtual,

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -44,11 +44,24 @@ class ComTerp;
 // as four integers (narg(), nkey(), nids(), pedepth()) used for storing
 // necessary command and keyword state after code conversion and during 
 // interpretation.  
-#define COMVALUE_BQUOTE_FLAG     0x01  // backquote -- return symbol without lookup
-#define COMVALUE_LHS_ASSIGN_FLAG 0x02  // set by AssignFunc on global() or local() ComValue in lhs context
-#define COMVALUE_LOCAL_FLAG      0x04  // set by local() on its lvalue symbol -- write the default symbol table, skipping any func frame
-#define COMVALUE_COLONED_FLAG    0x08  // set by ColonListFunc -- an ArrayType built by ':', not ','
-#define COMVALUE_SLICED_FLAG     0x10  // set on a StringType sliced from another string (#395) -- sliceoff()/slicelen() hold the window, narg()/nkey() read 0
+// Packed into the high bits of the shared _ext3 word (AttributeValue's
+// widened block, attrvalue.h) -- NOT the _state/_command_symid word: a real
+// command_symid is an unbounded symbol-table index (e.g. "global" itself
+// landed on 225 == 0xE1, colliding with an early flag bit tried there), so
+// nothing that shares space with it can use small fixed bits safely.  _ext3
+// has no such problem: its low byte is nids() (bounded by the scanner's own
+// TOK_* range, comterp.h, comfortably under 0x80) and every flag bit here
+// starts at 0x100, clear of it.  nids()'s own accessor (comvalue.c) reads/
+// writes only that low byte, sign-extended, so -1 (nids()'s own "bare
+// identifier" sentinel) never bleeds into these bits the way _command_symid's
+// -1 sentinel did into the old _state-packed flags.  blocksz() (StringType's
+// still-unconsumed chunk-size field, #395) gives up its dedicated storage
+// here in favor of sliced() -- nothing sets a nonzero blocksz today.
+#define COMVALUE_BQUOTE_FLAG     0x0100 // backquote -- return symbol without lookup
+#define COMVALUE_LHS_ASSIGN_FLAG 0x0200 // set by AssignFunc on global()/local()/at() ComValue in lhs context (also ListAtFunc's ArrayType result, #318)
+#define COMVALUE_LOCAL_FLAG      0x0400 // set by local() on its lvalue symbol -- write the default symbol table, skipping any func frame
+#define COMVALUE_COLONED_FLAG    0x0800 // set by ColonListFunc -- an ArrayType built by ':', not ','
+#define COMVALUE_SLICED_FLAG     0x1000 // set on a StringType sliced from another string (#395) -- sliceoff()/slicelen() hold the window, narg()/nkey() read 0
 
 class ComValue : public AttributeValue {
 public:
@@ -128,52 +141,54 @@ public:
     // language needs separate input/output arglists it counts those too.
     // Always 0 for a StringType, whose storage doubles as a slice's chunk
     // size (#395) -- use blocksz() to read that.
-    void narg(int n) {_narg = n; }
+    void narg(int n) {_ext1 = n; }
     // set number of arguments associated with this command or keyword.
-    void nkey(int n) {_nkey = n; }
+    void nkey(int n) {_ext2 = n; }
     // set number of keywords associated with this command.
-    void nids(int n) {_nids = n; }
-    // set the matched-paren-delimiter kind following a SymbolType.
+    void nids(int n) { _ext3 = (_ext3 & ~0xff) | (n & 0xff); }
+    // set the matched-paren-delimiter kind following a SymbolType -- packed
+    // into _ext3's low byte, sign-extended by nids() (comvalue.c); the flag
+    // bits below share this same word, starting at 0x100.
     int bquote() const;
     // get flag that says this SymbolType has been backquoted
-    void bquote(int flag) { if(flag) _flags |= COMVALUE_BQUOTE_FLAG; else _flags &= ~COMVALUE_BQUOTE_FLAG; }
+    void bquote(int flag) { if (flag) _ext3 |= COMVALUE_BQUOTE_FLAG; else _ext3 &= ~COMVALUE_BQUOTE_FLAG; }
     // set flag that says this SymbolType has been backquoted
     int lhs_assign() const;
     // return flag that indicates this CommandType is on left-hand side of an assignment.
-    void lhs_assign(int flag) { if(flag) _flags |= COMVALUE_LHS_ASSIGN_FLAG; else _flags &= ~COMVALUE_LHS_ASSIGN_FLAG; }
+    void lhs_assign(int flag) { if (flag) _ext3 |= COMVALUE_LHS_ASSIGN_FLAG; else _ext3 &= ~COMVALUE_LHS_ASSIGN_FLAG; }
     // set flag that indicates this CommandType is on the left-hand side of an assignment.
     int local_flag() const;
     // return flag that marks a local() lvalue symbol -- assignment writes the
     // default symbol table, skipping any func frame.
-    void local_flag(int flag) { if(flag) _flags |= COMVALUE_LOCAL_FLAG; else _flags &= ~COMVALUE_LOCAL_FLAG; }
+    void local_flag(int flag) { if (flag) _ext3 |= COMVALUE_LOCAL_FLAG; else _ext3 &= ~COMVALUE_LOCAL_FLAG; }
     // set flag that marks a local() lvalue symbol.
     int coloned() const;
     // return flag that marks an ArrayType as built by ':' rather than ','.
-    void coloned(int flag) { if(flag) _flags |= COMVALUE_COLONED_FLAG; else _flags &= ~COMVALUE_COLONED_FLAG; }
+    void coloned(int flag) { if (flag) _ext3 |= COMVALUE_COLONED_FLAG; else _ext3 &= ~COMVALUE_COLONED_FLAG; }
     // set flag that marks an ArrayType as built by ':' rather than ','.
 
     int sliced() const;
     // return flag that marks a StringType value as a slice of another
     // string, sharing its symid rather than owning a copy (#395).
-    void sliced(int flag) { if(flag) _flags |= COMVALUE_SLICED_FLAG; else _flags &= ~COMVALUE_SLICED_FLAG; }
+    void sliced(int flag) { if (flag) _ext3 |= COMVALUE_SLICED_FLAG; else _ext3 &= ~COMVALUE_SLICED_FLAG; }
     // set flag that marks a StringType value as a slice.
     int sliceoff() const;
     // offset of a slice's window into its symid string; valid only when sliced().
-    void sliceoff(int off) { _narg = off; }
+    void sliceoff(int off) { _ext1 = off; }
     // set a slice's window offset.
     int slicelen() const;
     // length of a slice's window into its symid string; valid only when sliced().
-    void slicelen(int len) { _nkey = len; }
+    void slicelen(int len) { _ext2 = len; }
     // set a slice's window length.
-    int blocksz() const;
-    // chunk size of a slice, in bytes -- 0 (the default) means an ordinary
-    // byte-granular slice, same as today; a future consumer reading a
-    // nonzero value would treat sliceoff()/slicelen() as counts of
-    // blocksz()-byte chunks rather than raw bytes, so a string slice can
-    // describe more than chars, Go-style (#395).  Not consumed anywhere
-    // yet -- this is the storage, not the feature.
-    void blocksz(int sz) { _nids = sz; }
-    // set a slice's chunk size.
+    int blocksz() const { return 0; }
+    // chunk size of a slice, in bytes -- always 0 (an ordinary byte-granular
+    // slice) for now.  Was its own field in _ext3 (#395); gave up that
+    // storage to sliced() and the rest of the flag bits above, since nothing
+    // sets a nonzero blocksz yet -- this was documented as reserved storage,
+    // not a shipped feature, before the giveback.  A real implementation
+    // needs its own field again, found some other way.
+    void blocksz(int sz) { }
+    // no-op -- see blocksz() above.
 
     const char* cstr(std::string& scratch);
     // the slice-aware way to get a StringType value's text (#395) --
@@ -256,13 +271,12 @@ public:
     // return true if ObjectType of DateObj
 
 protected:
-    void zero_vals() { _narg = _nkey = _nids = _pedepth = _flags = 0; }
+    // narg/nkey/nids (_ext1/_ext2/_ext3) and the flag bits packed into
+    // _state are all inherited storage -- see AttributeValue's comment on
+    // its own union (attrvalue.h) for why they live there instead of here.
+    void zero_vals() { _ext1 = _ext2 = _ext3 = _pedepth = 0; }
 
-    int _narg;
-    int _nkey;
-    int _nids;
     int _pedepth;
-    int _flags;  // bitfield: COMVALUE_BQUOTE_FLAG, COMVALUE_LHS_ASSIGN_FLAG, ...
     unsigned _linenum;
 
     static const ComTerp* _comterp;

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -26,12 +26,15 @@
 //
 // Known gaps, not yet attempted: :set/:ins/:del through a slice (listfunc.c
 // falls back to nil for any coloned index in an lhs_assign context); slicing
-// a plain list/array (only listv.is_only_string() triggers slice logic); a
-// slice passed as a function keyword arg or captured free variable loses
-// its sliced()/sliceoff()/slicelen() the same way a colon-list's coloned()
-// does (Greptile, #437) -- AttributeList only ever stores a plain
-// AttributeValue (#438), which has no room for either.  Not independently
-// fixable here; test 8 pins it as a documented gap rather than a silent one.
+// a plain list/array (only listv.is_only_string() triggers slice logic).
+//
+// A slice passed as a function keyword arg or captured free variable used
+// to lose its sliced()/sliceoff()/slicelen() the same way a colon-list's
+// coloned() did (Greptile, #437) -- AttributeList only ever stores a plain
+// AttributeValue, which had no room for either (#438).  Fixed by widening
+// AttributeValue itself to carry that block (attrvalue.h) instead of
+// ComValue alone, so a plain `new AttributeValue(value)` (attrlist.c's
+// add_attr) now copies it too -- test 8.
 //
 // slice==string DOES work (test 9) -- EqualFunc/NotEqualFunc (boolfunc.c)
 // were fixed to compare text via cstr() for any StringType operand,
@@ -74,10 +77,14 @@ ok=ok&&(("abc"@0:5)==nil)
 print("5 hi==cap is an empty slice, hi>cap is nil (expect 0 nil): %s %s\n" size("abc"@3:3) "abc"@0:5)
 
 // --- 6: a slice assigned to a variable keeps its sliced-ness across the
-//        symbol-table round trip -- lookup_symval() (comterp.c) has to
-//        carry sliced()/sliceoff()/slicelen() over explicitly, the same
-//        way it already does for coloned() (#429/Greptile), since
-//        assignval() only ever copies AttributeValue's base fields ---
+//        symbol-table round trip -- AttributeValue's own narg/nkey/nids/
+//        flags block (attrvalue.h) makes assignval() carry sliceoff()/
+//        slicelen()/sliced() (and coloned(), #429/Greptile) automatically;
+//        lookup_symval() (comterp.c) only has to undo the same copy's
+//        narg/nkey/nids and bquote() for a non-StringType resolution,
+//        where those fields mean something else entirely (arity, or a
+//        stored value's own "don't resolve me" marker that must not
+//        outlive the read) ---
 v=s@2:5
 ok=ok&&(size(v)==3 && print(v :str)=="cde")
 print("6 a sliced variable keeps its window (expect 3 cde): %s %s\n" size(v) print(v :str))
@@ -94,13 +101,13 @@ ok=ok&&(print(sl3@1:3 :str)=="de")
 ok=ok&&((sl3@0:10)==nil)
 print("7 nesting: sl3@0:1, sl3@1:3, sl3@0:10 (expect c de nil): %s %s %s\n" print(sl3@0:1 :str) print(sl3@1:3 :str) sl3@0:10)
 
-// --- 8: KNOWN GAP, pinned so a future #438 fix is a deliberate change
-//        here too, not a silent one -- a slice passed as a function
-//        keyword arg loses its sliced()-ness (see the file header) and
-//        reads back as the whole parent string, not its own window ---
+// --- 8: a slice passed as a function keyword arg keeps its window --
+//        used to read back as the whole parent string (#438, see the
+//        file header); fixed the same way test 6 already covers for a
+//        plain symbol-table read ---
 f8=func(print(x :str))
-ok=ok&&(f8(:x s3@2:5)=="abcdef")
-print("8 KNOWN GAP: a sliced :x arg reads as the whole parent (expect abcdef, not cde): %s\n" f8(:x s3@2:5))
+ok=ok&&(f8(:x s3@2:5)=="cde")
+print("8 a sliced :x arg keeps its own window (expect cde): %s\n" f8(:x s3@2:5))
 
 // --- 9: slice==string compares the slice's own text, not the parent's,
 //        and not by symid identity (which would always be false -- a

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "bb39a856"
+#define PATCH_KEY "72125377"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`ComValue`'s `narg`/`nkey`/`nids` and its five flag bits (`bquote`, `lhs_assign`, `local`, `coloned`, `sliced`) used to live in `ComValue`-only storage, invisible to `AttributeValue`'s base-class copy paths (`operator=`, `assignval`). A `ComValue` boxed down into a plain `AttributeValue` — a func keyword arg, a captured closure free variable, any `AttributeList` entry — silently lost them. That's the actual mechanism behind #437 (a colon-list's `coloned()` print form lost on round-trip) and #438 (a sliced string reading back as its whole parent once passed as a keyword arg or captured free variable).

`AttributeValue` now carries the storage itself: the existing `_command_symid`/`_state` union slot plus three new ints (`_ext1`/`_ext2`/`_ext3`), widening the block to 128 bits total. `AttributeValue` only stores and copies these bytes — `ComValue` (comvalue.h) is the only class that interprets them:
- `narg()`/`nkey()` → `_ext1`/`_ext2` (doubling as `sliceoff()`/`slicelen()` for a `StringType`, same as before)
- the five `COMVALUE_*_FLAG` bits → packed into `_ext3`, above `nids()`'s own low byte

Flags couldn't share the `_command_symid` slot: a real command symbol id is an unbounded symbol-table index, not a small fixed value — confirmed empirically (`` `global ``'s own id collided with the first flag bit tried there). `_ext3` was the one word with genuinely spare, bounded bits, since `nids()`'s real range (the scanner's small `TOK_*` codes, plus a `-1` "bare identifier" sentinel) fits comfortably in a signed byte. `blocksz()` gave up its dedicated word to the flags — nothing sets a nonzero one yet, matching its own "storage, not the feature" note (#395).

`assignval()` copying this block unconditionally is what fixes #437/#438, but it also meant `lookup_symval()` needed to explicitly undo two things for a non-`StringType` resolution that used to be protected by the old narrow, base-class-only copy:
- the identifier's own call-site arity (`narg`/`nkey`/`nids` — e.g. a keyword call's arg count), which the resolved value's own (irrelevant) arity would otherwise clobber
- `bquote()`, which must never survive a read: a stored bquoted value's "don't resolve me" marker describes how *it* was written, not how a *later* read of the variable holding it should behave. Carrying it through breaks a documented, tested behavior (`nilcompare.comt` test 7 — a bquoted symbol reads as falsy, because a second resolution attempt on it correctly fails and degrades to `nullval()`).

Both are handled in a new `restore_call_arity()` helper, with a comment explaining the asymmetry (StringType's slice window must survive; everything else's stale arity/bquote must not).

`colonslice.comt` test 8, previously pinned as a documented #438 gap ("KNOWN GAP... expect abcdef, not cde"), now asserts the fixed value.

## Test plan

- [x] Full local `src/comterp_/tests/` suite: 44 of 45 scripts that report pass/fail (excludes the network-dependent `updown.comt`), each individually confirmed to end with its own `<name>: true`
- [x] Stock-code A/B comparison (git-stash based) at each stage to separate genuine regressions from pre-existing/unrelated noise
- [x] Targeted repros for the two bugs this surfaced along the way (call-site arity clobbered by symbol resolution; bquote surviving a variable read) confirmed fixed, not just papered over
- [x] Confirmed the underlying #437/#438 fix directly: a sliced string and a colon-list both now keep their window/`coloned()`-ness through a keyword arg and a closure capture
- [x] PATCH_KEY bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)