### PR TITLE
Give AttributeValue a render hook for its own ArrayType/StringType (#437/#438 follow-up)

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -57,6 +57,7 @@ LeakChecker* AttributeValue::_leakchecker = nil;
 /*****************************************************************************/
 
 int* AttributeValue::_type_syms = nil;
+AttributeValue::RenderHook AttributeValue::_render_hook = nil;
 
 AttributeValue::AttributeValue(ValueType valtype) {
 #ifdef LEAKCHECK
@@ -871,6 +872,17 @@ void AttributeValue::out_char_brief(ostream& out, unsigned char cv, boolean quot
 }
 
 ostream& operator<< (ostream& out, const AttributeValue& sv) {
+    /* Only these two types ever have ComTerp-specific meaning layered on
+       the shared narg/nkey/nids/flags block this class merely stores
+       (attrvalue.h) -- a coloned() list's ':' form, a sliced string's own
+       window via cstr().  Every other type's printing is already correct
+       here; routing it through the hook too would swap in ComValue's own
+       "brief" REPL-echo conventions (e.g. an unquoted char) in a context
+       -- an attribute's embedded value -- that wants this class's own,
+       different-on-purpose formatting instead. */
+    if (AttributeValue::_render_hook &&
+        (sv.type() == AttributeValue::ArrayType || sv.type() == AttributeValue::StringType))
+      return AttributeValue::_render_hook(out, sv);
     AttributeValue* svp = (AttributeValue*)&sv;
     const char* title;
     const char* symbol;

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -429,9 +429,34 @@ public:
     // return true if ObjectType matches or is a parent class
 
     friend ostream& operator << (ostream& s, const AttributeValue&);
-    // output AttributeValue to ostream.
+    // output AttributeValue to ostream -- consults render_hook() first
+    // (below) for ArrayType/StringType if one is installed, since those are
+    // the only two types with ComTerp-specific meaning layered on the
+    // shared block (see install_render_hook()'s own comment); every other
+    // type always uses this class's own generic printing.
     virtual const char* String();
     // generate string using << operator
+
+    typedef ostream& (*RenderHook)(ostream&, const AttributeValue&);
+    static void install_render_hook(RenderHook hook) { _render_hook = hook; }
+    // let a caller from outside this library render an ArrayType/StringType
+    // value its own way -- e.g. ComTerp (comvalue.c) installs one at
+    // library-load time so an AttributeList's own top-level print of an
+    // attribute's value (its stored type is always a plain AttributeValue*,
+    // attrlist.c) goes through ComValue::operator<< instead of this
+    // class's own generic printing, and so gets ComTerp-specific
+    // interpretation of the shared narg/nkey/nids/flags block (a
+    // coloned() list's ':' form, a sliced string's own window via
+    // cstr()) that this class only stores, never interprets (see the
+    // block's own comment below).  Every other type keeps this class's own
+    // formatting regardless of whether a hook is installed -- it's already
+    // correct, and ComValue's own printing follows different, brief-REPL-
+    // echo conventions for some of them (e.g. an unquoted char) that would
+    // be wrong in an attribute's embedded-value context.  Passing nil
+    // clears the hook, reverting to this class's own rendering for
+    // ArrayType/StringType too -- handy for seeing exactly what the raw
+    // bytes look like without any hook's interpretation layered on.
+    static RenderHook _render_hook;
 
     void* value_ptr() { return &_v; }
     // returns void* pointer to value struct.

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -2199,6 +2199,8 @@ void ComTerp::add_defaults() {
     add_command("isclass", new IsClassFunc(this));
     add_command("iscomm", new IsCommFunc(this));
     add_command("isfunc", new IsFuncFunc(this));
+    add_command("isslice", new IsSliceFunc(this));
+    add_command("islist", new IsListFunc(this));
 
     add_command("bquote", new BackQuoteFunc(this));
 

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -435,6 +435,27 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
     return out;
 }
 
+/* AttributeValue::install_render_hook() (attrvalue.h) lets a value stored
+   as a plain AttributeValue* -- e.g. an Attribute's own value, attrlist.c,
+   which can never be a ComValue* since Attribute lives in a lower library
+   that can't see ComTerp -- still print with ComTerp's own interpretation
+   of the shared narg/nkey/nids/flags block (a coloned() list's ':' form, a
+   sliced string's own window via cstr()) instead of AttributeValue's
+   generic fallback.  Installed once, here, at library-load time (the same
+   self-registering-static-local idiom this file already uses for one-time
+   symbol setup, e.g. ComValue::is_funcobj()'s posteval check) rather than
+   at any particular print call site: the hook itself is stateless (brief
+   mode etc. still comes from the existing ComValue::comterp() pointer, set
+   independently at each print call site), so it never needs re-arming, and
+   -- since nothing ever clears it mid-traversal -- it's already in effect
+   at any nesting depth a list's own recursive printing reaches. */
+static ostream& comvalue_render_hook(ostream& out, const AttributeValue& av) {
+  ComValue cv((AttributeValue&)av);
+  return out << cv;
+}
+static boolean _comvalue_render_hook_installed =
+  (AttributeValue::install_render_hook(comvalue_render_hook), true);
+
 const char* ComValue::String() {
     streambuf* strmbuf = nil;
 #pragma GCC diagnostic push

--- a/src/ComTerp/typefunc.c
+++ b/src/ComTerp/typefunc.c
@@ -321,3 +321,53 @@ void IsFuncFunc::execute() {
   else
     push_stack(match ? ComValue::trueval() : ComValue::falseval());
 }
+
+/*****************************************************************************/
+
+IsSliceFunc::IsSliceFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void IsSliceFunc::execute() {
+  ComValue arg0(stack_arg(0));
+  reset_stack();
+  boolean match = arg0.is_type(ComValue::StringType) && arg0.sliced();
+  push_stack(match ? ComValue::trueval() : ComValue::falseval());
+}
+
+/*****************************************************************************/
+
+IsListFunc::IsListFunc(ComTerp* comterp) : ComFunc(comterp) {
+}
+
+void IsListFunc::execute() {
+  ComValue arg0(stack_arg(0));
+  static int list_symid = symbol_add("list");
+  static int attr_symid = symbol_add("attr");
+  static int colon_symid = symbol_add("colon");
+  static int any_symid = symbol_add("any");
+  ComValue listflag(stack_key(list_symid));
+  ComValue attrflag(stack_key(attr_symid));
+  ComValue colonflag(stack_key(colon_symid));
+  ComValue anyflag(stack_key(any_symid));
+  reset_stack();
+  boolean is_array = arg0.is_type(ComValue::ArrayType);
+  boolean is_colon = is_array && arg0.coloned();
+  boolean is_attr = arg0.is_object(AttributeList::class_symid());
+  boolean match;
+  if (anyflag.is_true())
+    match = is_array || is_attr;
+  else if (colonflag.is_true())
+    match = is_colon;
+  else if (listflag.is_true())
+    match = is_array && !is_colon;
+  else if (attrflag.is_true())
+    match = is_attr;
+  else
+    /* bare, no keyword: any ArrayType, comma- or colon-built together --
+       "can this be indexed/iterated like a list", not "how was it built"
+       (list()'s own constructor keeps the opposite default -- bare
+       list(...) builds only a comma-list -- since a constructor has to
+       commit to exactly one shape, where a predicate doesn't). */
+    match = is_array;
+  push_stack(match ? ComValue::trueval() : ComValue::falseval());
+}

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -133,6 +133,33 @@ public:
       return "flag=%s(var :sym) -- true if var holds a func(), without evaluating it"; }
 };
 
+//: true if var is a StringType sliced from another string (#395).
+// flag=isslice(var) -- unlike istype()/isclass()/iscomm()/isfunc(), var
+// is evaluated normally: this tests the shape of a value, not a bare
+// symbol's own binding, so isslice(s@2:5) works on the slice expression's
+// result, not on "s".
+class IsSliceFunc : public ComFunc {
+public:
+    IsSliceFunc(ComTerp*);
+    virtual void execute();
+
+    virtual const char* docstring() {
+      return "flag=%s(var) -- true if var is a string sliced from another string (#395)"; }
+};
+
+//: true if var is list-shaped -- an ArrayType (comma- or colon-built) or
+// an attribute list, keyword-selected which.  Evaluated normally, same
+// as isslice() above, not istype()'s family.
+// flag=islist(var [:list] [:attr] [:colon] [:any])
+class IsListFunc : public ComFunc {
+public:
+    IsListFunc(ComTerp*);
+    virtual void execute();
+
+    virtual const char* docstring() {
+      return "flag=%s(var [:list] [:attr] [:colon] [:any]) -- true if var is list-shaped; bare (no keyword) matches any ArrayType, comma- or colon-built; :list or :colon alone narrows to just that one; :attr matches an attribute list (`.` dot targets, list(:attr)) instead; :any matches any of the three"; }
+};
+
 #endif /* !defined(_typefunc_h) */
 
 

--- a/src/comterp_/tests/colonslice.comt
+++ b/src/comterp_/tests/colonslice.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/colonslice.comt -- ':' as a string-slice operator (#395)
 //
-// funcs: colonlist at size print eq split string strcap + index gt lt ge le
+// funcs: colonlist at size print eq split string strcap + index gt lt ge le isslice islist
 //
 // str@lo:hi builds a slice: an ordinary StringType ComValue sharing str's
 // own symid (its memory stays exactly where it was allocated, reachable at
@@ -259,6 +259,35 @@ ok=ok&&(("abc"<3.14)==nil)
 ok=ok&&(("abc">=3.14)==nil)
 ok=ok&&(("abc"<=3.14)==nil)
 print("22 string vs non-string ordering comparison (expect nil x4): %v %v %v %v\n" "abc">3.14 "abc"<3.14 "abc">=3.14 "abc"<=3.14)
+
+// --- 23: isslice() -- the only script-level way to ask "is this a slice"
+//         other than printing (there wasn't one before) ---
+s23="abcdef"
+sl23=s23@2:5
+ok=ok&&(isslice(sl23)==true)
+ok=ok&&(isslice(s23)==false)
+ok=ok&&(isslice(5)==false)
+print("23 isslice(sl23), isslice(s23), isslice(5) (expect true false false): %v %v %v\n" isslice(sl23) isslice(s23) isslice(5))
+
+// --- 24: islist() -- keyword-selected: bare matches an ArrayType either
+//         way it was built (comma or colon); :list/:colon narrow to just
+//         one; :attr matches an attribute list instead; :any matches any
+//         of the three.  Deliberately not post_eval, unlike istype.comt's
+//         whole family -- these test a value's shape, not a bare symbol's
+//         binding, so islist(c24) has to evaluate c24 first. ---
+c24=1:2
+l24=1,2,3
+al24=(:x 1)
+ok=ok&&(islist(c24)==true && islist(l24)==true)
+ok=ok&&(islist(c24 :colon)==true && islist(l24 :colon)==false)
+ok=ok&&(islist(c24 :list)==false && islist(l24 :list)==true)
+ok=ok&&(islist(al24)==false && islist(al24 :attr)==true)
+ok=ok&&(islist(al24 :any)==true && islist(c24 :any)==true)
+print("24 islist(c24), islist(l24) bare (expect true true): %v %v\n" islist(c24) islist(l24))
+print("   islist(c24 :colon), islist(l24 :colon) (expect true false): %v %v\n" islist(c24 :colon) islist(l24 :colon))
+print("   islist(c24 :list), islist(l24 :list) (expect false true): %v %v\n" islist(c24 :list) islist(l24 :list))
+print("   islist(al24), islist(al24 :attr) (expect false true): %v %v\n" islist(al24) islist(al24 :attr))
+print("   islist(al24 :any), islist(c24 :any) (expect true true): %v %v\n\n" islist(al24 :any) islist(c24 :any))
 
 print("colonslice: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "3fd092e3"
+#define PATCH_KEY "bb0f570a"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "72125377"
+#define PATCH_KEY "3fd092e3"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -430,6 +430,13 @@ Print a usage summary of all the invocation modes above and exit.
  flag=isfunc(var :sym) -- true if var holds a func(), without evaluating it;
  with :sym, return `FuncObj (nil if false) instead of a flag
 
+ flag=isslice(var) -- true if var is a string sliced from another string
+
+ flag=islist(var [:list] [:attr] [:colon] [:any]) -- true if var is
+ list-shaped; bare (no keyword) matches any array, comma- or colon-built;
+ :list or :colon alone narrows to just that one; :attr matches an
+ attribute list instead; :any matches any of the three
+
  int=ctoi(char) -- convert character to integer
 
  flag=isspace(char) -- return true if character is whitespace


### PR DESCRIPTION
## Summary

Follow-up to #450, prompted by:

```
(comt) a.b=c:d
a.b=c:d
c:d
(comt) a
a
(:b c,d)
```

`a.b` read back correctly through dot access (`c:d`), but printing the whole attrlist showed `c,d` — the colon-list's `coloned()` form was lost. Same bug affects a sliced string assigned to an attribute (prints the whole parent, not its own window).

#450 widened `AttributeValue`'s storage so an attribute's value carries its `coloned()`/`sliced()` bits through assignment now — the *storage* is fine. The gap is in `AttributeList`'s own top-level print (`attrlist.c`'s `serialize()`), which calls the plain `AttributeValue::operator<<` on `attr->Value()` (always a base-class `AttributeValue*` — `Attribute` lives in a lower library that can't see `ComTerp`/`ComValue`). That operator has no way to interpret `coloned()`/`sliced()` — those are `ComValue`-only concepts.

`AttributeValue` now exposes a small, generic hook slot (`install_render_hook()`) that a caller from outside the library can fill in. `ComTerp` (`comvalue.c`) installs one once, at library-load time, via a self-registering static local (the same idiom already used elsewhere in that file for one-time symbol setup) — not at any particular print call site, since the hook itself is stateless (brief-mode etc. still comes from the existing, independently-set `ComValue::comterp()` pointer). The installed hook wraps the value in a `ComValue` and delegates to `ComValue::operator<<`.

`AttributeValue` gains no new interpretive API from this — it only knows there's a hook slot, and only consults it for `ArrayType`/`StringType`, the only two types with any ComTerp-specific meaning layered on the shared block from #450. Every other type keeps this class's own formatting unconditionally: `ComValue`'s own printing follows different, brief-REPL-echo conventions for some of them (an unquoted char, in particular) that would be wrong in an attribute's embedded-value display — caught by `char.comt` test 9 during this PR's own verification, fixed by narrowing the hook's scope to just those two types.

Passing `nil` to `install_render_hook()` clears it, reverting every call site to the base class's own rendering — useful for seeing exactly what the raw bytes look like with no ComTerp interpretation layered on.

A separate, pre-existing, hand-rolled printer (`operator<<(ostream&, const AttributeValueList&)`, attrlist.c) never delegated to `AttributeValue::operator<<` in the first place, so it's outside this hook's reach — noted but out of scope, since it's not what the reported bug hit.

## Also in this PR: isslice()/islist() predicates

Prompted by a follow-on question: other than printing, there was no way to ask a script whether a value is a colon-list or a sliced string. Added:

- `isslice(var)` — true if `var` is a `StringType` sliced from another string
- `islist(var [:list] [:attr] [:colon] [:any])` — bare matches either `ArrayType` flavor together (comma- or colon-built); `:list`/`:colon` narrow to just one; `:attr` matches an attribute list instead; `:any` matches any of the three

Named `is<noun>` to match the language's one existing predicate family (`istype`/`isclass`/`iscomm`/`isfunc`/`isspace`/`isdigit`/`isalpha`) rather than the `coloned()`/`sliced()` C++ accessor names, and `islist()`'s keywords reuse `list()`'s own `:attr`/`:colon` constructor vocabulary rather than inventing new ones (`:dot` was considered and dropped for that reason). Unlike `istype()`'s family, both evaluate their argument normally — they test a value's shape, not a bare symbol's binding.

Man page (`comterp.1`) and `colonslice.comt` (tests 23–24) updated.

## Test plan

- [x] Both repros from the report confirmed fixed: `a.b=c:d` → `print(a)` now shows `(:b c:d)`; a sliced-string attribute now prints its own window, not the whole parent
- [x] `isslice()`/`islist()` behavior confirmed against all documented keyword combinations (colonslice.comt tests 23–24)
- [x] Full local `src/comterp_/tests/` suite: 44 of 45 scripts that report pass/fail (excludes network-dependent `updown.comt`), each individually confirmed `<name>: true` — including `char.comt`, which caught the over-broad first version of the render hook
- [x] PATCH_KEY bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)