### PR TITLE
Quote a high byte the way everything else is quoted, so it can be read back

### DIFF
--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -866,16 +866,17 @@ void AttributeValue::out_char_brief(ostream& out, unsigned char cv, boolean quot
     out << "'" << '\\' << (char)cv << "'";
   else if (cv < 0x80 && isprint(cv))
     out << q << (char)cv << q;
-  else {
-    /* the octal escape carries its own delimiters when quoted, because `\240`
-       has to be readable back; printed bare it sheds them like the other two
-       forms do, and takes the same ambiguity caret notation already takes --
-       run characters together and a literal backslash is indistinguishable
+  else
+    /* q, the same delimiter the other two forms take.  It used to be a pair of
+       backquotes, which read back as nothing: `\240` in a serialized attrlist
+       is an illegal character to the lexer, so the export path was writing a
+       form its own reader rejects.  '\240' is what the lexer already reads,
+       and it round-trips to the byte it came from.  Bare, when printing, the
+       delimiters go and the escape takes the same ambiguity caret notation
+       takes -- run characters together and a literal backslash cannot be told
        from the start of an escape.  Printing is for reading, not re-reading */
-    const char* bq = quoted ? "`" : "";
-    out << bq << "\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
-	<< std::dec << bq << std::resetiosflags(std::ios_base::basefield);
-  }
+    out << q << "\\" << std::setw(3) << std::setfill('0') << std::oct << (unsigned int)cv
+	<< std::dec << q << std::resetiosflags(std::ios_base::basefield);
 }
 
 ostream& operator<< (ostream& out, const AttributeValue& sv) {

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -7,8 +7,10 @@
 // for anything at or above 0x80, where there is nothing readable to show.
 //
 // Printed, all three come bare.  Quoted -- which is the export path, test 9 --
-// each takes its delimiters back, the escape as `\NNN`, so the value can be
-// read again.  Bare display costs the same ambiguity throughout: run
+// each takes the same single quotes back, so the value can be read again.  The
+// escape used to take backquotes there instead, and `\240` is an illegal
+// character to the lexer: the export path was writing a form its own reader
+// rejects, and an attrlist holding a high byte came back nil.  Bare display costs the same ambiguity throughout: run
 // characters together and a literal caret is indistinguishable from a control
 // byte, a literal backslash from the start of an escape.  That is the price of
 // text reading as text, and it is only paid where nothing has to read it back.
@@ -92,16 +94,21 @@ print("8 values untouched; a high byte is signed unless :u (expect CharType 97 -
 // be read back as one, since `a` parses as a symbol, and a control or high
 // byte went into the file raw ---
 al9=(:p char(97) :c char(7) :h char(160))
-ok=ok&&(print(al9 :str)=="(:p 'a' :c '^G' :h `\\240`)")
-print("9 a char attribute value is quoted (expect (:p 'a' :c '^G' :h `\\240`)): %s\n" print(al9 :str))
+ok=ok&&(print(al9 :str)=="(:p 'a' :c '^G' :h '\\240')")
+print("9 a char attribute value is quoted (expect (:p 'a' :c '^G' :h '\\240')): %s\n" print(al9 :str))
 
 // --- 10: so a printable char attribute round-trips now, which it could not
-// when it serialized bare.  The caret and escape forms still do not: they are
-// display forms the lexer does not read, the same trade the value display
-// makes, and the reason is the same -- safety first ---
+// when it serialized bare -- and so does a high byte, which could not while it
+// serialized between backquotes.  The caret form still does not: '^G' is a
+// display form the lexer does not read, and reads back as UnknownType.  That
+// is the one remaining place where what is written out cannot be read in ---
 al10=eval("(:p 'a')")
 ok=ok&&(type(attrval(al10))=="CharType")
-print("10 (:p 'a') reads back as a char (expect CharType): %s\n" type(attrval(al10)))
+al10b=eval("(:h '\\240')")
+ok=ok&&(type(attrval(al10b))=="CharType")&&(attrval(al10b)==char(160))
+al10c=eval("(:c '^G')")
+ok=ok&&(type(attrval(al10c))=="UnknownType")
+print("10 'a' and '\\240' read back as chars, '^G' does not (expect CharType CharType UnknownType): %s %s %s\n" type(attrval(al10)) type(attrval(al10b)) type(attrval(al10c)))
 
 // --- 11: the two bytes that cannot sit bare between the quotes -- a backslash
 // would escape the closing quote, an apostrophe would be it -- take the escape

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "7d3e05b1"
+#define PATCH_KEY "b8c40f27"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Stacked on #465 — review that first; this diff is against it.

The octal escape took a pair of backquotes where the printable and control forms take single quotes. `` `\240` `` is an **illegal character to the lexer**, so the export path was writing a form its own reader rejects:

```
eval("(:h '\240')")   ->  CharType, equal to char(160)
eval("(:h `\240`)")   ->  comterp: (1) Illegal character (ASCII -96)
                          nil
```

Serialize an attrlist holding a high byte, feed it back, and the whole attrlist came back nil.

`'\240'` is what the lexer already reads, and it round-trips to the byte it came from. So the escape now takes `q`, the same delimiter as the other two forms — which also removes the separate `bq` that #465 had to introduce. One delimiter, chosen once, for all three.

### Why the printed form stays bare

`print()` is `printf()`: its job is emitting the value, not echoing it. The delimiters belong to the REPL's echo and to the export path — the two places where something has to be read back afterwards.

```
             print()    REPL echo      serialized
  'a'        a          'a'            'a'
  '\001'     ^A         '^A'           '^G'
  '\240'     \240       '\240'         '\240'     <- was `\240` in the last two
```

### Tests

```
9 a char attribute value is quoted (expect (:p 'a' :c '^G' :h '\240')): (:p 'a' :c '^G' :h '\240')
10 'a' and '\240' read back as chars, '^G' does not (expect CharType CharType UnknownType): CharType CharType UnknownType

char: true
run_all: true
```

Test 10 gains the round-trip the escape could not make before, and pins the one that still cannot: `'^G'` reads back as `UnknownType`. That is now the only place where what is written out cannot be read in — caret notation is a display form the lexer does not read, which the file has always said.