### PR TITLE
Make RandFunc::drand's bound half-open

### DIFF
--- a/src/ComTerp/randfunc.c
+++ b/src/ComTerp/randfunc.c
@@ -62,7 +62,7 @@ double RandFunc::drand(double minval, double maxval) {
 #define RAND_MAX INT_MAX
 #endif
 
-  double gain = (maxval-minval)/RAND_MAX;
+  double gain = (maxval-minval)/(RAND_MAX+1.0);
   double bias = minval;
 
   int rnum = rand();

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "58b3c72e"
+#define PATCH_KEY "b5c46f6e"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `RandFunc::drand(minval, maxval)` divided by `RAND_MAX` instead of `RAND_MAX+1`, making `maxval` reachable exactly (probability `1/(RAND_MAX+1)`) instead of the intended half-open `[minval, maxval)`. That matters for callers using it to pick an index (`int(rand(0,n))` could return `n` itself).
- Fixed as `RAND_MAX+1.0`, not `RAND_MAX+1` — `RAND_MAX` is `INT_MAX` on this platform, so plain `int` arithmetic overflows (UB, wraps to `INT_MIN` in practice) before the division ever promotes it to `double`, which flips `gain` negative and makes `drand()` return negative values across the board. The `.0` forces the promotion first.
- Bumped `PATCH_KEY`.

## Test plan
- [x] Verified the exact arithmetic expression in a standalone reproduction outside the ivtools build (this checkout's local build is currently broken independent of this change — libc++'s own `<version>` feature-test header collides with the repo's top-level `version` release-notes file once `../../` lands on the include path — so a full in-tree rebuild wasn't possible here): confirmed `rnum=0 -> minval` exactly, `rnum=RAND_MAX -> just under maxval` (never equal), and that plain `RAND_MAX+1` silently produces negative results while `RAND_MAX+1.0` does not.
- [ ] Full in-tree build/test once the unrelated `version`-header collision is sorted out.