### PR TITLE
Cut the ComUtil comments back the same way

### DIFF
--- a/src/ComUtil/_lexscan.c
+++ b/src/ComUtil/_lexscan.c
@@ -266,21 +266,14 @@ int bs_ident = 0;
 	     (*outfunc) ( get_command_prompt(), outfile);
 	 }
 	 _continuation_prompt = 0;
-	 /* self-echo: with the OS's own tty echo suppressed (tty_echo_off(),
-	    ttyecho.c -- issue #76), nothing else shows what was just read,
-	    typed or pasted.  Echo it here, right where each line becomes
-	    known, so it stays correctly interleaved with each line's own
-	    result even for a multi-line paste that the OS would otherwise
-	    have dumped to the screen all at once, well before this point.
-	    Gated on !_continuation_prompt_disabled, same as the prompt print
-	    above -- a caller that's already asking for no prompt (e.g. a
-	    piped/non-interactive script) wants no echo of its own either.
-	    Also gated on the one-shot suppress-next flag (ttyecho.c) -- see
-	    its comment for why that, and not a held-open disable_prompt(),
-	    is what's safe to use around a single internal eval like
-	    comdraw/drawserv's startup seed update(); consumed here exactly
-	    once regardless of whether this line turns out to be a comment
-	    or the real one, so it only ever swallows the next line read. */
+	 /* self-echo: with the OS's tty echo suppressed, nothing else shows
+	    what was just read.  Echoing here, where each line becomes known,
+	    keeps it interleaved with that line's own result even for a
+	    multi-line paste the OS would have dumped all at once.  Gated on
+	    !_continuation_prompt_disabled, as the prompt print above is -- a
+	    caller wanting no prompt wants no echo either -- and on the one-shot
+	    suppress-next flag, which is consumed here exactly once, so it only
+	    ever swallows the next line read. */
 	 /* tty_echo_before_read() hands echo back to the OS when nothing is
 	    buffered, so typing is visible and line-edited normally; each read
 	    is followed by tty_echo_after_read(), which suppresses echo for the
@@ -289,9 +282,8 @@ int bs_ident = 0;
 	 { int echo_suppressed = tty_echo_consume_suppress_next();
 	   int self_echo = 0;
 	   /* only when this lexer is reading the terminal itself.  A string
-	      source (ComTerpServ::s_fgets -- comdraw/drawserv, and every
-	      internal eval such as the startup update() seed) must leave the
-	      tty alone, or it turns echo off with nothing to turn it back on. */
+	      source must leave the tty alone, or it turns echo off with
+	      nothing to turn it back on. */
 	   int on_tty = (infile == (void*)stdin);
 	 if (linecmtchr || linecmtstr)
 	   while( (on_tty ? tty_echo_before_read() : (void)0,
@@ -1014,13 +1006,11 @@ token_return:
 /* ----------------------------------------------------------------------- */
 
    *toktype = token_state;
-   /* recorded in true document-scan order, unlike the *toktype and
-      *bufptr output params themselves -- _parser.c's lookahead can call
-      scanner() (and so lexscan()) more than once per token it hands the
-      caller, so by the time a caller reads those params back they may
-      reflect whichever call happened to run last, not "the token
-      immediately before this one" in source order (#423, trailing-side
-      colon scanner surgery -- see _scanner.c's use of these). */
+   /* recorded in true document-scan order, unlike the *toktype and *bufptr
+      output params: lookahead can call scanner(), and so lexscan(), more than
+      once per token handed to the caller, so those params may reflect
+      whichever call ran last rather than the token immediately before this
+      one in source order. */
    _lexscan_last_tokend = *bufptr;
    _lexscan_last_toktype = token_state;
    return FUNCOK;

--- a/src/ComUtil/_scanner.c
+++ b/src/ComUtil/_scanner.c
@@ -141,21 +141,17 @@ int search_state = LOOK_START; /* State of what has been found */
                                       /* in error file */
 int status;
 
-/* #423 (trailing side): a ':' immediately touching the end of a
-   completed operand -- no whitespace between them -- reads as an infix
-   operator (a:b, a range/pair), not the start of a fresh ":keyword".
-   Real ":keyword" usage never glues the colon directly onto a preceding
-   value with zero space (it's always its own space-separated argument,
-   or the first thing after an opening delimiter like '(' -- both of
-   which stay eligible for the merge below, since neither token type is
-   in the whitelist).  Read from _lexscan_last_tokend/_toktype
-   (_lexscan.c), NOT the *bufptr and *toktype output params below -- those
-   get overwritten by this very function's own lexscan() calls (and by
-   whatever lookahead _parser.c does across separate scanner() calls),
-   so by now they may no longer hold the true previous token in source
-   order.  _lexscan_last_* are updated in exactly one place, lexscan()'s
-   own common return path, so they always reflect the last real token
-   actually scanned off the input, regardless of caller-side lookahead. */
+/* a ':' touching the end of a completed operand, with no whitespace between,
+   reads as an infix operator -- a:b, a range or pair -- rather than the start
+   of a fresh ":keyword".  Real keyword usage never glues the colon onto a
+   preceding value: it is always space-separated, or the first thing after an
+   opening delimiter, and both stay eligible for the merge below.
+
+   Read from _lexscan_last_tokend/_toktype, not the *bufptr and *toktype output
+   params, which this function's own lexscan() calls overwrite -- and which
+   caller-side lookahead can overwrite too, so they may no longer hold the
+   previous token in source order.  _lexscan_last_* is updated in exactly one
+   place, lexscan()'s common return path. */
 unsigned prev_tokend = _lexscan_last_tokend;
 unsigned prev_toktype = _lexscan_last_toktype;
 
@@ -239,25 +235,13 @@ unsigned prev_toktype = _lexscan_last_toktype;
                break;
 
             case ':' :
-               /* Only TOK_IDENTIFIER, deliberately -- real ":keyword"
-                  usage always has a space before it (at(r 0 :raw),
-                  colonlist.comt test 4), so that spacing was never at
-                  risk from this check either way, whatever the
-                  preceding token's type.  The question is only what a
-                  number or closing delimiter glued straight onto a
-                  keyword with NO space (at(lst 0:raw), f():key) ought
-                  to mean, since nothing establishes that today one way
-                  or the other; tried including them in this whitelist
-                  and it read that hypothetical shape as a colon-pair
-                  instead of a keyword, on the reasoning that a keyword
-                  glued to a preceding value with zero space isn't
-                  something anyone currently writes -- backed off rather
-                  than take on an ambiguity nothing forces a call on. An
-                  identifier glued to a colon the same way IS the shape
-                  #423 needs (confirmed via the full run_all.comt suite:
-                  nothing relies on one being glued to a keyword
-                  either), so it's the one case narrow enough to claim
-                  outright. */
+               /* TOK_IDENTIFIER only, deliberately.  Real ":keyword" usage
+                  always has a space before it, so that spacing is not at risk
+                  here whatever the preceding token.  What a number or closing
+                  delimiter glued straight onto a keyword should mean --
+                  at(lst 0:raw), f():key -- is undecided, and nothing forces
+                  the call, so those stay out of the whitelist.  An identifier
+                  glued to a colon is the one shape narrow enough to claim. */
                if( isident( buffer[*bufptr] ) &&
                    !( prev_tokend == *tokstart &&
                       prev_toktype == TOK_IDENTIFIER ))

--- a/src/ComUtil/errsys.c
+++ b/src/ComUtil/errsys.c
@@ -213,12 +213,10 @@ See Also:  err_read, err_set, err_get, err_print, err_str, err_clear,
     }
 
     if (!fptr) {
-	/* RELLIBALLDIR/ABSLIBALLDIR are preprocessor macros supplied by
-	   -D flags in ComUtil/Imakefile, substituted with the real
-	   install paths at compile time -- bare here, not quoted, so the
-	   preprocessor actually expands them (a macro name inside a
-	   string literal is never macro-expanded, which is why this used
-	   to always look for a literal file named "RELLIBALLDIR"). */
+	/* RELLIBALLDIR/ABSLIBALLDIR are preprocessor macros supplied by -D
+	   flags in the Imakefile, carrying the real install paths.  Bare here
+	   rather than quoted, so the preprocessor expands them: a macro name
+	   inside a string literal is never expanded. */
 	strcpy( fullpath, RELLIBALLDIR );
 	if (fullpath[strlen(fullpath)-1] != '/') strcat( fullpath, "/" );
 	strcat( fullpath, errfile );

--- a/src/ComUtil/optable.c
+++ b/src/ComUtil/optable.c
@@ -116,30 +116,20 @@ struct _opr_tbl_default_entry {
   // "@"(77), so lo:hi groups before @ applies (str@0:3 reads as str@(0:3),
   // not (str@0):3).  "colonlist" is registered as a command separately.
   {":",          "colonlist",          78,         FALSE,      OPTYPE_BINARY },
-  // "@" as sugar for at(): lst@0 == at(lst 0), lst@0@1@2 chains (LtoR).
-  // Deliberately its own operator, not folded into ".": a numeric rhs on
-  // "." would need the same digit-continuation special-casing "." picked
-  // up trying this once already (see #318/#319, closed) -- "@" carries
-  // none of that baggage, since '@' is never part of any number's own
-  // syntax, so lst@0@1@2 can never collide with float literals the way
-  // lst.0.1.2 did.  Priority 77, NOT tied to "."(130): placed just below
-  // the numeric stream-producing operators (..=90, **=80, %%=79) so a
-  // range/repeat/replay expression indexes directly without parens --
-  // lst@0..10, lst@0**3, lst@s%%2 -- while staying above plain arithmetic
-  // (60-70) so lst@i+1 and lst@i*2 still read as (lst@i)+1/(lst@i)*2, the
-  // far more common case.  ","," (concat, 75) is stream-structural, not
-  // numeric, so it isn't part of this band either way; "@" ended up on the
-  // tight side of it (77 > 75) as a side effect of sitting under %%, not
-  // by any requirement of its own.
+  // "@" as sugar for at(): lst@0 == at(lst 0), and lst@0@1@2 chains left to
+  // right.  Its own operator rather than a numeric rhs on ".", since '@' is
+  // never part of a number's syntax and so cannot collide with float literals
+  // the way lst.0.1.2 does.  Priority 77 sits just below the stream-producing
+  // operators (..=90, **=80, %%=79), so lst@0..10 and lst@0**3 index without
+  // parens, and above arithmetic (60-70), so lst@i+1 still reads as
+  // (lst@i)+1 -- much the commoner case.
   {"@",          "at",                 77,         FALSE,      OPTYPE_BINARY },
   {",,",         "concat",             75,         FALSE,      OPTYPE_BINARY },
-  // "next" sits one above "mpy" (71 vs 70), not level with it: when the
-  // parser resolves "2 * *s" (no parens) it must settle each * token's role
-  // -- binary vs unary-prefix -- before either can be pushed, and an exact
-  // priority tie between the two roles of the same operator string makes it
-  // misparse (the binary mpy gets emitted before its right operand is even
-  // read).  One point of separation is enough for the unary role to declare
-  // itself distinctly; see starnext.comt test 3b.
+  // "next" sits one above "mpy" (71 vs 70) rather than level with it: parsing
+  // "2 * *s" means settling each * token's role, binary or unary-prefix,
+  // before either can be pushed, and an exact tie between the two roles of the
+  // same operator string misparses -- the binary mpy is emitted before its
+  // right operand is read.  One point of separation is enough.
   {"*",          "next",               71,         TRUE,       OPTYPE_UNARY_PREFIX },
   {"%",          "mod",                70,         FALSE,      OPTYPE_BINARY },
   {"*",          "mpy",                70,         FALSE,      OPTYPE_BINARY },

--- a/src/ComUtil/ttyecho.c
+++ b/src/ComUtil/ttyecho.c
@@ -23,31 +23,20 @@
 /*
 ttyecho.c        stdin echo control for interactive comterp/comdraw/drawserv
 
-Summary:         The OS's own cooked-mode tty echo displays every pasted
-                  character the instant it lands in the kernel input
-                  buffer -- before the application ever calls read(), and
-                  well before it's ready to interleave that text with each
-                  line's own result.  For a multi-line paste, this dumps
-                  the whole block to the screen at once, then the
-                  interpreter works through it one line at a time
-                  afterward, leaving the (comt) prompts and results out of
-                  sync with the echoed text (issue #76).
+Summary:         The OS's cooked-mode tty echo displays every pasted character
+                  the instant it lands in the kernel input buffer, before the
+                  application calls read().  For a multi-line paste that puts
+                  the whole block on screen at once, while the interpreter
+                  works through it a line at a time afterward, leaving the
+                  prompts and results out of sync with the echoed text.
 
-                  tty_echo_off() disables only the OS's ECHO bit (ICANON
-                  stays set -- line editing, backspace, Ctrl-U etc. still
-                  work exactly as before); the caller is then responsible
-                  for echoing each line itself at the moment it becomes
-                  known, which is exactly what _lexscan.c does immediately
-                  after each successful infunc() read (see tty_echo_is_off()).
-                  This keeps echo and execution correctly interleaved
-                  regardless of whether the line arrived by typing or by
-                  paste, and whether it's read via a blocking fgets loop
-                  (plain comterp) or one byte at a time from a reactor
-                  callback (comdraw/drawserv's ComterpHandler) -- the OS
-                  echo suppression and the self-echo both operate on
-                  whole lines either way.
-
-History:         Added for issue #76, July 2026
+                  tty_echo_off() clears only the ECHO bit -- ICANON stays set,
+                  so line editing still works -- and the caller then echoes
+                  each line itself as it becomes known, which is what
+                  _lexscan.c does after each successful read.  That keeps echo
+                  and execution interleaved whether the line was typed or
+                  pasted, and whether it is read by a blocking fgets loop or a
+                  byte at a time from a reactor callback.
 */
 
 #include <stdio.h>
@@ -91,17 +80,15 @@ void tty_echo_off(void) {
 
 int tty_echo_is_off(void) { return _tty_echo_off; }
 
-/* Echo is held off only while a line is being executed, not for the whole
-   session (issue #76 did the latter, which left typing invisible in a raw
-   terminal -- ICANON gives the app nothing until Return, so with ECHO clear
-   nobody shows the keystrokes).  Waiting at the prompt runs with ECHO on, so
-   the OS shows typing and does its own line editing.
+/* echo is held off only while a line is executing, not for the whole session:
+   ICANON gives the application nothing until Return, so clearing ECHO for the
+   duration leaves typing invisible.  Waiting at the prompt runs with ECHO on,
+   so the OS shows typing and does its own line editing.
 
-   The cost is that a paste landing at an idle prompt is echoed by the OS as
-   one block.  Those bytes are already on screen, so self-echoing them as they
-   are consumed would show them twice; _pre_echoed records how many bytes were
-   already pending -- and therefore already echoed -- at the moment echo went
-   off, and they are charged off line by line. */
+   The cost is that a paste landing at an idle prompt is echoed by the OS as one
+   block, and self-echoing those bytes as they are consumed would show them
+   twice.  _pre_echoed records how many were already pending, and therefore
+   already echoed, when echo went off; they are charged off line by line. */
 static long _pre_echoed = 0;
 void tty_echo_hold(void);
 
@@ -146,17 +133,13 @@ void tty_echo_hold(void) {
 }
 
 
-/* One-shot self-echo suppression for a single internal, not-typed-by-the-
-   user eval -- e.g. comdraw/drawserv's startup seed update(1000000).  NOT
-   a general "disable prompt for the duration of a call" mechanism: unlike
-   disable_prompt()/enable_prompt() (_parser.c), which stay set for as long
-   as the caller holds them open, this flag is consumed and cleared the
-   instant _lexscan.c reads the very next line -- during read_expr(), which
-   runs to completion before eval_expr() (and whatever event-loop pumping
-   the evaluated command does) ever starts.  So it never overlaps the
-   window where a reentrant stdin event could observe it still set; a
-   held-open flag spanning the whole call does (see issue #76 history --
-   that's what broke comdraw's own reentrant-paste handling when tried). */
+/* one-shot self-echo suppression for a single internal eval the user did not
+   type.  Not a general "disable prompt for the duration of a call": unlike
+   disable_prompt(), which stays set as long as the caller holds it open, this
+   flag is consumed the instant the next line is read, during read_expr(),
+   which completes before eval_expr() and any event-loop pumping begins.  So it
+   never overlaps the window where a reentrant stdin event could observe it
+   still set, which a held-open flag would. */
 static int _suppress_next_echo = 0;
 
 void tty_echo_suppress_next(void) { _suppress_next_echo = 1; }
@@ -167,16 +150,13 @@ int tty_echo_consume_suppress_next(void) {
     return flag;
 }
 
-/* atexit() (tty_echo_off()'s own registration) and the explicit call in
-   ComTerp::exit() (comterp.c, ahead of its deliberate _exit()) both cover
-   an orderly exit -- neither runs when the process dies by signal, which
-   for an interactive session is the COMMON case: Ctrl-C is SIGINT.  A
-   signal-terminated comterp/comdraw/drawserv would otherwise leave the
-   user's shell with ECHO still cleared, invisible typing until `stty
-   echo`/`reset`.  Restore, then re-raise with the default disposition --
-   so the process still actually dies of the signal (correct exit status,
-   core dump if applicable for SIGSEGV-like signals) -- we're only
-   cleaning up the tty first, not changing how the process exits. */
+/* atexit() and the explicit call in ComTerp::exit() cover an orderly exit;
+   neither runs when the process dies by signal, which for an interactive
+   session is the common case -- Ctrl-C is SIGINT.  Otherwise a signal-killed
+   session leaves the user's shell with ECHO cleared and typing invisible until
+   `stty echo`.  Restore, then re-raise with the default disposition, so the
+   process still dies of the signal with the right status; only the tty is
+   cleaned up first. */
 static void tty_echo_signal_handler(int sig) {
     tty_echo_restore();
     signal(sig, SIG_DFL);

--- a/src/ComUtil/util.c
+++ b/src/ComUtil/util.c
@@ -117,15 +117,14 @@ static const char* ca_tz(const char* mon) {
   return "PST";
 }
 
-/* build_stamp: build identity as a string in comterp attrlist-literal notation --
-   (:built YYYY:Mon:DD:HH:MM:SS:TZ :patch "key").  The colon-chain is the readable
-   date/time/zone literal the post-eval ":" operator consumes (TZ a trailing
-   timezone symbol, like the month, closing the timestamp); nothing here evaluates
-   it -- the banner just prints a string comterp *could* parse once ":" knows the
-   timezone vocabulary.  date/time are a caller's __DATE__/__TIME__ ("Mon DD YYYY"
-   day space-padded, "HH:MM:SS") and patch_key its PATCH_KEY -- those stay in each
-   main.c so bumping PATCH_KEY there recompiles that main.c and refreshes its
-   __DATE__/__TIME__; only this formatter lives here. */
+/* build_stamp: build identity as a string in comterp attrlist-literal notation,
+   (:built YYYY:Mon:DD:HH:MM:SS:TZ :patch "key").  The colon-chain is the
+   date/time/zone literal the ":" operator consumes; nothing here evaluates it,
+   the banner only prints a string comterp could parse once ":" knows the
+   timezone vocabulary.  date and time come from a caller's __DATE__/__TIME__
+   and patch_key from its PATCH_KEY, all of which stay in each main.c so that
+   bumping PATCH_KEY recompiles it and refreshes the timestamp; only the
+   formatter lives here. */
 const char* build_stamp(const char* date, const char* time, const char* patch_key) {
   static char buf[160];
   char mon[4]; mon[0]=date[0]; mon[1]=date[1]; mon[2]=date[2]; mon[3]=0;

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "9c1f47a2"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Same pass as #473, over the comments this library gained in the past half year. Comments only, no code touched. `run_all.comt` green.

**154 lines out, 95 in, across 6 files.**

### The library's own original comments are untouched

This mattered more here than in ComTerp. `dmm.c`, `xdll.c`, `mblock.c`, `comerr.c`, `atox.c`, `funcptrs.c` and `types.c` carry ~2000 lines of original function-header comment between them — and none of those files has been modified in this window at all, so every comment in them is baseline. None was read or changed.

The work is in the files that did change:

```
_scanner.c    the trailing-colon rule
_parser.c     stream-literal slip-ins
_lexscan.c    self-echo, and why _lexscan_last_* rather than the output params
optable.c     "@" and "next" priorities
ttyecho.c     the whole file is new
errsys.c      the install-path lookup
util.c        build_stamp
```

### What came out

Mostly scope rather than substance: which test suite confirmed a spacing rule, what was tried before backing off, and cross-library pointers into ComTerp and comdraw that only mattered while the change was being made. Two issue references and the `#76` history line in `ttyecho.c`'s header.

### What stayed

- why `_lexscan_last_*` and not the `*bufptr`/`*toktype` output params — lookahead can call `scanner()` more than once per token, so those may reflect whichever call ran last
- why ECHO is cleared only while a line executes — ICANON gives the app nothing until Return, so clearing it for the session leaves typing invisible
- why the suppress-next flag is one-shot rather than held open — it is consumed during `read_expr()`, before any event-loop pumping, so it never overlaps a reentrant stdin event
- why `RELLIBALLDIR` is bare and not quoted — a macro name inside a string literal is never expanded
- why `symbol_new()` entries stay out of the reverse index — a later `symbol_add()` of matching text would otherwise resolve onto a buffer meant to be written through

`optable.c`'s `"@"` priority note kept the reasoning about where 77 sits between the stream operators and arithmetic, since that is exactly what someone changing a priority needs; what went was the aside about an approach abandoned earlier.