### PR TITLE
Requote a char landing bare at the REPL, not under print()

### DIFF
--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -1396,15 +1396,19 @@ int ComTerp::print_stack(std::ostream& out) const {
 int ComTerp::print_stack_top() const {
     if (_stack_top < 0) return true;
     ComValue::comterp(this);
+    ComValue::echo(true);
     ComValue cv(_stack[_stack_top]);
     fprintf(stdout, "%s\n", cv.String());
+    ComValue::echo(false);
     return true;
 }
 
 int ComTerp::print_stack_top(ostream& out) const {
     if (_stack_top < 0) return true;
     ComValue::comterp(this);
+    ComValue::echo(true);
     out << _stack[_stack_top];
+    ComValue::echo(false);
     return true;
 }
 

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -62,6 +62,7 @@ ComValue ComValue::_acharval('a', ComValue::CharType);
 /*****************************************************************************/
 
 const ComTerp* ComValue::_comterp = nil;
+boolean ComValue::_echo = false;
 
 ComValue::ComValue(const ComValue& sv) {
     *this = sv;
@@ -270,14 +271,14 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
 	    
 	case ComValue::CharType:
 	  if (brief)
-	    AttributeValue::out_char_brief(out, (unsigned char)svp->char_ref(), false);
+	    AttributeValue::out_char_brief(out, (unsigned char)svp->char_ref(), ComValue::echo());
 	  else
 	    out << "char( " << svp->char_ref() << ":" << (int)svp->char_ref() << " )";
-	  break;	    
+	  break;
 
 	case ComValue::UCharType:
 	  if (brief)
-	    AttributeValue::out_char_brief(out, (unsigned char)svp->uchar_ref(), false);
+	    AttributeValue::out_char_brief(out, (unsigned char)svp->uchar_ref(), ComValue::echo());
 	  else
 	    out << "uchar( " << svp->uchar_ref() << ":" << (int)svp->uchar_ref() << " )";
 	  break;

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -230,6 +230,15 @@ public:
     static const ComTerp* comterp() { return _comterp; }
     // return static pointer to ComTerp used to provide brief flag.
 
+    static void echo(boolean flag) { _echo = flag; }
+    // set static flag, true only while ComTerp::print_stack_top(ostream&)
+    // is echoing a bare top-level result back at the REPL prompt -- as
+    // opposed to a value being written out by the print() command.  Lets
+    // operator<< requote a standalone char there ('a') without requoting
+    // one that print() sends through unquoted.
+    static boolean echo() { return _echo; }
+    // return static REPL-echo flag.
+
     static ComValue& nullval();
     // returns reference to UnknownType ComValue.
     static ComValue& trueval();
@@ -278,6 +287,7 @@ protected:
     unsigned _linenum;
 
     static const ComTerp* _comterp;
+    static boolean _echo;
     static ComValue _nullval;
     static ComValue _trueval;
     static ComValue _falseval;

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "89ea67dc"
+#define PATCH_KEY "9ea67dc8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- A recent change (`23346a0`, "Show a char bare under %v") made `CharType`/`UCharType` display unquoted everywhere brief output applies -- so `'a'` typed bare at the REPL echoed back as `a`, indistinguishable from a symbol.
- `print()` and the REPL's top-level echo both flow through the same `ComValue::operator<<`, so a new static `ComValue::echo()` flag marks the narrow window where `ComTerp::print_stack_top()` is echoing the stack top back at the prompt. Only there does `out_char_brief` get its quoting turned back on. `print()`'s call sites never set the flag, so `print('a')` still reads as `a`.

## Test plan
- [x] `src/comterp_/tests/char.comt` -- green
- [x] `src/comterp_/tests/run_all.comt` (47 suites) -- green
- [x] Manual REPL check: `'a'` echoes `'a'`, `print('a')` prints `a`, `"a"`/`print("a")` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)