### PR TITLE
Land a grant on the node that asked for it

### DIFF
--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -399,6 +399,8 @@ void GraphicIdFunc::execute() {
   ComValue grantv(stack_key(grant_sym));
   static int state_sym = symbol_add("state");
   ComValue statev(stack_key(state_sym));
+  static int notaken_sym = symbol_add("notaken");
+  ComValue notakenv(stack_key(notaken_sym));
   static int deny_sym = symbol_add("deny");
   ComValue denyv(stack_key(deny_sym));
   static int table_sym = symbol_add("table");
@@ -452,8 +454,11 @@ void GraphicIdFunc::execute() {
       uuid_t gid;
       uuid_parse(grantv.string_ptr(), gid);
       
-      ((DrawServ*)unidraw)->grid_message_callback
-	(link, id, selector, statev.int_val(), gid);
+      if (notakenv.is_true())
+	((DrawServ*)unidraw)->grid_notaken(link, id, selector, gid);
+      else
+	((DrawServ*)unidraw)->grid_message_callback
+	  (link, id, selector, statev.int_val(), gid);
     }
     
   } else if (idv.is_known() && selectorv.is_unknown()) {

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -54,7 +54,7 @@ public:
     GraphicIdFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s(id) -- lookup compview by uuid\n\tgrid(id selector :state selected :request newselector :grant oldselector :deny) -- command to send message between remote selections\n\tgrid(:table) -- return the gridtable as a list of (:grid :comptype :selector :selected) rows, uuids as 8-char prefixes"; }
+	return "%s(id) -- lookup compview by uuid\n\tgrid(id selector :state selected :request newselector :grant oldselector :deny :notaken) -- command to send message between remote selections\n\tgrid(:table) -- return the gridtable as a list of (:grid :comptype :selector :selected) rows, uuids as 8-char prefixes"; }
 };
 
 //: command to return point list associated with a graphic

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -659,8 +659,32 @@ void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
   if (!ptr) return;
   GraphicId* grid = (GraphicId*)ptr;
 
-  if (granter != NULL && uuid_compare(granter, sessionid())==0 &&
-      responder != NULL && uuid_compare(grid->selector(), responder)==0) {
+  if (granter==NULL || uuid_is_null(granter)) return;
+
+  /* not our grant: a grant reaches its recipient through linkget(selector),
+     so the response has to travel back the same way rather than stopping at
+     the relay it happens to arrive on. */
+  if (uuid_compare(granter, sessionid())) {
+    DrawLink* glink = linkget(granter);
+    if (glink && glink != link) {
+      uuid_string_t responder_str;
+      responder_str[0] = '\0';
+      if (responder != NULL && !uuid_is_null(responder))
+	uuid_unparse(responder, responder_str);
+      uuid_string_t granter_str;
+      uuid_unparse(granter, granter_str);
+      char buf[BUFSIZ];
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :notaken :class \"%s\")%c",
+	       grid->idstr(), responder_str, granter_str,
+	       grid->compclass(), '\0');
+      SendCmdString(glink, buf);
+      fprintf(stderr, "grid: grant-not-taken passed along to granter\n");
+    } else
+      fprintf(stderr, "grid: grant-not-taken undeliverable, dropped\n");
+    return;
+  }
+
+  if (responder != NULL && uuid_compare(grid->selector(), responder)==0) {
     grid->selector(sessionid());
     fprintf(stderr, "grid: grant not taken, ownership restored here\n");
   } else

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -613,11 +613,24 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       if (((const char *)newselector)==NULL || uuid_is_null(newselector)) {
 	if (linklist()->Number()>1)
 	  fprintf(stderr, "grid: state change passed along to everyone else\n");
-	grid->selector(selector);
-	grid->selected(state);
+
+	/* an announcement of "free, and still held by the node we asked" is the
+	   condition our request is waiting on, not news that voids it -- the
+	   grant is already on its way, and grid_message_callback recognises it
+	   only while the state reads WaitingToBeSelected.  every other change
+	   does void the request and resets it as before. */
+	if (!(grid->selected()==LinkSelection::WaitingToBeSelected &&
+	      state==LinkSelection::NotSelected &&
+	      selector != NULL &&
+	      uuid_compare(grid->selector(), selector)==0)) {
+	  grid->selector(selector);
+	  grid->selected(state);
+	}
+
+	/* relay what was announced, not what we hold */
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d :class \"%s\")%c",
-		 grid->idstr(), grid->selectorstr(), grid->selected(),
+		 grid->idstr(), selector_str, state,
 		 grid->compclass(), '\0');
 	DistributeCmdString(buf, link);
       } 
@@ -633,6 +646,25 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       }
     }
   }
+}
+
+/* a grant of ours that the responder could not take.  the grant is identified,
+   so a response that has been overtaken -- we have since handed the graphic to
+   someone else -- is recognisable and ignored. */
+void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
+			    uuid_t granter)
+{
+  void* ptr = nil;
+  gridtable()->find(ptr, uuid_key(id));
+  if (!ptr) return;
+  GraphicId* grid = (GraphicId*)ptr;
+
+  if (granter != NULL && uuid_compare(granter, sessionid())==0 &&
+      responder != NULL && uuid_compare(grid->selector(), responder)==0) {
+    grid->selector(sessionid());
+    fprintf(stderr, "grid: grant not taken, ownership restored here\n");
+  } else
+    fprintf(stderr, "grid: grant-not-taken overtaken, ignored\n");
 }
 
 // handle callback from remote DrawLink.
@@ -667,6 +699,25 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
 	sel->AddComp(comp);
 	grid_message(grid);
       }
+    }
+
+    /* a grant addressed to us that we could not take: say so rather than
+       sending it back out.  linkget(selector) is our own link when the
+       selector is this session, so forwarding it returns it to the node that
+       granted it, which forwards it here again -- 313k messages in half a
+       minute, for eight graphics. */
+    else if (selector != NULL && uuid_compare(selector, sessionid())==0) {
+      fprintf(stderr, "grid:  grant for us arrived on a graphic in %s, dropped\n",
+	      LinkSelection::selected_string(grid->selected()));
+      /* the granter commits the handoff when it sends the grant, so it has to
+	 be told this one did not land.  answer the grant itself rather than
+	 announcing state: a state message is an unconditional assertion and a
+	 stale one would undo a later handoff. */
+      char buf[BUFSIZ];
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :notaken :class \"%s\")%c",
+	       grid->idstr(), sessionidstr(), oldselector_str,
+	       grid->compclass(), '\0');
+      SendCmdString(link, buf);
     }
 
     /* otherwise, pass the granting message along */

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -150,6 +150,9 @@ public:
 			   int state, uuid_t newselector=NULL);
   // handle graphic id selection message
 
+  void grid_notaken(DrawLink* link, uuid_t id, uuid_t responder, uuid_t granter);
+  // handle a grant of ours that the responder could not take
+
   void grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector, 
 			     int state, uuid_t oldselector);
   // callback for graphic id selection message 

--- a/src/drawserv_/examples/kid.comt
+++ b/src/drawserv_/examples/kid.comt
@@ -1,0 +1,93 @@
+// One fourth grader at the table.  Whatever drawserv runs this can draw
+// animals, adventurers and trees wherever the dice land -- and every other
+// drawserv at the table gets them over the links.
+//
+// The magic words ride on one object rather than as floating functions, the
+// way zoomap's zoo=(...) does -- and they have to be defined INLINE here:
+// naming a func fires it niladically, so kid=(:animal kid_animal) would store
+// the nil that calling it returned.  Arguments arrive as keywords.
+//
+// Loaded with -runfile this lands in the node's main interpreter, and every
+// connection made later is seeded from it -- so the kid is taught once, at
+// startup, and any socket may ask.  (Connections do not see each OTHER: a kid
+// taught down one socket after startup is invisible to the next.)
+
+kid=(
+  :colour "#888888"
+
+  :animal func(
+    ellipse(x,y, 26,16);            // body
+    colorsrgb(c "#FFFFFF");
+    ellipse(x+24,y-8, 11,10);       // head
+    colorsrgb(c "#FFFFFF");
+    ellipse(x-22,y+2, 7,5);         // tail
+    colorsrgb(c "#FFFFFF")
+  )
+
+  :adventurer func(
+    rect(x-7,y, x+7,y+30);          // body
+    colorsrgb(c "#FFFFFF");
+    ellipse(x,y+40, 10,10);         // head
+    colorsrgb("#FFDDAA" "#FFFFFF");
+    line(x+7,y+22, x+22,y+34);      // sword arm
+    colorsrgb(c "#FFFFFF")
+  )
+
+  :tree func(
+    rect(x-4,y, x+4,y+22);          // trunk
+    colorsrgb("#8B5A2B" "#FFFFFF");
+    ellipse(x,y+34, 20,16);         // leaves
+    colorsrgb("#33AA33" "#FFFFFF")
+  )
+
+  // kid.play(:n 6) -- draw n things, pausing between them.  The pause is the
+  // point: a fourth grader draws at mouse speed, not at socket speed.
+  :play func(
+    i=0;
+    while(i<n
+      xx=60+int(rand(0,520));
+      yy=50+int(rand(0,300));
+      pick=int(rand(0,2.99));
+      if(pick==0 :then kid.animal(:x xx :y yy :c kid.colour) :else
+        if(pick==1 :then kid.adventurer(:x xx :y yy :c kid.colour)
+          :else kid.tree(:x xx :y yy)));
+      update(1);
+      usleep(400000);
+      i=i+1);
+    /* put it down when finished.  Creating a graphic selects it, and a
+       selection is a claim the other tables have to ask for: everything a kid
+       still holds is refused to everyone else, and their requests sit in
+       WaitingToBeSelected until it lets go.  A fourth grader who has finished a
+       dragon is not still holding it. */
+    select(:clear);
+    i)
+)
+
+// Like spirograph.comt, this leaves you somewhere to stand rather than just
+// falling silent: one creature so you can see the script took, and the magic
+// words.  Load it into a drawserv's -comt pane and you are a fourth grader,
+// with or without kidmo and the rest of the table.
+//
+// The greeting is printed plainly, so it lands in the -comt pane a person is
+// looking at.  A bare print() goes to whatever is listening, which over a
+// socket is the reply stream -- the banner would arrive where an answer was
+// expected and put every later question on that connection one behind -- so a
+// caller loading this to drive from, rather than to read, sets quiet=true
+// first.  kidmo does exactly that on its own connection.
+
+/* only when there is nothing here yet: with -comt kid.comt the pane loads this
+   at startup, and kidmo loads it again over its own connection to drive from --
+   two loads, and without this, two welcome creatures */
+if(size(grid(:table))==0 :then kid.animal(:x 300 :y 220 :c kid.colour))
+
+if(quiet!=true :then
+  print("\n===============================================\n");
+  print("   YOU ARE A FOURTH GRADER WITH A DRAWSERV\n");
+  print("   That grey creature is kid.animal() -- and\n");
+  print("   anything you draw goes to everyone you are\n");
+  print("   linked to.  Try typing:\n");
+  print("       kid.play(:n 3)\n");
+  print("       kid.colour=\"#DD3333\"\n");
+  print("       kid.adventurer(:x 200 :y 120 :c kid.colour)\n");
+  print("       kid.tree(:x 420 :y 120)\n");
+  print("===============================================\n"))


### PR DESCRIPTION
A node that asks for a graphic marks it `WaitingToBeSelected`, and
`grid_message_callback` recognises the incoming grant only while the state still
reads that way.  Any incoming `:state` reset it — and the announcement doing the
resetting is the one the owner emits when its unlock bracket lets the graphic go:
`state 0, selector = the owner`, i.e. *"free, and still mine"*.  That is the very
condition the request is waiting on, and it arrives microseconds ahead of the
grant it predicts.

So the request died, the grant landed unmatched, and because the owner commits
the handoff when it *sends* the grant, the two nodes were left each believing the
other held the graphic.  Every later request was then forwarded to the node that
had sent it and forwarded straight back — measured at 78k messages in twelve
seconds over eight graphics, linear in wall-clock, i.e. a free-running cycle
rather than a hop count.

## Changes

**Narrow the reset.** An incoming `:state` still voids a pending request for every
change that genuinely makes it moot — someone else took it, or the selector moved
to a third party.  It no longer voids one on the single announcement that confirms
the request is about to succeed.  The relay now forwards the *announced* values
rather than the local ones, so a node that keeps its pending state still passes
the news along faithfully.

**`:notaken`.** The missing third leg of the handshake, and the counterpart of the
`:deny` added in 5dbd4ec3 — which likewise replaced a `:state` message being used
to answer a specific request.  A grant arriving unmatched for any other reason is
answered by naming the grant; the granter restores its own ownership only while
its record still names the responder, so a response overtaken by a later handoff
is recognised and ignored.

**Drop, don't forward, a grant we can't take.** `linkget(selector)` is our own link
when the selector is this session, so the old path returned the grant to the
granter to be sent again.  That was the ping-pong.

Also: `kid.comt`'s welcome guard reads `grid(:table)` rather than claiming the
whole canvas with `select(:all)` in order to count it.

## Testing

Two nodes, one drawing under unlock brackets while the other selects what arrives:

| | before | after |
|---|---|---|
| graphics acquired | 0 / 8 | 8 / 8 |
| grants unmatched | 8 | 0 |
| requests forwarded | 78,643 | 0 |

Mutual exclusion re-checked separately: a graphic the far node is genuinely
holding is still denied, and stays held.

**drawmo has not gated this.** It currently dies in `updown` on this machine with a
SIGSEGV in the orchestrator's comterp — `stack_arg_post_eval` → `UpdateFunc::execute`
→ `push_stack` → `ComValue::operator=` → `AttributeValue::assignval` — identically
with and without this branch (control run performed), before reaching any code
touched here.  Unrelated, and worth its own investigation.

## Not addressed

- `waiting_count` leaks when a request is voided by a state change: it is
  incremented at request time and unwound only via `request_resolved_check` on
  accept or `:deny`.  The right unwind point needs a decision about which
  `LinkSelection` owns the count when the request was made by a previous one.
- Request forwarding still has no hop limit, so a three-node selector cycle
  (A→B→C→A) remains possible.  The link graph has `cycletest`; the selector graph
  has no equivalent.
- No drawmo coverage for selecting across ownership while the far node runs
  unlock-bracketed commands — the gap that let this live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)