### PR TITLE
Shed the delimiters on a printed high byte, the way the other two forms do

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -866,9 +866,16 @@ void AttributeValue::out_char_brief(ostream& out, unsigned char cv, boolean quot
     out << "'" << '\\' << (char)cv << "'";
   else if (cv < 0x80 && isprint(cv))
     out << q << (char)cv << q;
-  else
-    out << "`\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
-	<< std::dec << "`" << std::resetiosflags(std::ios_base::basefield);
+  else {
+    /* the octal escape carries its own delimiters when quoted, because `\240`
+       has to be readable back; printed bare it sheds them like the other two
+       forms do, and takes the same ambiguity caret notation already takes --
+       run characters together and a literal backslash is indistinguishable
+       from the start of an escape.  Printing is for reading, not re-reading */
+    const char* bq = quoted ? "`" : "";
+    out << bq << "\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
+	<< std::dec << bq << std::resetiosflags(std::ios_base::basefield);
+  }
 }
 
 ostream& operator<< (ostream& out, const AttributeValue& sv) {

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -3,8 +3,15 @@
 // funcs: char print index type int
 //
 // A char shows as itself where that is safe: 'a' for a printable byte, caret
-// notation for a control byte ('^A', '^['), and the older backquote-octal
-// escape `\NNN` for anything at or above 0x80.
+// notation for a control byte ('^A', '^['), and the older octal escape \NNN
+// for anything at or above 0x80, where there is nothing readable to show.
+//
+// Printed, all three come bare.  Quoted -- which is the export path, test 9 --
+// each takes its delimiters back, the escape as `\NNN`, so the value can be
+// read again.  Bare display costs the same ambiguity throughout: run
+// characters together and a literal caret is indistinguishable from a control
+// byte, a literal backslash from the start of an escape.  That is the price of
+// text reading as text, and it is only paid where nothing has to read it back.
 //
 // The escape is what the whole display used to be, and the reason was safety:
 // a general print of a character must never put a real control byte into the
@@ -29,14 +36,14 @@ print("1 printable chars show as themselves, bare (expect A a and a space): %s %
 ok=ok&&(print(char(126) :str)=="~")
 print("2 the top of the printable range (expect ~): %s\n" print(char(126) :str))
 
-// --- 3-4: the sign-extension regression, unchanged.  A byte at or above 0x80
-// keeps the escape, so these assert exactly what they always did: the byte is
-// not widened with sign extension ---
-ok=ok&&(print('\xa0' :str)=="`\\240`")
-print("3 print('\\xa0' :str) is `\\240`, not sign-extended (expect true): %v\n" print('\xa0' :str)=="`\\240`")
+// --- 3-4: the sign-extension regression.  A byte at or above 0x80 keeps the
+// escape -- bare here, delimited in test 9 -- so these still assert what they
+// always did: the byte is not widened with sign extension ---
+ok=ok&&(print('\xa0' :str)=="\\240")
+print("3 print('\\xa0' :str) is \\240 bare, not sign-extended (expect true): %v\n" print('\xa0' :str)=="\\240")
 
-ok=ok&&(print('\xff' :str)=="`\\377`")
-print("4 print('\\xff' :str) is `\\377`, not sign-extended (expect true): %v\n" print('\xff' :str)=="`\\377`")
+ok=ok&&(print('\xff' :str)=="\\377")
+print("4 print('\\xff' :str) is \\377 bare, not sign-extended (expect true): %v\n" print('\xff' :str)=="\\377")
 
 // The display is bare, with no quotes: printing a run of characters should
 // read as the text it is.  The export path keeps its quotes -- test 9 -- since

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c4b17e93"
+#define PATCH_KEY "7d3e05b1"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Follow-on to #464, found while checking whether #464 was actually present in a branch.

#464 gave a char its quotes back when the REPL echoes it and not when `print()` sends it through. Only two of the three display forms could act on that: a printable byte and a control byte both take their delimiters from `q`, while the octal escape for anything at or above `0x80` wrote its backquotes unconditionally.

```
             print()    REPL echo
  'a'        a          'a'
  '\001'     ^A         '^A'
  '\224'     `\224`     `\224`      <- the odd one out
```

So `print('a')` came out bare and `print('\224')` could not.

### The change

```c
const char* bq = quoted ? "`" : "";
out << bq << "\\" << setw(3) << setfill('0') << oct << (unsigned int)cv << dec << bq;
```

The delimiters exist so `` `\240` `` can be read back, which is the export path's concern rather than `print()`'s — printing is for reading, not re-reading. Printed bare, the escape now takes the same ambiguity caret notation has always taken: run characters together and a literal caret cannot be told from a control byte, nor a literal backslash from the start of an escape. `char.comt` already said that outright for the caret form; it now says it for both.

### Tests

Tests 3 and 4 move to the bare form. **Test 9 does not** — an attribute value is serialized through the quoted path, so `(:p 'a' :c '^G' :h `\240`)` is unchanged and still round-trips, which is what keeps the export format readable back.

```
3 print('\xa0' :str) is \240 bare, not sign-extended (expect true): true
4 print('\xff' :str) is \377 bare, not sign-extended (expect true): true
9 a char attribute value is quoted: (:p 'a' :c '^G' :h `\240`)

char: true
run_all: true
```

The sign-extension regression tests 3 and 4 were written to guard is untouched — they still assert the byte is not widened, just without the delimiters around it.