### PR TITLE
Write down the build and distributed-selection first aid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,15 @@ instructions are in **`INSTALL`**.
   `*.o`, `a.out`, …) are git-ignored.
 - `ARCHBUILD.sh` is the canonical full-from-scratch build recipe (it runs
   `configure` + `make` + `make Makefiles` + `make` to settle imake deps).
+- Header dependencies live in `Makefile.depend`, which `make depend` writes as a
+  snapshot rather than maintaining automatically. Add an `#include` and that
+  dependency stays invisible until `make depend` is rerun, so later edits to the
+  header rebuild nothing that needs it. Objects built against an old copy of a
+  header then link beside new ones, and when the header changed the layout of a
+  class the crash surfaces far from the edit that caused it, usually inside a
+  copy or an assignment. Rerun `make depend` after adding includes; when a
+  segfault doesn't correspond to what you changed, `make clean` and rebuild
+  before digging further.
 - To build with AddressSanitizer for memory debugging, follow
   **`config/SANITIZE.md`** — note the imake-specific gotcha: use the `OTHER_*`
   flag hooks in Imakefiles, **not `EXTRA_*`** (which `config/params.def`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ instructions are in **`INSTALL`**.
   `*.o`, `a.out`, …) are git-ignored.
 - `ARCHBUILD.sh` is the canonical full-from-scratch build recipe (it runs
   `configure` + `make` + `make Makefiles` + `make` to settle imake deps).
+- `doc/TROUBLESHOOTING.md` indexes recurring symptoms (a crash unrelated to your
+  change, `update()` not waiting, a loop that never ends) by what you see, with
+  the first move for each.
 - Header dependencies live in `Makefile.depend`, which `make depend` writes as a
   snapshot rather than maintaining automatically. Add an `#include` and that
   dependency stays invisible until `make depend` is rerun, so later edits to the

--- a/INSTALL
+++ b/INSTALL
@@ -230,6 +230,15 @@ If you have any trouble at this stage take a look at:
 ** that suppress the make stateges, make.makefile, make.makefiles,
 ** make.depend, and make.make.
 
+** Header dependencies are a snapshot: "make depend" records them, it does
+** not maintain them.  A new #include stays unknown to the build until
+** "make depend" is rerun, so later edits to that header rebuild nothing
+** that needs it, and objects built against an old copy of a header end up
+** linked alongside newer ones.  If the header altered the layout of a class
+** the crash then appears far from the edit that caused it.  Rerun "make
+** depend" after adding includes; a "make clean" and rebuild is the cheap
+** first move when a segfault does not match your change.
+
 3. Testing:
 
 Each directory under ivtools/src that begins in lower case (except

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -1,0 +1,38 @@
+# Troubleshooting: symptoms and their first moves
+
+Things that have cost someone here an afternoon, indexed by what you actually
+see rather than by what turns out to be wrong. Each entry is short on purpose —
+symptom, what is going on, the first move, and where the real detail lives.
+
+## A crash that has nothing to do with what you changed
+
+Typically a SIGSEGV inside a copy or an assignment, in a file you never
+touched.
+
+Header dependencies live in `Makefile.depend`, which `make depend` writes as a
+snapshot rather than maintaining. An `#include` added since the last run stays
+unknown to the build, so later edits to that header rebuild nothing that needs
+it. Objects built against an old copy of a header then link alongside newer
+ones, and if the header changed the layout of a class the crash surfaces far
+from the cause.
+
+**First move:** `make clean` and rebuild before reading any more code. Rerun
+`make depend` after adding includes. See `INSTALL`.
+
+## `update()` came back immediately instead of waiting
+
+`update(usec)` is `handle_events` — it returns on the first event, not after
+the timeout. It is not a settle, and using it as one leaves whatever you were
+waiting for racing whatever you expected to have finished.
+
+**First move:** poll for the condition you actually care about, with `update()`
+inside the loop rather than in place of it.
+
+## A loop that never ends, or ends immediately
+
+Comparisons against `nil` do not behave like comparisons against zero: `nil != 0`
+is true, while `nil > 0` is `nil`. A termination test that a `nil` satisfies
+never terminates.
+
+**First move:** test for the value you expect rather than for its absence, and
+check what the variable holds before the loop starts.

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b5c46f6e"
+#define PATCH_KEY "5c46f6eb"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Two pieces of first aid that were only learnable by losing an afternoon to them.

## `doc/TROUBLESHOOTING.md` (new)

Indexed by symptom rather than by cause, so you find an entry with the words you
are already thinking when something goes wrong. Three entries, each kept to
symptom / what is going on / first move / pointer to the real detail:

- a crash that has nothing to do with what you changed
- `update()` returning immediately instead of waiting
- a loop that never ends, comparing against `nil`

Kept deliberately short so it stays an index and does not drift into a second
copy of the documentation. Only settled behaviour goes in — a doc reads as how
things are, so anything still in motion stays out until it has stopped moving.

## The `Makefile.depend` note (`AGENTS.md`, `INSTALL`)

`make depend` writes header dependencies as a snapshot and does not maintain
them. An `#include` added since the last run stays unknown to the build, so
later edits to that header rebuild nothing that needs it — objects built against
an old copy of a header link alongside newer ones, and if the header changed the
layout of a class the crash surfaces far from the cause.

This cost a full session: drawmo's entire suite was failing on a SIGSEGV in
`AttributeValue::assignval`, which read as a regression in the change under test.
It was four ComTerp objects — `comhandler.o`, `parser.o`, `postfixspan.o`,
`socket.o` — compiled the day before `b3dfed83` widened `AttributeValue`. A clean
rebuild of ComTerp alone fixed it, and the suite then went 14 for 14.

The note goes in `AGENTS.md` beside the other build gotchas, and in `INSTALL`
right after the paragraph that already explains what `make clean` removes —
which described the mechanism without ever saying when you would want it.

No behaviour change; documentation only.