### PR TITLE
Keep select() and the editor telling the same story

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1657,7 +1657,22 @@ void SelectFunc::execute() {
         }
       }
 
+      /* Clear() above hid the outgoing selection's tic marks and highlighting,
+	 and nothing here put them back: repairing damage repaints graphics and
+	 never draws a handle.  A grant arriving does redraw them, AddComp
+	 ending in Selection::Update, which is why they are only missing when a
+	 select resolves without one -- everything either already ours or
+	 refused outright.  Restore them in the order Selection::Update uses,
+	 with the repaint below standing in for its Repair, and read the
+	 editor's selection since a wait may have replaced ours. */
+      OverlaySelection* shown = (OverlaySelection*)_ed->GetSelection();
+      if (shown)
+	shown->ShowHighlights(viewer);
+
       unidraw->Update();
+
+      if (shown && shown->HandlesEnabled())
+	shown->ShowHandles(viewer);
     }
     reset_stack();
     ComValue retval(avl);

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1665,14 +1665,19 @@ void SelectFunc::execute() {
 	 refused outright.  Restore them in the order Selection::Update uses,
 	 with the repaint below standing in for its Repair, and read the
 	 editor's selection since a wait may have replaced ours. */
-      OverlaySelection* shown = (OverlaySelection*)_ed->GetSelection();
-      if (shown)
-	shown->ShowHighlights(viewer);
-
       unidraw->Update();
 
+      /* Clear() above hid the outgoing selection's tic marks and highlighting
+	 and nothing put them back.  unidraw->Update() cannot: it defers, and
+	 the repaint it schedules repairs the damage that hiding them made --
+	 over anything drawn here beforehand.  Selection::Update repairs and
+	 then draws, which is the order that survives, and it is what #210 took
+	 out of here for the cost of its Repair; keep that saving where it was
+	 aimed, at animation loops, which run with handles disabled.  Read the
+	 editor's selection since a wait may have replaced ours. */
+      OverlaySelection* shown = (OverlaySelection*)_ed->GetSelection();
       if (shown && shown->HandlesEnabled())
-	shown->ShowHandles(viewer);
+	shown->Update(viewer);
     }
     reset_stack();
     ComValue retval(avl);

--- a/src/ComUnidraw/unifunc.c
+++ b/src/ComUnidraw/unifunc.c
@@ -129,13 +129,33 @@ HandlesFunc::HandlesFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed
 }
 
 void HandlesFunc::execute() {
-  ComValue dflt(0);
-  ComValue flag(stack_arg(0, false, dflt));
+    static int get_symid = symbol_add("get");
+    boolean get_flag = stack_key(get_symid).is_true();
+    ComValue flag(stack_arg(0));
     reset_stack();
-    if (flag.int_val()) 
-	((OverlaySelection*)_ed->GetSelection())->EnableHandles();
-    else
-	((OverlaySelection*)_ed->GetSelection())->DisableHandles();
+
+    OverlaySelection* sel = (OverlaySelection*)_ed->GetSelection();
+    if (!sel) {
+	push_stack(ComValue::falseval());
+	return;
+    }
+
+    /* same shape as pastemode(): :get reads, no argument toggles, an argument
+       sets, and every one of them says what the value now is */
+    boolean enable;
+    if (get_flag)
+	enable = sel->HandlesEnabled();
+    else {
+	enable = flag.is_known()
+	    ? (boolean)flag.int_val()
+	    : !sel->HandlesEnabled();
+	if (enable)
+	    sel->EnableHandles();
+	else
+	    sel->DisableHandles();
+    }
+
+    push_stack(enable ? ComValue::trueval() : ComValue::falseval());
 }
 
 /*****************************************************************************/

--- a/src/ComUnidraw/unifunc.h
+++ b/src/ComUnidraw/unifunc.h
@@ -62,13 +62,15 @@ public:
 };
 
 //: command to turn on or off the selection tic marks in comdraw.
-// handles(flag) -- enable/disable current selection tic marks and/or highlighting
+// flag=handles([flag] :get) -- enable/disable current selection tic marks and/or
+// highlighting.  :get reads, no argument toggles, an argument sets, and each
+// returns the value now in force, as pastemode() does
 class HandlesFunc : public UnidrawFunc {
 public:
     HandlesFunc(ComTerp*,Editor*);
     virtual void execute();
     virtual const char* docstring() { 
-	return "%s([flag]) -- disable/enable current selection tic marks and/or highlighting"; }
+	return "flag=%s([flag] :get) -- disable/enable current selection tic marks and/or highlighting, toggle if no argument, returns the value in force"; }
 };
 
 //: command to paste a graphic in comdraw.

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -408,15 +408,48 @@ void LinkSelectFunc::resolve_requests(OverlaySelection* sel) {
   const int slice_usec = 10000;
   const int spin_limit = 200;   /* two seconds */
   int spins = 0;
-  while (spins++ < spin_limit) {
-    LinkSelection* cur = (LinkSelection*)_ed->GetSelection();
-    if (!cur || cur->waiting_count()==0) break;
-    cur->silent() = true;
+  boolean timed_out = false;
+  while (1) {
+    /* compare, never dereference: another connection's select() deletes this
+       selection when it installs its own, and then the requests we were
+       waiting on are that select's business, not ours. */
+    if ((OverlaySelection*)_ed->GetSelection() != sel) return;
+    if (lsel->waiting_count()==0) break;
+    if (spins++ >= spin_limit) { timed_out = true; break; }
+    lsel->silent() = true;
     ACE_Time_Value timeout(0, slice_usec);
     ComterpHandler::reactor_singleton()->handle_events(timeout);
   }
-  LinkSelection* done = (LinkSelection*)_ed->GetSelection();
-  if (done) done->silent() = false;
+  lsel->silent() = false;
+  if (!timed_out) return;
+
+  /* nobody answered.  take the requests back rather than leaving them
+     outstanding: the count would be inherited by the next select through
+     CopyFlags and waited on again, and a graphic left WaitingToBeSelected is
+     one a late grant would still be accepted into -- so select() would have
+     reported nothing acquired and then quietly acquired it.  A grant that
+     arrives after this finds NotSelected, is refused, and the :notaken answer
+     puts the granter's record back, so the two orderings agree.
+
+     Reserve() removed these from the selection when it asked, so the grid
+     table is where they are found; safe because we are still the installed
+     selection, and CopyFlags carries the count forward, so there is only ever
+     the one asker. */
+  GraphicIdTable* table = ((DrawServ*)unidraw)->gridtable();
+  TableIterator(GraphicIdTable) it(*table);
+  int withdrawn = 0;
+  for (; it.more(); it.next()) {
+    GraphicId* grid = (GraphicId*)it.cur_value();
+    if (grid && grid->selected()==LinkSelection::WaitingToBeSelected) {
+      grid->selected(LinkSelection::NotSelected);
+      lsel->request_withdrawn();
+      withdrawn++;
+    }
+  }
+  /* any residue would be inherited and waited on again */
+  while (lsel->waiting_count() > 0)
+    lsel->request_withdrawn();
+  fprintf(stderr, "select: gave up waiting, %d request(s) withdrawn\n", withdrawn);
 }
 
 /*****************************************************************************/

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -398,6 +398,17 @@ void LinkSelectFunc::resolve_requests(OverlaySelection* sel) {
   LinkSelection* lsel = (LinkSelection*)sel;
   if (!lsel || lsel->waiting_count()==0) return;
 
+  /* a select that arrived over a link is part of somebody else's distributed
+     command -- the :unlock/:lock bracket around a graphic state change runs
+     three of them.  Nothing else in such a command yields, unidraw->Update()
+     deferring rather than repainting, so a grant cannot arrive in the middle of
+     one and be taken for an answer to it.  Waiting here would be the one thing
+     that opened that door, and would stall a node for two seconds over a colour
+     it was only relaying.  Fire and forget, the way the interactive select
+     does. */
+  DrawServHandler* wire = comterp() ? (DrawServHandler*)comterp()->handler() : nil;
+  if (wire && wire->drawlink()) return;
+
   /* a request answered by another session comes back asynchronously -- the same
      resolution that beeps or dings for an interactive select.  wait for it, so
      the list returned is the answer rather than the question, and keep it quiet

--- a/src/man/man1/comdraw.1
+++ b/src/man/man1/comdraw.1
@@ -141,9 +141,12 @@ graphical object assigned to an interpreter variable.
  sx,sy=ssize() -- size of screen
  dx,dy=dsize() -- size of drawing
 
- handles([flag]) --     
-   -- disable/enable current selection tic marks 
-      and/or highlighting
+ flag=handles([flag] :get)
+   -- disable/enable current selection tic marks
+      and/or highlighting.  :get reads without
+      changing, no argument toggles, an argument
+      sets, and each returns the value now in
+      force, as pastemode() does
  highlight(compview compviewgs)
    -- set the highlight graphic state for a graphic
 


### PR DESCRIPTION
Three ways `select()`, the editor, and the screen could tell different stories.

## The tic marks a select takes down

`select(:all)` on a node holding one graphic while another session holds the rest
keeps the one it has, asks for nothing, beeps at the immediate refusal — and
leaves that graphic selected with no tic marks on it.

`OverlaySelection::Clear` hides the outgoing selection's handles and highlighting
on the way through, and nothing put them back. It only shows when a select
resolves with **no grant**: `LinkSelection::AddComp`, the path a granted graphic
takes, ends in `Selection::Update`, which redraws them for the whole selection.
So any select that acquires something looks right, and only one where everything
is either already yours or refused outright comes back bare. The beep is the
tell — it fires on `remote_flag && !wtbs_flag`, immediate refusal with nothing
pending, hence no grant, hence no redraw.

`unidraw->Update()` cannot stand in for it. It defers — sets a flag, `DoUpdate()`
running later from the main loop — so anything drawn beforehand is drawn ahead of
a repaint that repairs the damage hiding the handles made, over the top of it.
`Selection::Update` repairs and *then* draws, which is the order that survives.
That is the call #210 removed from here for the cost of its `Repair`; the saving
was aimed at animation loops, which run with handles disabled, so this is gated
on handles being enabled and they keep it.

## Requests nobody answered

The wait added with the waiting `select()` is bounded so an unresponsive node
cannot stall the one that asked — but giving up left the requests standing. The
count is inherited by the next select through `CopyFlags` and waited on again,
and the graphics stay in `WaitingToBeSelected`, the one state a late grant is
still accepted into. So `select()` would report nothing acquired and then quietly
acquire it — a real disagreement between what it returned and what the editor
holds.

Withdraw them instead. A grant arriving afterwards finds `NotSelected`, is
refused, and the `:notaken` answer puts the granter's record back, so both
orderings of that race agree. `Reserve()` removed them from the selection when it
asked, so the grid table is where they are found — safe only while we are still
the installed selection, which is now also the condition for waiting at all.
Another connection's `select()` deletes ours when it installs its own, after
which the requests are that select's business and the pointer is not ours to
dereference.

## Atomicity, and who is allowed to give it up

The reactor is the only place anything yields, so a command that does not touch
it runs whole against arriving traffic. That is why a grant cannot land in the
middle of a distributed graphic state change and be taken for an answer to it:
the `:unlock`/`:lock` bracket's three selects and the `colors()` between them
never pump, and `unidraw->Update()` defers rather than repainting.

Waiting for a selection answer is the one thing that gives that up, and it has no
business doing so on a select that arrived over a link — the restoring select of
a bracket will ask for a graphic that went foreign meanwhile, and would then sit
pumping events for two seconds on a node relaying somebody else's colour.
Wire-driven selects now fire and forget, the way the interactive one does. Only a
select whose caller is here waits.

## Testing

Two linked nodes, the reported sequence plus a distributed brush:

```
B select(:all)   -> 3
A select(:all)   -> 1     editor holds 1, same graphic (mbr {266,264,316,314})
A select again   -> 1     stable on repeat
handles(0)       -> 1     disabled path unaffected
brush over link  ->       B still holds 3, no stall, 0 timeouts
```

Not verified: the tic marks themselves, which need an eye on the screen — the
`handles()` command sets state rather than reporting it. And the timeout
withdrawal end to end; provoking a genuine non-answer needs a node that reads but
will not reply, since freezing one makes the peer block on socket writes instead.

## handles() reads, toggles and sets

It took a flag and returned nothing, and bare `handles()` did nothing useful —
the argument defaulted to 0, so calling it with nothing turned the tic marks off
and calling it again turned them off again.

`pastemode()` already had the shape for this — the one command in comdraw that
reads, toggles and sets through the same name. `handles()` now follows it, so the
second such command in the vocabulary works like the first:

```
handles(true)   -> true      set
handles(:get)   -> true      read, unchanged
handles()       -> false     toggle
handles(:get)   -> false     read
handles(false)  -> false     set, idempotent
```

Nothing in the examples calls it bare — every use passes true or false — so the
no-argument case was free to take on the toggle. Docstring and `comdraw.1` follow.
