### PR TITLE
Stop reaching for what other people draw, and count the runs

### DIFF
--- a/src/DrawServ/draweditor.c
+++ b/src/DrawServ/draweditor.c
@@ -89,6 +89,7 @@ void DrawEditor::AddCommands(ComTerp* comterp) {
   comterp->add_command("drawlink", new DrawLinkFunc(comterp, this));
   comterp->add_command("sid", new SessionIdFunc(comterp, this));
   comterp->add_command("grid", new GraphicIdFunc(comterp, this));
+  comterp->add_command("grabnew", new GrabNewFunc(comterp, this));
 
   comterp->add_command("points", new DrawPointsFunc(comterp, this));
 

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -390,6 +390,30 @@ void SessionIdFunc::execute() {
 
 /*****************************************************************************/
 
+GrabNewFunc::GrabNewFunc(ComTerp* comterp, Editor* ed) : UnidrawFunc(comterp, ed) {
+}
+
+void GrabNewFunc::execute() {
+    static int get_symid = symbol_add("get");
+    boolean get_flag = stack_key(get_symid).is_true();
+    ComValue flag(stack_arg(0));
+    reset_stack();
+
+    boolean on;
+    if (get_flag)
+	on = LinkSelection::grabnew();
+    else {
+	on = flag.is_known()
+	    ? (boolean)flag.int_val()
+	    : !LinkSelection::grabnew();
+	LinkSelection::grabnew() = on;
+    }
+
+    push_stack(on ? ComValue::trueval() : ComValue::falseval());
+}
+
+/*****************************************************************************/
+
 LinkSelectFunc::LinkSelectFunc(ComTerp* comterp, Editor* ed)
 : SelectFunc(comterp, ed) {
 }

--- a/src/DrawServ/drawfunc.c
+++ b/src/DrawServ/drawfunc.c
@@ -566,11 +566,19 @@ void GraphicIdFunc::execute() {
     if (tablev.is_true()) {
       /* return the gridtable as a list of rows, mirroring the columns of
          print_gridtable(): grid (8-char uuid prefix), comptype, selector,
-         selected.  same idiom as sid(:table). */
+         selected, unlocked.  same idiom as sid(:table).
+
+         unlocked is the bypass LinkSelection::Reserve() consults: a graphic
+         owned by another session is dropped from a selection unless it is set,
+         and the relay bracket -- select(grid :unlock KEY) around a distributed
+         command, select(s :lock KEY) after -- is what sets and clears it.  A
+         graphic left unlocked by a bracket that never closed is selectable by
+         anyone, quietly, so it is worth being able to look. */
       static int grid_row_sym     = symbol_add("grid");
       static int comptype_row_sym = symbol_add("comptype");
       static int selector_row_sym = symbol_add("selector");
       static int selected_row_sym = symbol_add("selected");
+      static int unlocked_row_sym = symbol_add("unlocked");
       DrawServ* drawserv = (DrawServ*)unidraw;
       AttributeValueList* avl = new AttributeValueList();
       GraphicIdTable* table = drawserv->gridtable();
@@ -594,6 +602,7 @@ void GraphicIdFunc::execute() {
         row->add_attr(comptype_row_sym, new AttributeValue(comptype));
         row->add_attr(selector_row_sym, new AttributeValue(sel8));
         row->add_attr(selected_row_sym, new AttributeValue(LinkSelection::selected_string(grid->selected())));
+        row->add_attr(unlocked_row_sym, new AttributeValue(grid->unlocked() ? "unlocked" : "locked"));
         avl->Append(new AttributeValue(AttributeList::class_symid(), (void*)row));
         it.next();
       }

--- a/src/DrawServ/drawfunc.h
+++ b/src/DrawServ/drawfunc.h
@@ -58,6 +58,20 @@ public:
 	return "%s(id) -- lookup compview by uuid\n\tgrid(id selector :state selected :request newselector :grant oldselector :deny :notaken) -- command to send message between remote selections\n\tgrid(:table) -- return the gridtable as a list of (:grid :comptype :selector :selected) rows, uuids as 8-char prefixes"; }
 };
 
+//: command to stop reaching for what other sessions draw, in drawserv.
+// flag=grabnew([flag] :get) -- whether a graphic arriving from another session
+// is selected here.  Selecting one is what asks its owner to hand it over, so
+// with this off a node keeps what it drew and leaves everyone else's alone.
+// :get reads, no argument toggles, an argument sets, each returning the value
+// now in force, as pastemode() does.
+class GrabNewFunc : public UnidrawFunc {
+public:
+    GrabNewFunc(ComTerp*,Editor*);
+    virtual void execute();
+    virtual const char* docstring() { 
+	return "flag=%s([flag] :get) -- whether graphics arriving from other sessions are selected here, toggle if no argument, returns the value in force"; }
+};
+
 //: select() that waits for the distributed answer, in drawserv.
 // select([compview ...] :all :clear :unlock key :lock key) -- as comdraw's
 // select(), but a request that has to be answered by another session is waited

--- a/src/DrawServ/drawserv-handler.c
+++ b/src/DrawServ/drawserv-handler.c
@@ -60,9 +60,13 @@ int DrawServHandler::open (void * ptr)
   return 0;
 }
 
+DrawServHandler* DrawServHandler::_current = nil;
+
 int
 DrawServHandler::handle_input (ACE_HANDLE fd) {
   int save_alt_fd = _alt_fd;
+  DrawServHandler* save_current = _current;
+  _current = this;
   if (_drawlink != NULL) {
     _alt_fd = _drawlink->portnum();
   } else {
@@ -71,6 +75,7 @@ DrawServHandler::handle_input (ACE_HANDLE fd) {
     
   int status = UnidrawComterpHandler::handle_input(fd);
   
+  _current = save_current;
   _alt_fd = save_alt_fd;
   return status;
 }

--- a/src/DrawServ/drawserv-handler.h
+++ b/src/DrawServ/drawserv-handler.h
@@ -38,6 +38,12 @@ public:
   // = Initialization and termination methods.
   DrawServHandler (ComTerpServ* serv = NULL);
 
+  static DrawServHandler* current() { return _current; }
+  // the handler dispatching the command being executed right now, or nil when
+  // nothing arrived over a connection -- saved and restored around each
+  // dispatch, so a command that runs the event loop and nests another leaves
+  // this reading correctly on the way back out
+
   DrawLink* drawlink() { return _drawlink; }
   // get DrawLink associated with this handler
   void drawlink(DrawLink* link);
@@ -57,6 +63,7 @@ public:
 
 protected:
   DrawLink* _drawlink;
+  static DrawServHandler* _current;
   static int _sigpipe_handler_initialized;
   int _sigpipe_handler;
 

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -852,17 +852,18 @@ void DrawServ::grid_message_callback(DrawLink* link, uuid_t id, uuid_t selector,
 void DrawServ::print_gridtable() {
   GraphicIdTable* table = gridtable();
   GraphicIdTable_Iterator it(*table);
-  printf("grid     comptype              selector  selected\n");
-  printf("-------- --------------------  --------  --------\n");
+  printf("grid     comptype              selector  selected             unlocked\n");
+  printf("-------- --------------------  --------  -------------------  --------\n");
   while(it.more()) {
     GraphicId* grid = (GraphicId*)it.cur_value();
     OverlayComp* comp = (OverlayComp*)grid->grcomp();
     const char* comptype = comp ? comp->GetClassName() : "nil";
     uuid_string_t idstr;
     uuid_unparse(grid->id(), idstr);
-    printf("%.8s %-20s  %.8s  %s\n",
+    printf("%.8s %-20s  %.8s  %-19s  %s\n",
  	   idstr, comptype,
- 	   grid->selectorstr(), LinkSelection::selected_string(grid->selected()));
+ 	   grid->selectorstr(), LinkSelection::selected_string(grid->selected()),
+ 	   grid->unlocked() ? "unlocked" : "locked");
     it.next();
   }
 }

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -625,9 +625,9 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       else {
 	fprintf(stderr, "grid: request would go back where it came from, refused\n");
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :gen %d :class \"%s\")%c",
 		 grid->idstr(), newselector_str, sessionidstr(),
-		 grid->compclass(), '\0');
+		 gen, grid->compclass(), '\0');
 	SendCmdString(link, buf);
       }
     }
@@ -683,9 +683,9 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       else {
 	fprintf(stderr, "grid:  request would go back where it came from, refused\n");
 	char buf[BUFSIZ];
-	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :gen %d :class \"%s\")%c",
 	  grid->idstr(), newselector_str, sessionidstr(),
-	  grid->compclass(), '\0');
+	  gen, grid->compclass(), '\0');
 	SendCmdString(link, buf);
       }
     }

--- a/src/DrawServ/drawserv.c
+++ b/src/DrawServ/drawserv.c
@@ -608,13 +608,27 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       } 
       
       /* else reformulate this request and pass it along */
-      else {
+      else if (linkget(grid->selector()) != link) {
 	fprintf(stderr, "grid: request passed along to current selector\n");
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :gen %d :class \"%s\")%c",
 		 grid->idstr(), grid->selectorstr(), newselector_str,
 		 gen, grid->compclass(), '\0');
 	SendCmdString(linkget(grid->selector()), buf);
+      }
+
+      /* our record points back where the request came from, so passing it on
+	 returns it to the node that sent it.  Refuse instead: the asker gets an
+	 answer, which is more than a request bounced between two nodes will
+	 ever give it -- and on a spoke, whose only link is the hub, an answer
+	 coming back for somebody else cannot be delivered at all. */
+      else {
+	fprintf(stderr, "grid: request would go back where it came from, refused\n");
+	char buf[BUFSIZ];
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+		 grid->idstr(), newselector_str, sessionidstr(),
+		 grid->compclass(), '\0');
+	SendCmdString(link, buf);
       }
     }
 
@@ -656,13 +670,23 @@ void DrawServ::grid_message_handle(DrawLink* link, uuid_t id, uuid_t selector,
       } 
 
       /* else pass the request on to the target selector */
-      else {
+      else if (linkget(grid->selector()) != link) {
 	fprintf(stderr, "grid:  request passed along to targeted selector\n");
 	char buf[BUFSIZ];
 	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :request \"%s\" :gen %d :class \"%s\")%c",
 	  grid->idstr(), selector_str, newselector_str,
 	  gen, grid->compclass(), '\0');
 	SendCmdString(linkget(grid->selector()), buf);
+      }
+
+      /* as above: back the way it came is not onward */
+      else {
+	fprintf(stderr, "grid:  request would go back where it came from, refused\n");
+	char buf[BUFSIZ];
+	snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :deny \"%s\" :class \"%s\")%c",
+	  grid->idstr(), newselector_str, sessionidstr(),
+	  grid->compclass(), '\0');
+	SendCmdString(link, buf);
       }
     }
   }

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -111,7 +111,10 @@ void LinkSelection::Clear(Viewer* viewer) {
   Reserve();
 }
 
-boolean LinkSelection::_grabnew = true;
+/* off by default: reaching for what other people draw is the unusual want, and
+   having to turn it off on every node before drawing anything is worse than
+   having to turn it on when you want it. */
+boolean LinkSelection::_grabnew = false;
 
 /* Selecting an arrival is what makes this node ask to own it, so a table where
    everybody selects everything is a table where every drawing changes hands the

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -86,27 +86,6 @@ void LinkSelection::Clear(Viewer* viewer) {
 #if 0
   fprintf(stderr, "LinkSelection::Clear\n");
 #endif
-#if 0
-  CompIdTable* table = ((DrawServ*)unidraw)->compidtable();
-  Iterator it;
-  First(it);
-  while(!Done(it)) {
-    OverlayView* view = GetView(it);
-    OverlayComp* comp = view ? view->GetOverlayComp() : nil;
-    void* ptr = nil;
-    table->find(ptr, (void*)comp);
-    if (ptr) {
-      GraphicId* grid = (GraphicId*)ptr;
-      if (grid->selected()==LocallySelected || grid->selected()==WaitingToBeSelected) 
-	grid->selected(NotSelected);
-      char buf[BUFSIZ];
-      snprintf(buf, BUFSIZ, "grid(\"%s\" \"%s\" :state %d)%c",
-	       grid->idstr(), grid->selectorstr(), grid->selected(), '\0');
-      ((DrawServ*)unidraw)->DistributeCmdString(buf);
-    }
-    Next(it);
-  }
-#endif
   OverlaySelection::Clear(viewer);
   Reserve();
 }

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -111,6 +111,20 @@ void LinkSelection::Clear(Viewer* viewer) {
   Reserve();
 }
 
+boolean LinkSelection::_grabnew = true;
+
+/* Selecting an arrival is what makes this node ask to own it, so a table where
+   everybody selects everything is a table where every drawing changes hands the
+   moment it lands.  With grabnew off, only what is drawn here is selected, and
+   what arrives is left where it is -- still there, still distributed, still
+   selectable by hand, just not reached for. */
+boolean LinkSelection::select_arrivals() {
+  if (grabnew()) return true;
+  DrawServHandler* handler =
+    (DrawServHandler*)((DrawEditor*)_editor)->GetComTerp()->handler();
+  return !(handler && handler->drawlink());
+}
+
 void LinkSelection::Reserve() {
 #if 0
   fprintf(stderr, "LinkSelection::Reserve\n");

--- a/src/DrawServ/linkselection.c
+++ b/src/DrawServ/linkselection.c
@@ -121,11 +121,14 @@ boolean LinkSelection::_grabnew = false;
    moment it lands.  With grabnew off, only what is drawn here is selected, and
    what arrives is left where it is -- still there, still distributed, still
    selectable by hand, just not reached for. */
+boolean LinkSelection::over_a_link() {
+  DrawServHandler* handler = DrawServHandler::current();
+  return handler && handler->drawlink();
+}
+
 boolean LinkSelection::select_arrivals() {
   if (grabnew()) return true;
-  DrawServHandler* handler =
-    (DrawServHandler*)((DrawEditor*)_editor)->GetComTerp()->handler();
-  return !(handler && handler->drawlink());
+  return !over_a_link();
 }
 
 void LinkSelection::Reserve() {

--- a/src/DrawServ/linkselection.h
+++ b/src/DrawServ/linkselection.h
@@ -91,6 +91,12 @@ public:
   
   boolean request_resolved_check(boolean granted, const char* fileline);
 
+  boolean over_a_link();
+  // whether the command being executed arrived from another session.  Asked of
+  // the handler dispatching right now rather than of the editor's own
+  // interpreter: drawserv runs a ComTerpServ per connection, so the editor's is
+  // a different object from the one executing a command off a link.
+
   virtual boolean select_arrivals();
   // a graphic that arrived over a link is selected only while grabnew is on;
   // one drawn here always is

--- a/src/DrawServ/linkselection.h
+++ b/src/DrawServ/linkselection.h
@@ -91,6 +91,13 @@ public:
   
   boolean request_resolved_check(boolean granted, const char* fileline);
 
+  virtual boolean select_arrivals();
+  // a graphic that arrived over a link is selected only while grabnew is on;
+  // one drawn here always is
+
+  static boolean& grabnew() { return _grabnew; }
+  // whether graphics arriving from other sessions are selected on arrival
+
   boolean& silent() { return _silent; }
   // when set, a resolved request unwinds the count without the beep or ding:
   // a scripted select() waits for the answer and returns it instead.
@@ -114,6 +121,7 @@ protected:
 
   int _waiting_count;
   boolean _silent;
+  static boolean _grabnew;
   int _granted_count;
   boolean _wtbs_flag;
   boolean _remote_flag;

--- a/src/OverlayUnidraw/ovcomps.c
+++ b/src/OverlayUnidraw/ovcomps.c
@@ -1101,6 +1101,10 @@ void OverlaysComp::SetMobility (Mobility m) {
 
 void OverlaysComp::SelectViewsOf (OverlayComp* comp, Editor* ed) {
     Selection* s = ed->GetSelection();
+
+    /* as in SelectClipboard: an arrival that is not selected is not asked for */
+    if (!((OverlaySelection*)s)->select_arrivals()) return;
+
     s->Clear();
     Viewer* viewer;
 
@@ -1114,6 +1118,11 @@ void OverlaysComp::SelectViewsOf (OverlayComp* comp, Editor* ed) {
 
 void OverlaysComp::SelectClipboard (Clipboard* cb, Editor* ed) {
     Selection* s = ed->GetSelection();
+
+    /* leaving the selection alone is how a node stops reaching for what other
+       people draw: selecting an arrival is what sends the request. */
+    if (!((OverlaySelection*)s)->select_arrivals()) return;
+
     s->Clear();
     Viewer* viewer;
     Iterator i;

--- a/src/OverlayUnidraw/ovselection.h
+++ b/src/OverlayUnidraw/ovselection.h
@@ -70,6 +70,7 @@ public:
     OverlaySelection* ViewsWithin(IntCoord l, IntCoord b, IntCoord r, IntCoord t);
 
     virtual void Reserve() { return; }
+
     // for use of derived classes
 
     virtual void CopyFlags(OverlaySelection* from) {}  // no-op base

--- a/src/Unidraw/grcomp.c
+++ b/src/Unidraw/grcomp.c
@@ -968,6 +968,10 @@ void GraphicComps::Write (ostream& out) {
 
 void GraphicComps::SelectViewsOf (GraphicComp* comp, Editor* ed) {
     Selection* s = ed->GetSelection();
+
+    /* a graphic not selected on arrival is a graphic not asked for */
+    if (!s->select_arrivals()) return;
+
     s->Clear();
     Viewer* viewer;
 
@@ -981,6 +985,10 @@ void GraphicComps::SelectViewsOf (GraphicComp* comp, Editor* ed) {
 
 void GraphicComps::SelectClipboard (Clipboard* cb, Editor* ed) {
     Selection* s = ed->GetSelection();
+
+    /* a graphic not selected on arrival is a graphic not asked for */
+    if (!s->select_arrivals()) return;
+
     s->Clear();
     Viewer* viewer;
     Iterator i;

--- a/src/drawserv_/tests/TESTING.md
+++ b/src/drawserv_/tests/TESTING.md
@@ -84,6 +84,32 @@ using `lsof` if available, falling back to `fuser`.
 The spin loop uses `update()` rather than `usleep()` so drawmo's own
 ComTerp event loop keeps processing incoming connections during the wait.
 
+## What `remote()` Does, and Why Shutdown Has Three Steps
+
+`remote(sock cmd)` writes the command plus a newline, then reads **one
+newline-terminated line** back, one byte at a time, and — unless you pass
+`:str` — runs that line through the *local* interpreter and returns its value.
+One line per call, no more, no less.
+
+So a command that answers with exactly one line can be asked on any socket.
+`size(select())` and `grid(:table)` are such commands. `:nowait` skips the read
+entirely, which is right only when nothing is coming back, or when something
+else is reading that socket.
+
+The shutdown sequence in step 6 is three things and needs all three:
+
+1. `remote(sock "exit" :nowait)` — `exit` sends **no reply**, so a blocking
+   `remote()` on it waits for a line that never comes.
+2. `close(sock)` — after the peer exits, this end sits in `CLOSE_WAIT` still
+   holding the port.
+3. `kill_port()` only for one that did not go. It kills **by port**, and
+   `lsof -ti` lists every process holding that port, this end included — so
+   killing a port you are still connected to kills the test itself.
+
+Shut down by asking, not by killing; check with `pgrep -f '[d]rawserv -comdraw
+<port>'` and kill only what stayed. Killing by port while connected is silent:
+the test dies with SIGTERM and reports nothing, which reads exactly like a hang.
+
 ## Test Inventory
 
 ### updown
@@ -119,6 +145,38 @@ assertion is `size(sidtable)==1`.
 **Purpose:** Verifies that a freshly-launched drawserv has a clean
 drawlink table and exactly one sid entry. This is the baseline against
 which connected-peer tests will diff.
+
+### seltest
+
+Two spokes on a hub, which is the arrangement where an answer between spokes is
+not delivered by the node that produced it. Spoke 1 draws and holds a graphic;
+spoke 2 reaches for it and must be **refused**, with the refusal routed home
+across the hub; spoke 1 lets go and spoke 2 reaches again and must be
+**granted**, likewise across the hub. Before the refusal named its asker it went
+back one hop and stopped, leaving the spoke that asked stuck in
+`WaitingToBeSelected` with no retry to rescue it — a request is only made from
+`NotSelected`.
+
+## agreetest — counting runs rather than trusting one
+
+`agreetest` is not a drawmo test and is run on its own:
+
+```
+./agreetest --runs 10 --kids 4
+```
+
+It runs the same scenario n times and tallies how many came out consistent:
+every node holding the one graphic it drew, every node seeing all of them. The
+four-node case answers differently to identical input, so a single run of it will
+tell you a change fixed something or broke something when it did neither — a
+claim about anything distributed should move the tally rather than produce one
+good run. It went 0 of 4 to 8 of 8 across one fix, and that number is what
+located the bug.
+
+It is shell rather than comterp, unlike everything else here. Driving several
+drawservs and reading answers back from each is worth getting right in a demo,
+but in a test whose whole job is to be trusted it is one more thing that can be
+wrong about the test rather than about drawserv.
 
 ## What Belongs Here vs comterp_/tests
 

--- a/src/drawserv_/tests/TESTING.md
+++ b/src/drawserv_/tests/TESTING.md
@@ -146,7 +146,7 @@ assertion is `size(sidtable)==1`.
 drawlink table and exactly one sid entry. This is the baseline against
 which connected-peer tests will diff.
 
-### seltest
+### sel
 
 Two spokes on a hub, which is the arrangement where an answer between spokes is
 not delivered by the node that produced it. Spoke 1 draws and holds a graphic;

--- a/src/drawserv_/tests/agreetest
+++ b/src/drawserv_/tests/agreetest
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# agreetest  do the drawservs agree about who holds what?
+#
+# Usage:  agreetest [--runs n] [--kids n] [--help]
+#
+# The same scenario, over and over, counted.  Drawservs round a hub, each
+# drawing one graphic of its own, and then the only two questions that have a
+# right answer: does every node hold exactly the one it drew, and does every
+# node see all of them.  One run proves nothing -- identical runs give different
+# answers, which is the whole reason this exists -- so it is the tally across n
+# runs that means something, and a change claiming to fix something distributed
+# should move the tally rather than produce one good run.
+#
+# Shell rather than comterp, unlike drawmo and kidmo beside it: the harness has
+# to drive several drawservs and read answers back from each, and doing that
+# down comterp sockets means minding which connection may be asked a question
+# and which may only be written to.  That is a thing worth getting right in a
+# demo; in a test whose whole job is to be trusted, it is one more thing that
+# can be wrong about the test rather than about drawserv.
+
+runs=5
+kids=4
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --runs) shift; runs=$1 ;;
+    --kids) shift; kids=$1 ;;
+    --help|-h|-\?)
+      sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "agreetest: unknown argument $1" >&2 ;;
+  esac
+  shift
+done
+[ "$kids" -lt 2 ] && kids=2
+[ "$kids" -gt 4 ] && kids=4
+
+comterp=${COMTERP:-comterp}
+drawserv=${DRAWSERV:-drawserv}
+ports=(22002 23002 24002 25002)
+
+echo "agreetest: $runs runs of $kids drawservs, one graphic each" >&2
+passed=0
+
+for r in $(seq 1 "$runs"); do
+  pkill -f "$drawserv -comdraw 2[2-5]002" 2>/dev/null
+  sleep 2
+  for k in $(seq 0 $((kids-1))); do
+    p=${ports[$k]}
+    $drawserv -comdraw "$p" -import $((p-1)) -stdin_off > /dev/null 2>&1 &
+    disown 2>/dev/null
+  done
+  sleep 15
+
+  {
+    for k in $(seq 0 $((kids-1))); do
+      echo "s$k=socket(\"127.0.0.1\" ${ports[$k]})"
+    done
+    for k in $(seq 1 $((kids-1))); do
+      echo "remote(s$k \"drawlink(\\\"127.0.0.1\\\" ${ports[0]})\")"
+      echo "usleep(2500000)"
+    done
+    for k in $(seq 0 $((kids-1))); do
+      echo "remote(s$k \"text($((60+k*150)),20 \\\"kid$((k+1))\\\")\")"
+      echo "usleep(700000)"
+    done
+    echo "usleep(4000000)"
+    for k in $(seq 0 $((kids-1))); do
+      echo "print(\"ANSWER $k %v %v\\n\" remote(s$k \"size(select())\") remote(s$k \"size(children())\"))"
+    done
+    echo "exit"
+  } | $comterp 2>/dev/null | grep "^ANSWER" > /tmp/agreetest.$$
+
+  ok=yes
+  while read -r _ node held seen; do
+    [ "$held" = "1" ] || ok=no
+    [ "$seen" = "$kids" ] || ok=no
+  done < /tmp/agreetest.$$
+  [ "$(grep -c . /tmp/agreetest.$$)" = "$kids" ] || ok=no
+
+  if [ "$ok" = yes ]; then
+    passed=$((passed+1))
+    echo "  run $r/$runs: agree" >&2
+  else
+    echo "  run $r/$runs: DISAGREE   $(tr '\n' ' ' < /tmp/agreetest.$$)" >&2
+  fi
+  rm -f /tmp/agreetest.$$
+done
+
+pkill -f "$drawserv -comdraw 2[2-5]002" 2>/dev/null
+echo "agreetest: $passed of $runs runs consistent" >&2
+[ "$passed" = "$runs" ]

--- a/src/drawserv_/tests/agreetest
+++ b/src/drawserv_/tests/agreetest
@@ -37,7 +37,19 @@ done
 
 comterp=${COMTERP:-comterp}
 drawserv=${DRAWSERV:-drawserv}
-ports=(22002 23002 24002 25002)
+
+# Find a free pair the way drawmo and kidmo do, stepping up by ten until both
+# the comdraw port and the import port below it are unused.  Fixed ports are not
+# safe: a drawserv already on one keeps listening, the child that failed to bind
+# keeps running, and the harness then sends drawlink and text into somebody
+# else's session and reports its state as the tally.
+find_open_port() {
+  local port=$1
+  while lsof -i ":$port" >/dev/null 2>&1 || lsof -i ":$((port-1))" >/dev/null 2>&1; do
+    port=$((port+10))
+  done
+  echo "$port"
+}
 
 echo "agreetest: $runs runs of $kids drawservs, one graphic each" >&2
 passed=0
@@ -47,14 +59,30 @@ for r in $(seq 1 "$runs"); do
   # takes down a drawserv somebody else is using -- another test, or a window
   # open on the desk -- and the tally then measures that instead.
   mypids=()
-  sleep 2
+  ports=()
+  base=22002
   for k in $(seq 0 $((kids-1))); do
-    p=${ports[$k]}
+    p=$(find_open_port $base)
+    ports+=("$p")
+    base=$((p+10))
     $drawserv -comdraw "$p" -import $((p-1)) -stdin_off > /dev/null 2>&1 &
     mypids+=($!)
     disown 2>/dev/null
   done
-  sleep 5
+  sleep 15
+
+  # and whoever is listening has to be who we started, or we are about to draw
+  # on a stranger's canvas
+  mine=yes
+  for k in $(seq 0 $((kids-1))); do
+    owner=$(lsof -ti ":${ports[$k]}" 2>/dev/null | head -1)
+    [ "$owner" = "${mypids[$k]}" ] || mine=no
+  done
+  if [ "$mine" != yes ]; then
+    echo "  run $r/$runs: SKIPPED, ports ${ports[*]} not held by our own drawservs" >&2
+    for pid in "${mypids[@]}"; do kill "$pid" 2>/dev/null; done
+    continue
+  fi
 
   {
     for k in $(seq 0 $((kids-1))); do

--- a/src/drawserv_/tests/agreetest
+++ b/src/drawserv_/tests/agreetest
@@ -43,11 +43,15 @@ echo "agreetest: $runs runs of $kids drawservs, one graphic each" >&2
 passed=0
 
 for r in $(seq 1 "$runs"); do
-  pkill -f "$drawserv -comdraw 2[2-5]002" 2>/dev/null
+  # Only ever kill what this run started.  An unanchored pkill on a fixed port
+  # takes down a drawserv somebody else is using -- another test, or a window
+  # open on the desk -- and the tally then measures that instead.
+  mypids=()
   sleep 2
   for k in $(seq 0 $((kids-1))); do
     p=${ports[$k]}
     $drawserv -comdraw "$p" -import $((p-1)) -stdin_off > /dev/null 2>&1 &
+    mypids+=($!)
     disown 2>/dev/null
   done
   sleep 5
@@ -84,9 +88,9 @@ for r in $(seq 1 "$runs"); do
   else
     echo "  run $r/$runs: DISAGREE   $(tr '\n' ' ' < /tmp/agreetest.$$)" >&2
   fi
+  for pid in "${mypids[@]}"; do kill "$pid" 2>/dev/null; done
   rm -f /tmp/agreetest.$$
 done
 
-pkill -f "$drawserv -comdraw 2[2-5]002" 2>/dev/null
 echo "agreetest: $passed of $runs runs consistent" >&2
 [ "$passed" = "$runs" ]

--- a/src/drawserv_/tests/agreetest
+++ b/src/drawserv_/tests/agreetest
@@ -50,7 +50,7 @@ for r in $(seq 1 "$runs"); do
     $drawserv -comdraw "$p" -import $((p-1)) -stdin_off > /dev/null 2>&1 &
     disown 2>/dev/null
   done
-  sleep 15
+  sleep 5
 
   {
     for k in $(seq 0 $((kids-1))); do

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,7 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
+# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|seltest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,9 +10,9 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|seltest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|gsexim|gsbrushA|gsbrushB]\n");
+    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|seltest|gsexim|gsbrushA|gsbrushB]\n");
     print("\t\t\ttests to run (comma-separated), returns -1 on error\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
@@ -84,6 +84,7 @@ grid_has_id=func(
    reason -- the test funcs call them. */
 run("./updown.comt")
 run("./gstests.comt")
+run("./seltest.comt")
 
 /* run selected tests */
 ok=true;
@@ -97,6 +98,13 @@ if(tests_flag :then
         print("updown: pass\n" :err)
       :else
         print("updown: FAIL\n" :err);
+        ok=false));
+    if(t==`seltest || t==`all :then
+      print("running seltest test\n" :err);
+      if(seltest_test(:dummy 0) :then
+        print("seltest: pass\n" :err)
+      :else
+        print("seltest: FAIL\n" :err);
         ok=false));
     if(t==`updown1 || t==`all :then
       print("running updown1 test\n" :err);

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -2,7 +2,10 @@
 #
 # drawmo  drawserv orchestrator and test suite
 #
-# Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|seltest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help
+# Usage:  drawmo [--tests <name>[,<name>...]] [--port n] [--help]
+#   names: all updown updown1 updown2 updown3A updown3B updown4A updown4B
+#          updown4C ringtest seltest parsetest optabletest gsexim gsbrushA
+#          gsbrushB
 #   no args runs all tests, portnum defaults to 10002
 #
 
@@ -10,10 +13,21 @@
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("drawmo  drawserv orchestrator and test suite\n");
-    print("Usage:  drawmo [--tests all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|seltest|gsexim|gsbrushA|gsbrushB] --port [portnum] --help\n\n");
+    print("Usage:  drawmo [--tests <name>[,<name>...]] [--port n] [--help]\n\n");
     print("  (no args)             run all tests\n");
-    print("--tests [all|updown|updown1|updown2|updown3A|updown3B|updown4A|updown4B|updown4C|ringtest|parsetest|optabletest|seltest|gsexim|gsbrushA|gsbrushB]\n");
-    print("\t\t\ttests to run (comma-separated), returns -1 on error\n");
+    print("--tests [name,...]  tests to run, comma-separated; -1 on error\n");
+    print("      all                 everything below\n");
+    print("      updown              one drawserv up and down again\n");
+    print("      updown1 updown2     one linked, then two\n");
+    print("      updown3A updown3B   three, chained and forked\n");
+    print("      updown4A updown4B updown4C\n");
+    print("                          four, to the second level\n");
+    print("      ringtest            a ring cannot be formed\n");
+    print("      seltest             an answer that has to cross a relay\n");
+    print("      parsetest optabletest\n");
+    print("                          parser and operator table\n");
+    print("      gsexim gsbrushA gsbrushB\n");
+    print("                          graphic state over a link\n");
     print("--port [portnum]\tport drawmo listens on for callbacks (default 10002)\n");
     print("--help\t\t\tprint this help message\n");
     exit)

--- a/src/drawserv_/tests/drawmo
+++ b/src/drawserv_/tests/drawmo
@@ -4,7 +4,7 @@
 #
 # Usage:  drawmo [--tests <name>[,<name>...]] [--port n] [--help]
 #   names: all updown updown1 updown2 updown3A updown3B updown4A updown4B
-#          updown4C ringtest seltest parsetest optabletest gsexim gsbrushA
+#          updown4C ring sel parsetest optabletest gsexim gsbrushA
 #          gsbrushB
 #   no args runs all tests, portnum defaults to 10002
 #
@@ -22,8 +22,8 @@ if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
     print("      updown3A updown3B   three, chained and forked\n");
     print("      updown4A updown4B updown4C\n");
     print("                          four, to the second level\n");
-    print("      ringtest            a ring cannot be formed\n");
-    print("      seltest             an answer that has to cross a relay\n");
+    print("      ring                a ring cannot be formed\n");
+    print("      sel                 an answer that has to cross a relay\n");
     print("      parsetest optabletest\n");
     print("                          parser and operator table\n");
     print("      gsexim gsbrushA gsbrushB\n");
@@ -98,8 +98,12 @@ grid_has_id=func(
    reason -- the test funcs call them. */
 run("./updown.comt")
 run("./gstests.comt")
-run("./seltest.comt")
+run("./sel.comt")
 
+/* Run selected tests.  A test name must not be the name of a comterp command:
+   the dispatch below compares against a bare symbol, and a bare symbol naming a
+   command fires it -- `optable with no arguments segfaults.  parsetest and
+   optabletest keep their suffix for that reason and not for tidiness. */
 /* run selected tests */
 ok=true;
 if(tests_flag :then
@@ -113,12 +117,12 @@ if(tests_flag :then
       :else
         print("updown: FAIL\n" :err);
         ok=false));
-    if(t==`seltest || t==`all :then
-      print("running seltest test\n" :err);
-      if(seltest_test(:dummy 0) :then
-        print("seltest: pass\n" :err)
+    if(t==`sel || t==`all :then
+      print("running sel test\n" :err);
+      if(sel_test(:dummy 0) :then
+        print("sel: pass\n" :err)
       :else
-        print("seltest: FAIL\n" :err);
+        print("sel: FAIL\n" :err);
         ok=false));
     if(t==`updown1 || t==`all :then
       print("running updown1 test\n" :err);
@@ -162,12 +166,12 @@ if(tests_flag :then
       :else
         print("updown4B: FAIL\n" :err);
         ok=false));
-    if(t==`ringtest || t==`all :then
-      print("running ringtest\n" :err);
-      if(ringtest_test(:dummy 0) :then
-        print("ringtest: pass\n" :err)
+    if(t==`ring || t==`all :then
+      print("running ring test\n" :err);
+      if(ring_test(:dummy 0) :then
+        print("ring: pass\n" :err)
       :else
-        print("ringtest: FAIL\n" :err);
+        print("ring: FAIL\n" :err);
         ok=false));
     if(t==`parsetest || t==`all :then
       print("running parsetest\n" :err);

--- a/src/drawserv_/tests/sel.comt
+++ b/src/drawserv_/tests/sel.comt
@@ -1,4 +1,4 @@
-/* seltest -- can a graphic be asked for, refused, and then granted, when the
+/* sel -- can a graphic be asked for, refused, and then granted, when the
    answer has to cross a relay?
 
    Two spokes on a hub, which is the arrangement where an answer between spokes
@@ -9,7 +9,7 @@
    across the hub: refused while the owner holds the graphic, granted once the
    owner lets go. */
 
-seltest_test=func(
+sel_test=func(
   poll_usec=2000000;
   timeout=60*1000000/poll_usec;
 
@@ -17,18 +17,18 @@ seltest_test=func(
   sp1_port=find_open_port(:base_port 30002);
   sp2_port=find_open_port(:base_port 40002);
 
-  global(seltest_up)=0;
-  print("seltest: launching hub %d, spokes %d and %d\n" hub_port sp1_port sp2_port :err);
+  global(sel_up)=0;
+  print("sel: launching hub %d, spokes %d and %d\n" hub_port sp1_port sp2_port :err);
   j=0;
   while(j<3
     p=if(j==0 :then hub_port :else if(j==1 :then sp1_port :else sp2_port));
-    shell(print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(seltest_up)=global(seltest_up)+1\\\")\" &" p p-1 callback_port :str));
+    shell(print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(sel_up)=global(sel_up)+1\\\")\" &" p p-1 callback_port :str));
     j=j+1);
 
   cnt=0;
-  while(global(seltest_up)<3 && cnt<timeout update(poll_usec);cnt++);
-  if(global(seltest_up)<3 :then
-    print("seltest: FAIL only %d of 3 drawservs came up\n" global(seltest_up) :err);
+  while(global(sel_up)<3 && cnt<timeout update(poll_usec);cnt++);
+  if(global(sel_up)<3 :then
+    print("sel: FAIL only %d of 3 drawservs came up\n" global(sel_up) :err);
     kill_port(:kill_port_num hub_port);kill_port(:kill_port_num hub_port-1);
     kill_port(:kill_port_num sp1_port);kill_port(:kill_port_num sp1_port-1);
     kill_port(:kill_port_num sp2_port);kill_port(:kill_port_num sp2_port-1);
@@ -38,52 +38,52 @@ seltest_test=func(
   sp1=socket("127.0.0.1" sp1_port);
   sp2=socket("127.0.0.1" sp2_port);
 
-  print("seltest: linking spoke1\n" :err);
+  print("sel: linking spoke1\n" :err);
   remote(sp1 print("drawlink(%c127.0.0.1%c %d)" 34 34 hub_port :str));
   usleep(3000000);
-  print("seltest: linking spoke2\n" :err);
+  print("sel: linking spoke2\n" :err);
   remote(sp2 print("drawlink(%c127.0.0.1%c %d)" 34 34 hub_port :str));
   usleep(4000000);
 
   ok=true;
 
-  print("seltest: spoke1 draws\n" :err);
+  print("sel: spoke1 draws\n" :err);
   remote(sp1 "rect(10,10,60,60)");
   usleep(4000000);
   held=remote(sp1 "size(select())");
-  print("seltest: spoke1 holds %v\n" held :err);
+  print("sel: spoke1 holds %v\n" held :err);
   if(held!=1 :then
-    print("seltest: FAIL spoke1 drew a rect and holds %v of it\n" held :err);
+    print("sel: FAIL spoke1 drew a rect and holds %v of it\n" held :err);
     ok=false);
 
   /* refused, and the refusal has to come back across the hub; without that the
      select never resolves and the graphic sticks for good */
   if(ok :then
-    print("seltest: spoke2 reaches for it while held\n" :err);
+    print("sel: spoke2 reaches for it while held\n" :err);
     remote(sp2 "select(:all)");
     usleep(5000000);
     got=remote(sp2 "size(select())");
     still=remote(sp1 "size(select())");
-    print("seltest: spoke2 got %v, spoke1 still holds %v\n" got still :err);
+    print("sel: spoke2 got %v, spoke1 still holds %v\n" got still :err);
     if(got!=0 :then
-      print("seltest: FAIL spoke2 was refused but came away with %v\n" got :err);
+      print("sel: FAIL spoke2 was refused but came away with %v\n" got :err);
       ok=false);
     if(still!=1 :then
-      print("seltest: FAIL spoke1 was holding it and now holds %v\n" still :err);
+      print("sel: FAIL spoke1 was holding it and now holds %v\n" still :err);
       ok=false));
 
   /* and the grant crosses the hub the same way once the owner lets go */
   if(ok :then
-    print("seltest: spoke1 lets go\n" :err);
+    print("sel: spoke1 lets go\n" :err);
     remote(sp1 "select(:clear)");
     usleep(3000000);
-    print("seltest: spoke2 reaches again\n" :err);
+    print("sel: spoke2 reaches again\n" :err);
     remote(sp2 "select(:all)");
     usleep(5000000);
     got=remote(sp2 "size(select())");
-    print("seltest: spoke2 got %v\n" got :err);
+    print("sel: spoke2 got %v\n" got :err);
     if(got!=1 :then
-      print("seltest: FAIL spoke1 let go and spoke2 still came away with %v\n" got :err);
+      print("sel: FAIL spoke1 let go and spoke2 still came away with %v\n" got :err);
       ok=false));
 
   /* Shut down by asking, not by killing.  exit sends no reply, so it goes
@@ -92,7 +92,7 @@ seltest_test=func(
      the port.  Only a drawserv that would not go is killed, and it says so --
      kill_port kills by port, and lsof -ti lists everyone holding it, this end
      included, so killing one still connected to would kill the test itself. */
-  print("seltest: asking the three to go\n" :err);
+  print("sel: asking the three to go\n" :err);
   remote(hub "exit" :nowait);close(hub);
   remote(sp1 "exit" :nowait);close(sp1);
   remote(sp2 "exit" :nowait);close(sp2);
@@ -101,7 +101,7 @@ seltest_test=func(
   while(j<3
     p=if(j==0 :then hub_port :else if(j==1 :then sp1_port :else sp2_port));
     if(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" p :str))==0 :then
-      print("seltest: drawserv on %d would not go, sending it\n" p :err);
+      print("sel: drawserv on %d would not go, sending it\n" p :err);
       kill_port(:kill_port_num p);kill_port(:kill_port_num p-1));
     j=j+1);
 

--- a/src/drawserv_/tests/seltest.comt
+++ b/src/drawserv_/tests/seltest.comt
@@ -1,0 +1,108 @@
+/* seltest -- can a graphic be asked for, refused, and then granted, when the
+   answer has to cross a relay?
+
+   Two spokes on a hub, which is the arrangement where an answer between spokes
+   is not delivered by the node that produced it.  A refusal built without
+   naming the asker went back one hop and stopped there, leaving the spoke that
+   asked in WaitingToBeSelected with nothing that would ever resolve it -- and
+   no retry, a request being made only from NotSelected.  Both halves are asked
+   across the hub: refused while the owner holds the graphic, granted once the
+   owner lets go. */
+
+seltest_test=func(
+  poll_usec=2000000;
+  timeout=60*1000000/poll_usec;
+
+  hub_port=find_open_port(:base_port 20002);
+  sp1_port=find_open_port(:base_port 30002);
+  sp2_port=find_open_port(:base_port 40002);
+
+  global(seltest_up)=0;
+  print("seltest: launching hub %d, spokes %d and %d\n" hub_port sp1_port sp2_port :err);
+  j=0;
+  while(j<3
+    p=if(j==0 :then hub_port :else if(j==1 :then sp1_port :else sp2_port));
+    shell(print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(seltest_up)=global(seltest_up)+1\\\")\" &" p p-1 callback_port :str));
+    j=j+1);
+
+  cnt=0;
+  while(global(seltest_up)<3 && cnt<timeout update(poll_usec);cnt++);
+  if(global(seltest_up)<3 :then
+    print("seltest: FAIL only %d of 3 drawservs came up\n" global(seltest_up) :err);
+    kill_port(:kill_port_num hub_port);kill_port(:kill_port_num hub_port-1);
+    kill_port(:kill_port_num sp1_port);kill_port(:kill_port_num sp1_port-1);
+    kill_port(:kill_port_num sp2_port);kill_port(:kill_port_num sp2_port-1);
+    return(false));
+
+  hub=socket("127.0.0.1" hub_port);
+  sp1=socket("127.0.0.1" sp1_port);
+  sp2=socket("127.0.0.1" sp2_port);
+
+  print("seltest: linking spoke1\n" :err);
+  remote(sp1 print("drawlink(%c127.0.0.1%c %d)" 34 34 hub_port :str));
+  usleep(3000000);
+  print("seltest: linking spoke2\n" :err);
+  remote(sp2 print("drawlink(%c127.0.0.1%c %d)" 34 34 hub_port :str));
+  usleep(4000000);
+
+  ok=true;
+
+  print("seltest: spoke1 draws\n" :err);
+  remote(sp1 "rect(10,10,60,60)");
+  usleep(4000000);
+  held=remote(sp1 "size(select())");
+  print("seltest: spoke1 holds %v\n" held :err);
+  if(held!=1 :then
+    print("seltest: FAIL spoke1 drew a rect and holds %v of it\n" held :err);
+    ok=false);
+
+  /* refused, and the refusal has to come back across the hub; without that the
+     select never resolves and the graphic sticks for good */
+  if(ok :then
+    print("seltest: spoke2 reaches for it while held\n" :err);
+    remote(sp2 "select(:all)");
+    usleep(5000000);
+    got=remote(sp2 "size(select())");
+    still=remote(sp1 "size(select())");
+    print("seltest: spoke2 got %v, spoke1 still holds %v\n" got still :err);
+    if(got!=0 :then
+      print("seltest: FAIL spoke2 was refused but came away with %v\n" got :err);
+      ok=false);
+    if(still!=1 :then
+      print("seltest: FAIL spoke1 was holding it and now holds %v\n" still :err);
+      ok=false));
+
+  /* and the grant crosses the hub the same way once the owner lets go */
+  if(ok :then
+    print("seltest: spoke1 lets go\n" :err);
+    remote(sp1 "select(:clear)");
+    usleep(3000000);
+    print("seltest: spoke2 reaches again\n" :err);
+    remote(sp2 "select(:all)");
+    usleep(5000000);
+    got=remote(sp2 "size(select())");
+    print("seltest: spoke2 got %v\n" got :err);
+    if(got!=1 :then
+      print("seltest: FAIL spoke1 let go and spoke2 still came away with %v\n" got :err);
+      ok=false));
+
+  /* Shut down by asking, not by killing.  exit sends no reply, so it goes
+     :nowait or the remote() waits for one for ever, and this side's socket is
+     closed too since after the peer exits it sits in CLOSE_WAIT still holding
+     the port.  Only a drawserv that would not go is killed, and it says so --
+     kill_port kills by port, and lsof -ti lists everyone holding it, this end
+     included, so killing one still connected to would kill the test itself. */
+  print("seltest: asking the three to go\n" :err);
+  remote(hub "exit" :nowait);close(hub);
+  remote(sp1 "exit" :nowait);close(sp1);
+  remote(sp2 "exit" :nowait);close(sp2);
+  usleep(2000000);
+  j=0;
+  while(j<3
+    p=if(j==0 :then hub_port :else if(j==1 :then sp1_port :else sp2_port));
+    if(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" p :str))==0 :then
+      print("seltest: drawserv on %d would not go, sending it\n" p :err);
+      kill_port(:kill_port_num p);kill_port(:kill_port_num p-1));
+    j=j+1);
+
+  ok)

--- a/src/drawserv_/tests/updown.comt
+++ b/src/drawserv_/tests/updown.comt
@@ -121,7 +121,7 @@ updown1_test=func(
   print("updown1: drawserv shut down\n" :err);
   ok)
 
-/* parsetest test -- one drawserv, TWO connections to it.  Each connection is
+/* parsetest -- one drawserv, TWO connections to it.  Each connection is
    served by an interpreter of its own, but the parser keeps the stack that
    counts a call's arguments and keywords in a file static, so a client's saved
    copy has to be installed when it takes the globals over.  Nothing initialized
@@ -202,15 +202,15 @@ parsetest_test=func(
   print("parsetest: drawserv shut down\n" :err);
   ok)
 
-/* optabletest test -- the operator table is the one piece of parse state that is
+/* optabletest -- the operator table is the one piece of parse state that is
    meant to be shared: every interpreter wants the same operators, and
    optable(:insert) edits it while a drawserv is running (%% is defined that
    way).  A command's execution is atomic unless it deliberately re-enters the
    interpreter, as drawlink's handshake wait does with a nested Run, and
    OptableFunc::execute does nothing of the sort -- so an insert cannot be
    caught half-done by another connection.  Same two-connection shape as
-   parsetest: edit on one, parse on the other in the gap, then use the new
-   operator from both.  Unlike parsetest this is a property test, not a
+   parse: edit on one, parse on the other in the gap, then use the new
+   operator from both.  Unlike parse this is a property test, not a
    regression test: it passes with or without the parse-state fix. */
 optabletest_test=func(
 
@@ -1110,14 +1110,14 @@ updown4C_test=func(
   print("updown4C: ds4 shut down\n" :err);
   ok)
 
-/* ringtest test -- RING refused: ds1 -> ds2, ds2 -> ds3, then ds3 -> ds1 to
+/* ring test -- RING refused: ds1 -> ds2, ds2 -> ds3, then ds3 -> ds1 to
    close the loop.  drawserv detects the cycle during the one_way handshake and
    casts the connection off, so the ring never forms and the topology stays a
    chain.  Every relay depends on that: LinkBrushCmd and its four siblings break
    loops by excluding the link toward the graphic's owner, which is sufficient
    only because two non-owner nodes can never be linked to each other.  Nothing
    tested the guarantee those relays lean on until this. */
-ringtest_test=func(
+ring_test=func(
 
   poll_usec=2000000;
   timeout=60*1000000/poll_usec;
@@ -1127,67 +1127,67 @@ ringtest_test=func(
   ds1_port=find_open_port(:base_port 20002);
   ds1_import=ds1_port-1;
   global(drawserv_upring1)=false;
-  print("ringtest: launching ds1 on port %d\n" ds1_port :err);
+  print("ring: launching ds1 on port %d\n" ds1_port :err);
   cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upring1)=true\\\")\" &" ds1_port ds1_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upring1) && cnt<timeout
-    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ringtest: still waiting for ds1 after %d secs\n" cnt*poll_usec/1000000 :err)));
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ring: still waiting for ds1 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upring1) :then
-    print("ringtest: FAIL timeout waiting for ds1 callback\n" :err);
+    print("ring: FAIL timeout waiting for ds1 callback\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds1_import);
     return(false));
-  print("ringtest: ds1 up on %d\n" ds1_port :err);
+  print("ring: ds1 up on %d\n" ds1_port :err);
 
   /* --- launch ds2 (30002) --- */
   ds2_port=find_open_port(:base_port 30002);
   ds2_import=ds2_port-1;
   global(drawserv_upring2)=false;
-  print("ringtest: launching ds2 on port %d\n" ds2_port :err);
+  print("ring: launching ds2 on port %d\n" ds2_port :err);
   cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upring2)=true\\\")\" &" ds2_port ds2_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upring2) && cnt<timeout
-    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ringtest: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ring: still waiting for ds2 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upring2) :then
-    print("ringtest: FAIL timeout waiting for ds2 callback\n" :err);
+    print("ring: FAIL timeout waiting for ds2 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds2_import);
     return(false));
-  print("ringtest: ds2 up on %d\n" ds2_port :err);
+  print("ring: ds2 up on %d\n" ds2_port :err);
 
   /* --- launch ds3 (40002) --- */
   ds3_port=find_open_port(:base_port 40002);
   ds3_import=ds3_port-1;
   global(drawserv_upring3)=false;
-  print("ringtest: launching ds3 on port %d\n" ds3_port :err);
+  print("ring: launching ds3 on port %d\n" ds3_port :err);
   cmdstr=print("drawserv -comdraw %d -import %d -stdin_off -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(drawserv_upring3)=true\\\")\" &" ds3_port ds3_import callback_port :str);
   shell(cmdstr);
   cnt=0;
   while(!global(drawserv_upring3) && cnt<timeout
-    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ringtest: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
+    update(poll_usec);cnt++;if(cnt%progress_interval==0 :then print("ring: still waiting for ds3 after %d secs\n" cnt*poll_usec/1000000 :err)));
   if(!global(drawserv_upring3) :then
-    print("ringtest: FAIL timeout waiting for ds3 callback\n" :err);
+    print("ring: FAIL timeout waiting for ds3 callback\n" :err);
     s1=socket("127.0.0.1" ds1_port);if(type(s1)!=`UnknownType :then remote(s1 "exit" :nowait);close(s1));
     s2=socket("127.0.0.1" ds2_port);if(type(s2)!=`UnknownType :then remote(s2 "exit" :nowait);close(s2));
     while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
     while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import);
     return(false));
-  print("ringtest: ds3 up on %d\n" ds3_port :err);
+  print("ring: ds3 up on %d\n" ds3_port :err);
 
   /* --- connect to all three --- */
   sock1=socket("127.0.0.1" ds1_port);
   sock2=socket("127.0.0.1" ds2_port);
   sock3=socket("127.0.0.1" ds3_port);
   if(type(sock1)==`UnknownType || type(sock2)==`UnknownType || type(sock3)==`UnknownType :then
-    print("ringtest: FAIL could not connect to all three drawservs\n" :err);
+    print("ring: FAIL could not connect to all three drawservs\n" :err);
     kill_port(:kill_port_num ds1_port);kill_port(:kill_port_num ds2_port);kill_port(:kill_port_num ds3_port);
     return(false));
 
   /* --- build the chain: ds1->ds2 (on ds1), then ds2->ds3 (on ds2) --- */
-  print("ringtest: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
+  print("ring: chaining ds1(%d)->ds2(%d)->ds3(%d)\n" ds1_port ds2_port ds3_port :err);
   /* cycletest() compares the offered session id against the table the target
      already holds, so ds1 can only recognize the cycle once ds3's session id
      has reached it -- wait for each hop to reach ds1 before making the next,
@@ -1202,15 +1202,15 @@ ringtest_test=func(
   cnt=0;
   while(remote(sock1 "size(sid(:table))")<3 && cnt<50 usleep(200000);cnt++);
   nsid=remote(sock1 "size(sid(:table))");
-  print("ringtest: ds1 knows %v of 3 sessions\n" nsid :err);
+  print("ring: ds1 knows %v of 3 sessions\n" nsid :err);
   if(nsid!=3 :then
-    print("ringtest: FAIL session ids never propagated around the chain\n" :err));
+    print("ring: FAIL session ids never propagated around the chain\n" :err));
 
   /* --- now try to close the ring.  cycletest() compares the offered session
      id, host, user and pid against the session table this node already knows,
      and a match means the far end is already reachable another way -- so the
      handshake answers ackback(cycle) and drops the connection. --- */
-  print("ringtest: closing the ring, ds3(%d)->ds1(%d)\n" ds3_port ds1_port :err);
+  print("ring: closing the ring, ds3(%d)->ds1(%d)\n" ds3_port ds1_port :err);
   remote(sock3 print("drawlink(\"127.0.0.1\" %d)" ds1_port :str));
   usleep(5000000);
 
@@ -1221,10 +1221,10 @@ ringtest_test=func(
      instead, where the wait can be bounded. */
   n1=remote(sock1 "size(drawlink(:table))");
   n2=remote(sock2 "size(drawlink(:table))");
-  print("ringtest: links held -- ds1=%v ds2=%v\n" n1 n2 :err);
+  print("ring: links held -- ds1=%v ds2=%v\n" n1 n2 :err);
   chain=(n1==1) && (n2==2);
-  if(!chain :then print("ringtest: FAIL the ring formed -- expected 1,2 links\n" :err));
-  if(chain :then print("ringtest: ring refused, topology stayed a chain\n" :err));
+  if(!chain :then print("ring: FAIL the ring formed -- expected 1,2 links\n" :err));
+  if(chain :then print("ring: ring refused, topology stayed a chain\n" :err));
 
   /* the counts alone would also read 1,2 if that third drawlink had failed for
      some reason of its own, so make the refusal prove itself: casting off the
@@ -1234,12 +1234,12 @@ ringtest_test=func(
   while(remote(sock1 "size(grid(:table))")<1 && cnt<200 usleep(100000);cnt++);
   id1=remote(sock1 "at(grid(:table)).grid");
   if(type(id1)!=`StringType :then
-    print("ringtest: FAIL could not read grid id from ds1 (got %v)\n" id1 :err);
+    print("ring: FAIL could not read grid id from ds1 (got %v)\n" id1 :err);
     relay=false
   :else
     relay=grid_has_id(:gh_sock sock2 :gh_id id1);
-    print("ringtest: graphic reached ds2 over the surviving link: %v\n" relay :err));
-  if(!relay :then print("ringtest: FAIL the refusal took the good link with it\n" :err));
+    print("ring: graphic reached ds2 over the surviving link: %v\n" relay :err));
+  if(!relay :then print("ring: FAIL the refusal took the good link with it\n" :err));
 
   /* A two_way leg answers a link that was opened and is still being waited on.
      One naming a link already up answers nothing, and must not be able to take
@@ -1255,7 +1255,7 @@ ringtest_test=func(
      start empty, and a platform that hands back a dirty one served the rubbish */
   lidok=(size(lid)==36) && (index(lid "-" :substr)==8);
   if(!lidok :then
-    print("ringtest: FAIL drawlink(:table) lid is not a uuid: [%v]\n" lid :err));
+    print("ring: FAIL drawlink(:table) lid is not a uuid: [%v]\n" lid :err));
 
   legcmd=print("drawlink(%c%s%c :port %d :state 2 :sid %c%s%c :linkid %c%s%c :pid %d :user %c%s%c)"
     34 row.host 34 ds2_port 34 row.sid 34 34 lid 34 row.pid 34 row.user 34 :str);
@@ -1265,20 +1265,20 @@ ringtest_test=func(
   usleep(3000000);
   n1b=remote(sock1 "size(drawlink(:table))");
   legok=(n1b==1);
-  print("ringtest: ds1 links after a two_way leg naming a link already up: %v\n" n1b :err);
+  print("ring: ds1 links after a two_way leg naming a link already up: %v\n" n1b :err);
   if(!legok :then
-    print("ringtest: FAIL a leg naming an established link took it down\n" :err));
-  if(legok :then print("ringtest: a leg naming an established link left it alone\n" :err));
+    print("ring: FAIL a leg naming an established link took it down\n" :err));
+  if(legok :then print("ring: a leg naming an established link left it alone\n" :err));
 
   ok=chain && relay && legok && lidok && (nsid==3);
 
   /* --- tear all three down --- */
   remote(sock1 "exit" :nowait);close(sock1);
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds1_port :str))==0 usleep(200000));
-  print("ringtest: ds1 shut down\n" :err);
+  print("ring: ds1 shut down\n" :err);
   remote(sock2 "exit" :nowait);close(sock2);
   while(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds2_port :str))==0 usleep(200000));
-  print("ringtest: ds2 shut down\n" :err);
+  print("ring: ds2 shut down\n" :err);
 
   /* ds3 had a link cast off under it, so its shutdown doubles as the liveness
      check: exit is sent :nowait and the wait is bounded, and a node that never
@@ -1290,9 +1290,9 @@ ringtest_test=func(
     usleep(200000);cnt++);
   stuck=shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" ds3_port :str))==0;
   if(stuck :then
-    print("ringtest: FAIL ds3 stopped serving its comdraw port after the refusal\n" :err);
+    print("ring: FAIL ds3 stopped serving its comdraw port after the refusal\n" :err);
     kill_port(:kill_port_num ds3_port);kill_port(:kill_port_num ds3_import)
   :else
-    print("ringtest: ds3 shut down\n" :err));
+    print("ring: ds3 shut down\n" :err));
   ok=ok && !stuck;
   ok)

--- a/src/include/Unidraw/selection.h
+++ b/src/include/Unidraw/selection.h
@@ -51,6 +51,11 @@ public:
     virtual void Init(Viewer* = nil);   /* explicitly init handles */
     virtual void Clear(Viewer* = nil);	/* removes & clears all views */
 
+    virtual boolean select_arrivals() { return true; }
+    /* whether a graphic appearing in the editor should become the selection.
+       Always, until a selection that is shared with other sessions, where
+       selecting one is what asks its owner to hand it over. */
+
     void Append(GraphicView*);
     void Prepend(GraphicView*);
     void InsertAfter(Iterator, GraphicView*);

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c89ea67d"
+#define PATCH_KEY "89ea67dc"
 
 #endif /* _patch_h */


### PR DESCRIPTION
The drawserv-level changes found while building kidmo, separated out so they can
be reviewed and merged on their own before the demo is built on top. Sits between
#459 and the kidmo work.

## grabnew(): stop reaching for what other people draw

Selecting a graphic is what asks its owner to hand it over. A graphic *arriving*
from another session was being selected exactly as one drawn here is — `PasteCmd`
selects what it pastes, which is right for a paste and says nothing about whose
graphic it is. So a drawing changed hands the moment it landed, and a drawserv
ended up holding graphics it never drew: it drew one and won the others.

`grabnew(false)` leaves an arrival where it is — still there, still distributed,
still selectable by hand, just not reached for. Read/toggle/set shape as
`pastemode()` and `handles()`, and **off by default**, since reaching for other
people's drawings is the unusual want.

The hook is `Selection::select_arrivals()`. It has to live on `Selection` rather
than `OverlaySelection` because `SelectClipboard` is not virtual and each comp
layer has its own copy, so the decision must be somewhere both can ask.

## Ask the handler that is dispatching

`LinkSelection` answered "did this command arrive from another session" by
reading the *editor's* comterp. drawserv runs a `ComTerpServ` per connection, so
that is a different object from the one executing a command off a link, and the
answer described the editor rather than the command. Everything else that needs
to know reaches it through `comterp()`, being a `ComFunc`; a `Selection` has no
such handle, so `DrawServHandler` now records itself for the duration of a
dispatch — saved and restored the way `_alt_fd` already is, so a command that
runs the event loop and nests another unwinds correctly.

## Never pass a request back down the link it came in on

A node whose record named the sender as the selector forwarded the request
straight back, and the answer then arrived at a node with nowhere to put it — on
a spoke, whose only link is the hub, a refusal addressed to another spoke cannot
be delivered at all. Refuse instead: the asker gets an answer, which is more than
a request bouncing between two nodes will ever give it.

## Two tests, and why there are two

`agreetest` runs the same scenario n times and tallies how many came out
consistent — every node holding the one graphic it drew, every node seeing all of
them. The four-node case answers differently to identical input, and a single run
of it repeatedly told me a change had fixed or broken something when it had done
neither. It went **0 of 4 before the dispatching-handler fix, 8 of 8 after**, and
turning "looks flaky" into a number is what located that bug.

It is shell rather than comterp, unlike drawmo and kidmo beside it: driving
several drawservs and reading answers back from each is a thing worth getting
right in a demo, but in a test whose whole job is to be trusted it is one more
thing that can be wrong about the test rather than about drawserv.

`seltest` is a drawmo test (`--tests seltest`, and included in `all`) for the
relay case #459 fixed: two spokes on a hub, refused while the owner holds the
graphic, granted once it lets go, both answers crossing the hub.

```
spoke2 got 0, spoke1 still holds 1     refusal delivered across the hub
spoke1 lets go
spoke2 got 1                            grant delivered across the hub
```

Its teardown asks the drawservs to exit and kills only one that would not go.
That ordering is load-bearing: `exit` sends no reply so it must be `:nowait`;
this side's socket is closed too since after the peer exits it sits in
`CLOSE_WAIT` still holding the port; and `kill_port` kills by port, with `lsof
-ti` listing everyone who holds it — so killing a port still connected to kills
the test itself, which it did until the asking came first.

## Also

- `grid(:table)` and the printed table gain an `unlocked` column — the flag
  decides whether `Reserve()` drops a graphic owned elsewhere or lets it
  through, and there was no way to look at it
- the `#if 0` announcement loop is gone from `Clear()`; it read as though
  clearing a selection tells the other sessions about it, which it does not and
  has not for as long as the block has been off
- the guard added to `GraphicComps` comes back out — a probe shows neither
  method there is reached in drawserv, `OverlaysComp` having cloned rather than
  inherited them