### PR TITLE
Cut the ComTerp comments back to what a reader of the code needs

### DIFF
--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -56,7 +56,7 @@ void AssignFunc::execute() {
     if (operand1.type() != ComValue::SymbolType) {
         // if lhs is a global() or local() call, set lhs_assign flag on its
         // ComValue so the scope command can distinguish lhs from rhs context.
-        // Same for at() (including via the @ operator, lst@N=val, #318) --
+        // Same for at() (including via the @ operator, lst@N=val) --
         // ListAtFunc checks its own lhs_assign() (symbolfunc.c's
         // GlobalFunc/LocalFunc do the same) to tell "lst@0=val" apart from
         // an ordinary read.  Only matters for the ArrayType (plain list)
@@ -138,7 +138,7 @@ void AssignFunc::execute() {
       Attribute* attr = (Attribute*)operand1.obj_val();
       attr->Value(operand2);
     } else if (operand1.is_array() && operand1.lhs_assign()) {
-      /* #318 (@ operator): lst@N=val.  ListAtFunc (listfunc.c), seeing its
+      /* the @ operator: lst@N=val.  ListAtFunc (listfunc.c), seeing its
 	 own lhs_assign() flag set and an ArrayType before-part, handed back
 	 a [list, idx] pair instead of performing a read (lhs_assign() still
 	 set on the pair itself, so this branch can tell it apart from an

--- a/src/ComTerp/boolfunc.c
+++ b/src/ComTerp/boolfunc.c
@@ -303,14 +303,11 @@ void EqualFunc::execute() {
 	}
 	break;
       case ComValue::StringType: {
-	/* always a text comparison, never symbol_val() identity -- interning
-	   dedups an ordinary string by content, so identity happened to work
-	   there, but a slice (#395) shares its PARENT's symid, unrelated to
-	   its own effective text (sl=="cde" compared false this way even
-	   though sl prints as "cde", confirmed live).  cstr(), not
-	   string_ptr() -- string_ptr() isn't slice-aware at all (comvalue.h,
-	   attrvalue.h), so it would just read the whole shared parent
-	   string here regardless. */
+	/* always a text comparison, never symbol_val() identity: interning
+	   dedups an ordinary string by content, so identity works there by
+	   accident, but a slice shares its parent's symid, unrelated to its own
+	   text.  cstr() rather than string_ptr(), which is not slice-aware and
+	   would read the whole shared parent string. */
 	std::string scratch1, scratch2;
 	const char* str1 = operand1.cstr(scratch1);
 	const char* str2 = operand2.cstr(scratch2);
@@ -416,8 +413,7 @@ void NotEqualFunc::execute() {
       }
       break;
     case ComValue::StringType: {
-      /* always a text comparison, never symbol_val() identity -- a slice
-	 (#395) shares its parent's symid, unrelated to its own text.
+      /* always a text comparison, never symbol_val() identity -- a slice shares its parent's symid, unrelated to its own text.
 	 cstr(), not string_ptr(): string_ptr() isn't slice-aware at all
 	 (see EqualFunc above for the full reasoning). */
       std::string scratch1, scratch2;
@@ -504,18 +500,18 @@ void GreaterThanFunc::execute() {
 	result.boolean_ref() = operand1.double_val() > operand2.double_val();
 	break;
     case ComValue::SymbolType: {
-	/* Greptile, #445: operand1 matching this case says nothing about
+	/* operand1 matching this case says nothing about
 	   operand2 -- a mismatched operand2 (anything not string-like)
 	   would otherwise get read through cstr()/symbol_ptr() as if its
 	   raw union storage were a symid, either comparing against an
 	   unrelated interned symbol or handing strcmp() a null pointer.
-	   Bail to nil the same way the pre-#445 default case always did
+	   Bail to nil the same way the default case always did
 	   for a mismatch, rather than pass unrelated bits through. */
 	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc>s@0:3,
-	   still needs the slice-aware read, #395). */
+	   still needs the slice-aware read). */
 	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
 	const char* str2 = operand2.cstr(scratch2);
@@ -530,7 +526,7 @@ void GreaterThanFunc::execute() {
 	   its comment. */
 	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
-	   gap, not something #395 broke, but the same cstr() migration
+	   gap rather than something slicing broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
 	   pattern as EqualFunc's own StringType case. */
 	std::string scratch1, scratch2;
@@ -603,7 +599,7 @@ void GreaterThanOrEqualFunc::execute() {
 	result.boolean_ref() = operand1.double_val() >= operand2.double_val();
 	break;
     case ComValue::SymbolType: {
-	/* Greptile, #445: see GreaterThanFunc's identical guard -- operand1
+	/* see GreaterThanFunc's identical guard -- operand1
 	   matching this case says nothing about operand2, and a mismatched
 	   operand2 read through cstr()/symbol_ptr() would compare against
 	   unrelated union bits or crash strcmp() on a null pointer. */
@@ -611,7 +607,7 @@ void GreaterThanOrEqualFunc::execute() {
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc>=s@0:3,
-	   still needs the slice-aware read, #395). */
+	   still needs the slice-aware read). */
 	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
 	const char* str2 = operand2.cstr(scratch2);
@@ -626,7 +622,7 @@ void GreaterThanOrEqualFunc::execute() {
 	   its comment. */
 	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
-	   gap, not something #395 broke, but the same cstr() migration
+	   gap rather than something slicing broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
 	   pattern as EqualFunc's own StringType case. */
 	std::string scratch1, scratch2;
@@ -694,7 +690,7 @@ void LessThanFunc::execute() {
 	result.boolean_ref() = operand1.double_val() < operand2.double_val();
 	break;
     case ComValue::SymbolType: {
-	/* Greptile, #445: see GreaterThanFunc's identical guard -- operand1
+	/* see GreaterThanFunc's identical guard -- operand1
 	   matching this case says nothing about operand2, and a mismatched
 	   operand2 read through cstr()/symbol_ptr() would compare against
 	   unrelated union bits or crash strcmp() on a null pointer. */
@@ -702,7 +698,7 @@ void LessThanFunc::execute() {
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc<s@0:3,
-	   still needs the slice-aware read, #395). */
+	   still needs the slice-aware read). */
 	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
 	const char* str2 = operand2.cstr(scratch2);
@@ -717,7 +713,7 @@ void LessThanFunc::execute() {
 	   its comment. */
 	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
-	   gap, not something #395 broke, but the same cstr() migration
+	   gap rather than something slicing broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
 	   pattern as EqualFunc's own StringType case. */
 	std::string scratch1, scratch2;
@@ -790,7 +786,7 @@ void LessThanOrEqualFunc::execute() {
 	result.boolean_ref() = operand1.double_val() <= operand2.double_val();
 	break;
     case ComValue::SymbolType: {
-	/* Greptile, #445: see GreaterThanFunc's identical guard -- operand1
+	/* see GreaterThanFunc's identical guard -- operand1
 	   matching this case says nothing about operand2, and a mismatched
 	   operand2 read through cstr()/symbol_ptr() would compare against
 	   unrelated union bits or crash strcmp() on a null pointer. */
@@ -798,7 +794,7 @@ void LessThanOrEqualFunc::execute() {
 	/* operand1.symbol_ptr(), not cstr() -- a symbol can't be sliced or
 	   modified, so there's nothing for cstr() to narrow; operand2
 	   isn't provably a symbol here (a mixed comparison, `abc<=s@0:3,
-	   still needs the slice-aware read, #395). */
+	   still needs the slice-aware read). */
 	std::string scratch2;
 	const char* str1 = operand1.symbol_ptr();
 	const char* str2 = operand2.cstr(scratch2);
@@ -813,7 +809,7 @@ void LessThanOrEqualFunc::execute() {
 	   its comment. */
 	if (!operand2.is_string()) { result = ComValue::nullval(); break; }
 	/* StringType never handled here at all before -- a pre-existing
-	   gap, not something #395 broke, but the same cstr() migration
+	   gap rather than something slicing broke, but the same cstr() migration
 	   applies once it's added: slice-aware for both operands, same
 	   pattern as EqualFunc's own StringType case. */
 	std::string scratch1, scratch2;

--- a/src/ComTerp/comfunc.c
+++ b/src/ComTerp/comfunc.c
@@ -94,13 +94,11 @@ ComValue& ComFunc::stack_arg(int n, boolean symbol, ComValue& dflt) {
 	        argref = _comterp->lookup_symval(argref);
 		if (slotwrapper != AttributeValue::NoWrapper)
 		  argref.wrapper(slotwrapper);
-		/* fire_if_funcobj() returns a reference into its own
-		   per-fire pool entry, never a shared slot -- a caller
-		   (e.g. EqualFunc) resolving two pending FuncObj operands
-		   before consuming either gets two DISTINCT entries, so the
-		   second fire can't alias/overwrite the first (regression
-		   test: posteval.comt test 10, h(:a func(1) :b func(2))).
-		   See _fire_scratch_pool's own comment in comterp.h. */
+		/* fire_if_funcobj() returns a reference into its own per-fire
+		   pool entry rather than a shared slot, so a caller resolving
+		   two pending FuncObj operands before consuming either gets
+		   two distinct entries and the second fire cannot overwrite
+		   the first. */
 		if (was_pending && argref.is_object(FuncObj::class_symid()))
 		  return _comterp->fire_if_funcobj(argref);
 	    }
@@ -147,25 +145,18 @@ ComValue& ComFunc::stack_dotname(int n) {
 }
 
 ComValue ComFunc::stack_arg_post_eval(int n, boolean symbol, ComValue& dflt) {
-  /* No keys to skip and no fixed arg at position n -> there is definitively
-     nothing to fire, so there is nothing that needs a valid anchor either.
-     Mirrors stack_key_post_eval's nkeys()==0 bail-out: an empty {}/[]
-     literal's internal construction calls this with nargsfixed()==0, and
-     that's a normal, silent no-op, not evidence of anything wrong -- check
-     it before reading the anchor so that case never reaches the guard
-     below and never warns. */
+  /* no keys to skip and no fixed arg at position n means nothing to fire, so
+     nothing needs a valid anchor either.  An empty {} or [] literal's own
+     construction calls this with nargsfixed()==0, which is a silent no-op --
+     checked before the anchor is read, so it never reaches the guard below. */
   if (nkeys()==0 && n>=nargsfixed()) return dflt;
 
   ComValue argoff(comterp()->stack_top());
   int offtop = argoff.int_val()-comterp()->_pfnum;
-  /* same anchor-recovered-offtop guard as stack_key_post_eval (see note
-     there) -- this one was missed when that hardening landed, and it's the
-     path DotFunc/GrDotFunc use to fire arg 0 (e.g. at(grid(:table)) in
-     at(grid(:table)).grid), so a corrupt anchor here doesn't crash, it
-     just walks _pfcomvals from the wrong position and returns whatever
-     garbage token happens to sit there -- observed as a bogus CommandType
-     value routinely, not a crash, which is what made this so hard to
-     pin down. */
+  /* the same anchor-recovered-offtop guard stack_key_post_eval uses.  This is
+     the path DotFunc and GrDotFunc take to fire arg 0, where a corrupt anchor
+     does not crash: it walks _pfcomvals from the wrong position and returns
+     whatever token sits there, typically a bogus CommandType. */
   if (offtop > 0 || comterp()->_pfnum + offtop < 1) {
     fprintf(stderr, "comterp: stack_arg_post_eval: offtop out of range "
             "(offtop=%d nkeys=%d argoff=%d _pfnum=%d) -- argoff anchor missing "
@@ -379,17 +370,13 @@ AttributeList* ComFunc::bookmark_stack_keys_post_eval() {
 
 ComValue ComFunc::stack_key_post_eval
 (int id, boolean symbol, ComValue& dflt) {
-  /* No keyword tokens for this command -> the sought keyword is definitively
-     absent, and an absent keyword is a normal, silent result in comterp -- not
-     an error.  Return nil WITHOUT reading the operand stack.  This also
-     disarms the offtop guard below for the benign case it kept tripping on:
-     when remote() re-enters the interpreter to de-serialize a returned list
-     literal, the argoff anchor on the shared operand stack still belongs to
-     the outer in-flight command (the whole reply evaluates inside it), so
-     the anchor read here is bogus -- but with nkeys()==0 there is nothing to
-     find anyway, so skip the read and stay quiet.  The guard's warning is
-     preserved only for nkeys()>0, where a bad anchor is a genuine anomaly
-     and not just proof that a keyword is missing. */
+  /* no keyword tokens for this command means the sought keyword is absent,
+     which is a normal silent result -- return nil without reading the operand
+     stack.  That also disarms the offtop guard below for a benign case: when
+     remote() re-enters the interpreter to de-serialize a returned list, the
+     argoff anchor still belongs to the outer in-flight command, so the anchor
+     read here would be bogus.  The warning stays for nkeys()>0, where a bad
+     anchor is a genuine anomaly. */
   if (nkeys() == 0)
     return ComValue::nullval();
 

--- a/src/ComTerp/comfunc.h
+++ b/src/ComTerp/comfunc.h
@@ -190,7 +190,7 @@ public:
     // same token-span walk as stack_arg_post_eval_nargsfixed(), but never
     // evaluates anything -- each fixed positional's span becomes a
     // FuncObjPendingArg marker (postfunc.h) in the returned array instead
-    // of a real value.  Used by NilFunc's dynamic gate (#328) when its
+    // of a real value.  Used by NilFunc's dynamic gate when its
     // resolved target is :posteval, so the args stay unevaluated exactly
     // the way FuncObj::posteval() promises.
 

--- a/src/ComTerp/comterp.c
+++ b/src/ComTerp/comterp.c
@@ -254,19 +254,10 @@ int ComTerp::eval_expr(boolean nested) {
 
   if (!nested) {
     _stack_top = -1;
-    /* a genuinely new top-level statement -- nothing from here on can
-       legitimately alias a fire_if_funcobj() result from a PRIOR
-       statement, so it's safe to reclaim the pool now.  Reclaiming only
-       ever happens across this boundary, never mid-statement
-       (nested==true keeps appending to it instead), so two fires within
-       one statement's evaluation -- however deeply nested -- always
-       land in distinct, individually-allocated entries.  This is also
-       the reset that bounds the pool's growth to one top-level
-       statement rather than the process lifetime, even across a whole
-       runfile() session -- see _fire_scratch_pool's own comment in
-       comterp.h for how the next top-level entry (ComterpHandler::
-       handle_input) always reaches this branch, with pause()'s
-       force_nested(1) as the one deliberate exception. */
+    /* a genuinely new top-level statement -- nothing from here on can alias a
+       fire_if_funcobj() result from a prior one, so the pool is safe to
+       reclaim.  This happens only at this boundary, never mid-statement, so
+       two fires within one statement always land in distinct entries. */
     _fire_scratch_pool->clear();
   }
   while (_pfoff < _pfnum) {
@@ -299,16 +290,12 @@ int ComTerp::eval_expr(ComValue* pfvals, int npfvals) {
   return FUNCOK;
 }
 
-/* Bounds-safe snprintf accumulation into a fixed buffer -- plain
-   'pos += snprintf(buf+pos, sizeof(buf)-pos, ...)' is unsafe to repeat:
-   once the buffer is full, snprintf returns the length it WOULD have
-   written (not what it actually wrote), so pos can end up past the
-   buffer's end.  The next call then computes buf+pos as an out-of-bounds
-   pointer and sizeof(buf)-pos as a size_t underflow (huge, since
-   sizeof() is unsigned) -- snprintf believes it has nearly unlimited
-   room and writes past the real allocation (Greptile, PR #337).  This
-   clamps pos to stay valid after every call, so a signature long enough
-   to fill the buffer truncates safely instead of overflowing it. */
+/* bounds-safe snprintf accumulation into a fixed buffer.  Plain
+   'pos += snprintf(buf+pos, sizeof(buf)-pos, ...)' is unsafe to repeat: once
+   the buffer fills, snprintf returns the length it WOULD have written, so pos
+   runs past the end and the next call underflows sizeof(buf)-pos into a huge
+   size_t.  Clamping pos keeps every call valid, truncating rather than
+   overflowing. */
 static void append_bounded(char* buf, size_t bufsize, int& pos, const char* fmt, ...) {
   if (pos < 0 || (size_t)pos >= bufsize - 1) return;  /* already full/invalid -- skip */
   va_list ap;
@@ -333,25 +320,17 @@ static void render_comvalue(ComValue& v, char* out, size_t outsize) {
   out[outsize - 1] = '\0';
 }
 
-/* #334 (staged from #170 phase 1): the bare IO-contract signature for
-   help(f) where f is a bare, unfired FuncObj -- see the fuller comment on
-   ComTerp::describe_funcobj in comterp.h.  Positionals render as
-   arg0/arg1/... (the arg(n) indices themselves, since a positional has no
-   other name) or "..." when the count can't be pinned down statically (a
-   computed index, or narg() usage -- see FuncObjVarScan::scan_positionals).
-   Keywords are read-only union read-before-write only -- per #170's own
-   framing, write-before-read is local scratch a caller's keyword would
-   just be clobbering, not a real input, so it's omitted; escaping
-   (local()/global()) vars are reported in a trailing annotation instead
-   of the parens themselves, since they're not part of the func's own
-   frame at all. */
+/* the IO-contract signature for help(f) on a bare, unfired FuncObj.
+   Positionals render as arg0/arg1/..., or "..." when the count cannot be
+   pinned down statically.  Keywords are read-only plus read-before-write;
+   write-before-read is local scratch, not an input.  Escaping local()/global()
+   vars go in a trailing annotation rather than the parens. */
 ComValue ComTerp::describe_funcobj(FuncObj* fo) {
   boolean* is_plain_var = FuncObjVarScan::build_is_plain_var(this, fo->toks(), fo->ntoks());
   AttributeList* classification = FuncObjVarScan::classify(fo->toks(), fo->ntoks(), is_plain_var);
   ComValue classification_owner(AttributeList::class_symid(), (void*)classification);
-  /* #336 (staged from #170's "Future" section): recognizes only the
-     canonical if(x==nil :then DEFAULT :else x) idiom -- needs
-     is_plain_var too, so computed before it's freed below. */
+  /* recognizes only the canonical if(x==nil :then DEFAULT :else x) idiom.
+     Needs is_plain_var, so it runs before that is freed below. */
   AttributeList* defaults = FuncObjVarScan::scan_defaults(this, fo->toks(), fo->ntoks(), is_plain_var);
   ComValue defaults_owner(AttributeList::class_symid(), (void*)defaults);
   delete [] is_plain_var;
@@ -367,12 +346,10 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
     append_bounded(buf, sizeof(buf), pos, "...");
     first = false;
   } else {
-    /* Reserve room for a " ... argMAX)" tail (worst case ~19 bytes for a
-       10-digit index) so a huge literal index like arg(2000000000) -- the
-       same repro as the DoS this loop's bound guards against, Greptile,
-       PR #337 -- renders as many arg%d entries as fit and then names the
-       true final index instead of just stopping mid-list with no
-       indication anything was cut off. */
+    /* reserve room for a " ... argMAX)" tail, worst case ~19 bytes for a
+       10-digit index, so a huge literal index like arg(2000000000) renders
+       as many arg%d entries as fit and then names the true final index
+       rather than stopping mid-list with nothing to show it was cut. */
     const int tail_reserve = 32;
     int i = 0;
     for (; i < posinfo.count && pos < (int)sizeof(buf) - 1 - tail_reserve; i++) {
@@ -391,24 +368,19 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
     int kind = attr->Value()->int_val();
     if (kind == FuncObjVarScan::ReadOnly || kind == FuncObjVarScan::ReadBeforeWrite) {
       AttributeValue* defval = defaults->find(attr->SymbolId());
-      /* #310's declaration-time capture can make the coded default
-	 above unreachable: if this name already had a real value in
-	 scope when func() ran, ReadOnly capture grabbed THAT value, not
-	 nil -- the x==nil check inside the body will never be true for
-	 as long as that capture stands, so the :then literal is
-	 currently dead code.  Surface this rather than let :help claim
-	 a default that the func will actually never produce. */
+      /* declaration-time capture can make the coded default unreachable: if
+	 the name already had a value in scope when func() ran, the capture
+	 grabbed that rather than nil, so the body's x==nil test never fires
+	 and the :then literal is dead.  Say so rather than claim a default
+	 the func will never produce. */
       AttributeValue* capval = nil;
       if (fo->captures().is_object(AttributeList::class_symid())) {
         capval = ((AttributeList*)fo->captures().obj_val())->find(attr->SymbolId());
       }
       boolean cap_shadows = capval && !ComValue(*capval).is_unknown();
       if (defval) {
-        /* #336: render the detected default inline, :name [value] --
-           comterp contracts are textually communicated wherever
-           possible (postfix(help)'s trailing * for post-eval commands,
-           help()'s own docstring/dockeys rendering); this is the same
-           idea applied to a func's own IO contract. */
+        /* render the detected default inline as :name [value], the way
+           comterp states contracts textually elsewhere. */
         char defbuf[256];
         ComValue defv(*defval);
         render_comvalue(defv, defbuf, sizeof(defbuf));
@@ -459,26 +431,17 @@ ComValue ComTerp::describe_funcobj(FuncObj* fo) {
 void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* lazy_posvals) {
   EvalFunc ef(this);
   ef.funcid(symbol_add("eval"));
-  /* keywords still build the body's locals (the _alist); the fixed
-     positionals become the func's eager actual args, captured here so
-     arg(n)/narg() can serve them inside the body (see funcobj_arg).
-     The keywords sit above the positionals on the stack (no positionals
-     after keywords), so pop them first.  narg() counts non-keyword args
-     *including* values that follow keywords, and each keyword carries its
-     own keynarg (0 for a bare flag), so the fixed-positional count is narg
-     minus the keyword values actually consumed -- not narg-nkey.  (When
-     extra_keys is supplied, narg() is already positional-only -- the
-     caller's keywords never touched the shared stack -- so no post-
-     keyword deduction applies there; see below.  When lazy_posvals is
-     supplied, val.narg() is exactly its length -- nothing to deduct,
-     nothing was pushed for the args at all.) */
+  /* keywords build the body's locals (the _alist); the fixed positionals
+     become the func's eager actual args, served by arg(n)/narg() inside the
+     body.  Keywords sit above the positionals on the stack, so pop them
+     first.  narg() counts non-keyword args including values that follow
+     keywords, and each keyword carries its own keynarg, so the positional
+     count is narg minus the keyword values consumed -- not narg-nkey. */
   int npos = val.narg();
   AttributeList* al = new AttributeList();
-  /* #310: seed al from this funcobj's own declaration-time captures
-     (read-only/read-before-write free variables, funcobjscan.h)
-     before keyword args land on top -- add_attr's replace-by-symid
-     below then makes an explicit :x val keyword override a capture
-     for free, no special-case needed. */
+  /* seed al from this funcobj's declaration-time captures before keyword
+     args land on top, so add_attr's replace-by-symid below lets an explicit
+     :x val override a capture with no special case. */
   FuncObj* callee_fo = (FuncObj*)val.obj_val();
   if (callee_fo->captures().is_object(AttributeList::class_symid())) {
     AttributeList* caps = (AttributeList*)callee_fo->captures().obj_val();
@@ -489,15 +452,11 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* l
     }
   }
   if (extra_keys) {
-    /* caller already built the call's keyword AttributeList some other way
-       instead of leaving marker+value pairs on the shared stack --
-       NilFunc's dynamic re-check (ComFunc::stack_keys_post_eval) for an
-       eager target, or (a :posteval target) FuncObjPendingArg markers
-       instead of real values.  Either way fire_funcobj just copies the
-       entries into al -- it doesn't care whether they're real or pending,
-       only funcobj_arg()/the bare-read fallthrough do.  Same add_attr call
-       as the ordinary loop below, still lands after captures, so an
-       explicit :x val keyword still overrides a capture for free. */
+    /* the caller built the keyword AttributeList some other way instead of
+       leaving marker+value pairs on the shared stack.  Either way this only
+       copies the entries into al, real or still-pending alike, through the
+       same add_attr as the loop below -- landing after captures, so an
+       explicit :x val still overrides one. */
     ALIterator ekit;
     for (extra_keys->First(ekit); !extra_keys->Done(ekit); extra_keys->Next(ekit)) {
       Attribute* ekattr = extra_keys->GetAttr(ekit);
@@ -510,13 +469,9 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* l
       if (knarg==0) {
 	al->add_attr(keyv.keyid_val(), ComValue::trueval());  /* :flag => flag true */
       } else {
-	/* knarg is 0 or 1 by construction: the parser emits every keyword
-	   token with narg 0 (bare flag) or 1 (keyword+value) -- the
-	   TOK_KEYWORD PFOUT sites in ComUtil/_parser.c -- and keynarg is set
-	   from token->narg (comterp.c:927).  So knarg>1 is unreachable; this
-	   loop is written generally only.  Even if it ran, add_attr dedups by
-	   symid (replaces, never appends), binding a single value, and every
-	   value is popped so the positional count (npos) stays correct. */
+	/* knarg is 0 or 1 by construction -- the parser emits every keyword
+	   token with narg 0 (bare flag) or 1 (keyword+value) -- so knarg>1 is
+	   unreachable and this loop is general only for form's sake. */
 	for(int j=0; j<knarg; j++) {
 	  ComValue valv(pop_stack());
 	  al->add_attr(keyv.keyid_val(), valv);
@@ -552,21 +507,12 @@ void ComTerp::fire_funcobj(ComValue& val, AttributeList* extra_keys, ComValue* l
   _funcobj_argvals = saved_argvals;
   _funcobj_nargs = saved_nargs;
   _funcobj_active = saved_active;
-  /* free any FuncObjPendingArg markers still standing at invocation end --
-     AttributeValue::unref_as_needed() (Attribute/attrvalue.c) only knows
-     how to clean up ArrayType/StreamType/StringType and (for ObjectType)
-     AttributeList/Attribute specifically, nothing generic for an arbitrary
-     ObjectType payload, so a marker nobody explicitly deletes just leaks.
-     A positional's marker is usually still here regardless of whether
-     arg(n) ever pulled it -- UNLESS the pulled result was a stream, in
-     which case funcobj_arg() already replaced the slot with the real
-     stream object and deleted the marker itself (pinning, not re-firing
-     -- see its own comment); is_object() below correctly skips those,
-     since they're no longer markers at all by the time we get here.  A
-     keyword's marker only survives to here if it was never read at all
-     -- one that was gets replaced by pull_alist_pending()'s (or, for a
-     stream result, peek_alist_pending()'s) own add_attr call, which
-     deletes the old marker there instead, right as it's overwritten. */
+  /* free any FuncObjPendingArg markers still standing at invocation end:
+     unref_as_needed() has no generic cleanup for an arbitrary ObjectType
+     payload, so a marker nobody deletes just leaks.  A positional's marker is
+     usually still here whether or not arg(n) pulled it -- unless the result
+     was a stream, in which case funcobj_arg() already replaced the slot and
+     deleted the marker.  A keyword's survives only if it was never read. */
   for (int i=0; i<npos; i++) {
     if (posvals[i].is_object(FuncObjPendingArg::class_symid()))
       delete (FuncObjPendingArg*)posvals[i].obj_val();
@@ -584,13 +530,11 @@ void ComTerp::eval_expr_internals(int pedepth) {
   static int step_symid = symbol_add("step");
   ComValue sv = pop_stack(false);
 
-  /* ~~ spread expansion, upstream of the command/funcobj dispatch: if any of
-     this call's args on the stack is a STREAM_SPREAD-tagged stream (left there
-     by SpreadFunc), drain it in place so its elements become separate
-     positionals for whatever consumes them -- an eager command via stack_arg,
-     or a funcobj via its captured actuals.  Runs before the CommandType
-     overdrive scan, so a tagged stream spreads rather than overdrives.  Skipped
-     for post_eval commands, whose args are token-spans, not stack values. */
+  /* ~~ spread expansion, ahead of command/funcobj dispatch: a STREAM_SPREAD-
+     tagged stream among this call's args is drained in place so its elements
+     become separate positionals.  Runs before the overdrive scan, so a tagged
+     stream spreads rather than overdrives; skipped for post_eval commands,
+     whose args are token spans rather than stack values. */
   if ((sv.type() == ComValue::CommandType &&
        !((ComFunc*)sv.obj_val())->post_eval()) ||
       sv.type() == ComValue::SymbolType) {
@@ -670,12 +614,10 @@ void ComTerp::eval_expr_internals(int pedepth) {
   }
 
   /* a funcobj call with a stream arg and no :posteval overdrives like a
-     command call -- the stream drives the INVOCATION, firing the body once per
-     element with arg(n) bound to a scalar, so control flow inside the body is
-     ordinary scalar code.  :posteval is excluded: its contract is the opposite,
-     internal one, where the arguments stay unevaluated and the body itself
-     drains the pinned stream with *arg(n).  Only symbol-bound funcobjs reach
-     here; that is every named call site. */
+     command call: the stream drives the invocation, firing the body once per
+     element with arg(n) bound to a scalar.  :posteval is the opposite
+     contract -- the args stay unevaluated and the body drains the pinned
+     stream itself with *arg(n). */
   if (sv.type() == ComValue::SymbolType && (sv.narg() || sv.nkey())) {
     AttributeValue* funcval = lookup_symval(&sv, false);
     if (funcval && funcval->is_object(FuncObj::class_symid()) &&
@@ -732,15 +674,11 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	  has_streams = stack_top(-i).is_stream();
 	else if (stack_top(-i).is_symbol() &&
 		 is_posteval_pending(stack_top(-i).symbol_val())) {
-	  /* a still-pending :posteval operand can't answer "am I a stream"
-	     without being pulled, and overdrive is an upfront, whole-
-	     expression decision made once here -- not something a later,
-	     single-value resolution (stack_arg/stack_key) could retrofit
-	     per operand the way a bare-funcobj fire can (see is_funcobj's
-	     own comment).  So it never overdrives: leave it unpulled,
-	     treat as not-a-stream, and let it resolve to whatever it
-	     resolves to -- stream or not -- as an ordinary scalar operand
-	     when it's actually consumed. */
+	  /* a still-pending :posteval operand cannot answer "am I a stream"
+	     without being pulled, and overdrive is a whole-expression decision
+	     made once, here.  So it never overdrives: leave it unpulled, treat
+	     it as not-a-stream, and let it resolve as an ordinary scalar
+	     operand when it is consumed. */
 	  has_streams = false;
 	}
 	else {
@@ -762,34 +700,21 @@ void ComTerp::eval_expr_internals(int pedepth) {
       }
 
       for(int i=0; i<sv.narg()+sv.nkey(); i++) {
-	/* Resolve EVERY stream-valued arg, not just the first one found.
-	   A stream held in a variable arrives here as a symbol; left unresolved
-	   (as the old pop_stack(i==streamid) did for all but the first) it is not is_stream()
-	   in the AVL, so the per-element zip treats it as a whole non-stream
-	   argument -- which is why stream-var*stream-var (and var*literal)
-	   returned only the left operand's elements.  Resolving it makes it a
-	   stream value that zips per-element like a stream literal.  Scalar args
-	   stay unresolved (symbols) for per-element re-evaluation (broadcast). */
+	/* resolve EVERY stream-valued arg, not just the first.  A stream held in
+	   a variable arrives as a symbol, and left unresolved it is not
+	   is_stream() in the AVL, so the per-element zip treats it as one whole
+	   argument.  Resolving makes it zip per-element like a stream literal.
+	   Scalar args stay symbols, for per-element re-evaluation. */
 	boolean argstream;
 	boolean alist_bound = false;
 	if (!stack_top().is_symbol() && !stack_top().is_attribute())
 	  argstream = stack_top().is_stream();
 	else {
-	  /* a symbol bound through _alist (a func-local keyword or #310
-	     capture) is fixed for the life of this call -- nothing
-	     legitimately mutates it mid-broadcast, so there's no "re-read
-	     fresh each iteration" benefit to leaving it as a deferred
-	     symbol the way a true outer-scope global's comment above
-	     intends.  Worse, leaving it deferred is actively wrong: the
-	     packed value returned here can propagate out past this call
-	     (e.g. as the func's own return value, driven forward later by
-	     whatever pulls it -- list(), an outer print(), etc.), and by
-	     then _alist no longer points at this call's AttributeList at
-	     all, so the deferred read silently falls through to global
-	     scope instead (#343).  Resolve now, same as a genuinely
-	     stream-valued operand already does, whenever the symbol
-	     resolves through the CURRENT _alist specifically; a true
-	     global stays deferred, unchanged. */
+	  /* a symbol bound through _alist -- a func-local keyword or capture --
+	     is fixed for the life of this call, and deferring it is wrong: the
+	     packed value can outlive the call, by which point _alist points
+	     elsewhere and the read falls through to global scope.  A true
+	     global stays deferred. */
 	  if (!stack_top().global_flag() && _alist &&
 	      _alist->find(stack_top().symbol_val()))
 	    alist_bound = true;
@@ -826,13 +751,10 @@ void ComTerp::eval_expr_internals(int pedepth) {
 	else
 	  func_for_next_expr_post_eval = 1;
       }
-      /* sv.command_symid(), not func->funcid(): for the ordinary case
-	 they're the same symbol (sv resolved to exactly the command it
-	 named), but token_to_comvalue's nil-substitution fallback dispatches
-	 an unresolved call-shaped symbol to the single shared NilFunc
-	 instance while still recording the ORIGINAL requested name in
-	 sv.command_symid() -- func->funcid() would always read "nil" there,
-	 losing the name NilFunc needs to dynamically re-check (issue #328). */
+      /* sv.command_symid(), not func->funcid(): ordinarily the same symbol,
+	 but an unresolved call-shaped symbol dispatches to the shared NilFunc
+	 while sv.command_symid() still records the original name -- which is
+	 the name NilFunc needs to re-check dynamically. */
       func->push_funcstate(nargs, nkeys, pedepth, sv.command_symid(), sv.linenum());
     }
 
@@ -1487,7 +1409,7 @@ void ComTerp::token_to_comvalue(postfix_token* token, ComValue* sv) {
        eagerly evaluates it -- exactly the "sit in the postfix buffer until
        pulled" contract a posteval func's args need.  A symbol that's simply
        undefined still resolves to NilFunc's real "not found" behavior at
-       dispatch time (comterp.c's dynamic gate, #328); one that resolves to a
+       dispatch time; one that resolves to a
        posteval FuncObj here is re-checked there too, so a later reassignment
        within the same statement chain is never trusted from this static
        snapshot -- only used to decide whether to defer at all. */
@@ -1629,30 +1551,21 @@ ComValue& ComTerp::fire_if_funcobj(ComValue& val) {
    to pop a keyword marker+value for it.  assignval() (AttributeValue)
    now copies a resolved value's own narg/nkey/nids over comval's
    unconditionally, because that same storage doubles as a StringType's
-   slice window (#395) and a sliced variable's window must win here.  For
-   every other resolved type those fields are either unused (0) or, for a
-   FuncObj, irrelevant to this call, so restore comval's pre-lookup
-   values instead of letting a stale 0 clobber real call-site arity --
-   the inverse of the StringType case.  (Before AttributeValue grew this
-   storage, assignval() couldn't reach these ComValue-only fields at
-   all, and a StringType's window needed its own explicit carry instead;
-   now the same widening that lets a slice survive assignval() is what
-   needs undoing here for every non-StringType resolution.)
+   slice window, and a sliced variable's window must win here.  For every
+   other resolved type those fields are unused, or for a FuncObj irrelevant
+   to this call, so restore comval's pre-lookup values rather than let a
+   stale 0 clobber real call-site arity.
 
    bquote() gets the opposite treatment, and unconditionally: it must
    NEVER survive a resolution, in every type, StringType included.  A
    stored value's bquote() records that *it* was written as a literal
    backquoted expression (`EOS) -- it says nothing about how a *later*
-   read of the variable holding it should behave.  Carrying it through
-   is actively wrong: lookup_symval()'s own entry check
-   (`if (comval.bquote()) return comval;`) would then short-circuit a
-   second resolution attempt that's supposed to run and legitimately
-   fail -- e.g. a variable holding `EOS is itself an ordinary (non-
-   bquoted) SymbolType read, and resolving *that* symbol ("EOS") as if
-   it were a variable name correctly finds nothing and degrades to
-   nullval() (UnknownType, falsy) -- the actual mechanism nilcompare.comt
-   depends on for "a bquoted symbol is falsy" (test 7), broken by
-   assignval() carrying bquote() through until this reset. */
+   read of the variable holding it should behave.  Carrying it through is
+   wrong: lookup_symval()'s entry check would short-circuit a second
+   resolution that is supposed to run and legitimately fail.  A variable
+   holding `EOS is itself an ordinary SymbolType read, and resolving "EOS"
+   as a variable name correctly finds nothing and degrades to nullval() --
+   which is what makes a bquoted symbol falsy. */
 static void restore_call_arity(ComValue& comval, ComValue& resolved,
                                 int saved_narg, int saved_nkey, int saved_nids) {
   comval.bquote(0);
@@ -1676,19 +1589,14 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
 	  if (aval) {
 	    /* _alist (a func's keyword-bound locals, fire_funcobj() comterp.c)
 	       is populated via AttributeList::add_attr(int, AttributeValue&)
-	       (attrlist.c), same as attrlist() itself, which constructs a
-	       plain `new AttributeValue(value)` -- still not a ComValue, but
-	       AttributeValue itself now carries the narg/nkey/nids/flags block
-	       (attrvalue.h), so coloned()/sliced()/etc. DO survive into aval
-	       when the original value had them set (#438) -- reading them via
-	       ((ComValue*)aval)->coloned() is exactly the intended, now-real
-	       recovery, not undefined behavior.  narg()/nkey()/nids() and
-	       bquote() need the same restore_call_arity() treatment as the
-	       localtable/globaltable branches below, for the same reason: a
-	       func-local variable read (e.g. invoking a FuncObj received
-	       through a keyword arg or captured free variable) must keep its
-	       own call-site arity, not inherit the stored value's -- Greptile,
-	       #450. */
+	       (attrlist.c) -- a plain `new AttributeValue(value)`, not a
+	       ComValue, but AttributeValue carries the narg/nkey/nids/flags
+	       block itself, so coloned()/sliced() survive into aval and
+	       reading them through ((ComValue*)aval) is intended rather than
+	       undefined.  narg()/nkey()/nids() and bquote() still need
+	       restore_call_arity() here, same as the localtable/globaltable
+	       branches below: a func-local read must keep its own call-site
+	       arity, not inherit the stored value's. */
 	    int saved_narg = comval.narg(), saved_nkey = comval.nkey(), saved_nids = comval.nids();
 	    ComValue newval(*aval);
 	    *&comval = newval;
@@ -1717,10 +1625,9 @@ ComValue& ComTerp::lookup_symval(ComValue& comval) {
     } else if (comval.is_object(Attribute::class_symid())) {
       /* Attribute::Value() returns whatever AttributeList::add_attr()
 	 (attrlist.c) stored -- a plain `new AttributeValue(value)`, never a
-	 ComValue, but AttributeValue's own narg/nkey/nids/flags block
-	 (attrvalue.h) now survives into it regardless (#438), same as the
-	 _alist branch above.  bquote() must not survive this read either,
-	 same reasoning as restore_call_arity()'s comment. */
+	 ComValue, though AttributeValue's own narg/nkey/nids/flags block
+	 survives into it, same as the _alist branch above.  bquote() must not
+	 survive this read either -- see restore_call_arity(). */
       ComValue attrval = *((Attribute*)comval.obj_val())->Value();
       comval.assignval(attrval);
       comval.bquote(0);
@@ -1845,12 +1752,10 @@ void ComTerp::exit(int status) {
      wrapping live client sockets, and flushing one whose peer has stalled could
      block the exit -- stdout/stderr are all a final print() needs.
 
-     tty_echo_restore() (ComUtil/ttyecho.c, issue #76) is registered via
-     atexit() when stdin echo was disabled, but atexit handlers are exactly
-     what _exit() skips -- call it explicitly here too, so a scripted
-     exit()/quit() doesn't leave the user's terminal echo off after this
-     process is gone.  Safe unlike arbitrary atexit handlers: it only
-     touches tty state, never the interpreter itself. */
+     tty_echo_restore() is registered via atexit() when stdin echo was
+     disabled, and atexit handlers are exactly what _exit() skips -- so call
+     it explicitly, or a scripted exit() leaves the terminal's echo off.
+     Safe unlike an arbitrary handler: it touches tty state only. */
   fflush(stdout);
   fflush(stderr);
   tty_echo_restore();
@@ -2291,22 +2196,14 @@ int ComTerp::runfile(const char* filename, boolean popen_flag) {
 	if (read_expr()) {
 	    /* Drain a leftover orphaned stream from the PREVIOUS statement
 	       now that read_expr() confirms a genuine next statement
-	       exists (checking any earlier, e.g. unconditionally at the
-	       top of the loop, would incorrectly drain the truly LAST
-	       statement's retval too, on whatever trailing pass finds
-	       nothing left to read and the while() condition was
-	       nonetheless still true for). Before this iteration's own
-	       eval_expr() runs, not after: draining can have visible side
-	       effects of its own (e.g. a print() overdrive stream defers
-	       each repetition's actual print() call until that element is
-	       pulled -- draining fires all of them at once), and checking
-	       this any later (e.g. the "save last thing on stack" spot
-	       below, which used to have this check) would run it AFTER
-	       the next statement's own eval_expr() already produced its
-	       output, interleaving the two out of script order -- see the
-	       identical fix and full explanation in ComTerpServ::runfile(),
-	       comterpserv.c, the override actually exercised by
-	       `comterp run <file>`. */
+	       exists.  Checking any earlier would also drain the last
+	       statement's own result, on the trailing pass that finds nothing
+	       left to read.  Draining happens before this iteration's
+	       eval_expr() rather than after, because it has visible side
+	       effects of its own -- a print() overdrive stream fires every
+	       deferred repetition at once -- which would otherwise interleave
+	       with the next statement's output.  ComTerpServ::runfile() does
+	       the same thing. */
 	    if (retval && retval->is_stream() && retval->stream_list() &&
 	        retval->stream_list()->refcount_==1) {
 	      orphan_stream_count(*retval);

--- a/src/ComTerp/comterp.h
+++ b/src/ComTerp/comterp.h
@@ -144,75 +144,36 @@ public:
 
     boolean is_posteval_pending(int id);
     // true iff _alist holds a still-pending FuncObjPendingArg marker under
-    // 'id' -- a bare existence check, never pulls/evaluates anything.
-    // Lets a caller (ComValue::is_funcobj(), the has_streams pre-scan in
-    // eval_expr_internals) tell "still-pending :posteval keyword" apart
-    // from every other case without forcing the one-time evaluation a
-    // real pull would cost.
+    // 'id' -- an existence check that never pulls or evaluates anything.
 
     ComValue& fire_if_funcobj(ComValue& val);
-    // if 'val' resolves to a bare FuncObj, fire it (niladic call, same as
-    // an ordinary unguarded funcobj reference already does elsewhere) and
-    // return a reference to the result -- via a fresh slot in
-    // _fire_scratch_pool, NOT by writing back through 'val' itself, since
-    // 'val' may be a reference into _stack[] and firing pushes/pops
-    // internally (through fire_funcobj/EvalFunc, running the func body),
-    // which can dmm_realloc _stack (push_stack, comterp.c) and invalidate
-    // any reference taken before the call.  A fresh pool slot per call
-    // (not one reused slot) matters too: a caller that resolves two
-    // operands before consuming either must not have the second fire
-    // silently overwrite the first result out from under it.  A
-    // non-funcobj 'val' is returned unchanged, by reference, as a plain
-    // pass-through.
-    //
-    // The only place this actually fires anything is the deferred-
-    // :posteval-keyword case ComValue::is_funcobj() now declines to
-    // check early (see its own comment in comvalue.c) -- an ordinary
-    // eager symbol bound to a funcobj is already fired earlier, at push
-    // time in load_sub_expr, by is_funcobj's own unchanged fast path.
-    // ComFunc::stack_arg()/stack_key() are the callers, right after their
-    // own real (non-pending) resolution.
+    // if 'val' resolves to a bare FuncObj, fire it niladically and return a
+    // reference to the result.  The result lands in _fire_scratch_pool rather
+    // than being written back through 'val', because firing can realloc
+    // _stack and invalidate any reference taken before the call.  A
+    // non-funcobj 'val' passes through unchanged.
     ComValue describe_funcobj(FuncObj* fo);
-    // #334 (staged from #170 phase 1): the bare IO-contract signature for
-    // help(f) where f is a bare, unfired FuncObj -- help() reads its
-    // argument symbol-preserving (post_eval(), stack_arg(i, true)) so it
-    // never fires f itself; HelpFunc::execute() (helpfunc.c) resolves that
-    // symbol via lookup_symval, checks is_object(FuncObj::class_symid()),
-    // and calls this instead of falling through to its usual registered-
-    // command docstring lookup.  Returns a StringType ComValue rendering
-    // positionals (from FuncObjVarScan::scan_positionals) and read-only/
-    // read-before-write keywords (from FuncObjVarScan::classify) as
-    // "(arg0 arg1 :key1 :key2)", with any escaping (local()/global())
-    // variables reported in a trailing "  -- escapes: name->scope"
-    // annotation instead.  Never runs fo's body.
+    // the IO-contract signature for help(f) on a bare, unfired FuncObj:
+    // a StringType rendering positionals and keywords as
+    // "(arg0 arg1 :key1 :key2)", with any escaping variables in a trailing
+    // "-- escapes: name->scope" annotation.  Never runs fo's body.
 
     AttributeValue* lookup_symval(ComValue*, boolean freeze=true);
     // look up a pointer to an AttributeValue associated with a symbol
     // (specified in the input ComValue) in the local or global symbol
     // tables.  Do not alter the input ComValue.  'freeze' governs a still-
-    // pending :posteval keyword found in _alist: true (the default, and
-    // what every existing caller gets unchanged) memoizes via
-    // pull_alist_pending() -- required by compound-assign (assignfunc.c),
-    // whose op1val->assignval(result) needs a real, addressable slot to
-    // mutate in place, and assignment freezing a lazy keyword into an
-    // ordinary owned local from then on is the intended behavior anyway.
-    // false peeks via peek_alist_pending() instead -- pulls fresh every
-    // call, writes nothing to _alist -- for a caller that only needs a
-    // momentary look at the value (has_streams/array detection below)
-    // and would otherwise force an unwanted freeze as a side effect of
-    // merely checking a type.
+    // pending :posteval keyword: true memoizes it into an ordinary local,
+    // which compound assignment needs since it mutates the slot in place;
+    // false peeks without writing anything back.
     ComValue& lookup_symval(int symid);
     // look up a ComValue associated with a symbol (specified with a
     // symbol id) in the local or global symbol tables.
 
     void token_to_comvalue(postfix_token*, ComValue*);
-    // resolve a raw postfix_token into its ComValue -- a symbol-shaped
-    // token is promoted from SymbolType to CommandType iff it names a
-    // currently-registered command.  Pure/side-effect-free (a table
-    // lookup, nothing executed); public so a static pre-pass over a
-    // detached token buffer (e.g. FuncObjVarScan, #310/#170) can classify
-    // symbol-vs-command the same way ordinary evaluation would, without
-    // duplicating the lookup.
+    // resolve a raw postfix_token into its ComValue, promoting a symbol to
+    // CommandType iff it names a registered command.  A table lookup with no
+    // side effects, public so a static pre-pass over a detached token buffer
+    // can classify symbol-vs-command the way ordinary evaluation would.
 
     ComValue& stack_top(int n=0);
     // return reference to top of the stack, offset by 'n' (usually negative).
@@ -254,45 +215,25 @@ public:
     // 'nested' indicates contents of stack should be preserved.
 
     ComValue orphan_stream_count(ComValue& streamv);
-    // drain a stream (same traversal EachFunc uses) and return the count
-    // of elements pulled from it.  Used wherever a "final result of a
-    // stand-alone expression" gets shown to the user and that result is
-    // an orphaned stream -- never assigned to anything, never streamed
-    // further -- so the more informative element count gets shown
-    // instead of an uninformative, still-unconsumed-looking print.
+    // drain a stream and return the count of elements pulled, so a
+    // stand-alone expression ending in an orphaned stream reports its element
+    // count instead of printing as though still unconsumed.
 
     void fire_funcobj(ComValue& val, AttributeList* extra_keys=nil,
 		       ComValue* lazy_posvals=nil);
-    // val must be a FuncObj-holding ComValue whose val.narg() worth of
-    // already-evaluated positional arguments are sitting on the stack,
-    // ready to pop (topmost = last positional).  Builds the call's
-    // AttributeList (declaration-time captures seeded first, #310), sets
-    // up funcobj_arg()'s eager-positional view, and fires it via EvalFunc.
-    // Factored out of eval_expr_internals' ordinary SymbolType/FuncObj
-    // dispatch so NilFunc can reuse it once it dynamically re-resolves to
-    // a real FuncObj (issue #328) instead of duplicating this stack-
-    // unpacking logic.
+    // fire the FuncObj in 'val', whose val.narg() already-evaluated
+    // positionals are sitting on the stack, topmost last.  Builds the call's
+    // AttributeList and runs it through EvalFunc.
     //
-    // extra_keys nil (the ordinary-dispatch case): keyword marker+value
-    // pairs are popped off the SAME shared stack as the positionals,
-    // val.nkey() of them, topmost first -- the original calling
-    // convention, unchanged.
-    // extra_keys non-nil: the caller has already built the call's keyword
-    // AttributeList some other way instead of leaving marker+value pairs on
-    // the shared stack (NilFunc's dynamic re-check, ComFunc::stack_keys_-
-    // post_eval; or a :posteval target, whose entries are
-    // FuncObjPendingArg markers instead of real values -- fire_funcobj
-    // doesn't care, it just copies them into al either way); val.nkey() is
-    // not consulted and nothing extra is popped for them.
+    // extra_keys nil: val.nkey() keyword marker+value pairs are popped off
+    // the same stack, topmost first.  Non-nil: the caller has already built
+    // the keyword list, val.nkey() is not consulted, and nothing extra is
+    // popped.
     //
-    // lazy_posvals non-nil (val's FuncObj is :posteval): used directly as
-    // this invocation's funcobj_argvals() array instead of popping val.-
-    // narg() values off the stack -- nothing was pushed for them in the
-    // first place (the pedepth pre-pass left their whole span un-evaluated
-    // in the caller's buffer).  Its entries are ordinarily FuncObjPendingArg
-    // markers (postfunc.h), pulled on demand and memoized in place by
-    // funcobj_arg() the same array slot every other invocation already uses
-    // -- no separate lazy-argument channel or save/restore needed.
+    // lazy_posvals non-nil (a :posteval FuncObj): used directly as this
+    // invocation's funcobj_argvals() instead of popping, since nothing was
+    // pushed for those arguments.  Its entries are FuncObjPendingArg markers,
+    // pulled on demand and memoized in place by funcobj_arg().
 
     virtual int runfile(const char* filename, boolean popen_flag=0);
     // run interpreter on contents of 'filename'.
@@ -438,70 +379,36 @@ public:
     int funcobj_narg() { return _funcobj_nargs; }
     // number of positional args of the current FuncObj invocation.
     ComValue funcobj_arg(int n);
-    // nth positional arg of the current FuncObj invocation -- an
-    // already-materialized eager value, or (:posteval) pulled fresh on
-    // *every* call, never memoized: arg(n) has no lvalue form (no
-    // "arg(0)=..."), so there's no write-before-read escape the way a
-    // keyword has, and no write-through caller ever needs a stable
-    // address for it either. The idiom for caching a repeatedly-read
-    // arg inside a loop is the same as for any post_eval command's own
-    // operand: assign it to a local once, then read that local.
+    // nth positional of the current FuncObj invocation: an eager value, or
+    // under :posteval pulled fresh on every call and never memoized, since
+    // arg(n) has no lvalue form.  Assign it to a local to pin one read.
     ComValue* funcobj_argvals() { return _funcobj_argvals; }
     // return the current positional-argument array itself (nil if inactive),
     // for a caller that needs to save it before installing its own.
     void set_funcobj_args(ComValue* argvals, int nargs, boolean active) {
       _funcobj_argvals = argvals; _funcobj_nargs = nargs; _funcobj_active = active; }
-    // install the per-invocation positional-argument channel that arg()/
-    // narg() read inside a func body -- caller saves funcobj_argvals()/
-    // funcobj_narg()/funcobj_active() first and restores them after, the
-    // same bracketing set_attributes()/get_attributes() use around an
-    // _alist swap (see DotFunc, which needs both at once to self-bind an
-    // attrlist method call and still serve its positional args).
+    // install the per-invocation positional-argument channel that arg() and
+    // narg() read inside a func body.  The caller saves funcobj_argvals(),
+    // funcobj_narg() and funcobj_active() first and restores them after.
 
     ComValue pull_funcobj_pending(class FuncObjPendingArg* marker);
-    // resolve one :posteval arg/keyword's still-pending token span --
-    // reaches back into the caller's parked postfix buffer via
-    // top_servstate() (the same frame push_servstate() already stashed
-    // there for ordinary nested-call bookkeeping, nothing new to allocate)
-    // and runs post_eval_expr() against it.  Doesn't memoize anything
-    // itself -- that's the caller's job (funcobj_arg() never does;
-    // pull_alist_pending() below always does), this just runs the
-    // pending expression once, fresh, whenever it's called.
+    // run one :posteval arg or keyword's still-pending token span against the
+    // caller's parked postfix buffer.  Memoizes nothing -- that is the
+    // caller's business.
 
     AttributeValue* pull_alist_pending(AttributeList* al, int id, AttributeValue* found);
-    // if 'found' (already the result of al->find(id)) is a still-pending
-    // FuncObjPendingArg marker, pull it via pull_funcobj_pending(), write
-    // the real value back into al under the same id, and delete the
-    // marker -- freezing this keyword into an ordinary owned local from
-    // here on.  The ONLY caller left is lookup_symval(ComValue*, true)
-    // (its default), compound-assign's path via ModAssignFunc et al in
-    // assignfunc.c: "y+=1" reads the old value then writes the new one
-    // through the same pointer, which requires a real, addressable slot
-    // to mutate in place -- and an assignment is exactly the moment a
-    // lazy keyword should stop being re-derived and become a plain local
-    // anyway (the same write-freezes convention #310's capture classifier
-    // already uses).  A plain read never reaches this -- see
-    // peek_alist_pending() below.
+    // if 'found' is a still-pending FuncObjPendingArg marker, pull it, write
+    // the real value back into al under the same id, and delete the marker,
+    // freezing the keyword into an ordinary local.  Compound assignment needs
+    // this: it reads and writes through the same pointer, so the slot has to
+    // be real and addressable.
 
     AttributeValue* peek_alist_pending(AttributeList* al, int id, AttributeValue* found);
-    // sibling of pull_alist_pending() for every OTHER _alist lookup --
-    // the bare-variable-read fallthrough in eval_expr_internals,
-    // lookup_symval(ComValue&) (which ComFunc::stack_arg/stack_key and
-    // ordinary operand resolution route through for a symbol used as an
-    // operand rather than read standalone -- the case a plain "y+y"
-    // exercises), and lookup_symval(ComValue*, false) (has_streams/array
-    // detection in eval_expr_internals, which only need a momentary type
-    // check).  If 'found' is a still-pending marker, pulls it fresh via
-    // pull_funcobj_pending() into a scratch slot (_peek_scratch) and
-    // returns a pointer to that -- valid only until the next peek/pull,
-    // which every caller here already respects (each copies out or
-    // finishes using the pointer before this could be called again).
-    // Never touches al, never memoizes: every plain read of a :posteval
-    // keyword re-fires, same as arg(n) already does (funcobj_arg()) --
-    // the deliberate choice over freezing on first read, since a keyword
-    // pulled straight from an unwritten :posteval arg is meant to behave
-    // like a live tap, not a constant; ycopy=y before ycopy*ycopy is the
-    // idiom for pinning one draw when that's what's wanted instead.
+    // sibling of pull_alist_pending() for every other _alist lookup: a
+    // still-pending marker is pulled fresh into _peek_scratch and a pointer
+    // to that returned, valid only until the next peek or pull.  al is never
+    // touched, so each plain read of a :posteval keyword re-fires -- it is a
+    // live tap rather than a constant, and ycopy=y pins one draw.
 
     void set_args(int argc, char** argv);
     // set command line arguments
@@ -630,46 +537,16 @@ protected:
     // true while executing inside a FuncObj invocation
 
     ComValue* _peek_scratch;
-    // holds peek_alist_pending()'s freshly-pulled :posteval value -- valid
-    // only until the next peek/pull, never persisted into any AttributeList.
-    // A pointer (not a plain member) because ComValue is only forward-
-    // declared this early in the header; allocated once in init().
+    // holds peek_alist_pending()'s freshly-pulled :posteval value, valid only
+    // until the next peek or pull.  A pointer because ComValue is only
+    // forward-declared this early; allocated in init().
 
     AttributeValueList* _fire_scratch_pool;
-    // fire_if_funcobj()'s fired results -- not a single reused slot like
-    // _peek_scratch: stack_arg()/stack_key() return a fired result by
-    // reference, and a caller that resolves two operands before
-    // consuming either (e.g. EqualFunc: operand1/operand2 both held live
-    // across both stack_arg() calls) needs each fire to land in its OWN
-    // storage -- a single shared slot means the second fire silently
-    // overwrites the first result out from under a caller still holding
-    // a reference to it. Each fire heap-allocates its own ComValue and
-    // Append()'s it -- unlike a contiguous growable array, appending to
-    // this list never relocates or invalidates a previously-returned
-    // entry's address, so a reference returned by an earlier fire in the
-    // same statement stays valid no matter how many more fires follow it
-    // (a flat array-with-doubling version of this pool had exactly that
-    // bug: growth deleted-and-copied into a new array, dangling any
-    // reference already handed out into the old one). Cleared (see
-    // eval_expr's !nested case), never resized.
-    //
-    // Growth is bounded by one top-level statement, not by process
-    // lifetime, even though runfile()'s own per-line loop drives every
-    // line of a script through eval_expr(true) (never clearing mid-file,
-    // same as _stack_top): the reset happens at the START of whichever
-    // top-level statement comes NEXT, because ComterpHandler::handle_input
-    // (comhandler.c) computes nested = reentrant ? true :
-    // force_nested() for every incoming command -- server request or
-    // interactively-typed line alike -- and force_nested defaults false.
-    // So the very next run(...), or the next line typed at a prompt,
-    // clears whatever the previous top-level statement accumulated
-    // before doing anything else. The one deliberate exception:
-    // comdraw's pause() (ComUnidraw/unifunc.c) sets force_nested(1) for
-    // the duration of an interactive breakpoint, so a script suspended
-    // mid-statement isn't corrupted by whatever gets typed while paused
-    // -- that extends the no-reset window to human-interaction
-    // timescale, not process lifetime, an accepted tradeoff for that
-    // one feature.
+    // fire_if_funcobj()'s fired results.  A list of separately allocated
+    // ComValues rather than one reused slot or a growable array: a result is
+    // returned by reference, so each fire needs storage of its own that
+    // appending cannot relocate.  Cleared at the start of each top-level
+    // statement.
 
     AttributeValueList* _top_commands;
     // list of top-most commands for this derived comterp

--- a/src/ComTerp/comterpserv.c
+++ b/src/ComTerp/comterpserv.c
@@ -308,16 +308,12 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
     int tokoff = _pfoff;
 
     int last_status = 0;
-    /* Tracks "the last thing we tried to parse was left incomplete" across
-       iterations.  *inbuf can't be used for this directly: when the file's
-       last real line ends with a newline, fgets succeeds without feof()
-       being set yet, so the loop runs one more iteration to detect true
-       EOF -- and that iteration clears inbuf (line "*inbuf='\0';" below)
-       before the post-loop check below can see what was pending.  Without
-       this flag, that clears the EOF diagnostic *and* skips the
-       parser_reset() cleanup below it, leaving the parser's own internal
-       incomplete-expression state dangling for whatever runs next to read
-       as if it were valid tokens. */
+    /* tracks "the last thing parsed was left incomplete" across iterations.
+       inbuf cannot serve: when the last real line ends in a newline, fgets
+       succeeds before feof() is set, so the loop runs once more to detect
+       true EOF -- and that pass clears inbuf before the post-loop check can
+       see what was pending, losing both the diagnostic and the parser_reset()
+       that follows it. */
     boolean pending_incomplete_expr = false;
     while( !feof(ifptr) ) {
 #if defined(TIMING_TEST)
@@ -341,22 +337,14 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
 
  	if (feof(ifptr) && !*inbuf)  // deal with last line without new-line
 	  break;
-        /* Drain a leftover orphaned stream from the PREVIOUS statement
-           now that a genuine next line/statement is confirmed to exist
-           (the loop's own while(!feof()) can be true here even though
-           this turns out to be the trailing EOF-probe pass above with
-           nothing left to read -- checking any earlier than this, e.g.
-           at the very top of the loop, would incorrectly drain the
-           truly last statement's retval too, since that probe pass
-           also enters the loop body).  Draining before this iteration's
-           own line runs, not after: it can have visible side effects of
-           its own (e.g. a print() overdrive stream defers each
-           repetition's actual print() call until that element is
-           pulled -- draining fires all of them at once), and checking
-           this any later (e.g. the matching spot below, which used to
-           have this check) would run it AFTER the next statement's own
-           eval_expr() already produced its output, interleaving the two
-           out of script order. */
+        /* drain a leftover orphaned stream from the previous statement, now
+           that a genuine next statement is confirmed to exist.  Checking any
+           earlier would also drain the last statement's own result, since the
+           trailing EOF-probe pass enters the loop body too.  Draining happens
+           before this line runs rather than after, because it has visible side
+           effects of its own -- a print() overdrive stream fires every
+           deferred repetition at once -- which would otherwise interleave with
+           the next statement's output. */
         if (retval && retval->is_stream() && retval->stream_list() &&
             retval->stream_list()->refcount_==1) {
           orphan_stream_count(*retval);
@@ -464,17 +452,13 @@ int ComTerpServ::runfile(const char* filename, boolean popen_flag) {
         *inbuf = '\0';
         parser_reset();
 
-        /* COMERR_SET1 pushes onto ComUtil's process-global error stack
-           (errsys.c), and nothing above drains it the way the *inbuf-error
-           branch above does via err_str().  Left unconsumed, it silently
-           outlives this runfile() call and gets misattributed to the next
-           unrelated err_str() call anywhere in the interpreter -- observed
-           as ComTerpServ::run(postfix_token*,int) (used to invoke a
-           user-defined func() body) mistaking it for a failure of that
-           unrelated call, which makes it substitute nullval() *without*
-           popping the value eval_expr() already pushed -- a stray value
-           left on the stack that later trips the "func ... pushed more
-           than a single value on stack" consistency check. */
+        /* COMERR_SET1 pushes onto ComUtil's process-global error stack, and
+           nothing above drains it the way the inbuf-error branch does through
+           err_str().  Left unconsumed it outlives this runfile() call and is
+           misattributed to the next unrelated err_str() anywhere in the
+           interpreter, which then substitutes nullval() without popping what
+           eval_expr() pushed -- a stray stack value that trips the
+           single-value consistency check later. */
         char eofbuf[BUFSIZ];
         char location[BUFSIZ];
         snprintf(location, BUFSIZ, "error in %s:%d", filename, _linenum);
@@ -513,13 +497,11 @@ ComValue ComTerpServ::run(const char* expression, boolean nested) {
     push_servstate();
     _pfcomvals = nil;
 
-    /* mark the interpreter running for the duration -- mirrors the base
-       ComTerp::run / ComTerpServ::runfile bracket, which this inline-eval
-       override otherwise drops.  Without it, a reactor event (e.g. stdin EOF)
-       firing inside a nested handle_events() -- comdraw's startup seed
-       update(1000000) is the classic trigger -- makes ComterpHandler::destroy()
-       see running()==false and free this live interpreter out from under the
-       eval loop, a use-after-free that clobbers the ComTerp vtable. */
+    /* mark the interpreter running for the duration, mirroring the
+       ComTerp::run / ComTerpServ::runfile bracket this inline-eval override
+       otherwise drops.  Without it a reactor event firing inside a nested
+       handle_events() lets ComterpHandler::destroy() see running()==false and
+       free the live interpreter under the eval loop. */
     int old_runflag = running();
     running(true);
 

--- a/src/ComTerp/comvalue.c
+++ b/src/ComTerp/comvalue.c
@@ -74,7 +74,7 @@ ComValue::ComValue(ComValue* sv) {
 }
 
 ComValue::ComValue(AttributeValue& sv) {
-    /* narg/nkey/nids and the flag bits (sliced() among them, #395) now live
+    /* narg/nkey/nids and the flag bits (sliced() among them) now live
        in AttributeValue's own storage, so the assignment above already
        carries them over when sv was itself a boxed ComValue -- zero_vals()
        must not stomp them back to 0 here, unlike before this storage moved
@@ -124,16 +124,11 @@ ComValue::ComValue(postfix_token* token) {
     clear();
     void* v1 = &_v;
     void* v2 = &token->v;
-    /* sizeof(token->v), not sizeof(_v): token->v is postfix_token's own
-       8-byte data_value union (ComUtil/comterp.h), narrower than
-       ComValue's 16-byte attr_value union (Attribute/attrvalue.h) -- a
-       stray sizeof(_v) here read 8 bytes past token->v into its own
-       adjacent type/narg fields, reinterpreted as the tail of whichever
-       multi-field union member (symval, objval, streamval, ...) this
-       token's type selects.  clear() already zeroed the full _v above,
-       so bounding the copy to the source's true size is always safe --
-       data_value's own widest member is 8 bytes, so no real payload is
-       ever lost by not reading further. */
+    /* sizeof(token->v), not sizeof(_v): token->v is postfix_token's 8-byte
+       data_value union, narrower than ComValue's 16-byte attr_value, so
+       sizeof(_v) would read past it into the adjacent type/narg fields.
+       clear() has already zeroed _v, and data_value's widest member is 8
+       bytes, so bounding the copy to the source loses nothing. */
     memcpy(v1, v2, sizeof(token->v));
     switch (token->type) {
     case TOK_STRING:  type(StringType); break;
@@ -191,16 +186,10 @@ int ComValue::sliceoff() const { return _ext1; }
 int ComValue::slicelen() const { return _ext2; }
 
 const char* ComValue::cstr(std::string& scratch) {
-  /* string_ptr() itself was tried as this mechanism (made virtual,
-     overridden here) and reverted -- see its own doc comment,
-     attrvalue.h.  Calling AttributeValue::string_ptr() explicitly (base-
-     qualified, never virtual) is what makes this safe to call on ANY
-     ComValue&, including a raw element of _stack (comterp.c) read
-     directly rather than copied to a genuine local first -- such an
-     element's own vtable pointer isn't reliably ComValue's own
-     (confirmed live: one resolved to plain AttributeValue's), but
-     sliced()/sliceoff()/slicelen() are plain field reads, unaffected
-     either way. */
+  /* AttributeValue::string_ptr() is called base-qualified, never virtually,
+     which is what makes this safe on any ComValue& -- including a raw _stack
+     element read in place, whose vtable pointer is not reliably ComValue's.
+     sliced()/sliceoff()/slicelen() are plain field reads, unaffected. */
   const char* full = AttributeValue::string_ptr();
   if (!sliced()) return full;
   scratch.assign(full + sliceoff(), slicelen());
@@ -439,20 +428,13 @@ ostream& operator<< (ostream& out, const ComValue& sv) {
     return out;
 }
 
-/* AttributeValue::install_render_hook() (attrvalue.h) lets a value stored
-   as a plain AttributeValue* -- e.g. an Attribute's own value, attrlist.c,
-   which can never be a ComValue* since Attribute lives in a lower library
-   that can't see ComTerp -- still print with ComTerp's own interpretation
-   of the shared narg/nkey/nids/flags block (a coloned() list's ':' form, a
-   sliced string's own window via cstr()) instead of AttributeValue's
-   generic fallback.  Installed once, here, at library-load time (the same
-   self-registering-static-local idiom this file already uses for one-time
-   symbol setup, e.g. ComValue::is_funcobj()'s posteval check) rather than
-   at any particular print call site: the hook itself is stateless (brief
-   mode etc. still comes from the existing ComValue::comterp() pointer, set
-   independently at each print call site), so it never needs re-arming, and
-   -- since nothing ever clears it mid-traversal -- it's already in effect
-   at any nesting depth a list's own recursive printing reaches. */
+/* install_render_hook() lets a value stored as a plain AttributeValue* -- an
+   Attribute's own value, which can never be a ComValue* since Attribute lives
+   in a lower library -- still print with ComTerp's reading of the shared
+   narg/nkey/nids/flags block: a coloned list's ':' form, a sliced string's own
+   window.  Installed once at library-load time rather than per print call
+   site, since the hook is stateless and so never needs re-arming, and is in
+   effect at any depth a list's recursive printing reaches. */
 static ostream& comvalue_render_hook(ostream& out, const AttributeValue& av) {
   ComValue cv((AttributeValue&)av);
   return out << cv;

--- a/src/ComTerp/comvalue.h
+++ b/src/ComTerp/comvalue.h
@@ -43,25 +43,17 @@ class ComTerp;
 // for returning constants useful in any application of ComTerp, as well
 // as four integers (narg(), nkey(), nids(), pedepth()) used for storing
 // necessary command and keyword state after code conversion and during 
-// interpretation.  
-// Packed into the high bits of the shared _ext3 word (AttributeValue's
-// widened block, attrvalue.h) -- NOT the _state/_command_symid word: a real
-// command_symid is an unbounded symbol-table index (e.g. "global" itself
-// landed on 225 == 0xE1, colliding with an early flag bit tried there), so
-// nothing that shares space with it can use small fixed bits safely.  _ext3
-// has no such problem: its low byte is nids() (bounded by the scanner's own
-// TOK_* range, comterp.h, comfortably under 0x80) and every flag bit here
-// starts at 0x100, clear of it.  nids()'s own accessor (comvalue.c) reads/
-// writes only that low byte, sign-extended, so -1 (nids()'s own "bare
-// identifier" sentinel) never bleeds into these bits the way _command_symid's
-// -1 sentinel did into the old _state-packed flags.  blocksz() (StringType's
-// still-unconsumed chunk-size field, #395) gives up its dedicated storage
-// here in favor of sliced() -- nothing sets a nonzero blocksz today.
+// interpretation.
+// These are packed into the high bits of the shared _ext3 word rather than
+// the _state/_command_symid word: a command_symid is an unbounded symbol
+// index, so nothing sharing space with it can use small fixed bits safely.
+// _ext3's low byte is nids(), bounded by the scanner's TOK_* range, and
+// every flag here starts at 0x100, clear of it.
 #define COMVALUE_BQUOTE_FLAG     0x0100 // backquote -- return symbol without lookup
-#define COMVALUE_LHS_ASSIGN_FLAG 0x0200 // set by AssignFunc on global()/local()/at() ComValue in lhs context (also ListAtFunc's ArrayType result, #318)
+#define COMVALUE_LHS_ASSIGN_FLAG 0x0200 // set by AssignFunc on global()/local()/at() ComValue in lhs context (also ListAtFunc's ArrayType result)
 #define COMVALUE_LOCAL_FLAG      0x0400 // set by local() on its lvalue symbol -- write the default symbol table, skipping any func frame
 #define COMVALUE_COLONED_FLAG    0x0800 // set by ColonListFunc -- an ArrayType built by ':', not ','
-#define COMVALUE_SLICED_FLAG     0x1000 // set on a StringType sliced from another string (#395) -- sliceoff()/slicelen() hold the window, narg()/nkey() read 0
+#define COMVALUE_SLICED_FLAG     0x1000 // set on a StringType sliced from another string -- sliceoff()/slicelen() hold the window, narg()/nkey() read 0
 
 class ComValue : public AttributeValue {
 public:
@@ -127,20 +119,19 @@ public:
 
     int narg() const;
     // number of arguments associated with this command or keyword; always 0
-    // for a StringType, whose storage doubles as a slice's offset (#395) --
-    // use sliceoff() to read that.
+    // for a StringType, whose storage doubles as a slice's offset -- use
+    // sliceoff() to read that.
     int nkey() const;
     // number of keywords associated with this command; always 0 for a
-    // StringType, whose storage doubles as a slice's length (#395) -- use
+    // StringType, whose storage doubles as a slice's length -- use
     // slicelen() to read that.
     int nids() const;
-    // for a SymbolType, -1 for a bare identifier or the matched-paren-
-    // delimiter kind following it otherwise (TOK_RPAREN/TOK_RBRACKET/...,
-    // comterp.c -- also how DotFunc, dotfunc.c, tells a bare field
-    // reference apart from an empty-parenthesized method call); when a
-    // language needs separate input/output arglists it counts those too.
-    // Always 0 for a StringType, whose storage doubles as a slice's chunk
-    // size (#395) -- use blocksz() to read that.
+    // for a SymbolType, -1 for a bare identifier or otherwise the matched-
+    // paren-delimiter kind following it (TOK_RPAREN/TOK_RBRACKET/..., which
+    // is also how DotFunc tells a bare field reference from an empty-
+    // parenthesized method call); a language needing separate input/output
+    // arglists counts those too.  Always 0 for a StringType, whose storage
+    // doubles as a slice's chunk size -- use blocksz() to read that.
     void narg(int n) {_ext1 = n; }
     // set number of arguments associated with this command or keyword.
     void nkey(int n) {_ext2 = n; }
@@ -169,7 +160,7 @@ public:
 
     int sliced() const;
     // return flag that marks a StringType value as a slice of another
-    // string, sharing its symid rather than owning a copy (#395).
+    // string, sharing its symid rather than owning a copy.
     void sliced(int flag) { if (flag) _ext3 |= COMVALUE_SLICED_FLAG; else _ext3 &= ~COMVALUE_SLICED_FLAG; }
     // set flag that marks a StringType value as a slice.
     int sliceoff() const;
@@ -181,34 +172,22 @@ public:
     void slicelen(int len) { _ext2 = len; }
     // set a slice's window length.
     int blocksz() const { return 0; }
-    // chunk size of a slice, in bytes -- always 0 (an ordinary byte-granular
-    // slice) for now.  Was its own field in _ext3 (#395); gave up that
-    // storage to sliced() and the rest of the flag bits above, since nothing
-    // sets a nonzero blocksz yet -- this was documented as reserved storage,
-    // not a shipped feature, before the giveback.  A real implementation
-    // needs its own field again, found some other way.
+    // chunk size of a slice, in bytes -- always 0, an ordinary byte-granular
+    // slice.  The storage it once had went to sliced() and the flag bits
+    // above; a real implementation needs a field of its own again.
     void blocksz(int sz) { }
     // no-op -- see blocksz() above.
 
     const char* cstr(std::string& scratch);
-    // the slice-aware way to get a StringType value's text (#395) --
-    // narrows to [sliceoff(), sliceoff()+slicelen()) when sliced() instead
-    // of AttributeValue::string_ptr()'s whole shared backing string;
-    // string_ptr() itself was tried as the mechanism for this (made
-    // virtual, overridden here) and reverted -- see its own doc comment,
-    // attrvalue.h, for why.  Named plainly, not slice_cstr() -- whether
-    // the value happens to be a slice is an implementation detail with no
-    // meaning to a caller that just wants its text.  Takes a caller-owned
-    // std::string rather than storing the copy on the ComValue itself:
-    // _stack (comterp.c) grows via dmm_realloc, a raw realloc of the
-    // whole ComValue array, so ComValue itself must stay a plain,
-    // trivially-relocatable type -- no member with real construction/
-    // destruction (like std::string) survives that move (confirmed by an
-    // actual crash on the very first string assignment when tried).  A
-    // real copy is unavoidable in the sliced case regardless of mechanism
-    // -- a mid-buffer slice's own end isn't a real '\0' in the shared
-    // backing string, and writing one there would be exactly #394's
-    // original bug.
+    // the slice-aware way to get a StringType value's text: narrows to
+    // [sliceoff(), sliceoff()+slicelen()) when sliced(), where
+    // AttributeValue::string_ptr() would return the whole shared backing
+    // string.  Takes a caller-owned std::string rather than keeping the copy
+    // on the ComValue, which must stay trivially relocatable -- _stack grows
+    // by dmm_realloc, a raw realloc of the whole ComValue array, so no member
+    // with real construction or destruction survives the move.  A copy is
+    // unavoidable in the sliced case: a mid-buffer slice's end is not a real
+    // '\0' in the backing string, and writing one there would corrupt it.
 
     int& pedepth() { return _pedepth; }
     // set/get depth of nesting in post-evaluated blocks of control commands.

--- a/src/ComTerp/ctrlfunc.c
+++ b/src/ComTerp/ctrlfunc.c
@@ -438,16 +438,14 @@ void PatchKeyFunc::execute() {
 	key = PATCH_KEY;
 
     if (key) {
-	/* PATCH_KEY (and any key passed in) is a plain literal, not derived
-	   from git, so resolving it to a commit means asking git to look up
-	   the matching tag pushed at merge time (patch-key.yml).
+	/* PATCH_KEY, and any key passed in, is a plain literal rather than
+	   something derived from git, so resolving it to a commit means asking
+	   git for the matching tag pushed at merge time.
 
-	   A caller-supplied key is reachable over ComTerp's socket interface
-	   (server/listen modes), so it must be rejected -- not merely quoted
-	   -- before it reaches the shell below: reject anything outside the
-	   character set an actual PATCH_KEY tag can contain, closing the
-	   shell-injection path a value like `"; rm -rf ~ ;"` would otherwise
-	   open via snprintf/popen. */
+	   A caller-supplied key is reachable over the socket interface, so it
+	   is rejected outright -- not merely quoted -- if it holds anything
+	   outside the character set a real PATCH_KEY tag can contain, closing
+	   the shell-injection path through snprintf/popen below. */
 	static const char* key_charset =
 	    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
 	if (key[0] == '\0' || strspn(key, key_charset) != strlen(key)) {
@@ -455,13 +453,11 @@ void PatchKeyFunc::execute() {
 	    return;
 	}
 
-	/* shell_string() (ComUtil/util.c) called directly, not through
-	   ShellFunc's stack/exec machinery -- same guard-the-empty-result
-	   discipline local_hostname() uses for a failed/empty scutil call:
-	   a nonexistent tag leaves stdout empty, so an empty result means
-	   "unresolved" (not-yet-tagged, or a stale/mistyped key), not an
-	   error to surface as a nonsense value.  Stderr routed to /dev/null
-	   so a failed lookup doesn't leak git's own diagnostic text. */
+	/* shell_string() called directly rather than through ShellFunc's
+	   stack machinery.  A nonexistent tag leaves stdout empty, so an empty
+	   result means unresolved -- not yet tagged, or a stale key -- rather
+	   than an error worth surfacing.  Stderr goes to /dev/null so a failed
+	   lookup does not leak git's diagnostics. */
 	char cmdbuf[BUFSIZ];
 	snprintf(cmdbuf, sizeof(cmdbuf), "git rev-list -n 1 refs/tags/%s 2>/dev/null", key);
 	const char* commitid = shell_string(cmdbuf);
@@ -528,19 +524,14 @@ NilFunc::NilFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
 void NilFunc::execute() {
-    /* token_to_comvalue (comterp.c) routes any call-shaped symbol here
-       (parens/args, not [yet] a registered command) at CONVERSION time --
-       once, frozen forever into that token.  That's wrong when the name
-       is defined earlier in the same already-tokenized ";"-sequence: the
-       whole sequence converts before any of it executes, so the earlier
-       "name=func(...)" hasn't run yet when "name(args)"'s own token gets
-       converted (issue #328).  Re-check dynamically, by name, right now --
-       if the gate has since opened (the name really is a FuncObj by the
-       time this actually fires), evaluate the pending args -- positional
-       and keyword alike -- for real and dispatch to it, same as an
-       ordinary call would.  If it's still closed, fall through unchanged:
-       never touch the args (the deliberate plugin-hook gate idiom,
-       symboldrain.comt) and return nil. */
+    /* token_to_comvalue routes any call-shaped symbol here at conversion
+       time, once, frozen into the token -- which is wrong when the name is
+       defined earlier in the same ";"-sequence, since the whole sequence
+       converts before any of it runs.  So re-check by name here: if the name
+       is a FuncObj by the time this fires, evaluate the pending args and
+       dispatch to it as an ordinary call would.  If not, fall through without
+       touching the args and return nil, which is the plugin-hook gate
+       idiom. */
     static int nil_symid = symbol_add("nil");
     int comm_symid = funcstate()->command_symid();
     if (comm_symid && comm_symid != nil_symid) {

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -43,16 +43,11 @@ using std::cerr;
 /*****************************************************************************/
 
 
-/* off by default -- capturing the pre-fire source text of both args (see
-   execute() below) costs a cout redirect + two print_stack_arg_post_eval
-   calls on every dot-expression, even the overwhelmingly common case where
-   nothing goes wrong.  A malformed-dot warning always shows the RESOLVED
-   value of both sides regardless of this flag (before_part/after_raw,
-   already on hand -- no capture needed) -- this only adds the raw postfix-
-   token dump on top of that, for tracking down something the resolved
-   value alone doesn't explain.  Intentionally undocumented/internal: set
-   it via check_dbg_keyword()'s :dbg keyword if ever needed again, but it's
-   not advertised in DotFunc's public docstring. */
+/* off by default: capturing the pre-fire source text of both args costs a
+   cout redirect and two print_stack_arg_post_eval calls on every dot
+   expression.  A malformed-dot warning shows the resolved value of both sides
+   regardless; this only adds the raw postfix-token dump on top.  Internal --
+   set it through check_dbg_keyword()'s :dbg keyword if needed. */
 static boolean dotfunc_debug_expr = false;
 
 DotFunc::DotFunc(ComTerp* comterp) : ComFunc(comterp) {
@@ -103,16 +98,11 @@ static void restore_kw_if_unwritten(ComTerp* comterp, AttributeList* al, KwPendi
     al->Remove(now);
 }
 
-/* Unconditional counterpart for captures (#310), not keywords -- a capture
-   was never something the caller passed at this call site (unlike a
-   keyword, where a resulting object mutation is visible and deliberate to
-   whoever wrote :x val), so it must always behave like the bare-call
-   case's fresh, disposable per-call seed: revert every time, whether the
-   body wrote it or not, never leave a new permanent field on obj.
-   Confirmed live: without this, obj.bump=func(c=c+1) on a never-before-
-   seen capture c leaked a permanent :c field onto obj and accumulated
-   across calls (11, 12, 13) instead of restarting from the frozen capture
-   every time (11, 11, 11). */
+/* the unconditional counterpart for captures rather than keywords: a capture
+   was never something the caller passed at this call site, so it reverts every
+   time, written or not, and never leaves a permanent field on obj.  Otherwise
+   obj.bump=func(c=c+1) on a never-before-seen c leaves a :c field behind that
+   accumulates across calls instead of restarting from the capture. */
 static void restore_capture(AttributeList* al, KwPending& pending) {
   Attribute* now = al->GetAttr(pending.symid);
   if (!now) return;
@@ -122,29 +112,19 @@ static void restore_capture(AttributeList* al, KwPending& pending) {
     al->Remove(now);
 }
 
-/* obj.method(args) -- fire a FuncObj-valued attribute self-bound to obj.
-   Evaluates args in the caller's own scope (before any _alist swap, so a
-   variable reference in an arg resolves against the caller, not obj), then
-   temporarily swaps _alist to obj -- the same mechanism eval(fo :alist obj)
-   already uses (ctrlfunc.c's EvalFunc) -- and runs the method's own token
-   buffer directly, so self-bound reads/writes of obj's own fields mutate
-   the real object, not a per-call copy.  Positional args flow through the
-   funcobj_args channel (set_funcobj_args/funcobj_argvals, comterp.h) the
-   same way an ordinary FuncObj invocation's arg()/narg() are served.
+/* obj.method(args) -- fire a FuncObj-valued attribute self-bound to obj.  Args
+   are evaluated in the caller's own scope, before any _alist swap, so a
+   variable in an arg resolves against the caller rather than obj.  _alist is
+   then swapped to obj -- the mechanism eval(fo :alist obj) already uses -- and
+   the method's token buffer run directly, so self-bound reads and writes
+   mutate the real object.  Positionals flow through the funcobj_args channel,
+   as for any FuncObj call.
 
-   Getting at args without evaluating "method" itself: a symbol with an
-   attached arglist that isn't a registered global command gets rebound to
-   the nil command by ComTerp::token_to_comvalue at expression-conversion
-   time, unconditionally, before any command (including this one) runs --
-   that check only ever consults the global command table, never _alist, so
-   there is no way to make "method(args)" resolve through obj by evaluating
-   it as an ordinary sub-expression.  Instead: look "method" up in obj
-   directly (the same GetAttr() the bare-access path below already uses),
-   and get the args evaluated by retargeting a copy of just the arg tokens
-   at the existing echo() command -- an ordinary (non-post_eval) command
-   that already packages positionals/keywords into an inspectable value for
-   the ~~ round-trip -- so ordinary dispatch does the evaluation, still
-   never touching "method" as a symbol at all. */
+   "method" itself is never evaluated as a symbol: a symbol with an arglist
+   that is not a registered global command is rebound to nil at conversion
+   time, and that check consults the global command table only, never _alist.
+   So look "method" up in obj directly, and get the args evaluated by
+   retargeting a copy of just the arg tokens at echo(). */
 static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
 				  AttributeList* al, postfix_token* argtoks,
 				  int nargtoks) {
@@ -197,15 +177,10 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
       posvals[i] = *poslist->Get(i);
   }
 
-  /* #310: this funcobj's own declaration-time captures (read-only/
-     read-before-write free variables, funcobjscan.h) are ephemeral
-     defaults layered onto al the same way keyword args are below --
-     apply_kw/restore_capture solve the same "inject, fire, revert"
-     problem for captures that apply_kw/restore_kw_if_unwritten already
-     solve for keywords, so captures reuse the same mechanism rather than
-     mutating obj's real fields. Applied *before* keywords (this block) so
-     an explicit :x val keyword still overrides a capture's *value* via
-     the same apply_kw call landing on top. */
+  /* this funcobj's declaration-time captures are ephemeral defaults layered
+     onto al the way keyword args are below, so they reuse the same inject-
+     fire-revert mechanism rather than mutating obj's real fields.  Applied
+     before keywords, so an explicit :x val still overrides a capture. */
   int method_nkey_for_skip = method_nkey;
   int* kwsymids = method_nkey_for_skip>0 ? new int[method_nkey_for_skip] : nil;
   if (method_nkey_for_skip>0) {
@@ -233,28 +208,18 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
     for (caps->First(capit); !caps->Done(capit); caps->Next(capit)) {
       Attribute* capattr = caps->GetAttr(capit);
       int capsymid = capattr->SymbolId();
-      /* A name obj already owns as its own attribute is a real object
-	 field, not the free variable this capture was taken for -- skip
-	 it so the field stays live (self-bound reads/writes of obj's own
-	 fields must see obj's current value, never a declaration-time
-	 snapshot; only a name obj does NOT already have is genuinely
-	 free here). Confirmed live: without this guard,
-	 obj.increment=func(count=count+1) on obj=(:count 5) overwrote
-	 obj's real count with an unrelated (Unknown) capture before the
-	 body ran, "Unknown add operand: UnknownType+IntType". */
+      /* a name obj already owns is a real object field, not the free variable
+	 this capture was taken for -- skip it, so self-bound reads and writes
+	 see obj's current value rather than a declaration-time snapshot.
+	 Without the guard, obj.increment=func(count=count+1) on obj=(:count 5)
+	 overwrites the real count with an Unknown capture. */
       if (al->GetAttr(capsymid)) continue;
-      /* A name the caller also supplied as an explicit keyword this call
-	 is entirely the keyword mechanism's -- established, deliberate,
-	 tested behavior (62f557fb, LANGUAGE.md's "Keyword arguments to a
-	 method call are ephemeral unless the method writes them"): a
-	 self-bound write always persists, keyword-sourced or not. Skip
-	 applying the capture at all so apply_kw's own existed/oldval
-	 bookkeeping for the keyword below reflects the true pre-call
-	 state, not a value this capture injected first -- confirmed live:
-	 without this, a name that's both captured and keyword-supplied
-	 (nope=nope+1 declared free, then called as .setit(:nope 5)) had
-	 the capture's own unconditional revert wipe out the keyword
-	 write's result afterward, breaking attrlist.comt test 43. */
+      /* a name the caller also supplied as an explicit keyword belongs to the
+	 keyword mechanism entirely -- a self-bound write persists whether it
+	 came from a keyword or not.  Skip the capture, so apply_kw's own
+	 existed/oldval bookkeeping reflects the true pre-call state; applied
+	 first, the capture's unconditional revert would wipe out the keyword
+	 write afterward. */
       boolean also_keyword = false;
       for (int k=0; k<method_nkey_for_skip; k++)
 	if (kwsymids[k]==capsymid) { also_keyword = true; break; }
@@ -265,13 +230,10 @@ static void fire_attrlist_method(ComFunc* self, ComTerp* comterp,
   }
   delete [] kwsymids;
 
-  /* keyword args are ephemeral unless the method's own body writes that
-     same name -- reading it (or ignoring it) leaves al exactly as it was;
-     only a write (self-bound, so it lands on al) makes it stick.  Apply
-     each keyword now (saving what it's replacing), fire below, then
-     compare-and-revert after: unchanged from what was just injected means
-     nothing wrote it, so put the old value back (or remove it entirely if
-     the name didn't exist on al before this call). */
+  /* keyword args are ephemeral unless the method's body writes that name:
+     reading or ignoring it leaves al as it was, and only a self-bound write
+     makes it stick.  Apply each keyword now, saving what it replaces, fire,
+     then compare and revert -- unchanged means nothing wrote it. */
   int nkw = method_nkey;
   KwPending* kwpending = nkw>0 ? new KwPending[nkw] : nil;
   if (nkw>0) {
@@ -342,28 +304,19 @@ void DotFunc::peek_and_fire(ComValue& before_part, ComValue& after_raw, int& aft
 
     before_part = stack_arg(0, true);
     if (before_part.type()==ComValue::CommandType) {
-      /* a real command reference (e.g. the inner dot of node.left.val) --
-	 fire it to get its actual value.  A bare, unbound symbol (the
-	 compound-variable-on-first-use case just below) never gets promoted
-	 to CommandType by ComTerp::token_to_comvalue in the first place, so
-	 this never fires on a name DotFunc's own lookup below needs raw.
-	 symbol=false (the default) here, not true: this needs pop_stack's
-	 full finalization (resolve a symbol, unwrap an Attribute down to
-	 its own Value()), not the raw, unprocessed result. */
+      /* a real command reference, such as the inner dot of node.left.val --
+	 fire it for its value.  A bare unbound symbol is never promoted to
+	 CommandType, so this never fires on a name the lookup below needs raw.
+	 symbol=false, since this needs pop_stack's full finalization rather
+	 than the raw result. */
       before_part = stack_arg_post_eval(0);
     } else if (before_part.type()==ComValue::BlankType) {
-      /* a parenthesized sub-expression whose OWN result is a never-yet-
-	 pulled stream (e.g. ($$barnyard) inside ($$barnyard).calls) reads
-	 back as BlankType through the plain stack_arg(0,true) peek above
-	 -- comterp's own "streams don't self-evaluate mid-expression"
-	 discipline (see flowgraph-natural-computation-goal) leaves a Blank
-	 placeholder rather than surfacing the raw, unconsumed stream to an
-	 ordinary read.  stack_arg_post_eval(0) -- the SAME firing this
-	 function already uses for the CommandType case just above --
-	 correctly recovers the real StreamType value instead (confirmed
-	 live: probed both, Blank vs. a real is_stream()==true result).
-	 #304's LHS-stream support (execute_core() below) needs the real
-	 value, not the placeholder. */
+      /* a parenthesized sub-expression whose own result is a never-yet-pulled
+	 stream reads back as BlankType through the stack_arg(0,true) peek
+	 above: streams do not self-evaluate mid-expression, so a Blank
+	 placeholder stands in.  stack_arg_post_eval(0) -- the same firing used
+	 for the CommandType case above -- recovers the real StreamType value,
+	 which the LHS-stream support below needs. */
       before_part = stack_arg_post_eval(0);
     }
     after_raw = stack_arg(1, true);
@@ -373,14 +326,11 @@ void DotFunc::peek_and_fire(ComValue& before_part, ComValue& after_raw, int& aft
 void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_nids,
 			    const std::string& before_expr_text, const std::string& after_expr_text,
 			    boolean force_named_field) {
-    /* A named variable bound to a stream (sb=$$barnyard; sb.calls)
-       arrives here as a raw, unresolved SymbolType -- peek_and_fire()
-       never had reason to resolve it eagerly for the ordinary case,
-       since execute_core()'s own symbol-lookup logic below does that
-       itself. Resolve a copy just far enough to test is_stream() below;
-       before_part itself stays untouched so the ordinary (non-stream)
-       path further down still receives the ordinary bare symbol it
-       already knows how to resolve. */
+    /* a named variable bound to a stream (sb=$$barnyard; sb.calls) arrives
+       as a raw SymbolType, since execute_core() below does its own symbol
+       lookup.  Resolve a copy far enough to test is_stream(); before_part
+       stays untouched, so the ordinary path below still gets the bare
+       symbol it knows how to resolve. */
     ComValue before_resolved = before_part;
     if (before_resolved.is_symbol()) {
       AttributeValue* rv = comterp()->lookup_symval(&before_resolved, false);
@@ -388,8 +338,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
     }
     if (before_resolved.is_stream() && after_nids==-1) {
       /* (stream).field -- lazy, pulling .field from each element on
-	 demand rather than erroring on a raw StreamType before_part
-	 (#304).  Method-call-with-streaming-LHS (stream.method(args))
+	 demand rather than erroring on a raw StreamType before_part.  Method-call-with-streaming-LHS (stream.method(args))
 	 isn't handled here yet -- that falls through to the ordinary
 	 validity check below, which correctly warns rather than
 	 mishandling it silently. */
@@ -484,7 +433,7 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 	 ComTerp::lookup_symval uses -- otherwise a func-local variable
 	 (e.g. a keyword-bound param whose value only lives in _alist, never
 	 in localtable()) is invisible to dot access from inside the func
-	 body (#292). */
+	 body. */
       AttributeList* funcscope = !global ? comterp()->get_attributes() : nil;
       AttributeValue* fsval = funcscope ? funcscope->find(before_symid) : nil;
       if (fsval) {
@@ -554,15 +503,11 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
 }
 
 boolean DotFunc::check_dbg_keyword() {
-    /* Undocumented/internal: get/set dotfunc_debug_expr at runtime via a
-       :dbg keyword, so a live session (a running drawserv, say) can turn
-       on the raw postfix-token dump ON TOP OF the resolved-value detail
-       the malformed-dot warning already always shows, without an
-       edit+rebuild -- a fallback for a stranger case than the resolved
-       value alone explains, not something to advertise.  Checked first
-       and unconditionally: an ordinary a.b expression never supplies a
-       :dbg keyword, so this never touches the normal dispatch path
-       below. */
+    /* internal: get or set dotfunc_debug_expr at runtime through a :dbg
+       keyword, so a live session can turn on the raw postfix-token dump
+       without a rebuild.  Checked first and unconditionally -- an ordinary
+       a.b expression never supplies :dbg, so this never touches the normal
+       dispatch below. */
     static int dbg_symid = symbol_add("dbg");
     static int dbg_bare_symid = symbol_add("__dot_dbg_bare__");
     ComValue dbg_bare_sentinel(dbg_bare_symid, ComValue::SymbolType);
@@ -598,17 +543,11 @@ void DotStreamNextFunc::execute() {
        [0] the underlying before-stream and [1] the fixed after-dot field
        symbol in its stream_list() (see the STREAM_INTERNAL construction
        in DotFunc::execute_core() above). */
-    /* Deliberately no reset_stack() here, unlike every other *NextFunc
-       sibling's execute() -- this one delegates its actual dispatch to
-       execute_core() below, which already does its own single
-       reset_stack() in whichever branch it takes (mirroring how
-       DotFunc::execute() itself never resets directly -- peek_and_fire()
-       only peeks, execute_core() is the one reset). A second reset_stack()
-       call here, now that post_eval() is false, would flat decr_stack(1)
-       a SECOND time and silently cancel out this function's own final
-       push_stack() below -- confirmed live: stack height netted to zero
-       across the whole call, so the caller (NextFunc::execute_impl) saw
-       no growth and substituted a blank instead of the real value. */
+    /* deliberately no reset_stack() here, unlike the other *NextFunc
+       siblings: this one delegates to execute_core() below, which does its
+       own single reset in whichever branch it takes.  A second reset would
+       decr_stack(1) again and cancel out the push_stack() below, netting the
+       call to zero growth so the caller substitutes a blank. */
     ComValue selfstream(stack_arg(0));
 
     AttributeValueList* avl = selfstream.stream_list();
@@ -641,7 +580,7 @@ void DotStreamNextFunc::execute() {
       }
       before_next = comterp()->pop_stack();
     } else {
-      /* not exercised by the LHS-only case this lands in (#304's first
+      /* not exercised by the LHS-only case this lands in (the first
 	 slice) -- kept generic so a future RHS/zip extension (a fixed,
 	 non-stream "before" reused every pull while args advance) can
 	 reuse this same next-func without a second implementation. */
@@ -651,33 +590,23 @@ void DotStreamNextFunc::execute() {
     ComValue after_raw(afterval->symbol_val(), ComValue::SymbolType);
     execute_core(before_next, after_raw, -1, "", "", true);
 
-    /* execute_core()'s named-field branch pushes the raw internal
-       dotted-pair Attribute* wrapper (there's no attribute literal in
-       the language itself -- see its own comment), same as an ordinary
-       non-streamed .field access does. An ordinary read unwraps that
-       automatically further up the call chain (ComTerp::pop_stack's own
-       lookupsym=true branch, e.g. via assignment) before a caller ever
-       sees it; this synthetic per-pull call has no such caller, so do
-       the same unwrap explicitly here -- otherwise each pulled stream
-       element is the opaque wrapper, not its value (confirmed live:
-       list(sb.calls) rendered {,,}, three unwrapped Attribute objects,
-       instead of the actual :calls values). */
+    /* execute_core()'s named-field branch pushes the raw dotted-pair
+       Attribute* wrapper, as an ordinary .field access does.  A normal read
+       unwraps that further up the call chain, but this synthetic per-pull
+       call has no such caller, so unwrap explicitly -- otherwise each pulled
+       element is the wrapper rather than its value. */
     ComValue unwrapped(comterp()->pop_stack(true));
     push_stack(unwrapped);
 }
 
 /*****************************************************************************/
 
-/* attrname()/attrval() accept either shape a single attribute can take on
-   the stack: the internal dotted-pair Attribute* that "." exposes for a
-   named lookup (no attribute literal exists in the language itself, so
-   this is how one ever lands on the stack as a value in the first
-   place), or a single-entry AttributeList -- the literal, script-visible
-   stand-in for "one attribute" that at()/"@" return for an attrlist
-   position (a bare read, not :set), on the same principle a bare keyword
-   has no literal either and is always carried as part of an attrlist.
-   nil if neither shape matches, or the AttributeList has other than
-   exactly one entry. */
+/* attrname()/attrval() accept either shape a single attribute takes on the
+   stack: the internal dotted-pair Attribute* that "." exposes for a named
+   lookup -- the language has no attribute literal, so this is how one lands
+   on the stack at all -- or a single-entry AttributeList, which is what at()
+   and "@" return for an attrlist position.  nil if neither shape matches, or
+   the list holds other than one entry. */
 static Attribute* dotted_pair_or_singleton_attr(ComValue& val) {
     if (val.class_symid() == Attribute::class_symid())
         return (Attribute*)val.obj_val();
@@ -697,18 +626,12 @@ DotNameFunc::DotNameFunc(ComTerp* comterp) : ComFunc(comterp) {
 
 void DotNameFunc::execute() {
     ComValue dotted_pair(stack_arg(0, true));
-    /* stack_arg's symbol=true skips ordinary symbol resolution -- needed
-       so an inline at()/"." result isn't run back through
-       lookup_symval()'s own dotted-pair-unwrapping special case (below
-       this function). But that means a *bound variable* argument
-       (attrname(x), not attrname(at(al 0))) arrives as a raw, unresolved
-       SymbolType token instead of the value x is bound to, and fails the
-       shape check below unconditionally. Resolve it here instead, but
-       only when it's actually still a symbol -- lookup_symval() on a
-       SymbolType always returns the bound value as-is (its own
-       unwrapping branch is an "else if", only reached for a non-symbol
-       argument), so this can't reintroduce the very case symbol=true was
-       chosen to avoid. */
+    /* stack_arg's symbol=true skips ordinary resolution, so an inline at()
+       or "." result is not run back through lookup_symval()'s dotted-pair
+       unwrapping.  The cost is that a bound variable argument -- attrname(x)
+       rather than attrname(at(al 0)) -- arrives as a raw SymbolType and fails
+       the shape check below.  Resolve it here, but only while it is still a
+       symbol, which cannot reintroduce the case symbol=true avoids. */
     if (dotted_pair.type() == ComValue::SymbolType)
         lookup_symval(dotted_pair);
     reset_stack();

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -60,7 +60,7 @@ protected:
        attrlist lookup-or-create, and the actual dispatch (attribute
        fetch, or obj.method(args) self-bound firing). force_named_field,
        default false, lets a caller that already knows after_raw is a
-       genuine field symbol (DotStreamNextFunc::execute(), #304) skip the
+       genuine field symbol (DotStreamNextFunc::execute()) skip the
        nargs()>1 gate that distinguishes "al.field" from the rare 1-arg
        dot(name) form -- nargs() there reflects THIS invocation (always 1,
        the driving stream itself), not the original dot-expression's own
@@ -86,7 +86,7 @@ protected:
     boolean check_dbg_keyword();
 };
 
-//: hidden func used by next() to drive a lazy (stream).field access (#304).
+//: hidden func used by next() to drive a lazy (stream).field access.
 // Holds, in its own stream's stream_list(): [0] the underlying before-
 // stream, [1] the fixed after-dot field symbol. Each pull advances the
 // before-stream one element and re-runs DotFunc's own dispatch
@@ -112,7 +112,7 @@ public:
        ComValue this constructed from that garbage). */
     virtual boolean post_eval() { return false; }
     virtual const char* docstring() {
-      return "hidden func used by next command for (stream).field dot access (#304)."; }
+      return "hidden func used by next command for (stream).field dot access."; }
 
 };
 

--- a/src/ComTerp/funcobjscan.c
+++ b/src/ComTerp/funcobjscan.c
@@ -150,8 +150,7 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
 
     long maxidx = -1;           /* highest literal index seen: arg(0) -> 0 --
                                     long (not int) so maxidx+1 below can't
-                                    overflow for a literal near INT_MAX
-                                    (Greptile, PR #337) */
+                                    overflow for a literal near INT_MAX */
     boolean saw_arg = false;
     boolean saw_nonliteral = false;
 
@@ -182,7 +181,7 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
                 if (idx > maxidx) maxidx = idx;
             } else {
                 /* a computed index (arg(i), arg(i+1), ...) -- resolving
-                   simple cases statically is future work (#170 phase 1
+                   simple cases statically is future work (
                    point 2's "attempt, fall back to dynamic" allowance);
                    this first pass gives up gracefully instead of
                    guessing. */
@@ -197,10 +196,9 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
         /* maxidx+1 overflowing (maxidx == LONG_MAX) is signed-integer UB,
            not just "unlikely" -- check before doing the addition rather
            than let it wrap and rely on that wrapping to coincidentally
-           land back on the same -1 "can't be pinned down" sentinel
-           (Greptile, PR #337). This is unreachable through today's literal
+           land back on the same -1 "can't be pinned down" sentinel. This is unreachable through today's literal
            parsing (values above INT_MAX don't currently survive intact --
-           a separate, pre-existing bug, #342), but the guard costs nothing
+           a separate, pre-existing bug), but the guard costs nothing
            and removes the UB regardless of whether any path can trigger
            it today. */
         if (maxidx == LONG_MAX)
@@ -218,7 +216,7 @@ AttributeList* FuncObjVarScan::classify(postfix_token* toks, int ntoks, boolean*
     static int local_symid = symbol_add("local");
     static int global_symid = symbol_add("global");
     static int dot_symid = symbol_add("dot");
-    /* First operand is read-then-written in one occurrence -- see #310's
+    /* First operand is read-then-written in one occurrence -- see the capture classifier's
        plan: distinct from plain assign, whose first operand is a pure
        write (the old value is never read). */
     static int compound_assign_symids[] = {
@@ -234,16 +232,13 @@ AttributeList* FuncObjVarScan::classify(postfix_token* toks, int ntoks, boolean*
     int nrecs = 0, recs_cap = 0;
     EscapeRecord* escapes = nil;
     int nescapes = 0, escapes_cap = 0;
-    /* Symbols used anywhere in the body as a dot-chain root (obj.field) --
-       DotFunc's own attribute-write path already has a deliberate
-       fall-through order (_alist -> local -> global, see the #292 commit)
-       to decide whether obj already exists or needs creating fresh in the
-       outer scope.  A #310 capture pre-seeding al[obj] with a stale
-       declaration-time snapshot would make that path see "already
-       present" and stop short of the outer scope, breaking the documented
-       "dot free symbol bleeds to outer scope" behavior (attrlist.comt
-       tests 14/16).  So: excluded from capture globally, not just at the
-       point of this one dot access -- collected here, filtered at output. */
+    /* symbols used anywhere in the body as a dot-chain root (obj.field).
+       DotFunc's attribute-write path falls through _alist, then local, then
+       global to decide whether obj already exists or needs creating in the
+       outer scope.  A capture pre-seeding al[obj] with a declaration-time
+       snapshot would make that path see it as already present and stop short,
+       breaking the documented bleed to outer scope.  So they are excluded from
+       capture globally -- collected here, filtered at output. */
     int* dotroots = nil;
     int ndotroots = 0, dotroots_cap = 0;
 

--- a/src/ComTerp/funcobjscan.c
+++ b/src/ComTerp/funcobjscan.c
@@ -181,8 +181,7 @@ FuncObjVarScan::PositionalInfo FuncObjVarScan::scan_positionals(postfix_token* t
                 if (idx > maxidx) maxidx = idx;
             } else {
                 /* a computed index (arg(i), arg(i+1), ...) -- resolving
-                   simple cases statically is future work (
-                   point 2's "attempt, fall back to dynamic" allowance);
+                   simple cases statically is future work;
                    this first pass gives up gracefully instead of
                    guessing. */
                 saw_nonliteral = true;

--- a/src/ComTerp/funcobjscan.h
+++ b/src/ComTerp/funcobjscan.h
@@ -30,42 +30,33 @@ class AttributeList;
 class ComTerp;
 
 // FuncObjVarScan: classifies every distinct symbol referenced in a FuncObj
-// body's token span into #170's taxonomy -- read-only, read-before-write,
-// write-before-read, or escaping (local()/global()).  Used by #310 (func()
-// closures via declaration-time capture) and #170 (:help contract
-// derivation) -- one classifier, two consumers.
+// body's token span as read-only, read-before-write, write-before-read, or
+// escaping (local()/global()).  One classifier, two consumers: declaration-
+// time capture for func() closures, and help-contract derivation.
 //
-// Built on PostfixSpanWalk (postfixspan.h) for the underlying traversal.
-// Does no symbol-table lookup itself and needs no ComTerp access -- the
-// caller (a ComFunc, a friend of ComTerp, e.g. FuncObjFunc::execute) has
-// already resolved each token's symbol-vs-command status once via the
-// existing ComTerp::token_to_comvalue and passes the result in as
-// is_plain_var[], so this stays a pure structural pass with no
-// side effects and no dependency on live interpreter state.
+// Built on PostfixSpanWalk for the traversal.  It does no symbol-table lookup
+// and needs no ComTerp access: the caller has already resolved each token's
+// symbol-vs-command status via ComTerp::token_to_comvalue and passes the
+// result in as is_plain_var[], so this stays a pure structural pass.
 class FuncObjVarScan {
 public:
     enum Kind { ReadOnly, ReadBeforeWrite, WriteBeforeRead, EscapingLocal, EscapingGlobal };
 
     // is_plain_var[i] must be true iff toks[i] is a bare, zero-arg symbol
-    // reference (TOK_COMMAND, narg==0, nkey==0) that resolves to an
-    // ordinary variable rather than a registered command -- i.e. what
-    // ComTerp::token_to_comvalue leaves as ComValue::SymbolType instead of
-    // promoting to CommandType.  Every other token (real commands,
-    // literals, keywords) must be false here.
+    // reference (TOK_COMMAND, narg==0, nkey==0) resolving to an ordinary
+    // variable rather than a registered command -- what token_to_comvalue
+    // leaves as SymbolType instead of promoting to CommandType.  Every other
+    // token must be false.
     //
-    // Returns an AttributeList mapping each referenced variable's symid (as
-    // attribute name) to its Kind (stored as an IntType AttributeValue).
-    // Caller owns the returned list.
+    // Returns an AttributeList mapping each variable's symid to its Kind, as
+    // an IntType value.  Caller owns the list.
     static AttributeList* classify(postfix_token* toks, int ntoks, boolean* is_plain_var);
 
-    // Builds a fresh is_plain_var[] array for classify() above, resolving
-    // each token the same way ordinary evaluation would (token_to_comvalue
-    // is public specifically for this, see its own comment in comterp.h).
-    // Shared by #310's declaration-time capture (postfunc.c) and #170's
-    // :help fire-time analysis (comterp.c) so both go through one
-    // implementation of the nids<0 dot-rhs exclusion (HACKING.md's "Dot
-    // Operator Rhs" section) rather than two copies drifting apart. Caller
-    // owns the returned array (delete []).
+    // builds a fresh is_plain_var[] for classify(), resolving each token the
+    // way ordinary evaluation would.  Shared by declaration-time capture and
+    // help-contract analysis so both use one implementation of the nids<0
+    // dot-rhs exclusion rather than two that can drift.  Caller owns the
+    // returned array (delete []).
     static boolean* build_is_plain_var(ComTerp* comterp, postfix_token* toks, int ntoks);
 
     // Positional arg(n) usage, derived separately from classify() above --
@@ -73,9 +64,8 @@ public:
     // at all.
     struct PositionalInfo {
         long count;        // -1 means "count could not be pinned down statically";
-                            // long (not int) so a literal index near INT_MAX
-                            // doesn't overflow computing count = maxidx + 1
-                            // (Greptile, PR #337)
+                            // long, not int, so a literal index near INT_MAX
+                            // does not overflow computing maxidx + 1
         boolean uses_narg; // true if narg() appears anywhere in the body --
                             // treated as a signal the body is variadic
                             // (loops over an arg(n) run bounded by narg()),
@@ -83,31 +73,22 @@ public:
                             // literal arg(n) indices also found.
     };
 
-    // Scans for arg(n) calls, deriving the positional count from the
-    // highest literal index referenced (max constant index + 1).  A
-    // non-literal index (e.g. arg(i)) makes the count unresolvable the same
-    // way narg() usage does -- see #170 phase 1 point 2's "attempt simple
-    // computed n, fall back to dynamic" allowance; this first pass only
-    // resolves literal indices, computed-index resolution is future work.
+    // scans for arg(n) calls, deriving the positional count from the highest
+    // literal index referenced.  A non-literal index (arg(i)) makes the count
+    // unresolvable, the same as narg() usage does; only literal indices are
+    // resolved here.
     static PositionalInfo scan_positionals(postfix_token* toks, int ntoks);
 
-    // #336 (staged from #170's "Future" section, "Positional optionality"):
-    // recognizes the canonical "unsupplied keyword defaults to nil" idiom --
-    // if(x==nil :then DEFAULT :else x) -- and extracts DEFAULT where it's a
-    // single literal token. Only this one, well-known shape is matched
-    // (condition is exactly "x==nil"/"nil==x", the :else branch is exactly
-    // the bare keyword unchanged, the :then branch is exactly one literal
-    // token); anything more elaborate -- a computed default, extra
-    // keywords on the if(), a differently-shaped condition -- is silently
-    // skipped rather than guessed at, the same "attempt simple cases, give
-    // up gracefully" restraint scan_positionals uses for computed arg(n)
-    // indices. Needs ComTerp access (token_to_comvalue) to turn the
-    // literal token into a real ComValue, unlike classify()/
-    // scan_positionals() above.
+    // recognizes the canonical "unsupplied keyword defaults to nil" idiom,
+    // if(x==nil :then DEFAULT :else x), and extracts DEFAULT where it is a
+    // single literal token.  Only that exact shape is matched -- a computed
+    // default, extra keywords on the if(), a differently shaped condition are
+    // skipped rather than guessed at.  Needs ComTerp access to turn the
+    // literal token into a ComValue, unlike the two above.
     //
-    // Returns an AttributeList mapping each keyword's symid (only those
-    // with a recognized default) to its default ComValue. Always non-nil,
-    // possibly empty. Caller owns the returned list.
+    // Returns an AttributeList mapping each keyword's symid to its default,
+    // for those with a recognized one.  Always non-nil, possibly empty.
+    // Caller owns the list.
     static AttributeList* scan_defaults(ComTerp* comterp, postfix_token* toks, int ntoks, boolean* is_plain_var);
 };
 

--- a/src/ComTerp/helpfunc.c
+++ b/src/ComTerp/helpfunc.c
@@ -74,7 +74,7 @@ void HelpFunc::execute() {
   boolean* str_flags;
   int nfuncs = 0;
 
-  /* #334 (staged from #170 phase 1): help(f) where f is a bare, unfired
+  /* help(f) where f is a bare, unfired
      FuncObj -- parallel to comfuncs[]/command_ids[] above, populated only
      in the ordinary (non-:all/:top) branch below, since a user FuncObj is
      never a registered command and so can never appear via :all/:top's

--- a/src/ComTerp/iofunc.c
+++ b/src/ComTerp/iofunc.c
@@ -125,8 +125,7 @@ void PrintFunc::execute() {
   static int prefix_symid = symbol_add("prefix");
   ComValue prefixv(stack_key(prefix_symid));
 
-  /* cstr(), not string_ptr() -- formatstr can itself be a sliced string
-     (#395), and fstr backs fstrptr's scan through the whole multi-value
+  /* cstr(), not string_ptr() -- formatstr can itself be a sliced string, and fstr backs fstrptr's scan through the whole multi-value
      format string below (narg>1 branch); string_ptr() would read the
      shared parent's full text instead of just the slice's own window. */
   std::string fscratch;

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -144,17 +144,13 @@ void ListAtFunc::execute() {
      either way. */
   (void)rawflag;
 
-  /* str@lo:hi (#395): a coloned 2-element index into a string builds a
-     slice -- a StringType ComValue sharing str's own symid (so its memory
-     stays exactly as allocated, reachable at that symid) with an offset/
-     length window recorded via sliceoff()/slicelen() (comvalue.h) instead
-     of a copy.  lo/hi may have arrived as unresolved symbols (ColonListFunc
-     captures bare identifiers rather than looking them up), so each is run
-     through lookup_symval() here.  hi is exclusive, Go-style -- length is
-     hi-lo, and hi==cap is in bounds (an empty slice at the far end, same
-     as Go's s[len(s):len(s)]).  Not yet supported: writing through a slice
-     (:set/:ins/:del, or the #318 lhs_assign peek below) or slicing a plain
-     list/array -- both fall through to nil for now. */
+  /* str@lo:hi: a coloned 2-element index into a string builds a slice -- a
+     StringType ComValue sharing str's own symid, with an offset/length window
+     recorded via sliceoff()/slicelen() rather than a copy.  lo and hi may
+     arrive as unresolved symbols, so each goes through lookup_symval().  hi is
+     exclusive, Go-style: length is hi-lo, and hi==cap is in bounds.  Writing
+     through a slice, and slicing a plain list, are not supported and fall
+     through to nil. */
   if (listv.is_only_string() && nv.is_type(ComValue::ArrayType) && nv.coloned()) {
     AttributeValueList* range = nv.array_val();
     boolean forwrite = comterp()->stack_top(nkeys()+1).lhs_assign();
@@ -199,38 +195,27 @@ void ListAtFunc::execute() {
      list-valued index used to read as index 0 and hand back the first item,
      a wrong answer wearing a right one's clothes.  A stream of indices does
      fan out, through ordinary overdrive; whether the list spelling should
-     mean the same gather is #404.  Until then, say nil. */
+     mean the same gather is undecided.  Until then, say nil. */
   if (nv.is_array()) {
     reset_stack();
     push_stack(ComValue::nullval());
     return;
   }
 
-  /* #318 (@ operator): lst@N=val.  AssignFunc (assignfunc.c) flags this
-     call's own token with lhs_assign() when it's the before-part of an
-     assignment, before this execute() runs.  A plain list element is a
-     bare value, not a live handle the way an attrlist position's
-     Attribute* is -- an ordinary read here would hand AssignFunc a value
-     with no way back to 'lst'/N, so hand back a tiny [list, idx] pair
-     instead (lhs_assign() still set, so AssignFunc can tell it apart
-     from an ordinary array-valued read reaching here some other way).
-     AssignFunc completes the write by re-driving this same command with
-     a real :set keyword once it knows the rhs value, reusing the tested
-     :set logic below instead of duplicating it.  Guarded on a valid
-     (non-negative) index, same as the plain-read branch below -- a
-     negative index here is only ever the unary-minus sub-expression
-     "-N", not a literal, and that combination (a compound rhs sub-
-     expression + this lhs_assign peek/hand-back machinery) has a real,
-     reproducible stack-corruption bug somewhere in the general dispatch/
-     peek path, not in this command -- falling through to the ordinary
-     read below for that case avoids it entirely (matches this command's
-     own existing behavior for a negative read: nil, no mutation, no
-     crash). */
+  /* the @ operator: lst@N=val.  AssignFunc flags this call's token with
+     lhs_assign() when it is the before-part of an assignment.  A plain list
+     element is a bare value, not a live handle the way an attrlist position's
+     Attribute* is, so an ordinary read would leave AssignFunc no way back to
+     lst and N -- hand back a [list, idx] pair instead.  AssignFunc then
+     completes the write by re-driving this command with a real :set keyword,
+     reusing the logic below.  Guarded on a non-negative index: a negative one
+     here is always the sub-expression "-N", and that combination trips a
+     stack-corruption bug elsewhere in the dispatch path, so it falls through
+     to the ordinary read, which answers nil without mutating. */
   if ((listv.is_type(ComValue::ArrayType) || listv.is_only_string()) &&
       (nv.is_nil() || nv.int_val()>=0) &&
       comterp()->stack_top(nkeys()+1).lhs_assign()) {
-    /* a string takes the same route: its characters are writable in place
-       (#393), so s@N='c' has somewhere to write, and the pair carries the
+    /* a string takes the same route: its characters are writable in place, so s@N='c' has somewhere to write, and the pair carries the
        resolved index just as the list case does.  is_only_string(), not
        is_string(), keeps a symbol out -- its text is its identity. */
     int nvv;
@@ -318,18 +303,13 @@ void ListAtFunc::execute() {
 	    fprintf(stderr, "Insert not yet supported for AttributeList\n");
 	  } else if (setflag)
 	    *attr->Value() = setv;
-	  /* Return a detached, single-entry attrlist -- e.g. (:y 20) --
-	     not a live handle into al: al@n=val (#318's @ operator, pure
-	     sugar for this command) must never write through to al, and
-	     a bare positional read handing back a live Attribute* would
-	     make that unenforceable (AssignFunc's Attribute-lvalue branch
-	     writes through any live dotted pair on sight).  A plain
-	     AttributeList carries none of that write-through machinery,
-	     so al@n=val falls straight through to AssignFunc's generic
-	     non-writable-lvalue warning with no special-casing needed.
-	     attrname()/attrval() (dotfunc.c) accept this shape directly,
-	     using its one entry -- same as they've always accepted the
-	     dotted-pair Attribute* shape "." still produces. */
+	  /* return a detached single-entry attrlist, e.g. (:y 20), not a live
+	     handle into al: al@n=val must never write through, and handing back
+	     a live Attribute* would make that unenforceable, since AssignFunc
+	     writes through any dotted pair on sight.  A plain AttributeList has
+	     none of that machinery, so al@n=val reaches AssignFunc's ordinary
+	     non-writable-lvalue warning.  attrname()/attrval() accept this
+	     shape directly. */
 	  AttributeList* singleton = new AttributeList();
 	  singleton->add_attribute(new Attribute(attr->SymbolId(), new AttributeValue(*attr->Value())));
 	  ComValue retval(AttributeList::class_symid(), (void*)singleton);
@@ -341,21 +321,14 @@ void ListAtFunc::execute() {
     }
   } else if (listv.is_string()) {
     const char* str = listv.string_ptr();
-    /* a sliced listv (#395) indexes relative to its own window into the
-       shared parent buffer -- base offsets every read/write into it, and
-       cap is the slice's own length rather than the parent's capacity, so
-       indexing a slice can't read or write past its own bound into the
-       parent's neighboring bytes.  Reading or writing still goes through
-       the same shared storage as the parent (str+base), so a write here
-       stays visible through any other slice or the parent itself, same as
-       test 4 (colonslice.comt).  For an ordinary, unsliced string, this is
-       exactly the pre-#395 behavior: bounds-checked against capacity
-       (symbol_len(), the allocation's own byte count), not strlen() -- a
-       strlen()-based bound made every byte past the first NUL permanently
-       unreachable the moment one landed there (a fresh string(cap) buffer
-       is all NUL, so index 0 was "already past the end" before anything
-       was ever written), even though the underlying allocation still had
-       the room. */
+    /* a sliced listv indexes relative to its own window into the shared
+       parent buffer: base offsets every access, and cap is the slice's own
+       length rather than the parent's capacity, so a slice cannot reach past
+       its bound into neighboring bytes.  Storage is still shared, so a write
+       stays visible through the parent and any other slice.  Bounds are
+       checked against symbol_len(), the allocation's byte count, not
+       strlen() -- a strlen() bound would make every byte past the first NUL
+       unreachable, and a fresh string(cap) buffer is all NUL. */
     boolean isslice = listv.sliced();
     int base = isslice ? listv.sliceoff() : 0;
     int cap = isslice ? listv.slicelen() : symbol_len(listv.string_val());
@@ -372,7 +345,7 @@ void ListAtFunc::execute() {
     } else if (listv.is_only_string()) {
       /* is_string() is StringType||SymbolType, and a symbol's characters are
 	 its identity: every value holding that symid names the same text, so
-	 a write here would edit the symbol out from under all of them (#393).
+	 a write here would edit the symbol out from under all of them.
 	 Reads above stay open to both. */
       if(nvv<cap && nvv>=0) {
 	*((char *)str+base+nvv) = setv.char_val();
@@ -415,7 +388,7 @@ void ListSizeFunc::execute() {
       return;			  
     }
   } else if (listv.is_string() || listv.is_symbol()) {
-    /* a slice's own length (#395), not its shared parent's -- strlen()
+    /* a slice's own length, not its shared parent's -- strlen()
        would run past the slice's window into whatever the parent holds
        beyond it. */
     int len = listv.sliced() ? listv.slicelen() : (int)strlen(listv.symbol_ptr());
@@ -493,28 +466,18 @@ void ColonListFunc::execute() {
   ComValue lo(stack_arg(0, true));
   ComValue hi(stack_arg(1, true));
   reset_stack();
-  /* chained ':' flattens rather than nests -- 1:2:3 parses left-
-     associatively as (1:2):3, so by the time THIS call runs, lo is
-     already the coloned() 2-element list (1:2) built by the inner
-     call.  Appending hi onto that existing list, instead of always
-     wrapping lo in a fresh 2-element list, is what turns the chain
-     into one flat N-element list ({1,2,3}) rather than a nest
-     ({{1,2},3}) -- hr:min:sec (#423's other planned use) needs the
-     flat form to arrive at a future TimeObj consumer as 3 elements,
-     not 2-plus-1.
+  /* chained ':' flattens rather than nests.  1:2:3 parses left-associatively
+     as (1:2):3, so lo is already the coloned 2-element list by the time this
+     runs; appending hi to it, rather than wrapping lo again, yields one flat
+     {1,2,3} instead of {{1,2},3} -- which is what hr:min:sec needs to reach a
+     consumer as three elements.
 
-     Same nested_insert() guard TupleFunc (',') already uses, and for
-     the same reason (Greptile, #443): flattening in place is only
-     safe within ONE direct chain, evaluated as it's being built --
-     not onto a list some OTHER variable still points at.  x=1:2;
-     y=(x):3 would otherwise silently turn x into {1,2,3} too, since
-     lo and x share the same underlying AttributeValueList.  Nothing
-     ':'-specific needed to defend against that: eval_expr_internals
-     (comterp.c) already marks nested_insert(true) on any array pulled
-     back off a symbol table read, immediately before it's used as an
-     operator's first operand -- exactly the "this came from storage,
-     don't extend it in place" signal both operators need, and ':'
-     gets it for free by checking the same flag. */
+     Guarded by nested_insert(), the same flag TupleFunc uses and for the same
+     reason: flattening in place is safe only within one chain being built, not
+     onto a list another variable still points at.  x=1:2; y=(x):3 would
+     otherwise turn x into {1,2,3} as well, since both share the underlying
+     list.  eval_expr_internals already marks any array read back off the
+     symbol table, so ':' gets the signal for free. */
   if (lo.is_array() && lo.coloned() && !lo.array_val()->nested_insert()) {
     AttributeValueList* avl = lo.array_val();
     avl->Append(new AttributeValue(hi));
@@ -571,7 +534,7 @@ void ListIndexFunc::execute() {
 	  match =  comterp()->pop_stack().is_true();
 	} else {
 	  /* cstr(), not string_ptr() -- testv (a list element) or valv (the
-	     search value) can each independently be a slice (#395); a raw
+	     search value) can each independently be a slice; a raw
 	     string_ptr() would search the whole shared parent instead of
 	     just testv's/valv's own window. */
 	  std::string tscratch, vscratch;
@@ -596,7 +559,7 @@ void ListIndexFunc::execute() {
       };
       
   } else if (listorstrv.is_string()) {
-      /* cstr(), not string_ptr() -- listorstrv can be a slice (#395);
+      /* cstr(), not string_ptr() -- listorstrv can be a slice;
 	 the returned index stays relative to the slice's own window
 	 (position 0 of cstr()'s text), same convention split()/at()
 	 already use, not the shared parent's. */

--- a/src/ComTerp/numfunc.c
+++ b/src/ComTerp/numfunc.c
@@ -249,37 +249,23 @@ void AddFunc::execute() {
     case ComValue::StringType:
     case ComValue::SymbolType:
         { // braces are work-around for gcc-2.8.1 bug in stack mgmt.
-          /* Go-style append (#396): b's bytes go straight into operand1's
-             own backing symid, in place, when there's room -- no copy at
-             all.  operand1 must be_only_string() (StringType, never
-             SymbolType): a symbol's characters are its identity, shared by
-             every value holding that symid (#393), so writing through one
-             would corrupt everyone else's view.  An ordinary interned
-             string literal is excluded too, with no extra check needed --
-             its symid was sized to hold exactly its own text
-             (symbol_len()==strlen()), zero spare capacity, so the in-place
-             branch below never finds room and falls through to copy on its
-             own.  The in-place result is handed back as a slice
-             (sliceoff()/slicelen(), #395) over operand1's own symid, so a
-             caller holding operand1 at a nonzero sliceoff() doesn't have
-             its result misread from the front of the shared buffer.
+          /* Go-style append: b's bytes go into operand1's own backing symid
+             in place when there is room, with no copy.  operand1 must be
+             be_only_string(), never SymbolType -- a symbol's characters are
+             its identity, shared by every value holding that symid.  An
+             interned literal is excluded without an extra check, its symid
+             having been sized to exactly its own text, so the in-place branch
+             finds no room and falls through.  The result is handed back as a
+             slice over operand1's symid, so a caller holding it at a nonzero
+             sliceoff() does not read from the front of the shared buffer.
 
-             The fallback copy path intentionally still goes through
-             symbol_add() (dedup/intern by content), exactly like the
-             pre-#396 concatenation it replaces -- NOT symbol_new()'s
-             fresh, non-deduping, unfindable-by-text buffer.  Tried
-             symbol_new() with amortized (2x) headroom first, matching
-             #396's memory design note; it broke symadd()/global()'s
-             existing assumption that a StringType's own symid already
-             names a searchable symbol (symadd(global(p1)+global(p2)) --
-             global.comt test 11), since a symbol_new() id is deliberately
-             absent from symbol_find()'s reverse index (see symbol_new()'s
-             own doc comment, symbols.c).  So a plain concat -- not
-             starting from an already-over-allocated string()/strcap()
-             buffer -- gets no free growth headroom and must copy again on
-             its own next append, same as it always did; only appending
-             onto a deliberately over-provisioned string() buffer gets the
-             true zero-copy path above. */
+             The fallback copy goes through symbol_add(), which interns by
+             content, rather than symbol_new(), whose ids are deliberately
+             absent from symbol_find()'s reverse index -- symadd() and global()
+             rely on a StringType's symid naming a searchable symbol.  So a
+             plain concat gets no growth headroom and copies again on its next
+             append; only appending onto an over-provisioned string() buffer
+             takes the zero-copy path. */
           std::string scratch1, scratch2;
           const char* s1 = operand1.cstr(scratch1);
           int len1 = operand1.sliced() ? operand1.slicelen() : (int)strlen(s1);
@@ -293,7 +279,7 @@ void AddFunc::execute() {
             int len2 = operand2.sliced() ? operand2.slicelen() : (int)strlen(s2);
             if (growable && end1+len2 < cap1) {
               char* buf = (char*)symbol_pntr(operand1.symbol_val());
-              /* memmove, not memcpy (Greptile, #440): operand2 can share
+              /* memmove, not memcpy: operand2 can share
                  operand1's own backing symid -- e.g. appending an unsliced
                  buf onto a nonzero-offset slice of that same buf -- in
                  which case s2 (read via cstr() above) points into this

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -396,12 +396,12 @@ void FuncObjFunc::execute() {
     FuncObj* tokbufobj = new FuncObj(tokbuf, toklen);
     tokbufobj->posteval(postevalv.is_true());
 
-    /* #310: capture this body's free variables (read-only or
-       read-before-write, per #170's taxonomy -- see funcobjscan.h) at
+    /* capture this body's free variables (read-only or
+       read-before-write -- see funcobjscan.h) at
        declaration time, so a later fire sees the value that was live now,
        not whatever's live at call time.  is_plain_var[i] tells the
        classifier which tokens are ordinary variable references rather
-       than registered commands -- built by the same shared helper #170's
+       than registered commands -- built by the same shared helper the help path's
        :help fire-time analysis uses (FuncObjVarScan::build_is_plain_var),
        not reimplemented here. */
     boolean* is_plain_var = FuncObjVarScan::build_is_plain_var(comterp(), tokbuf, toklen);
@@ -421,12 +421,10 @@ void FuncObjFunc::execute() {
       int kind = attr->Value()->int_val();
       if (kind == FuncObjVarScan::ReadOnly || kind == FuncObjVarScan::ReadBeforeWrite) {
 	if (!captures) captures = new AttributeList();
-	/* lookup_symval(int) only checks localtable() -- the full
-	   fallthrough an ordinary read actually uses (_alist, then
-	   localtable unless global_flag, then globaltable) is the
-	   ComValue& overload; anything narrower under-captures (e.g. a
-	   name set only via global()=, confirmed live via global.comt
-	   test 13's "Unknown add operand" failure before this fix). */
+	/* lookup_symval(int) checks localtable() only; the full fallthrough an
+	   ordinary read uses -- _alist, then localtable unless global_flag,
+	   then globaltable -- is the ComValue& overload.  Anything narrower
+	   under-captures a name set only through global()=. */
 	ComValue symval(attr->SymbolId(), ComValue::SymbolType);
 	ComValue curval(comterp()->lookup_symval(symval));
 	captures->add_attr(attr->SymbolId(), curval);

--- a/src/ComTerp/postfunc.h
+++ b/src/ComTerp/postfunc.h
@@ -191,7 +191,7 @@ class FuncObj {
   postfix_token* toks() { return _toks; }
   int ntoks() { return _ntoks; }
 
-  // Free variables captured at declaration time (#310) -- an AttributeList
+  // Free variables captured at declaration time -- an AttributeList
   // wrapped in a ComValue so its constructor/destructor manage the
   // AttributeList refcount automatically (see HACKING.md's "Resource
   // ref/unref and AttributeValue Constructors" -- do not add manual

--- a/src/ComTerp/strmfunc.c
+++ b/src/ComTerp/strmfunc.c
@@ -299,19 +299,13 @@ void StreamFunc::execute_literal() {
     skip_key_in_expr(rescan, argcnt);
   }
 
-  /* fixed-format (positional) args first.
-     skip_arg_in_expr walks the postfix buffer BACKWARD from the command,
-     so pi=0 discovers the LAST source positional, pi=1 the second-to-last,
-     etc -- discovery order is the reverse of source order.  tokbuf (from
-     copy_post_eval_expr) is in FORWARD source order, so a naive running
-     elem_offset assigns (offset,count) pairs as if discovery order matched
-     tokbuf order -- correct only when all positionals are the same width
-     (e.g. (10 20 30), or ((1 2 3)(4 5 6)) where both elements are width 3),
-     and silently wrong for mixed-width elements like (1 (2 3)).
-
-     Fix: collect each pi's size, then compute true forward offsets via a
-     reverse-accumulation pass, and append to the AVL in reverse-pi order
-     so AVL element 0 corresponds to source positional 0. */
+  /* fixed-format (positional) args first.  skip_arg_in_expr walks the postfix
+     buffer backward from the command, so discovery order is the reverse of
+     source order, while tokbuf is in forward source order.  A running offset
+     would therefore be right only when every positional is the same width,
+     and silently wrong for a mixed-width case like (1 (2 3)).  So collect each
+     size, compute forward offsets by reverse accumulation, and append in
+     reverse-pi order, leaving AVL element 0 as source positional 0. */
   int* possizes = npositionals>0 ? new int[npositionals] : nil;
   for (int pi = 0; pi < npositionals; pi++) {
     argcnt = 0;
@@ -382,14 +376,11 @@ void SpreadFunc::execute() {
     if (operand1.is_array())
       avl = new AttributeValueList(operand1.array_val());
     else if (operand1.is_attributelist()) {
-      /* an attrlist spreads into KEYWORDS: stream its attributes, and the
-         expansion turns each back into a real ":key value" keyword.  Store an
-         OWNED COPY of each Attribute -- new Attribute(*attr) deep-copies the
-         value it owns -- NOT a raw pointer into the source attrlist.  A ~~ stream
-         is drained later (at the enclosing call), by which point the source
-         attrlist could be freed (unlike $$, which drains immediately), so the
-         stream must carry its own copies -- same reason the is_array path
-         copies the list. */
+      /* an attrlist spreads into keywords: stream its attributes, and the
+         expansion turns each back into a real ":key value".  Store an owned
+         copy of each Attribute rather than a pointer into the source list: a
+         ~~ stream drains later, at the enclosing call, by which point the
+         source attrlist may be gone. */
       avl = new AttributeValueList();
       AttributeList* al = (AttributeList*)operand1.obj_val();
       Iterator i;
@@ -409,13 +400,11 @@ void SpreadFunc::execute() {
 
   reset_stack();
 
-  /* Tag for spread and leave exactly ONE value on the stack.  The expansion
-     happens in eval_expr_internals, upstream of the command/funcobj dispatch,
-     which drains this tagged stream into the enclosing call's positionals.  So
-     ~~ obeys the one-value-per-func rule -- it never leaves the stack
-     unbalanced -- and works for any consumer (eager command OR funcobj), not
-     just the one dispatch branch push-N happened to patch.  The stream isn't
-     drained here at all; it's just flagged and handed on. */
+  /* tag for spread and leave exactly one value on the stack.  The expansion
+     happens in eval_expr_internals, upstream of dispatch, which drains the
+     tagged stream into the enclosing call's positionals -- so ~~ obeys the
+     one-value-per-func rule and works for any consumer, eager command or
+     funcobj alike.  Nothing is drained here; the stream is only flagged. */
   operand1.stream_mode(operand1.stream_mode() | STREAM_SPREAD);
   push_stack(operand1);
 }
@@ -638,14 +627,12 @@ void RepeatFunc::execute() {
       return;
     }
 
-    /* no bail-out for a stream operand here.  It read as a depth limit, but
-       overdrive has already unwrapped a level by the time this sees a stream,
-       so it fired on every stream operand and returned nullval from a
-       construction context -- which left the stack wrong ("func list pushed
-       more than a single value on stack"), not a clean nil.  Building the
-       repeat stream instead yields the operand's values; what a repeated
-       cursor still lacks is re-arm, so passes after the first come back
-       exhausted.  That is replay's business, not nesting's. */
+    /* no bail-out for a stream operand.  Overdrive has already unwrapped a
+       level by the time this sees a stream, so bailing fires on every stream
+       operand and returns nullval from a construction context, leaving the
+       stack unbalanced rather than a clean nil.  Build the repeat stream
+       instead; a repeated cursor still lacks re-arm, so passes after the
+       first come back exhausted -- that is replay's business. */
 
     ComValue operand2(stack_arg(1));
     reset_stack();
@@ -797,16 +784,11 @@ void IterateFunc::execute() {
       return;
     }
 
-    /* a non-stream, non-numeric operand (e.g. a plain array/list passed
-       where a stream was expected -- (1,2,3) is an ArrayType literal, not
-       a stream, so it never triggers the caller's broadcast/overdrive
-       packing and arrives here whole) must not fall through to int_val()/
-       int_ref() below: those blindly reinterpret whatever's in the
-       operand's union as an int, and for an ArrayType/ObjectType value
-       that union slot is a real heap pointer -- int_ref()++ on the drive-
-       forward branch corrupts that pointer in place, crashing on the next
-       dereference (segfault repro, issue #344). Fail gracefully instead,
-       same as the already-nil case just above. */
+    /* a non-stream, non-numeric operand -- (1,2,3) is an ArrayType literal
+       rather than a stream, so it arrives whole -- must not fall through to
+       int_val()/int_ref() below.  Those reinterpret the operand's union as an
+       int, and for an ArrayType or ObjectType that slot holds a heap pointer,
+       which int_ref()++ would corrupt in place.  Fail gracefully instead. */
     if (!operand1.is_num() || !operand2.is_num()) {
       push_stack(ComValue::nullval());
       return;
@@ -851,7 +833,7 @@ void NextFunc::execute_impl(ComTerp* comterp, ComValue& streamv) {
        re-checked in place within this same call frame; the earlier version
        restarted by calling execute_impl(streamv) again, which re-entered
        the C++ call stack once per element and could exhaust it given a
-       sufficiently long run (flagged in #288 review). */
+       sufficiently long run. */
     {
       AttributeValueList* avl = streamv.stream_list();
       for (;;) {
@@ -1219,7 +1201,7 @@ void StreamLiteralNextFunc::execute() {
          Resource::ref(al) here: the ComValue (classid, ptr) constructor
          already refs AttributeList payloads, and an extra unmatched ref
          pinned one singleton per keyword-element drain forever -- the
-         same born-ref bug fixed in ListFunc::execute (PR #208). */
+         same born-ref bug fixed in ListFunc::execute. */
       AttributeList* al = new AttributeList();
       al->add_attr(key_symid, keyval);
       ComValue result(AttributeList::class_symid(), (void*)al);
@@ -1268,11 +1250,11 @@ void InfoFunc::execute() {
        [2..]  element entries: positional = (offset,count) = 2 slots;
               keyword = KeywordType marker [+ (offset,count) if it has a value]
 
-     :raw returns the raw internal list directly -- layout-agnostic, so it works
-     unchanged as the directory evolves and is the probe used by regression
-     tests.  Without :raw, a named-field AttributeList is returned describing the
-     directory in the layout above.  Non-literal streams report (:mode "external"
-     :func `funcname) since their list layouts differ. */
+     :raw returns the raw internal list directly, which is layout-agnostic and
+     so keeps working as the directory evolves.  Without :raw, a named-field
+     AttributeList describes the directory in the layout above.  Non-literal
+     streams report (:mode "external" :func `funcname), their list layouts
+     being different. */
 
   /* fetch :raw from the post-eval region BEFORE reset_stack() clears it.
      InfoFunc is post_eval, so the keyword lives in the post-eval buffer. */
@@ -1427,16 +1409,12 @@ void FeedFunc::execute() {
     argv[0].stream_func() == (void*)fnfunc;
 
   if (arg0_is_fifo) {
-    /* append the remaining args to the existing FIFO's back end -- a
-       stream-valued arg is tagged STREAM_NESTED so NextFunc::execute_impl's
-       existing nested-stream unwrap (strmfunc.c ~750) drains it lazily, one
-       value per next(), instead of handing back the raw undrained stream.
-       _stream_mode and _command_symid share the same union slot (attrvalue.h),
-       so AttributeValue::assignval()'s `_command_symid = av._command_symid`
-       already carries a stream's mode across a copy -- the OR-in of
-       STREAM_NESTED below is applied to `elt` (the stored copy) rather than
-       to argv[i] simply to avoid mutating the shared source value; either
-       order would copy correctly. */
+    /* append the remaining args to the existing FIFO's back end.  A stream-
+       valued arg is tagged STREAM_NESTED so the nested-stream unwrap in
+       NextFunc::execute_impl drains it lazily, one value per next(), rather
+       than handing back the raw stream.  _stream_mode shares a union slot with
+       _command_symid, so assignval() already carries the mode across a copy;
+       the tag goes on the stored copy only to leave the source untouched. */
     AttributeValueList* avl = argv[0].stream_list();
     for (int i=1; i<n; i++) {
       /* a string is ingested as its characters, by becoming the same cursor

--- a/src/ComTerp/strmfunc.h
+++ b/src/ComTerp/strmfunc.h
@@ -118,8 +118,8 @@ public:
 //                                 directory: func, ntoks, nremaining,
 //                                 elemN_off/elemN_cnt..., nelem.  Non-literal
 //                                 streams report (:mode :func).
-// lst=info(streamobj :raw) -- the raw internal directory list, layout-
-//                                 agnostic; the probe used by regression tests.
+// lst=info(streamobj :raw) -- the raw internal directory list, which is
+//                                 layout-agnostic.
 class InfoFunc : public StrmFunc {
 public:
     InfoFunc(ComTerp*);

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -113,7 +113,7 @@ void SymAddFunc::execute() {
     if (val.is_type(AttributeValue::CommandType))
       symbol_ids[i] = val.command_symid();
     else if (val.is_type(AttributeValue::StringType))
-      /* symbol_add(), not val.string_val() (#396 fallout) -- a StringType's
+      /* symbol_add(), not val.string_val() -- a StringType's
 	 own symid is no longer guaranteed to already be a proper, findable
 	 symbol the way it always was pre-string()/strcap(): a writable
 	 buffer's symid is deliberately private, absent from symbol_find()'s
@@ -124,7 +124,7 @@ void SymAddFunc::execute() {
 	 while every string happened to already be one.  cstr() reads the
 	 text slice-aware, so this is also the fix for symadd() on a sliced
 	 string reading the parent's whole text instead of the slice's own
-	 window, a latent bug independent of #396. */
+	 window, a latent bug of its own. */
       symbol_ids[i] = symbol_add(val.cstr(scratch));
     else if (val.is_type(AttributeValue::SymbolType))
       symbol_ids[i] = val.symbol_val();
@@ -347,7 +347,7 @@ void SplitStrFunc::execute() {
   if (symvalv.is_string()) {
     AttributeValueList* avl = new AttributeValueList();
     ComValue retval(avl);
-    /* cstr(), not symbol_ptr() -- symvalv can be a slice (#395), and
+    /* cstr(), not symbol_ptr() -- symvalv can be a slice, and
        everything below reads the input purely through this one str
        pointer, walked forward, so this is the only place that needs to
        change for the whole function to split just the slice's own text

--- a/src/ComTerp/typefunc.h
+++ b/src/ComTerp/typefunc.h
@@ -133,7 +133,7 @@ public:
       return "flag=%s(var :sym) -- true if var holds a func(), without evaluating it"; }
 };
 
-//: true if var is a StringType sliced from another string (#395).
+//: true if var is a StringType sliced from another string.
 // flag=isslice(var) -- unlike istype()/isclass()/iscomm()/isfunc(), var
 // is evaluated normally: this tests the shape of a value, not a bare
 // symbol's own binding, so isslice(s@2:5) works on the slice expression's
@@ -144,7 +144,7 @@ public:
     virtual void execute();
 
     virtual const char* docstring() {
-      return "flag=%s(var) -- true if var is a string sliced from another string (#395)"; }
+      return "flag=%s(var) -- true if var is a string sliced from another string"; }
 };
 
 //: true if var is list-shaped -- an ArrayType (comma- or colon-built) or

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "5a90e6d3"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Comments only. No code touched. `run_all.comt` and `char.comt` both green.

Half a year of work left about 1200 lines of added comment in `src/ComTerp/`, and much of it was reasoning that belongs in the issue tracker rather than beside the code.

**1055 lines out, 569 in, across 24 files.**

### What went

- **Every issue and PR reference.** 53 comment lines carried `#NNN` or a Greptile citation; the library now has none. Where the number was woven into a sentence it was reworded, not just deleted.
- **Accounts of how a bug was found.** "Confirmed live: without this guard, …", "observed as … which is what made this so hard to pin down", "Tried `symbol_new()` with 2x headroom first; it broke …".
- **Which test failed before the fix.** `attrlist.comt test 43`, `global.comt test 13`, `posteval.comt test 10`, and a commit SHA.
- **Pointers into other libraries** that only mattered while chasing one problem — and one comment that cited a file outside the repository entirely.

### What stayed

The local hazard, which is what a reader of the function actually needs:

- why `cstr()` and not `string_ptr()` — the latter isn't slice-aware and reads the whole shared parent string
- why the result of a fire goes in a fresh pool slot rather than one reused slot — a caller holding two operands would have the second overwrite the first
- why `sizeof(token->v)` and not `sizeof(_v)` — the source union is 8 bytes, the destination 16
- why an `ArrayType` operand must not reach `int_ref()` — that union slot holds a heap pointer

Layout documentation stayed too: the stream directory's slots, the AVL element encoding, `attrname()`/`attrval()`'s two accepted shapes.

### Baseline comments

The window is commits since 2026-03-01, but the scope was checked per comment, not per file. Of the 1050 comment lines removed, **exactly one predates the window** — and only because a new paragraph had been appended to an original comment. That original sentence is restored verbatim and only the addition trimmed:

```
// look up a pointer to an AttributeValue associated with a symbol
// (specified in the input ComValue) in the local or global symbol
// tables.  Do not alter the input ComValue.  'freeze' governs a still-
// pending :posteval keyword: ...
```

`funcobjscan.h` and `postfixspan.h` did not exist at baseline at all.