### PR TITLE
Say who asked, so a refusal can be delivered

### DIFF
--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -477,6 +477,8 @@ void GraphicIdFunc::execute() {
   ComValue statev(stack_key(state_sym));
   static int notaken_sym = symbol_add("notaken");
   ComValue notakenv(stack_key(notaken_sym));
+  static int gen_sym = symbol_add("gen");
+  ComValue genv(stack_key(gen_sym));
   static int deny_sym = symbol_add("deny");
   ComValue denyv(stack_key(deny_sym));
   static int table_sym = symbol_add("table");
@@ -502,12 +504,13 @@ void GraphicIdFunc::execute() {
       /* the selector field is the asker, the value the node that refused */
       uuid_t denier;
       uuid_parse(denyv.string_ptr(), denier);
-      ((DrawServ*)unidraw)->grid_deny(link, id, selector, denier);
+      ((DrawServ*)unidraw)->grid_deny(link, id, selector, denier, genv.int_val());
     } else
       /* the older bare form names no asker, so it can only be meant for us,
 	 and the selector field is the node that refused */
       ((DrawServ*)unidraw)->grid_deny(link, id,
-				      ((DrawServ*)unidraw)->sessionid(), selector);
+				      ((DrawServ*)unidraw)->sessionid(), selector,
+				      genv.int_val());
     return;
   }
 
@@ -524,7 +527,7 @@ void GraphicIdFunc::execute() {
 	uuid_t rid;
 	uuid_parse(requestv.string_ptr(), rid);
 	((DrawServ*)unidraw)->grid_message_handle
-	  (link, id, selector, statev.int_val(), rid);
+	  (link, id, selector, statev.int_val(), rid, genv.int_val());
       }
       
     } else {
@@ -535,7 +538,7 @@ void GraphicIdFunc::execute() {
 	((DrawServ*)unidraw)->grid_notaken(link, id, selector, gid);
       else
 	((DrawServ*)unidraw)->grid_message_callback
-	  (link, id, selector, statev.int_val(), gid);
+	  (link, id, selector, statev.int_val(), gid, genv.int_val());
     }
     
   } else if (idv.is_known() && selectorv.is_unknown()) {

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -535,7 +535,7 @@ void GraphicIdFunc::execute() {
       uuid_parse(grantv.string_ptr(), gid);
       
       if (notakenv.is_true())
-	((DrawServ*)unidraw)->grid_notaken(link, id, selector, gid);
+	((DrawServ*)unidraw)->grid_notaken(link, id, selector, gid, genv.int_val());
       else
 	((DrawServ*)unidraw)->grid_message_callback
 	  (link, id, selector, statev.int_val(), gid, genv.int_val());

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -494,21 +494,22 @@ void GraphicIdFunc::execute() {
 
   LinkSelection* sel = (LinkSelection*)_ed->GetSelection();
   
- if (denyv.is_true()) {
-    void* ptr = nil;
-    ((DrawServ*)unidraw)->gridtable()->find(ptr, uuid_key(id));
-    if (ptr) {
-      GraphicId* grid = (GraphicId*)ptr;
-      grid->selected(LinkSelection::RemotelySelected);
-      grid->selector(selector);
-      fprintf(stderr, "grid: request denied\n");
-      if (sel) sel->request_resolved_check(false, FILELINE);
-    }
-    return;
-  }
-
   DrawServHandler* handler = comterp() ? (DrawServHandler*)comterp()->handler() : nil;
   DrawLink* link = handler ? (DrawLink*)handler->drawlink() : nil;
+
+  if (denyv.is_true() || denyv.is_string()) {
+    if (denyv.is_string()) {
+      /* the selector field is the asker, the value the node that refused */
+      uuid_t denier;
+      uuid_parse(denyv.string_ptr(), denier);
+      ((DrawServ*)unidraw)->grid_deny(link, id, selector, denier);
+    } else
+      /* the older bare form names no asker, so it can only be meant for us,
+	 and the selector field is the node that refused */
+      ((DrawServ*)unidraw)->grid_deny(link, id,
+				      ((DrawServ*)unidraw)->sessionid(), selector);
+    return;
+  }
 
   if (idv.is_known() && selectorv.is_known()) {
     

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -583,6 +583,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	     grid->selected()==LinkSelection::WaitingToBeSelected)) {
 	  grid->selected(LinkSelection::NotSelected);
 	  grid->selector(newselector);
+	  grid->grantgen(gen);
 	  char buf[BUFSIZ];
 	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :gen %d :class \"%s\")%c",
 		   grid->idstr(), newselector_str, sessionidstr(),
@@ -735,7 +736,7 @@ void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
    so a response that has been overtaken -- we have since handed the graphic to
    someone else -- is recognisable and ignored. */
 void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
-			    uuid_t granter)
+			    uuid_t granter, int gen)
 {
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
@@ -757,9 +758,9 @@ void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
       uuid_string_t granter_str;
       uuid_unparse(granter, granter_str);
       char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :notaken :class \"%s\")%c",
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :gen %d :notaken :class \"%s\")%c",
 	       grid->idstr(), responder_str, granter_str,
-	       grid->compclass(), '\0');
+	       gen, grid->compclass(), '\0');
       SendCmdString(glink, buf);
       fprintf(stderr, "grid: grant-not-taken passed along to granter\n");
     } else
@@ -767,7 +768,11 @@ void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
     return;
   }
 
-  if (responder != NULL && uuid_compare(grid->selector(), responder)==0) {
+  /* the same asker can be granted the same graphic twice, so naming the
+     responder is not enough to tell one grant from the next: a not-taken for
+     the first would otherwise roll back the second. */
+  if (responder != NULL && uuid_compare(grid->selector(), responder)==0 &&
+      (gen==0 || gen==grid->grantgen())) {
     grid->selector(sessionid());
     fprintf(stderr, "grid: grant not taken, ownership restored here\n");
   } else
@@ -823,9 +828,9 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
 	 announcing state: a state message is an unconditional assertion and a
 	 stale one would undo a later handoff. */
       char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :notaken :class \"%s\")%c",
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :gen %d :notaken :class \"%s\")%c",
 	       grid->idstr(), sessionidstr(), oldselector_str,
-	       grid->compclass(), '\0');
+	       gen, grid->compclass(), '\0');
       SendCmdString(link, buf);
     }
 
@@ -833,9 +838,12 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
     else {
       fprintf(stderr, "grid:  pass grant request along\n");
       char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :class \"%s\")%c",
+      /* a grant passed along kept none of its generation, so a requester two
+	 hops away was handed one reading zero and matched anything -- which in
+	 hub-and-spoke is every grant between spokes. */
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :gen %d :class \"%s\")%c",
 	       grid->idstr(), selector_str, oldselector_str,
-	       grid->compclass(), '\0');
+	       gen, grid->compclass(), '\0');
       SendCmdString(linkget(selector), buf);
     }
   }

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -716,7 +716,7 @@ void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
      leaves the state reading WaitingToBeSelected either way, so without the
      generation a delayed refusal for the first would be applied to the second,
      and the grant that answers the second then refused. */
-  if (gen != 0 && gen != grid->reqgen()) {
+  if (gen != grid->reqgen()) {
     fprintf(stderr, "grid: refusal for asking %d, we are on %d now, ignored\n",
 	    gen, grid->reqgen());
     return;
@@ -772,7 +772,7 @@ void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
      responder is not enough to tell one grant from the next: a not-taken for
      the first would otherwise roll back the second. */
   if (responder != NULL && uuid_compare(grid->selector(), responder)==0 &&
-      (gen==0 || gen==grid->grantgen())) {
+      gen==grid->grantgen()) {
     grid->selector(sessionid());
     fprintf(stderr, "grid: grant not taken, ownership restored here\n");
   } else
@@ -800,7 +800,7 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
     /* if request is granted, add to selection */
     if (grid->selected()==LinkSelection::WaitingToBeSelected && selector != NULL &&
 	uuid_compare(selector, sessionid())==0 &&
-	(gen==0 || gen==grid->reqgen())) {
+	gen==grid->reqgen()) {
       grid->selector(selector);
       grid->selected(LinkSelection::LocallySelected);
 

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -696,6 +696,16 @@ void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
     return;
   }
 
+  /* only while the question is still outstanding.  A refusal can arrive after
+     its request was withdrawn, or after an ownership change voided it -- and
+     applying it then overwrites newer state, while unwinding the count resolves
+     whatever question is outstanding now instead of the one this answers.  The
+     grant is accepted only into WaitingToBeSelected for the same reason. */
+  if (grid->selected() != LinkSelection::WaitingToBeSelected) {
+    fprintf(stderr, "grid: refusal for a request no longer outstanding, ignored\n");
+    return;
+  }
+
   if (denier != NULL && !uuid_is_null(denier)) {
     grid->selected(LinkSelection::RemotelySelected);
     grid->selector(denier);

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -589,8 +589,13 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	  /* else deny it, because it is selected */
 	else {
 	  char buf[BUFSIZ];
-	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny :class \"%s\")%c",
-		   grid->idstr(), sessionidstr(), grid->compclass(), '\0');
+	  /* the asker in the selector field and ourselves as the value, the
+	     shape a grant already has, so a refusal can be relayed the way a
+	     grant is: naming only the refuser left it with nowhere to go once
+	     it reached a node that had merely passed the request along. */
+	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+		   grid->idstr(), newselector_str, sessionidstr(),
+		   grid->compclass(), '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request denied, graphic locally selected\n");
 	}	
@@ -655,6 +660,50 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       }
     }
   }
+}
+
+/* a refusal on its way back to whoever asked.  A request carries the asker and
+   so does a grant, so both can be relayed; a refusal used to carry only the node
+   that refused, which in a hub-and-spoke table is not where it has to go -- it
+   was applied at the hub and dropped, and the spoke that asked waited for ever
+   in WaitingToBeSelected. */
+void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
+			 uuid_t denier)
+{
+  void* ptr = nil;
+  gridtable()->find(ptr, uuid_key(id));
+  if (!ptr) return;
+  GraphicId* grid = (GraphicId*)ptr;
+
+  if (requester != NULL && !uuid_is_null(requester) &&
+      uuid_compare(requester, sessionid())) {
+    DrawLink* rlink = linkget(requester);
+    if (rlink && rlink != link) {
+      uuid_string_t requester_str;
+      uuid_unparse(requester, requester_str);
+      uuid_string_t denier_str;
+      denier_str[0] = '\0';
+      if (denier != NULL && !uuid_is_null(denier))
+	uuid_unparse(denier, denier_str);
+      char buf[BUFSIZ];
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+	       grid->idstr(), requester_str, denier_str,
+	       grid->compclass(), '\0');
+      SendCmdString(rlink, buf);
+      fprintf(stderr, "grid: denial passed along to the node that asked\n");
+    } else
+      fprintf(stderr, "grid: denial undeliverable, dropped\n");
+    return;
+  }
+
+  if (denier != NULL && !uuid_is_null(denier)) {
+    grid->selected(LinkSelection::RemotelySelected);
+    grid->selector(denier);
+  }
+  fprintf(stderr, "grid: request denied\n");
+  LinkSelection* lsel =
+    (LinkSelection*)DrawKit::Instance()->GetEditor()->GetSelection();
+  if (lsel) lsel->request_resolved_check(false, FILELINE);
 }
 
 /* a grant of ours that the responder could not take.  the grant is identified,

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -541,8 +541,13 @@ void DrawServ::grid_message(GraphicId* grid) {
     DrawLink* link = _linklist->find_drawlink(grid);
     
     if (link) {
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :class \"%s\")%c", grid->idstr(), 
-	       grid->selectorstr(), sessionidstr(), grid->compclass(), '\0');
+      /* a fresh generation each time we ask, so an answer can say which asking
+	 it answers: a refusal delayed past a withdrawal would otherwise be
+	 applied to the request that replaced it, both reading
+	 WaitingToBeSelected and the states alone not telling them apart. */
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :gen %d :class \"%s\")%c",
+	       grid->idstr(), grid->selectorstr(), sessionidstr(),
+	       grid->next_reqgen(), grid->compclass(), '\0');
       SendCmdString(link, buf);
     }
   }
@@ -550,7 +555,7 @@ void DrawServ::grid_message(GraphicId* grid) {
   
 // handle reserve request from remote DrawLink.
 void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector, 
-				   int state, uuid_t newselector)
+				   int state, uuid_t newselector, int gen)
 {
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
@@ -579,9 +584,9 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	  grid->selected(LinkSelection::NotSelected);
 	  grid->selector(newselector);
 	  char buf[BUFSIZ];
-	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :class \"%s\")%c",
+	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :grant \"%s\" :gen %d :class \"%s\")%c",
 		   grid->idstr(), newselector_str, sessionidstr(),
-		   grid->compclass(), '\0');
+		   gen, grid->compclass(), '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request granted\n");
 	} 
@@ -593,9 +598,9 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
 	     shape a grant already has, so a refusal can be relayed the way a
 	     grant is: naming only the refuser left it with nowhere to go once
 	     it reached a node that had merely passed the request along. */
-	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+	  snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :gen %d :class \"%s\")%c",
 		   grid->idstr(), newselector_str, sessionidstr(),
-		   grid->compclass(), '\0');
+		   gen, grid->compclass(), '\0');
 	  SendCmdString(link, buf);
 	  fprintf(stderr, "grid: request denied, graphic locally selected\n");
 	}	
@@ -605,9 +610,9 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       else {
 	fprintf(stderr, "grid: request passed along to current selector\n");
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :class \"%s\")%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :gen %d :class \"%s\")%c",
 		 grid->idstr(), grid->selectorstr(), newselector_str,
-		 grid->compclass(), '\0');
+		 gen, grid->compclass(), '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
     }
@@ -653,9 +658,9 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       else {
 	fprintf(stderr, "grid:  request passed along to targeted selector\n");
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :class \"%s\")%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :gen %d :class \"%s\")%c",
 	  grid->idstr(), selector_str, newselector_str,
-	  grid->compclass(), '\0');
+	  gen, grid->compclass(), '\0');
 	SendCmdString(linkget(grid->selector()), buf);
       }
     }
@@ -668,7 +673,7 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
    was applied at the hub and dropped, and the spoke that asked waited for ever
    in WaitingToBeSelected. */
 void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
-			 uuid_t denier)
+			 uuid_t denier, int gen)
 {
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
@@ -686,9 +691,9 @@ void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
       if (denier != NULL && !uuid_is_null(denier))
 	uuid_unparse(denier, denier_str);
       char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :gen %d :class \"%s\")%c",
 	       grid->idstr(), requester_str, denier_str,
-	       grid->compclass(), '\0');
+	       gen, grid->compclass(), '\0');
       SendCmdString(rlink, buf);
       fprintf(stderr, "grid: denial passed along to the node that asked\n");
     } else
@@ -703,6 +708,16 @@ void DrawServ::grid_deny(DrawLink* link, uuid_t id, uuid_t requester,
      grant is accepted only into WaitingToBeSelected for the same reason. */
   if (grid->selected() != LinkSelection::WaitingToBeSelected) {
     fprintf(stderr, "grid: refusal for a request no longer outstanding, ignored\n");
+    return;
+  }
+
+  /* and only for the asking it answers: a request withdrawn and made again
+     leaves the state reading WaitingToBeSelected either way, so without the
+     generation a delayed refusal for the first would be applied to the second,
+     and the grant that answers the second then refused. */
+  if (gen != 0 && gen != grid->reqgen()) {
+    fprintf(stderr, "grid: refusal for asking %d, we are on %d now, ignored\n",
+	    gen, grid->reqgen());
     return;
   }
 
@@ -761,7 +776,7 @@ void DrawServ::grid_notaken(DrawLink* link, uuid_t id, uuid_t responder,
 
 // handle callback from remote DrawLink.
 void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector, 
-				     int state, uuid_t oldselector)
+				     int state, uuid_t oldselector, int gen)
 {
   void* ptr = nil;
   gridtable()->find(ptr, uuid_key(id));
@@ -778,7 +793,9 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
     GraphicId* grid = (GraphicId*)ptr;
 
     /* if request is granted, add to selection */
-    if (grid->selected()==LinkSelection::WaitingToBeSelected && selector != NULL && uuid_compare(selector, sessionid())==0) {
+    if (grid->selected()==LinkSelection::WaitingToBeSelected && selector != NULL &&
+	uuid_compare(selector, sessionid())==0 &&
+	(gen==0 || gen==grid->reqgen())) {
       grid->selector(selector);
       grid->selected(LinkSelection::LocallySelected);
 

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -150,6 +150,9 @@ public:
 			   int state, uuid_t newselector=NULL);
   // handle graphic id selection message
 
+  void grid_deny(DrawLink* link, uuid_t id, uuid_t requester, uuid_t denier);
+  // handle a refusal, relaying it on when we are not the one who asked
+
   void grid_notaken(DrawLink* link, uuid_t id, uuid_t responder, uuid_t granter);
   // handle a grant of ours that the responder could not take
 

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -147,17 +147,18 @@ public:
   // generate graphic id selection message
 
   void grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector, 
-			   int state, uuid_t newselector=NULL);
+			   int state, uuid_t newselector=NULL, int gen = 0);
   // handle graphic id selection message
 
-  void grid_deny(DrawLink* link, uuid_t id, uuid_t requester, uuid_t denier);
+  void grid_deny(DrawLink* link, uuid_t id, uuid_t requester, uuid_t denier,
+		 int gen = 0);
   // handle a refusal, relaying it on when we are not the one who asked
 
   void grid_notaken(DrawLink* link, uuid_t id, uuid_t responder, uuid_t granter);
   // handle a grant of ours that the responder could not take
 
   void grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector, 
-			     int state, uuid_t oldselector);
+			     int state, uuid_t oldselector, int gen = 0);
   // callback for graphic id selection message 
 
   void unique_grid(uuid_t grid);

--- a/src/DrawServ/drawserv.h
+++ b/src/DrawServ/drawserv.h
@@ -154,7 +154,8 @@ public:
 		 int gen = 0);
   // handle a refusal, relaying it on when we are not the one who asked
 
-  void grid_notaken(DrawLink* link, uuid_t id, uuid_t responder, uuid_t granter);
+  void grid_notaken(DrawLink* link, uuid_t id, uuid_t responder, uuid_t granter,
+		    int gen = 0);
   // handle a grant of ours that the responder could not take
 
   void grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector, 

--- a/src/DrawServ/grid.c
+++ b/src/DrawServ/grid.c
@@ -43,6 +43,7 @@ GraphicId::GraphicId (uuid_t sid)
 {
   _comp = nil;
   _unlocked = false;
+  _reqgen = 0;
   uuid_clear(_selector);
   memset(_selector_str, 0, sizeof(_selector_str));
   _selected = 0;

--- a/src/DrawServ/grid.c
+++ b/src/DrawServ/grid.c
@@ -44,6 +44,7 @@ GraphicId::GraphicId (uuid_t sid)
   _comp = nil;
   _unlocked = false;
   _reqgen = 0;
+  _grantgen = 0;
   uuid_clear(_selector);
   memset(_selector_str, 0, sizeof(_selector_str));
   _selected = 0;

--- a/src/DrawServ/grid.h
+++ b/src/DrawServ/grid.h
@@ -103,6 +103,12 @@ public:
   int next_reqgen() { return ++_reqgen; }
   // start a new one, when a fresh request goes out
 
+  int grantgen() { return _grantgen; }
+  void grantgen(int gen) { _grantgen = gen; }
+  // which asking we last granted this graphic for.  The generation is the
+  // asker's, so a granter has nothing of its own to compare a response
+  // against unless it remembers the one it answered.
+
   void unlocked(boolean flag) { _unlocked = flag; }
   // set flag indicating remote lock temporarily suspended for local modification
   boolean unlocked() { return _unlocked; }
@@ -120,6 +126,7 @@ protected:
   OverlayComp* _comp;
   boolean _unlocked;
   int _reqgen;
+  int _grantgen;
   // true when remote lock temporarily suspended for local modification
 
 };

--- a/src/DrawServ/grid.h
+++ b/src/DrawServ/grid.h
@@ -94,6 +94,15 @@ public:
   const char* compclass();
   // return name of comp's class
 
+  int reqgen() { return _reqgen; }
+  // which request of ours is outstanding on this graphic.  An answer names the
+  // generation it answers, so one arriving for a request already withdrawn --
+  // and replaced by another for the same graphic -- can be told apart from an
+  // answer to the request actually in flight, which the states alone cannot do:
+  // both read WaitingToBeSelected.
+  int next_reqgen() { return ++_reqgen; }
+  // start a new one, when a fresh request goes out
+
   void unlocked(boolean flag) { _unlocked = flag; }
   // set flag indicating remote lock temporarily suspended for local modification
   boolean unlocked() { return _unlocked; }
@@ -110,6 +119,7 @@ protected:
   
   OverlayComp* _comp;
   boolean _unlocked;
+  int _reqgen;
   // true when remote lock temporarily suspended for local modification
 
 };

--- a/src/DrawServ/grid.h
+++ b/src/DrawServ/grid.h
@@ -101,7 +101,13 @@ public:
   // answer to the request actually in flight, which the states alone cannot do:
   // both read WaitingToBeSelected.
   int next_reqgen() { return ++_reqgen; }
-  // start a new one, when a fresh request goes out
+  // start a new one, when a fresh request goes out.  Pre-incremented, so every
+  // request we make is numbered 1 or more, and an answer bearing zero cannot be
+  // the answer to anything we asked -- which is why zero is not read as
+  // matching.  Letting it match was there to tolerate a peer that sends no
+  // generation, and it reopened the hole it was meant to close: an answer
+  // without one, delayed past a withdrawal, resolved the request that had
+  // replaced it.
 
   int grantgen() { return _grantgen; }
   void grantgen(int gen) { _grantgen = gen; }

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -360,6 +360,15 @@ void LinkSelection::unlock_key(const char* keystr) {
     GraphicId* grid = (GraphicId*)ptr;
     if (grid && grid->selectorkey() == key)
       grid->unlocked(true);
+    else if (grid)
+      /* The node originating a distributed graphic state change holds its
+	 graphics link-selected until every other node has finished applying it,
+	 so the key names whoever this node believes holds the graphic and a
+	 mismatch means the records disagree.  Say so: silently unlocking
+	 nothing leaves the select to negotiate for a graphic it was told it
+	 could simply have. */
+      fprintf(stderr, "unlock_key: %.8s is held by %.8s here, not %s\n",
+	      grid->idstr(), grid->selectorstr(), keystr);
     Next(it);
   }
 }

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "dc89ea67"
+#define PATCH_KEY "c89ea67d"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Found in a kidmo run: four kids round a table, each drawing a tree in turn, and
the fourth left two graphics stuck in `WaitingToBeSelected` for good.

Both were spoke-to-spoke requests that had been **denied**.

## A refusal had nowhere to go

A request carries the node asking, and so does a grant:

```
request  grid("7D33579D…" "044DA348…" :request "C3996500…")
grant    grid("D896F37C…" "30DC0D46…" :grant   "C3996500…")
deny     grid("7D33579D…" "044DA348…" :deny)
```

That is how the first two can be passed along by a node that is only relaying.
The refusal named only the node refusing, so a relay had nothing to route by: it
went back one hop, was applied by whoever received it, and stopped.

On kidmo's hub-and-spoke table that hop is the hub. A spoke asking another spoke
for a graphic it is holding gets an answer the hub consumes on its own behalf,
and the spoke that asked never hears anything. Nothing rescues it either — a
request is only issued when the state reads `NotSelected`, and it now reads
`WaitingToBeSelected`, so the asker is stuck.

Traced across three logs for `C41D2E16`: Mia creates it and holds it; Sam
requests it; Mia receives the relayed request and answers `:deny`; Sam's log has
no answer for that graphic, ever.

## The fix

Give the refusal the shape the grant already has — asker in the selector field,
answering node as the keyword's value — and relay it toward the asker when we are
not it, mirroring how `:notaken` is relayed toward its granter. The bare `:deny`
is still understood, treated as meant for us, which is all it could ever have
been.

## Testing

Four nodes hub-and-spoke, as kidmo links them. One spoke draws and holds; another
spoke's arrival request is relayed across the hub and refused:

```
hub:     2 denial passed along to the node that asked
         2 request passed along to targeted selector
spoke3:  1 request denied
spoke3 table:  RemotelySelected      (was WaitingToBeSelected, for ever)
grep -c WaitingToBeSelected  ->  0 on every node
```