### PR TITLE
kidmo: a table of linked drawservs, and a --tests that checks one

### DIFF
--- a/src/drawserv_/examples/kid.comt
+++ b/src/drawserv_/examples/kid.comt
@@ -81,7 +81,7 @@ kid=(
 /* only when there is nothing here yet: with -comt kid.comt the pane loads this
    at startup, and kidmo loads it again over its own connection to drive from --
    two loads, and without this, two welcome creatures */
-if(size(children())==0 :then kid.animal(:x 300 :y 220 :c kid.colour))
+if(size(children())==0 && nowelcome!=true :then kid.animal(:x 300 :y 220 :c kid.colour))
 
 if(quiet!=true :then
   print("\n===============================================\n");

--- a/src/drawserv_/examples/kid.comt
+++ b/src/drawserv_/examples/kid.comt
@@ -41,10 +41,13 @@ kid=(
   )
 
   // kid.play(:n 6) -- draw n things, pausing between them.  The pause is the
-  // point: a fourth grader draws at mouse speed, not at socket speed.
+  // point: a fourth grader draws at mouse speed, not at socket speed.  Bare
+  // kid.play() draws one: an omitted keyword formal is nil, and i<nil is nil
+  // rather than true, so the loop would not run a single pass.
   :play func(
+    cnt=if(n==nil :then 1 :else n);
     i=0;
-    while(i<n
+    while(i<cnt
       xx=60+int(rand(0,520));
       yy=50+int(rand(0,300));
       pick=int(rand(0,2.99));
@@ -83,9 +86,9 @@ if(size(children())==0 :then kid.animal(:x 300 :y 220 :c kid.colour))
 if(quiet!=true :then
   print("\n===============================================\n");
   print("   YOU ARE A FOURTH GRADER WITH A DRAWSERV\n");
-  print("   That grey creature is kid.animal() -- and\n");
-  print("   anything you draw goes to everyone you are\n");
-  print("   linked to.  Try typing:\n");
+  print("   That grey creature was created by kid.animal()\n");
+  print("   -- and anything you draw goes to everyone you\n");
+  print("   are linked to.  Try typing:\n");
   print("       kid.play(:n 3)\n");
   print("       kid.colour=\"#DD3333\"\n");
   print("       kid.adventurer(:x 200 :y 120 :c kid.colour)\n");

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -182,14 +182,21 @@ have_comtfile=shell("drawserv -help 2>&1 | grep -q '^-comt .file.'")==0
    killing it, in case the number has been recycled, and report whether there
    was anything there to kill.
 
-   The check is the command line rather than the command name, because the name
-   is not identity: this desk runs drawservs constantly -- kidmo, drawmo,
-   agreetest, a second kidmo -- so "it is a drawserv" is exactly the thing a
-   recycled pid is most likely to still be true of.  A drawserv holding our
-   -comdraw port is ours, because two of them cannot hold the same one. */
+   A pid on its own is not identity, and neither is a pid that looks like a
+   drawserv: this desk runs them constantly -- kidmo, drawmo, agreetest, a
+   second kidmo -- so "it is a drawserv" is exactly the thing a recycled number
+   is most likely to still be true of.  Nor is the -comdraw port enough on its
+   own, since a kid that died released both its pid and its port for the next
+   drawserv to pick up together.
+
+   What settles it is when the process started, recorded beside the pid at
+   launch.  A different process wearing a recycled pid has a different start
+   time, and pids do not come round again inside the same second.  The port is
+   still matched as well, so a pid file that has been mangled rather than
+   recycled fails for a legible reason. */
 reap=func(
-  shell(print("pid=$(cat %s/kidmo-%d.pid 2>/dev/null); rc=1; if [ -n \"$pid\" ] && ps -p $pid -o args= 2>/dev/null | grep -q -- \"-comdraw %d\"; then kill $pid > /dev/null 2>&1; rc=0; fi; rm -f %s/kidmo-%d.pid; exit $rc"
-    log_dir pnum pnum log_dir pnum :str))==0)
+  shell(print("pid=$(sed -n 1p %s/kidmo-%d.pid 2>/dev/null); born=$(sed -n 2p %s/kidmo-%d.pid 2>/dev/null); rc=1; if [ -n \"$pid\" ] && [ \"$(ps -p $pid -o lstart= 2>/dev/null)\" = \"$born\" ] && ps -p $pid -o args= 2>/dev/null | grep -q -- \"-comdraw %d\"; then kill $pid > /dev/null 2>&1; rc=0; fi; rm -f %s/kidmo-%d.pid; exit $rc"
+    log_dir pnum log_dir pnum pnum log_dir pnum :str))==0)
 
 comt_flag=if(have_comtfile :then print("-comt '%s'" kid_file :str)
          :else if(have_comt :then "-comt" :else ""))
@@ -214,7 +221,7 @@ if(nkids<2 :then global(kid2_up)=true)
 j=0
 while(j<nkids
   p=at(kid_ports j);
-  shell(print("drawserv -comdraw %d -import %d -stdin_off %s -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(kid%d_up)=true\\\")\" > %s/kidmo-%d.log 2>&1 & echo $! > %s/kidmo-%d.pid" p p-1 comt_flag callback_port j+1 log_dir p log_dir p :str));
+  shell(print("drawserv -comdraw %d -import %d -stdin_off %s -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(kid%d_up)=true\\\")\" > %s/kidmo-%d.log 2>&1 & kidpid=$!; { echo $kidpid; ps -p $kidpid -o lstart=; } > %s/kidmo-%d.pid" p p-1 comt_flag callback_port j+1 log_dir p log_dir p :str));
   j=j+1)
 print("kidmo: %d drawserv(s) starting, logs in %s/kidmo-<port>.log\n" nkids log_dir :err)
 

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -1,19 +1,20 @@
 #! /usr/bin/env comterp_listen
 #
-# kidmo -- a table of linked drawservs, brought up, wired together, taught the
-# kid script, and left at the prompt for you to drive.
+# kidmo -- sit four fourth graders round a table, each with a drawserv of their
+# own, all linked, and leave you at the prompt to play with them.
 #
 //   kidmo                     // then, at the (comt) prompt it leaves you at:
-//   remote(k1 "kid.play(:n 2)")   // ask the kid at the head to draw two things
+//   todd.draw()               // Todd draws something he likes
+//   mia.draw(:n 3)            // Mia draws three things she likes
+//   all(:n 2)                 // everyone draws two
+//   wait_all()                // block until they have all reported done
 //   look()                    // what each table holds
 //   bye()                     // send them home
 //   kidmo --tests             // bring a table up, check it, take it down
 //
-// This is the table and the wiring: finding ports, starting a drawserv on each,
-// waiting to hear from them, linking them to the one at the head, teaching each
-// of them kid.comt, and taking them all down again.  What sits at the table --
-// a model per kid, with a name and a crayon and things you can ask it to draw
-// -- goes on top of this and is not here.
+// The table under all this -- ports, launching, linking, teaching, reaping --
+// is the layer below, and the kids here are a model apiece sitting on top of
+// the sockets it leaves us holding.
 //
 // Two sockets per kid, both opened once and kept.  The kids were written to
 // with :nowait once, so that all four acted at once rather than taking turns.
@@ -66,7 +67,7 @@ if(badchar!=nil :then
 if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
   arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
     print("kidmo  a table of linked drawservs\n\n");
-    print("Usage:  kidmo [--kids n] [--tests] [--help]\n");
+    print("Usage:  kidmo [--kids n] [--draw n] [--tests] [--help]\n");
     print("  Run it from anywhere -- it reads the kid.comt beside it.  It finds\n");
     print("  ports, brings a drawserv up on each, pulls the other chairs up to\n");
     print("  the one at the head of the table, teaches each of them the kid\n");
@@ -79,6 +80,8 @@ if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
     print("    look()               what each table is holding\n");
     print("    bye()                send them home\n\n");
     print("--kids [n]\t\thow many sit down (1-4, default 4)\n");
+    print("--draw [n]\t\thow many things each draws before the prompt\n");
+    print("\t\t\t(default 3; 0 for an empty canvas, welcome and all)\n");
     print("--tests\t\t\tbring a table up, check it, take it down, and\n");
     print("\t\t\treport -- no prompt, and non-zero if anything failed\n");
     print("--help\t\t\tprint this help message\n\n");
@@ -91,10 +94,13 @@ callback_port=int(arg(1))
 /* --kids dials the table down to a case small enough to reason about and then
    back up: two kids is one link, where the default is four kids and three. */
 nkids=4
+ndraw=-1
 tests=false
+global(nrect)=0
 for(i=2 i<narg() i++
   switch(substr(arg(i) 2 :after)
     :kids if(i+1>=narg() || substr(arg(i+1) 2)=="--" :then continue);i++;nkids=int(arg(i))
+    :draw if(i+1>=narg() || substr(arg(i+1) 2)=="--" :then continue);i++;ndraw=int(arg(i))
     :tests tests=true
     :default print("kidmo:  Unknown argument %s\n" arg(i) :err)))
 if(nkids<1 :then nkids=1)
@@ -198,7 +204,21 @@ reap=func(
   shell(print("pid=$(sed -n 1p %s/kidmo-%d.pid 2>/dev/null); born=$(sed -n 2p %s/kidmo-%d.pid 2>/dev/null); rc=1; if [ -n \"$pid\" ] && [ \"$(ps -p $pid -o lstart= 2>/dev/null)\" = \"$born\" ] && ps -p $pid -o args= 2>/dev/null | grep -q -- \"-comdraw %d\"; then kill $pid > /dev/null 2>&1; rc=0; fi; rm -f %s/kidmo-%d.pid; exit $rc"
     log_dir pnum log_dir pnum pnum log_dir pnum :str))==0)
 
-comt_flag=if(have_comtfile :then print("-comt '%s'" kid_file :str)
+/* --draw 0 wants an empty canvas, and the welcome creature cannot be talked out
+   of it from this end: the pane loads kid.comt in its own interpreter, which
+   never sees a nowelcome set on the driving connection, one connection not
+   being able to see another's variables.  Nor can it be cleared afterwards --
+   each kid holds its own creature and a select() from one node is refused the
+   rest.  So the pane loads a two-line wrapper instead, which sets the flag and
+   then runs kid.comt: the greeting still prints and kid.play is still there to
+   call, only the creature is missing, which is what was asked for. */
+pane_file=kid_file
+if(ndraw==0 :then
+  pane_file=print("%s/kidmo-nowelcome.comt" log_dir :str);
+  shell(print("echo 'nowelcome=true' > '%s'" pane_file :str));
+  shell(print("echo 'run(%c%s%c)' >> '%s'" 34 kid_file 34 pane_file :str)))
+
+comt_flag=if(have_comtfile :then print("-comt '%s'" pane_file :str)
          :else if(have_comt :then "-comt" :else ""))
 if(!have_comt :then
   print("kidmo: this drawserv has no -comt, so the kids get no pane\n" :err)
@@ -218,6 +238,15 @@ global(kid4_up)=false
 if(nkids<4 :then global(kid4_up)=true)
 if(nkids<3 :then global(kid3_up)=true)
 if(nkids<2 :then global(kid2_up)=true)
+
+/* done means "not in the middle of a play", so everyone starts done and draw()
+   clears it for the one kid it asks.  Leaving them unset instead makes wait_all
+   test !nil, which is true, and it waits out its full count on kids that were
+   never asked to do anything -- or on kids who are not at the table at all */
+global(kid1_done)=true
+global(kid2_done)=true
+global(kid3_done)=true
+global(kid4_done)=true
 j=0
 while(j<nkids
   p=at(kid_ports j);
@@ -280,6 +309,7 @@ while(j<nkids
      greeting is printed plainly so it reaches the pane, and plain output over a
      socket lands in the reply stream, putting every later question one behind */
   remote(at(kids j) "quiet=true");
+  if(ndraw>=0 :then remote(at(kids j) "nowelcome=true"));
   remote(at(kids j) print("run(%c%s%c)" 34 kid_file 34 :str));
   remote(at(kids j) print("kid.colour=%c%s%c" 34 at(kid_cols j) 34 :str));
   remote(at(kids j) print("srand(%d)" 11+j*7 :str));
@@ -312,6 +342,92 @@ bye=func(
   shell(print("rm -rf '%s'" log_dir :str));
   0)
 
+
+/* The reply is the completion.  Each kid used to call back on the listen port
+   to say it had finished, which made sense while the kids were written to with
+   :nowait and nobody read the reply.  Now that the reply is read, it already
+   means the play is over -- remote() gets its line only after the command it
+   sent has run -- and the callback was worse than redundant: it could not
+   complete at all from script context.  We block reading the reply, the kid
+   blocks writing the callback, and the reactor that would accept it does not
+   run until the next prompt.  kidmo --draw hung there, before any of this was
+   under test.
+
+   A model of each kid: name, crayon, the socket he is on, and the things we
+   can ask of him.  The funcs are defined inline because naming a func fires
+   it niladically -- (:draw todd_draw) would store the nil that calling it
+   returned -- and each refers to its own object by name, the way zoomap's
+   zoo.flash() does from inside zoo. */
+
+kid1=(
+  :name "Todd" :colour "#DD3333" :socket k1
+  :draw func( global(kid1_done)=false;
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid1.socket print("kid.play(:n %d)" cnt :str));
+    global(kid1_done)=true;
+    cnt)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid1.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+kid2=(
+  :name "Mia" :colour "#3366DD" :socket k2
+  :draw func( global(kid2_done)=false;
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid2.socket print("kid.play(:n %d)" cnt :str));
+    global(kid2_done)=true;
+    cnt)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid2.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+kid3=(
+  :name "Sam" :colour "#22AA55" :socket k3
+  :draw func( global(kid3_done)=false;
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid3.socket print("kid.play(:n %d)" cnt :str));
+    global(kid3_done)=true;
+    cnt)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid3.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+kid4=(
+  :name "Ana" :colour "#CC7722" :socket k4
+  :draw func( global(kid4_done)=false;
+    cnt=if(n==nil :then 1 :else n);
+    remote(kid4.socket print("kid.play(:n %d)" cnt :str));
+    global(kid4_done)=true;
+    cnt)
+  :one func( global(nrect)=global(nrect)+1;
+    remote(kid4.socket print("rect(%d,380,%d,410)" 40+global(nrect)*34 70+global(nrect)*34 :str));
+    global(nrect))
+)
+
+/* The kids are numbered kid1..kid<n>; the names are what you call them by.  A
+   chair nobody sat in is nil rather than a model with a dead socket in it, so
+   asking after a kid who is not at the table says so rather than hanging on a
+   connection that was never made. */
+if(nkids<2 :then kid2=nil)
+if(nkids<3 :then kid3=nil)
+if(nkids<4 :then kid4=nil)
+todd=kid1
+mia=kid2
+sam=kid3
+ana=kid4
+
+all=func( cnt=if(n==nil :then 1 :else n);
+  kid1.draw(:n cnt);
+  if(nkids>1 :then kid2.draw(:n cnt));
+  if(nkids>2 :then kid3.draw(:n cnt));
+  if(nkids>3 :then kid4.draw(:n cnt));
+  cnt)
+
+wait_all=func(
+  cnt=0;
+  while((!global(kid1_done) || !global(kid2_done) || !global(kid3_done) || !global(kid4_done)) && cnt<120
+    update(500000);cnt++);
+  cnt)
 
 /* --tests: the table is up and wired, so check what that was supposed to mean,
    take it down, and check that too.  The path guard is checked first because it
@@ -360,6 +476,18 @@ if(tests :then
     if(remote(at(kids j) "kid.play!=nil")!=true :then taught=false);
     j=j+1);
   check(:nm "taught" :got taught);
+  /* and the kids on top of it: one() puts a plain rect on the head kid's
+     canvas, draw() sends a whole play through and reports back done */
+  was=remote(e1 "size(children())");
+  kid1.one();
+  usleep(1000000);
+  check(:nm "one" :got remote(e1 "size(children())")==was+1);
+  was=remote(e1 "size(children())");
+  kid1.draw(:n 2);
+  wait_all();
+  check(:nm "draw" :got remote(e1 "size(children())")>was);
+  check(:nm "draw-default" :got kid1.draw(:n nil)==1);
+  wait_all();
   /* down again -- nobody left on a port, and no pid files left behind */
   bye();
   usleep(1000000);
@@ -378,5 +506,21 @@ if(tests :then
   exit(if(global(ok) :then 0 :else 1)))
 
 
-print("kidmo: ports %v %v %v %v\n" p1 p2 p3 p4 :err)
-print("kidmo: ready -- remote(k1 \"kid.play(:n 2)\")  look()  bye()\n" :err)
+/* a nametag apiece, so you can tell whose window is whose -- and since
+   everything distributes, every table ends up showing the whole class */
+nametag=func(
+  remote(at(kids who) print("text(%d,20 %c%s%c)" 60+who*150 34 nm 34 :str));
+  remote(at(kids who) print("colorsrgb(%c%s%c %c#FFFFFF%c)" 34 at(kid_cols who) 34 34 34 :str));
+  nm)
+nametag(:who 0 :nm "Todd")
+if(nkids>1 :then nametag(:who 1 :nm "Mia"))
+if(nkids>2 :then nametag(:who 2 :nm "Sam"))
+if(nkids>3 :then nametag(:who 3 :nm "Ana"))
+
+print("kidmo: Todd %v, Mia %v, Sam %v, Ana %v\n" p1 p2 p3 p4 :err)
+print("kidmo: ready -- todd.draw()  mia.draw(:n 3)  all(:n 2)  wait_all()  look()  bye()\n" :err)
+
+/* what they draw before you get the prompt.  --draw 0 leaves the canvas empty
+   -- with the welcome creature already off, that is a table of kids who have
+   drawn nothing, which is where to start when something is going wrong. */
+if(ndraw<0 :then all(:n 3) :else if(ndraw>0 :then all(:n ndraw)))

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -180,10 +180,16 @@ have_comtfile=shell("drawserv -help 2>&1 | grep -q '^-comt .file.'")==0
    not ours, and a kid that died before binding holds no port to be found by at
    all.  The pid came from $! at launch.  Check it is still a drawserv before
    killing it, in case the number has been recycled, and report whether there
-   was anything there to kill. */
+   was anything there to kill.
+
+   The check is the command line rather than the command name, because the name
+   is not identity: this desk runs drawservs constantly -- kidmo, drawmo,
+   agreetest, a second kidmo -- so "it is a drawserv" is exactly the thing a
+   recycled pid is most likely to still be true of.  A drawserv holding our
+   -comdraw port is ours, because two of them cannot hold the same one. */
 reap=func(
-  shell(print("pid=$(cat %s/kidmo-%d.pid 2>/dev/null); rc=1; if [ -n \"$pid\" ] && ps -p $pid -o comm= 2>/dev/null | grep -q drawserv; then kill $pid > /dev/null 2>&1; rc=0; fi; rm -f %s/kidmo-%d.pid; exit $rc"
-    log_dir pnum log_dir pnum :str))==0)
+  shell(print("pid=$(cat %s/kidmo-%d.pid 2>/dev/null); rc=1; if [ -n \"$pid\" ] && ps -p $pid -o args= 2>/dev/null | grep -q -- \"-comdraw %d\"; then kill $pid > /dev/null 2>&1; rc=0; fi; rm -f %s/kidmo-%d.pid; exit $rc"
+    log_dir pnum pnum log_dir pnum :str))==0)
 
 comt_flag=if(have_comtfile :then print("-comt '%s'" kid_file :str)
          :else if(have_comt :then "-comt" :else ""))

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -1,0 +1,336 @@
+#! /usr/bin/env comterp_listen
+#
+# kidmo -- a table of linked drawservs, brought up, wired together, taught the
+# kid script, and left at the prompt for you to drive.
+#
+//   kidmo                     // then, at the (comt) prompt it leaves you at:
+//   remote(k1 "kid.play(:n 2)")   // ask the kid at the head to draw two things
+//   look()                    // what each table holds
+//   bye()                     // send them home
+//   kidmo --tests             // bring a table up, check it, take it down
+//
+// This is the table and the wiring: finding ports, starting a drawserv on each,
+// waiting to hear from them, linking them to the one at the head, teaching each
+// of them kid.comt, and taking them all down again.  What sits at the table --
+// a model per kid, with a name and a crayon and things you can ask it to draw
+// -- goes on top of this and is not here.
+//
+// Two sockets per kid, both opened once and kept.  The kids were written to
+// with :nowait once, so that all four acted at once rather than taking turns.
+// That was wrong: :nowait skips reading the answer, which is only safe when
+// something else is reading that socket, and nothing was -- a comterp socket()
+// is a bare stream with no handler, so every reply piled up unread.  They are
+// asked for their answers now, which costs the simultaneity and is the honest
+// version until there is a handler to give it back.  :nowait is left only on
+// exit, which sends no reply for anyone to read.
+//
+// The kids report back the way drawserv's own AckBackHandler does -- over a
+// separate path -- which here is the listen port comterp_listen gives us, so a
+// kid that is up sets a global we can wait on.  Questions that are about the
+// node rather than the connection (the canvas) go down a throwaway socket.
+
+/* kid.comt sits beside this script, so find it from arg(0) rather than from
+   wherever you happened to be standing when you typed kidmo.  The kids need
+   this too, and more than kidmo does: they are handed the path over a socket
+   and resolve it against their own working directory.
+
+   The shell resolves PATH before execve, so even a bare "kidmo" reaches us as
+   an absolute path.  substr() keeps everything up to but not including the
+   last slash, and the "%s/kid.comt" below supplies the separator:
+     /opt/ivtools/src/drawserv_/examples/kidmo -> /opt/.../examples/kid.comt
+     ./kidmo                                   -> ./kid.comt */
+kidmo_slash=index(arg(0) "/" :last)
+kidmo_dir=if(kidmo_slash!=nil :then substr(arg(0) kidmo_slash) :else ".")
+kid_file=print("%s/kid.comt" kidmo_dir :str)
+
+/* That path crosses two parsers on its way to a kid: a shell command line, and
+   a comterp string literal inside the run() we send down the socket.  A quote
+   or a backslash survives neither -- and a single quote pasted into a shell
+   command is an injection rather than merely a breakage, running as whoever
+   started kidmo.  Escaping cleanly through both parsers is more machinery than
+   an example wants to carry, so refuse the path and say which character.  It is
+   a func so that --tests can hand it paths we would never want to launch. */
+badpathchar=func(
+  if(index(pth print("%c" 39 :str))!=nil :then "a single quote" :else
+  if(index(pth print("%c" 34 :str))!=nil :then "a double quote" :else
+  if(index(pth print("%c" 92 :str))!=nil :then "a backslash" :else nil))))
+badchar=badpathchar(:pth kid_file)
+if(badchar!=nil :then
+  print("kidmo: the path to this script contains %s:\n" badchar :err);
+  print("         %s\n" kid_file :err);
+  print("       it reaches the kids through a shell command and a comterp\n" :err);
+  print("       string literal, and survives neither.  Put the examples\n" :err);
+  print("       somewhere without quotes in the name.\n" :err);
+  exit(1))
+
+if(arg(2)=="help" || arg(2)=="-h" || arg(2)=="?" ||
+  arg(2)=="-help" || arg(2)=="--help" || arg(2)=="-?" :then
+    print("kidmo  a table of linked drawservs\n\n");
+    print("Usage:  kidmo [--kids n] [--tests] [--help]\n");
+    print("  Run it from anywhere -- it reads the kid.comt beside it.  It finds\n");
+    print("  ports, brings a drawserv up on each, pulls the other chairs up to\n");
+    print("  the one at the head of the table, teaches each of them the kid\n");
+    print("  script, and leaves you at the comterp prompt holding the sockets:\n\n");
+    print("    k1 k2 k3 k4          the connection to each kid, k1 at the head\n");
+    print("      (a chair nobody sat in is nil)\n");
+    print("    e1 e2 e3 e4          a second connection apiece, for asking\n");
+    print("                         about the canvas rather than driving it\n");
+    print("    remote(k1 \"kid.play(:n 2)\")   ask a kid to draw\n");
+    print("    look()               what each table is holding\n");
+    print("    bye()                send them home\n\n");
+    print("--kids [n]\t\thow many sit down (1-4, default 4)\n");
+    print("--tests\t\t\tbring a table up, check it, take it down, and\n");
+    print("\t\t\treport -- no prompt, and non-zero if anything failed\n");
+    print("--help\t\t\tprint this help message\n\n");
+    print("  What a kid can draw is the kid's own business, in kid.comt on their\n");
+    print("  machine -- this end only ever asks.\n");
+    exit(0))
+
+callback_port=int(arg(1))
+
+/* --kids dials the table down to a case small enough to reason about and then
+   back up: two kids is one link, where the default is four kids and three. */
+nkids=4
+tests=false
+for(i=2 i<narg() i++
+  switch(substr(arg(i) 2 :after)
+    :kids if(i+1>=narg() || substr(arg(i+1) 2)=="--" :then continue);i++;nkids=int(arg(i))
+    :tests tests=true
+    :default print("kidmo:  Unknown argument %s\n" arg(i) :err)))
+if(nkids<1 :then nkids=1)
+if(nkids>4 :then nkids=4)
+
+/* Ports the way drawmo finds them -- probe, and step up by ten until both the
+   comdraw port and the import port below it are free -- so a second kidmo, a
+   drawmo run, or yesterday's drawserv that never quite died cannot wedge the
+   demo before it starts.  The ones actually chosen get printed below, since a
+   demo you want to poke at from another window has to say where the kids are. */
+have_lsof=shell("which lsof > /dev/null 2>&1")==0;
+have_nc=shell("which nc > /dev/null 2>&1")==0;
+port_probe=if(have_lsof :then
+  "lsof -i :%d > /dev/null 2>&1"
+:else if(have_nc :then
+  "nc -z 127.0.0.1 %d > /dev/null 2>&1"
+:else
+  "false"));
+
+find_open_port=func(
+  port=base_port;
+  while(shell(print(port_probe port :str))==0 ||
+        shell(print(port_probe port-1 :str))==0
+    port=port+10);
+  port)
+
+kill_port=func(
+  if(have_lsof :then
+    shell(print("kill $(lsof -ti :%d) > /dev/null 2>&1" kill_port_num :str))
+  :else
+    shell(print("fuser -k %d/tcp > /dev/null 2>&1" kill_port_num :str))))
+
+p1=find_open_port(:base_port 21002)
+p2=find_open_port(:base_port 31002)
+p3=find_open_port(:base_port 41002)
+p4=find_open_port(:base_port 51002)
+kid_ports=(p1,p2,p3,p4)
+kid_cols=("#DD3333","#3366DD","#22AA55","#CC7722")
+
+/* Launch, each kid calling back when it is up -- no guessing at a settle.
+   -comt gives every kid an inline comterp pane in their own window: with
+   -stdin_off there is no terminal REPL, so that pane is the only way to ask a
+   kid something at the kid, rather than over a socket from here.  Type
+   grid(:table) or select(:all) straight into the window of whichever one is
+   behaving oddly.
+
+   Asked for only if this drawserv has it: an older one does not merely ignore
+   the option, it comes up and then exits, and four kids that die at birth look
+   exactly like four kids taking their time. */
+have_comt=shell("drawserv -help 2>&1 | grep -q '^-comt'")==0
+/* dots rather than \[file\]: a backslash does not survive comterp's string
+   parser into the shell, and the bracket then reads as a character class that
+   matches nothing here -- which quietly reported no file support at all */
+/* each kid's drawserv used to go to /dev/null, which is a poor place to keep
+   the grant traffic when the question is why a graphic will not select.  One
+   file per kid, named by the port so two kidmos do not write to the same one. */
+log_dir="/tmp"
+
+have_comtfile=shell("drawserv -help 2>&1 | grep -q '^-comt .file.'")==0
+
+/* Taking a kid down means the process we started, not whoever holds its port:
+   a port probed free a moment ago may since have been taken by somebody who is
+   not ours, and a kid that died before binding holds no port to be found by at
+   all.  The pid came from $! at launch.  Check it is still a drawserv before
+   killing it, in case the number has been recycled, and report whether there
+   was anything there to kill. */
+reap=func(
+  shell(print("pid=$(cat %s/kidmo-%d.pid 2>/dev/null); rc=1; if [ -n \"$pid\" ] && ps -p $pid -o comm= 2>/dev/null | grep -q drawserv; then kill $pid > /dev/null 2>&1; rc=0; fi; rm -f %s/kidmo-%d.pid; exit $rc"
+    log_dir pnum log_dir pnum :str))==0)
+
+comt_flag=if(have_comtfile :then print("-comt '%s'" kid_file :str)
+         :else if(have_comt :then "-comt" :else ""))
+if(!have_comt :then
+  print("kidmo: this drawserv has no -comt, so the kids get no pane\n" :err)
+:else if(!have_comtfile :then
+  print("kidmo: this drawserv takes -comt but not a file after it, so the pane\n" :err);
+  print("       comes up empty -- type run(\"kid.comt\") in it yourself\n" :err)))
+/* one by one rather than in the loop: global() wants a symbol, and
+   global(print("kid%d_up" ...)) assigns to nothing at all -- silently, bar a
+   warning, so the four of these were never being cleared */
+global(kid1_up)=false
+global(kid2_up)=false
+global(kid3_up)=false
+global(kid4_up)=false
+
+/* a chair nobody sat in is already up, so the four-way wait below reads
+   correctly without knowing how many kids there are */
+if(nkids<4 :then global(kid4_up)=true)
+if(nkids<3 :then global(kid3_up)=true)
+if(nkids<2 :then global(kid2_up)=true)
+j=0
+while(j<nkids
+  p=at(kid_ports j);
+  shell(print("drawserv -comdraw %d -import %d -stdin_off %s -runexpr \"remote(\\\"127.0.0.1\\\" %d \\\"global(kid%d_up)=true\\\")\" > %s/kidmo-%d.log 2>&1 & echo $! > %s/kidmo-%d.pid" p p-1 comt_flag callback_port j+1 log_dir p log_dir p :str));
+  j=j+1)
+print("kidmo: %d drawserv(s) starting, logs in %s/kidmo-<port>.log\n" nkids log_dir :err)
+
+cnt=0
+while((!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up)) && cnt<120
+  update(500000);cnt++)
+if(!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up) :then
+  print("kidmo: FAILED -- not every kid came up.  Is drawserv on PATH, and does\n" :err);
+  print("       it accept the options above?  An option it does not know makes\n" :err);
+  print("       it exit at startup.\n" :err);
+  /* and take down the ones that did: leaving them holding ports means the next
+     attempt steps past those ports and the desk fills with drawservs nobody
+     asked for */
+  j=0;
+  while(j<nkids
+    reap(:pnum at(kid_ports j));
+    j=j+1);
+  exit(1))
+print("kidmo: all %d answered\n" nkids :err)
+
+/* Two connections per kid, both opened once and kept.  The kids are written to
+   and asked for their answer, so nothing accumulates on either.  The eyes never
+   learn the kid -- one connection cannot see another's definitions -- but they
+   do not need to: they
+   only ask about the canvas, which belongs to the node rather than to any
+   connection.  look() is a snapshot, so a kid's shapes may still be in flight
+   to the others when it is called. */
+k1=socket("127.0.0.1" at(kid_ports 0))
+k2=if(nkids>1 :then socket("127.0.0.1" at(kid_ports 1)) :else nil)
+k3=if(nkids>2 :then socket("127.0.0.1" at(kid_ports 2)) :else nil)
+k4=if(nkids>3 :then socket("127.0.0.1" at(kid_ports 3)) :else nil)
+kids=(k1,k2,k3,k4)
+e1=socket("127.0.0.1" at(kid_ports 0))
+e2=if(nkids>1 :then socket("127.0.0.1" at(kid_ports 1)) :else nil)
+e3=if(nkids>2 :then socket("127.0.0.1" at(kid_ports 2)) :else nil)
+e4=if(nkids>3 :then socket("127.0.0.1" at(kid_ports 3)) :else nil)
+eyes=(e1,e2,e3,e4)
+
+/* the other chairs pull up to the one at the head of the table */
+j=1
+while(j<nkids
+  remote(at(eyes j) print("drawlink(%c127.0.0.1%c %d)" 34 34 at(kid_ports 0) :str));
+  usleep(3000000);
+  j=j+1)
+
+/* Each kid is taught down the connection that will later be told to play, and
+   that connection is then kept for good.  -runfile looks like it should do this
+   at startup and does not: the names load, but funcs defined in the startup
+   interpreter draw nothing when called from a connection.  Connections cannot
+   see each other's definitions either, so the eyes know nothing of kid -- which
+   is fine, they only ever ask about the canvas, which belongs to the node. */
+j=0
+while(j<nkids
+  /* quiet: this connection loads the kid to drive it, not to read it.  The
+     greeting is printed plainly so it reaches the pane, and plain output over a
+     socket lands in the reply stream, putting every later question one behind */
+  remote(at(kids j) "quiet=true");
+  remote(at(kids j) print("run(%c%s%c)" 34 kid_file 34 :str));
+  remote(at(kids j) print("kid.colour=%c%s%c" 34 at(kid_cols j) 34 :str));
+  remote(at(kids j) print("srand(%d)" 11+j*7 :str));
+  j=j+1)
+print("kidmo: hub holds %v links, everyone knows %v sessions\n" remote(e1 "size(drawlink(:table))") remote(e1 "size(sid(:table))") :err)
+
+look=func(
+  j=0;
+  while(j<nkids
+    print("  %v canvas=%v held=%v\n" at(kid_cols j)
+      remote(at(eyes j) "size(children())") remote(at(eyes j) "size(select())") :err);
+    j=j+1);
+  0)
+
+
+/* ask them to go home, then insist: a kid mid-something may never get to it */
+bye=func(
+  remote(k1 "exit" :nowait);
+  if(nkids>1 :then remote(k2 "exit" :nowait));
+  if(nkids>2 :then remote(k3 "exit" :nowait));
+  if(nkids>3 :then remote(k4 "exit" :nowait));
+  usleep(2000000);
+  j=0;
+  while(j<nkids
+    if(reap(:pnum at(kid_ports j)) :then
+      print("kidmo: kid %d would not go home, sending them\n" j+1 :err));
+    j=j+1);
+  0)
+
+
+/* --tests: the table is up and wired, so check what that was supposed to mean,
+   take it down, and check that too.  The path guard is checked first because it
+   needs nothing running -- and because it is the one piece here that refuses
+   rather than does, which is easy to break without noticing. */
+if(tests :then
+  /* global: check() sets it from inside a func, where a plain ok would be a
+     local and the verdict below would read nil however the checks went */
+  global(ok)=true;
+  /* :got rather than :got -- cond is a registered comterp command, so a
+     keyword formal by that name never binds and every check reads false */
+  check=func(
+    if(got :then print("%s: pass\n" nm :err) :else print("%s: FAIL\n" nm :err));
+    if(!got :then global(ok)=false);
+    got);
+  sq=print("/opt/it%cs/kid.comt" 39 :str);
+  dq=print("/opt/it%cs/kid.comt" 34 :str);
+  bs=print("/opt/it%cs/kid.comt" 92 :str);
+  check(:nm "guard-accepts-plain" :got badpathchar(:pth "/opt/ivtools/kid.comt")==nil);
+  check(:nm "guard-refuses-quote" :got badpathchar(:pth sq)!=nil);
+  check(:nm "guard-refuses-dquote" :got badpathchar(:pth dq)!=nil);
+  check(:nm "guard-refuses-bslash" :got badpathchar(:pth bs)!=nil);
+  /* the wiring: every chair but the head holds a link to the head, and every
+     node has heard of every session -- that is what linking them was for */
+  check(:nm "links" :got remote(e1 "size(drawlink(:table))")==nkids-1);
+  check(:nm "sessions" :got remote(e1 "size(sid(:table))")==nkids);
+  /* each kid answers about its own canvas on its own second connection */
+  j=0;
+  every=true;
+  while(j<nkids
+    if(remote(at(eyes j) "size(children())")==nil :then every=false);
+    j=j+1);
+  check(:nm "canvases" :got every);
+  /* and the kid script reached them: kid.play is a func on every node */
+  j=0;
+  taught=true;
+  while(j<nkids
+    if(remote(at(kids j) "kid.play!=nil")!=true :then taught=false);
+    j=j+1);
+  check(:nm "taught" :got taught);
+  /* down again -- nobody left on a port, and no pid files left behind */
+  bye();
+  usleep(1000000);
+  j=0;
+  gone=true;
+  files=true;
+  while(j<nkids
+    p=at(kid_ports j);
+    if(shell(print("pgrep -f '[d]rawserv -comdraw %d' > /dev/null 2>&1" p :str))==0 :then gone=false);
+    if(shell(print("test -f %s/kidmo-%d.pid" log_dir p :str))==0 :then files=false);
+    j=j+1);
+  check(:nm "shutdown" :got gone);
+  check(:nm "pidfiles" :got files);
+  print("kidmo: %s\n" if(global(ok) :then "all tests passed" :else "TESTS FAILED") :err);
+  exit(if(global(ok) :then 0 :else 1)))
+
+
+print("kidmo: ports %v %v %v %v\n" p1 p2 p3 p4 :err)
+print("kidmo: ready -- remote(k1 \"kid.play(:n 2)\")  look()  bye()\n" :err)

--- a/src/drawserv_/examples/kidmo
+++ b/src/drawserv_/examples/kidmo
@@ -150,8 +150,28 @@ have_comt=shell("drawserv -help 2>&1 | grep -q '^-comt'")==0
    matches nothing here -- which quietly reported no file support at all */
 /* each kid's drawserv used to go to /dev/null, which is a poor place to keep
    the grant traffic when the question is why a graphic will not select.  One
-   file per kid, named by the port so two kidmos do not write to the same one. */
-log_dir="/tmp"
+   file per kid, in a directory of our own.
+
+   Of our own, and not /tmp itself, for two reasons that turn out to be the same
+   reason.  A path under /tmp named by something guessable is a file anybody on
+   the machine can put a symlink at first, and the shell redirection that writes
+   the log or the pid then follows it and truncates whatever it points at, as
+   whoever is running kidmo.  And two kidmos that had both probed the same port
+   as free would write each other's pid files, so one would reap the other's
+   drawserv or lose its own and leave it running.
+
+   mkdir without -p is the primitive that fixes both: it is atomic, and it fails
+   rather than succeeds if anything is already at the path -- symlink included.
+   The name comes from the callback port, which comterp_listen has already bound
+   for us, so it is ours for as long as we are running and no second kidmo can
+   have the same one.  Mode 700 so what the kids log is ours to read. */
+log_dir=print("/tmp/kidmo-%d.d" callback_port :str)
+if(shell(print("mkdir -m 700 '%s'" log_dir :str))!=0 :then
+  print("kidmo: cannot make a private directory for the logs at\n" :err);
+  print("         %s\n" log_dir :err);
+  print("       something is there already.  If it is a leftover of yours from\n" :err);
+  print("       a kidmo that did not shut down cleanly, remove it and try again.\n" :err);
+  exit(1))
 
 have_comtfile=shell("drawserv -help 2>&1 | grep -q '^-comt .file.'")==0
 
@@ -206,6 +226,7 @@ if(!global(kid1_up) || !global(kid2_up) || !global(kid3_up) || !global(kid4_up) 
   while(j<nkids
     reap(:pnum at(kid_ports j));
     j=j+1);
+  shell(print("rm -rf '%s'" log_dir :str));
   exit(1))
 print("kidmo: all %d answered\n" nkids :err)
 
@@ -273,6 +294,9 @@ bye=func(
     if(reap(:pnum at(kid_ports j)) :then
       print("kidmo: kid %d would not go home, sending them\n" j+1 :err));
     j=j+1);
+  /* and the directory with them -- it is named for a port we are about to stop
+     holding, so leaving it behind is what makes the next run refuse to start */
+  shell(print("rm -rf '%s'" log_dir :str));
   0)
 
 
@@ -284,8 +308,12 @@ if(tests :then
   /* global: check() sets it from inside a func, where a plain ok would be a
      local and the verdict below would read nil however the checks went */
   global(ok)=true;
-  /* :got rather than :got -- cond is a registered comterp command, so a
-     keyword formal by that name never binds and every check reads false */
+  /* :got rather than the :cond this wanted to be called -- a func's keyword
+     formal cannot shadow a command symbol, and cond is one, so it never bound
+     and every check read false.  The limit is the comterp-level func: a
+     primitive written in C takes a keyword overlapping a command name quite
+     happily.  #347's self() is what resolves it in general, the way self.echo
+     still reaches the keyword with echo a command. */
   check=func(
     if(got :then print("%s: pass\n" nm :err) :else print("%s: FAIL\n" nm :err));
     if(!got :then global(ok)=false);
@@ -299,6 +327,10 @@ if(tests :then
   check(:nm "guard-refuses-bslash" :got badpathchar(:pth bs)!=nil);
   /* the wiring: every chair but the head holds a link to the head, and every
      node has heard of every session -- that is what linking them was for */
+  /* ours: a real directory rather than a symlink somebody left, and readable
+     by nobody else -- find -perm rather than stat, whose flags differ by OS */
+  check(:nm "logdir-private"
+    :got shell(print("test -d '%s' && test ! -L '%s' && test -n \"$(find '%s' -maxdepth 0 -perm 700)\"" log_dir log_dir log_dir :str))==0);
   check(:nm "links" :got remote(e1 "size(drawlink(:table))")==nkids-1);
   check(:nm "sessions" :got remote(e1 "size(sid(:table))")==nkids);
   /* each kid answers about its own canvas on its own second connection */
@@ -328,6 +360,7 @@ if(tests :then
     j=j+1);
   check(:nm "shutdown" :got gone);
   check(:nm "pidfiles" :got files);
+  check(:nm "logdir-gone" :got shell(print("test -e '%s'" log_dir :str))!=0);
   print("kidmo: %s\n" if(global(ok) :then "all tests passed" :else "TESTS FAILED") :err);
   exit(if(global(ok) :then 0 :else 1)))
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "f1cf24a8"
+#define PATCH_KEY "c4b17e93"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "89ea67dc"
+#define PATCH_KEY "f1cf24a8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
The wiring under the kidmo demo, on its own: find ports, start a drawserv on each, wait to be told they are up, link the other chairs to the one at the head, teach each of them `kid.comt`, and take them all down again. What sits at the table — a model per kid, with a name and a crayon and things you can ask it to draw — goes on top of this and is not here. That is the follow-on PR.

### Why it is split this way

This is the half with the process management in it: shell command lines, ports, pids, and a startup that can fail partway. The other half is comterp talking to sockets that are already connected.

That split is not a guess. Across five review passes on #441, every finding landed in this layer and none in the drawing:

```
9 findings   src/drawserv_/examples/kidmo   (paths into shells, ports, pids, startup failure)
0 findings   src/drawserv_/examples/kid.comt
```

So this layer is worth reviewing by itself, where a fix cannot introduce a new finding in code the same PR just added — which is what happened twice in a row on #441.

### `--tests`

`kidmo --tests` brings a table up, checks it, takes it down, and exits non-zero if anything failed.

```
$ ./kidmo --tests
kidmo: 4 drawserv(s) starting, logs in /tmp/kidmo-<port>.log
kidmo: all 4 answered
kidmo: hub holds 3 links, everyone knows 4 sessions
guard-accepts-plain: pass
guard-refuses-quote: pass
guard-refuses-dquote: pass
guard-refuses-bslash: pass
links: pass
sessions: pass
canvases: pass
taught: pass
shutdown: pass
pidfiles: pass
kidmo: all tests passed
exit=0
```

Passes at `--kids 1`, `--kids 2` and the default 4.

The path guard is checked first because it needs nothing running, and because it is the one piece here that refuses rather than acts — easy to break without noticing. `badpathchar()` is a func precisely so the test can hand it paths we would never want to launch.

### Two things carried over from #441 review, now with tests behind them

**The path never reaches a shell unescaped.** It crosses two parsers on the way to a kid — a shell command line, and a comterp string literal inside `run()`. A quote survives neither, and a single quote pasted into a shell command is an injection, not merely a breakage. Escaping cleanly through both is more machinery than an example should carry, so the path is checked once before the first `shell()` and refused with the character named.

**Children are reaped by pid, not by port.** A port probed free a moment ago may since belong to someone else, and a kid that died before binding holds no port to be found by at all. Each child records `$!` at launch; `reap()` kills that pid after confirming it is still a drawserv, in case the number was recycled, and reports whether there was anything to kill. Both the startup-failure path and `bye()` go through it.

### Notes for the reader

A func's keyword formal cannot shadow a command symbol. `cond` is one, so `:cond` never bound and every check silently read `false` until that was found; the checker takes `:got`. The limit is the comterp-level `func` — a primitive written in C takes a keyword overlapping a command name quite happily — and #347's `self()` is what resolves it in general, the way `self.echo` would still reach the keyword with `echo` a command. Separately, a func assigning to a plain name assigns to a local, so the verdict has to be `global(ok)`.

Supersedes the infrastructure half of #441. The DrawServ protocol work these demos were built on landed separately in #459 and #460.