### PR TITLE
Make select() say what it got, wait for the answer, and add children()

### DIFF
--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -152,6 +152,7 @@ void ComEditor::AddCommands(ComTerp* comterp) {
 
     comterp->add_command("depth", new GrDepthFunc(comterp));
     comterp->add_command("parent", new GrParentFunc(comterp));
+    comterp->add_command("children", new ChildrenFunc(comterp, this));
     comterp->add_command("rect", new CreateRectFunc(comterp, this));
     comterp->add_command("rectangle", new CreateRectFunc(comterp, this));
     comterp->add_command("line", new CreateLineFunc(comterp, this));

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1579,9 +1579,13 @@ void SelectFunc::execute() {
 	if (compval) {
 	  avl->Append(compval);
 	}
-	delete newSel;
-        newSel = nil;
       }
+      /* the query form installs no selection at all.  inside the loop this ran
+	 only when there was something to report, so querying an empty selection
+	 fell through to the block below and cleared the editor's selection --
+	 and, once select() waits, blocked on the pending count as well. */
+      delete newSel;
+      newSel = nil;
 
     } else {
 

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1536,9 +1536,6 @@ void SelectFunc::execute() {
       for (gv->First(i); !gv->Done(i); gv->Next(i)) {
 	GraphicView* subgv = gv->GetView(i);
 	newSel->Append(subgv);
-	OverlayComp* comp = (OverlayComp*)subgv->GetGraphicComp();
-	ComValue* compval = new ComValue(new OverlayViewRef(comp), comp->classid());
-	avl->Append(compval);
       }
 
     } else if (nargs()==0) {
@@ -1565,11 +1562,8 @@ void SelectFunc::execute() {
 	  OverlayComp* comp = (OverlayComp*)comview->GetSubject();
 	  if (comp) {
 	    GraphicView* view = comp->FindView(viewer);
-	    if (view) {
+	    if (view)
 	      newSel->Append(view);
-	      ComValue* compval = new ComValue(new OverlayViewRef(comp), comp->classid());
-	      avl->Append(compval);
-	    }
 	  }
 	} else if (obj.is_array()) {
 	  Iterator it;
@@ -1581,11 +1575,8 @@ void SelectFunc::execute() {
 	      OverlayComp* comp = (OverlayComp*)comview->GetSubject();
 	      if (comp) {
 		GraphicView* view = comp->FindView(viewer);
-		if (view) {
+		if (view)
 		  newSel->Append(view);
-		  ComValue* compval = new ComValue(new OverlayViewRef(comp), comp->classid());
-		  avl->Append(compval);
-		}
 	      }
 	    }
 	    al->Next(it);
@@ -1612,6 +1603,19 @@ void SelectFunc::execute() {
       newSel->Reserve();   // sees unlocked()==true
       if (lockv.is_string())
         newSel->lock_key(lockv.string_ptr());  // clear after Reserve()
+
+      /* report what was acquired rather than what was asked for: Reserve()
+         removes the graphics another session is holding, so a list built while
+         appending describes the request, and a select() that was refused reads
+         back as one that succeeded. */
+      Iterator si;
+      for (newSel->First(si); !newSel->Done(si); newSel->Next(si)) {
+        GraphicView* grview = newSel->GetView(si);
+        OverlayComp* comp = grview ? (OverlayComp*)grview->GetSubject() : nil;
+        if (comp)
+          avl->Append(new ComValue(new OverlayViewRef(comp), comp->classid()));
+      }
+
       unidraw->Update();
     }
     reset_stack();

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1634,16 +1634,23 @@ void SelectFunc::execute() {
       if (lockv.is_string())
         newSel->lock_key(lockv.string_ptr());  // clear after Reserve()
 
+      resolve_requests(newSel);
+
       /* report what was acquired rather than what was asked for: Reserve()
          removes the graphics another session is holding, so a list built while
          appending describes the request, and a select() that was refused reads
-         back as one that succeeded. */
-      Iterator si;
-      for (newSel->First(si); !newSel->Done(si); newSel->Next(si)) {
-        GraphicView* grview = newSel->GetView(si);
-        OverlayComp* comp = grview ? (OverlayComp*)grview->GetSubject() : nil;
-        if (comp)
-          avl->Append(new ComValue(new OverlayViewRef(comp), comp->classid()));
+         back as one that succeeded.  read the editor's selection rather than
+         newSel: resolve_requests() may have run the event loop, and anything
+         that arrived during it could have put a different selection in place. */
+      OverlaySelection* cursel = (OverlaySelection*)_ed->GetSelection();
+      if (cursel) {
+        Iterator si;
+        for (cursel->First(si); !cursel->Done(si); cursel->Next(si)) {
+          GraphicView* grview = cursel->GetView(si);
+          OverlayComp* comp = grview ? (OverlayComp*)grview->GetSubject() : nil;
+          if (comp)
+            avl->Append(new ComValue(new OverlayViewRef(comp), comp->classid()));
+        }
       }
 
       unidraw->Update();

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1500,6 +1500,36 @@ void ColorFunc::execute() {
 SelectFunc::SelectFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
 }
 
+ChildrenFunc::ChildrenFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
+}
+
+void ChildrenFunc::execute() {
+    ComValue parentv(stack_arg(0));
+    reset_stack();
+
+    Viewer* viewer = _ed->GetViewer();
+    GraphicView* gv = nil;
+    if (parentv.object_compview()) {
+      ComponentView* comview = (ComponentView*)parentv.obj_val();
+      OverlayComp* comp = (OverlayComp*)comview->GetSubject();
+      if (comp) gv = comp->FindView(viewer);
+    } else
+      gv = ((OverlayEditor*)_ed)->GetFrame();
+
+    AttributeValueList* avl = new AttributeValueList();
+    if (gv) {
+      Iterator i;
+      for (gv->First(i); !gv->Done(i); gv->Next(i)) {
+	GraphicView* subgv = gv->GetView(i);
+	OverlayComp* comp = subgv ? (OverlayComp*)subgv->GetGraphicComp() : nil;
+	if (comp)
+	  avl->Append(new ComValue(new OverlayViewRef(comp), comp->classid()));
+      }
+    }
+    ComValue retval(avl);
+    push_stack(retval);
+}
+
 void SelectFunc::execute() {
     static int all_symid = symbol_add("all");
     ComValue all_flagv(stack_key(all_symid));

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -249,6 +249,22 @@ class ColorRgbFunc : public UnidrawFunc {
     return "%s([fgcolorname bgcolorname]) -- set current colors by RGB name; return current colors as fgname,bgname if no args.\nThe colorname format is \"#RGB\" for 4 bits, \"#RRGGBB\" for 8 bits,\n\"#RRRGGGBBB\" for 12 bits,\"#RRRRGGGGBBBB\" for 16 bits"; }
 };
 
+//: command to list the graphics inside a composite in comdraw.
+// children([parent]) -- component views inside a composite, default what
+// frame() returns for the current frame.  the counterpart of parent(): that
+// climbs, this descends.  read-only -- it walks the view tree without
+// selecting anything, so it neither claims a graphic nor needs a link to be
+// up, and it reports every graphic present whatever state that graphic is in.
+// there is no compview for the document as a whole, so a frame is as wide as
+// this reaches.
+class ChildrenFunc : public UnidrawFunc {
+public:
+    ChildrenFunc(ComTerp*,Editor*);
+    virtual void execute();
+    virtual const char* docstring() { 
+	return "list=%s([parent]) -- component views inside a composite (dflt current frame), without selecting them"; }
+};
+
 //: command to select graphics in comdraw.
 // select([compview ...] :all :clear) -- make these graphics the current selection, 
 // default returns current selection.

--- a/src/ComUnidraw/grfunc.h
+++ b/src/ComUnidraw/grfunc.h
@@ -30,6 +30,7 @@
 
 #include <ComUnidraw/unifunc.h>
 
+class OverlaySelection;
 class Graphic;
 class RasterOvComp;
 class Transformer;
@@ -272,6 +273,9 @@ class SelectFunc : public UnidrawFunc {
 public:
     SelectFunc(ComTerp*,Editor*);
     virtual void execute();
+    virtual void resolve_requests(OverlaySelection* sel) {}
+    // wait for an answer that arrives asynchronously, before the returned list
+    // is built -- nothing to wait for below DrawServ
     virtual const char* docstring() { 
 	return "%s([compview ... | compview,compview[,... compview]] :all :clear) -- make these graphics the current selection (dflt is current)"; }
     virtual const char** dockeys() {

--- a/src/DrawServ/draweditor.c
+++ b/src/DrawServ/draweditor.c
@@ -93,7 +93,7 @@ void DrawEditor::AddCommands(ComTerp* comterp) {
   comterp->add_command("points", new DrawPointsFunc(comterp, this));
 
   /* re-register select() with DrawServ-specific :unlock/:lock keywords in docstring */
-  comterp->add_command("select", new SelectFunc(comterp, this), nil,
+  comterp->add_command("select", new LinkSelectFunc(comterp, this), nil,
     "%s([compview ... | compview,compview[,... compview]] :all :clear :unlock key :lock key)"
     " -- make these graphics the current selection\n"
     "        :all         select all graphics\n"

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -22,6 +22,7 @@
  */
 
 #include <DrawServ/ackback-handler.h>
+#include <ComTerp/comhandler.h>
 #include <DrawServ/draweditor.h>
 #include <DrawServ/drawclasses.h>
 #include <DrawServ/drawfunc.h>
@@ -386,6 +387,37 @@ void SessionIdFunc::execute() {
   }
 }
 
+
+/*****************************************************************************/
+
+LinkSelectFunc::LinkSelectFunc(ComTerp* comterp, Editor* ed)
+: SelectFunc(comterp, ed) {
+}
+
+void LinkSelectFunc::resolve_requests(OverlaySelection* sel) {
+  LinkSelection* lsel = (LinkSelection*)sel;
+  if (!lsel || lsel->waiting_count()==0) return;
+
+  /* a request answered by another session comes back asynchronously -- the same
+     resolution that beeps or dings for an interactive select.  wait for it, so
+     the list returned is the answer rather than the question, and keep it quiet
+     while waiting: the caller is being told by the return value.  bounded, a
+     node that never replies not being allowed to stall the one that asked, and
+     the selection re-read each time round because running the event loop lets
+     anything arrive, including a select that puts a different one in place. */
+  const int slice_usec = 10000;
+  const int spin_limit = 200;   /* two seconds */
+  int spins = 0;
+  while (spins++ < spin_limit) {
+    LinkSelection* cur = (LinkSelection*)_ed->GetSelection();
+    if (!cur || cur->waiting_count()==0) break;
+    cur->silent() = true;
+    ACE_Time_Value timeout(0, slice_usec);
+    ComterpHandler::reactor_singleton()->handle_events(timeout);
+  }
+  LinkSelection* done = (LinkSelection*)_ed->GetSelection();
+  if (done) done->silent() = false;
+}
 
 /*****************************************************************************/
 

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -26,6 +26,7 @@
 
 #include <DrawServ/draweditor.h>
 #include <ComUnidraw/unifunc.h>
+#include <ComUnidraw/grfunc.h>
 
 //: command to connect to another drawserv
 // drawlink([hoststr] :port portnum :state num :lid nu :rid num :close :dump) -- connect to remote drawserv
@@ -55,6 +56,18 @@ public:
     virtual void execute();
     virtual const char* docstring() { 
 	return "%s(id) -- lookup compview by uuid\n\tgrid(id selector :state selected :request newselector :grant oldselector :deny :notaken) -- command to send message between remote selections\n\tgrid(:table) -- return the gridtable as a list of (:grid :comptype :selector :selected) rows, uuids as 8-char prefixes"; }
+};
+
+//: select() that waits for the distributed answer, in drawserv.
+// select([compview ...] :all :clear :unlock key :lock key) -- as comdraw's
+// select(), but a request that has to be answered by another session is waited
+// on before returning, so the returned list is what was granted rather than
+// what was asked for.  the wait is silent: an interactive select beeps or dings
+// when its answer lands, a scripted one is told in the return value.
+class LinkSelectFunc : public SelectFunc {
+public:
+    LinkSelectFunc(ComTerp*,Editor*);
+    virtual void resolve_requests(OverlaySelection* sel);
 };
 
 //: command to return point list associated with a graphic

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -623,6 +623,15 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	      state==LinkSelection::NotSelected &&
 	      selector != NULL &&
 	      uuid_compare(grid->selector(), selector)==0)) {
+	  if (grid->selected()==LinkSelection::WaitingToBeSelected) {
+	    /* ownership moved while we were asking.  nobody refused us, but we
+	       are not getting it either, so resolve it the way a denial
+	       resolves -- the count has to come down, and from where the asker
+	       sits this is the same disappointment. */
+	    LinkSelection* lsel =
+	      (LinkSelection*)DrawKit::Instance()->GetEditor()->GetSelection();
+	    if (lsel) lsel->request_resolved_check(false, FILELINE);
+	  }
 	  grid->selector(selector);
 	  grid->selected(state);
 	}

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -70,6 +70,7 @@ void LinkSelection::Init(DrawEditor* editor) {
     _waiting_to_be_selected = new GraphicIdList;
   }
   waiting_count() = granted_count() = 0;
+  silent() = false;
   wtbs_flag() = remote_flag() = paste_in_progress_flag() = false;
 }
 
@@ -147,6 +148,8 @@ void LinkSelection::Reserve() {
 	if (grid->unlocked()) {
 	  /* was temporarily unlocked for distributed cmd -- silent drop */
 	} else {
+	  if (grid->selected()==WaitingToBeSelected)
+	    request_withdrawn();
 	  grid->selected(NotSelected);
 	  ((DrawServ*)unidraw)->grid_message(grid);
 	}
@@ -303,10 +306,27 @@ int LinkSelection::all_requests_resolved(boolean granted) {
   return 0;  // still waiting for more responses
 }
 
+/* a request of ours that died without an answer because we let the graphic go.
+   the count has to come down either way -- it gates the beep and the ding, and
+   a select() that waits on it -- but there is nothing to tell the user: they
+   moved on, which is what withdrew the request. */
+void LinkSelection::request_withdrawn() {
+  if (waiting_count() > 0)
+    waiting_count()--;
+  if (waiting_count() == 0) {
+    wtbs_flag() = false;
+    remote_flag() = false;
+    granted_count() = 0;
+  }
+}
+
 boolean LinkSelection::request_resolved_check(boolean granted, const char* fileline) {
   if (waiting_count() > 0) {
     int status = all_requests_resolved(granted);
-    if (status==-1)
+    if (silent()) {
+      /* a scripted select() is waiting on this and reports it as its return
+	 value -- the answer does not also need to be audible */
+    } else if (status==-1)
       Beep(fileline);
     else if (status==1)
       Ding(fileline);

--- a/src/DrawServ/linkselection.h
+++ b/src/DrawServ/linkselection.h
@@ -90,6 +90,14 @@ public:
   // -1 = all resolved, all denied (beep)
   
   boolean request_resolved_check(boolean granted, const char* fileline);
+
+  boolean& silent() { return _silent; }
+  // when set, a resolved request unwinds the count without the beep or ding:
+  // a scripted select() waits for the answer and returns it instead.
+
+  void request_withdrawn();
+  // unwind one outstanding request that will never be answered because we
+  // stopped asking.  silent: nobody refused us, we withdrew the question.
   // make beep/ding sound when request resolved and response is known
 
   virtual void unlock_key(const char* keystr);
@@ -105,6 +113,7 @@ protected:
   static const char* _selected_strings[];
 
   int _waiting_count;
+  boolean _silent;
   int _granted_count;
   boolean _wtbs_flag;
   boolean _remote_flag;

--- a/src/drawserv_/examples/kid.comt
+++ b/src/drawserv_/examples/kid.comt
@@ -78,7 +78,7 @@ kid=(
 /* only when there is nothing here yet: with -comt kid.comt the pane loads this
    at startup, and kidmo loads it again over its own connection to drive from --
    two loads, and without this, two welcome creatures */
-if(size(grid(:table))==0 :then kid.animal(:x 300 :y 220 :c kid.colour))
+if(size(children())==0 :then kid.animal(:x 300 :y 220 :c kid.colour))
 
 if(quiet!=true :then
   print("\n===============================================\n");


### PR DESCRIPTION
Three changes, each following from the one before.

## 1. select() reports what it got

`SelectFunc::execute` built its return list while appending views to the new
selection — before `Reserve()` removes the graphics another session holds. The
list described the *request*, not the result, so a refused `select()` read back
exactly like one that succeeded. That is how `size(select(:all))` reported 44 on
a kidmo node holding none of those 44, and sent an earlier diagnosis off in the
wrong direction.

Build the list after `Reserve()`, from what survived it.

Local behaviour is unchanged — `Reserve()` is a no-op below DrawServ. The
`:unlock` bracket keeps working, because Reserve's bypass leaves an unlocked
graphic *in* the selection rather than removing it: with the key you do have the
right to select it.

## 2. And waits for it

A request another session must answer comes back asynchronously, so `select()`
returned before the grant landed — reporting nothing acquired even when the
graphic was about to be handed over. Honest, but not useful.

The interactive select already waits, in its way: it returns, and the answer
arrives later as the beep or the ding, `waiting_count` reaching zero being the
moment it knows. Scripted select waits on that same condition, and silently —
interactive is told by ear, scripted by its return value.

| | before | after |
|---|---|---|
| grab a graphic another node holds | 1 (refused, looked like success) | 0 |
| grab one that is free | 1, then 0, then held later | 1 |
| grab one under an `:unlock` bracket | 1 | 1 |

Lives in a new `LinkSelectFunc` overriding a `resolve_requests()` hook left
empty in comdraw's `SelectFunc` — nothing to wait for below DrawServ. Bounded at
two seconds so a node that never replies cannot stall the one that asked. The
selection is re-read each time round the loop, because running the event loop
lets anything arrive, including a select that installs a different selection;
for the same reason the returned list is read from the editor's selection rather
than the one built before the wait.

### waiting_count leaked, and had to stop

It is raised when a request goes out and lowered only by
`request_resolved_check` on a grant or a deny, so a request that died unanswered
was never unwound. Until now that merely muted the beep; with a `select()` that
waits on the count, it would hang until the timeout.

Both deaths are now accounted for, and they sound different because they are
different:

- a graphic dropped from our own selection **withdraws** the question —
  `request_withdrawn()` unwinds it in silence, nobody having refused us and the
  user having moved on
- an announcement that ownership moved while we were asking resolves the way a
  **denial** resolves — nobody refused us, but the graphic is gone all the same

## 3. children() reads the canvas without claiming it

Which leaves nothing able to answer "what is on this canvas". `select(:all)`
claims everything it enumerates, and `grid(:table)` is empty until a link is up,
GraphicIds being minted only for distribution.

`children([parent])` returns the component views inside a composite, defaulting
to what `frame()` returns — the whole drawing under comdraw, the current frame
under flipbook and drawserv, `GetFrame()` being virtual and the same call
`select(:all)` walks, so `select(children())` stays equivalent to `select(:all)`
in both. The counterpart of `parent()`: that climbs, this descends.

Read-only by construction — no selection, no `Reserve()`, no wire traffic, and
no interpretation of any state a graphic carries, so a hidden or batched mode
later would still be reported here.

```
unlinked:  children()=2   grid(:table)=0   children(frame())=2
linked:    N3 children()=2   N3 holds=0   (saw the far node's graphics, claimed none)
```

Three questions one call used to answer, wrongly for two of them:
`size(children())` counts the canvas, `select(children())` claims it, and
`size(select(:all))` says how much of that claim succeeded.

`kid.comt`'s welcome guard moves onto it — `grid(:table)` answered zero for a kid
that had drawn but not yet linked, which would have put a second welcome creature
on a canvas that already had one.

## Testing

Two and four nodes, hub-and-spoke as kidmo links them, covering direct and
relayed (spoke-to-spoke) answers; refusal, grant, and unlock-bracket paths;
unlinked nodes; and a check that a select with nothing to wait for does not
stall. drawmo has not been run — it currently dies in `updown` with a SIGSEGV in
`AttributeValue::assignval`, unrelated to this branch and present without it.