### PR TITLE
Take the issue number off every ACE-lite file

### DIFF
--- a/src/ACE-lite/Imakefile
+++ b/src/ACE-lite/Imakefile
@@ -1,5 +1,5 @@
 XCOMM
-XCOMM source files for the ACE-lite library (in-tree ACE subset, issue #147).
+XCOMM source files for the ACE-lite library (in-tree ACE subset).
 XCOMM Headers live in src/include/ACE-lite; this builds the implementation.
 XCOMM
 

--- a/src/ACE-lite/event_handler.c
+++ b/src/ACE-lite/event_handler.c
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/event_handler.c
+ * ACE-lite.  src/ACE-lite/event_handler.c
  * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
  * group -- see src/ACE-lite/NOTICE.)
  *

--- a/src/ACE-lite/log_msg.c
+++ b/src/ACE-lite/log_msg.c
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/log_msg.c
+ * ACE-lite.  src/ACE-lite/log_msg.c
  * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
  * group -- see src/ACE-lite/NOTICE.)
  *

--- a/src/ACE-lite/reactor.c
+++ b/src/ACE-lite/reactor.c
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/reactor.c
+ * ACE-lite.  src/ACE-lite/reactor.c
  * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
  * group -- see src/ACE-lite/NOTICE.)
  *
@@ -241,11 +241,9 @@ int ACE_Reactor::handle_events(ACE_Time_Value* max_wait_time) {
     FD_ZERO(&eset);
 
     // FD_SET/FD_ISSET on a descriptor >= FD_SETSIZE indexes past the fixed-size
-    // fd_set -- undefined behavior (stack corruption).  Guard every use: a fd
-    // that large is skipped rather than corrupting memory.  ivtools' workloads
-    // keep fd numbers well under FD_SETSIZE; lifting the limit entirely means
-    // moving this select() loop to poll() (no FD_SETSIZE bound), noted as future
-    // work in issue #147.
+    // fd_set, which is undefined behavior.  Guard every use: a fd that large is
+    // skipped rather than corrupting memory.  Lifting the limit means moving
+    // this select() loop to poll(), which has no FD_SETSIZE bound.
     int maxfd = -1;
     for (std::map<ACE_HANDLE, ACE_Event_Handler*>::iterator it = read_.begin();
          it != read_.end(); ++it) {

--- a/src/ACE-lite/sock.c
+++ b/src/ACE-lite/sock.c
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/sock.c
+ * ACE-lite.  src/ACE-lite/sock.c
  * (ACE-lite reimplements a subset of the ACE interface; ACE is (c) the DOC
  * group -- see src/ACE-lite/NOTICE for attribution and the relationship.)
  * Implementations of the ACE-lite address and socket classes

--- a/src/ACE-lite/tests/acceptor_spawn.cc
+++ b/src/ACE-lite/tests/acceptor_spawn.cc
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/tests/acceptor_spawn.cc
+ * ACE-lite.  src/ACE-lite/tests/acceptor_spawn.cc
  * Standalone Phase-3 unit test for ACE_Acceptor + ACE_Svc_Handler, exercising
  * the accept-and-spawn path and the EOF retirement lifecycle
  * (handle_input -1 => reactor retire => handle_close => close => destroy)

--- a/src/ACE-lite/tests/log_fmt.cc
+++ b/src/ACE-lite/tests/log_fmt.cc
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/tests/log_fmt.cc
+ * ACE-lite.  src/ACE-lite/tests/log_fmt.cc
  * Standalone regression test for ace_lite_log's format handling.  The point is
  * the length modifiers: a %ld/%lu argument must be read as a long, not an int,
  * or on LP64 the va_list desyncs and every following argument is garbled.  We

--- a/src/ACE-lite/tests/reactor_loop.cc
+++ b/src/ACE-lite/tests/reactor_loop.cc
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/tests/reactor_loop.cc
+ * ACE-lite.  src/ACE-lite/tests/reactor_loop.cc
  * Standalone Phase-2 unit test for ACE_Reactor / ACE_Event_Handler.  Exercises
  * exactly the reactor API AceDispatcher and comhandler use:
  *   register_handler(fd, eh, READ_MASK), remove_handler(fd, RWE_MASK),

--- a/src/ACE-lite/tests/sock_loopback.cc
+++ b/src/ACE-lite/tests/sock_loopback.cc
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/ACE-lite/tests/sock_loopback.cc
+ * ACE-lite.  src/ACE-lite/tests/sock_loopback.cc
  * Standalone Phase-1 unit test for the ACE-lite address/socket layer -- no
  * reactor.  Binds a loopback acceptor on an OS-chosen port, connects to it,
  * round-trips a message both directions, and checks get_remote_addr /

--- a/src/include/ACE-lite/Acceptor.h
+++ b/src/include/ACE-lite/Acceptor.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Acceptor.h
+ * ACE-lite.  src/include/ACE-lite/Acceptor.h
  * ACE_Acceptor<HANDLER, PEER_ACCEPTOR> -- the accept-and-spawn template.  It is
  * itself an ACE_Event_Handler registered on the listen fd; when the fd is
  * readable it accept()s a connection, makes a HANDLER, hands it the new peer

--- a/src/include/ACE-lite/Event_Handler.h
+++ b/src/include/ACE-lite/Event_Handler.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Event_Handler.h
+ * ACE-lite.  src/include/ACE-lite/Event_Handler.h
  * ACE_Event_Handler -- the base class registered with ACE_Reactor.  ivtools'
  * ACE_IO_Handler (the InterViews IOHandler adapter) and, later, ACE_Svc_Handler
  * derive from it.  Only the slice ivtools uses is declared.

--- a/src/include/ACE-lite/INET_Addr.h
+++ b/src/include/ACE-lite/INET_Addr.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/INET_Addr.h
+ * ACE-lite.  src/include/ACE-lite/INET_Addr.h
  * ACE_INET_Addr -- an IPv4 host/port address wrapping sockaddr_in, the subset
  * of ACE's class the socket classes and consumer code use.
  */

--- a/src/include/ACE-lite/Imakefile
+++ b/src/include/ACE-lite/Imakefile
@@ -1,5 +1,5 @@
 XCOMM
-XCOMM include files for the ACE-lite package (in-tree ACE subset, issue #147)
+XCOMM include files for the ACE-lite package (in-tree ACE subset)
 XCOMM Installs the ACE-lite headers and the nested ace/ compatibility shim.
 XCOMM
 

--- a/src/include/ACE-lite/Log_Msg.h
+++ b/src/include/ACE-lite/Log_Msg.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Log_Msg.h
+ * ACE-lite.  src/include/ACE-lite/Log_Msg.h
  * The ACE_DEBUG / ACE_ERROR / ACE_ERROR_RETURN / ACE_ASSERT logging macros the
  * consumer code uses, routed to a small stderr logger that understands the few
  * ACE format directives ivtools actually passes (%P pid, %t thread, %p errno).

--- a/src/include/ACE-lite/OS.h
+++ b/src/include/ACE-lite/OS.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite -- a small, name-compatible in-tree subset of ACE (issue #147).
+ * ACE-lite -- a small, name-compatible in-tree subset of ACE.
  * src/include/ACE-lite/OS.h -- base types and OS-handle definitions shared by
  * the ACE-lite headers.  Declares the same ACE_* names the consumer code uses,
  * so source compiles unchanged against either backend (selected by EXTERN_ACE).

--- a/src/include/ACE-lite/Reactor.h
+++ b/src/include/ACE-lite/Reactor.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Reactor.h
+ * ACE-lite.  src/include/ACE-lite/Reactor.h
  * ACE_Reactor -- a self-contained select()-based event demultiplexer, the
  * drop-in for libACE's reactor.  It sits in the exact same slot: AceDispatcher
  * forwards the InterViews Dispatcher's attach/dispatch into it, and socket

--- a/src/include/ACE-lite/SOCK_Acceptor.h
+++ b/src/include/ACE-lite/SOCK_Acceptor.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/SOCK_Acceptor.h
+ * ACE-lite.  src/include/ACE-lite/SOCK_Acceptor.h
  * ACE_SOCK_Acceptor -- the low-level passive socket: socket()/bind()/listen()
  * and accept() of a new connection into an ACE_SOCK_Stream.  (The higher-level
  * ACE_Acceptor<Handler> accept-and-spawn template is built on this later.)

--- a/src/include/ACE-lite/SOCK_Connector.h
+++ b/src/include/ACE-lite/SOCK_Connector.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/SOCK_Connector.h
+ * ACE-lite.  src/include/ACE-lite/SOCK_Connector.h
  * ACE_SOCK_Connector -- actively opens a TCP connection (socket()+connect())
  * and hands the connected fd to an ACE_SOCK_Stream.
  */

--- a/src/include/ACE-lite/SOCK_Stream.h
+++ b/src/include/ACE-lite/SOCK_Stream.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/SOCK_Stream.h
+ * ACE-lite.  src/include/ACE-lite/SOCK_Stream.h
  * ACE_SOCK_Stream -- a connected-TCP file-descriptor wrapper.  The consumer
  * code mostly reads/writes the raw get_handle(), but recv/send/close/enable/
  * get_remote_addr are provided to match ACE.

--- a/src/include/ACE-lite/Singleton.h
+++ b/src/include/ACE-lite/Singleton.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Singleton.h
+ * ACE-lite.  src/include/ACE-lite/Singleton.h
  * ACE_Singleton<TYPE, LOCK> -- one shared instance of TYPE, reached via
  * instance().  The LOCK parameter is accepted for signature compatibility and
  * ignored (single-threaded build).

--- a/src/include/ACE-lite/Svc_Handler.h
+++ b/src/include/ACE-lite/Svc_Handler.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Svc_Handler.h
+ * ACE-lite.  src/include/ACE-lite/Svc_Handler.h
  * ACE_Svc_Handler<PEER_STREAM, SYNCH> -- the per-connection handler base that
  * ivtools' ComterpHandler and UnidrawImportHandler derive from.  It is an
  * ACE_Event_Handler holding a connected peer stream; the reactor dispatches its

--- a/src/include/ACE-lite/Synch.h
+++ b/src/include/ACE-lite/Synch.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Synch.h
+ * ACE-lite.  src/include/ACE-lite/Synch.h
  * ACE_Null_Mutex / ACE_NULL_SYNCH -- the no-op synchronization used as template
  * parameters in ivtools' single-threaded reactor world.
  */

--- a/src/include/ACE-lite/Test_and_Set.h
+++ b/src/include/ACE-lite/Test_and_Set.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Test_and_Set.h
+ * ACE-lite.  src/include/ACE-lite/Test_and_Set.h
  * ACE_Test_and_Set<LOCK, TYPE> -- holds a flag toggled by a signal and tested
  * by the event loop.  ivtools uses it (via ACE_Singleton) as the SIGINT quit
  * flag: COMTERP_QUIT_HANDLER::instance()->is_set().

--- a/src/include/ACE-lite/Time_Value.h
+++ b/src/include/ACE-lite/Time_Value.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/Time_Value.h
+ * ACE-lite.  src/include/ACE-lite/Time_Value.h
  * ACE_Time_Value -- a normalized (sec, usec) duration/instant, the subset of
  * ACE's class the consumer code and AceDispatcher use.
  */

--- a/src/include/ACE-lite/ace/Acceptor.h
+++ b/src/include/ACE-lite/ace/Acceptor.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Acceptor.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Event_Handler.h
+++ b/src/include/ACE-lite/ace/Event_Handler.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Event_Handler.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/INET_Addr.h
+++ b/src/include/ACE-lite/ace/INET_Addr.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/INET_Addr.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Log_Msg.h
+++ b/src/include/ACE-lite/ace/Log_Msg.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Log_Msg.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/OS.h
+++ b/src/include/ACE-lite/ace/OS.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/OS.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Reactor.h
+++ b/src/include/ACE-lite/ace/Reactor.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Reactor.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/SOCK_Acceptor.h
+++ b/src/include/ACE-lite/ace/SOCK_Acceptor.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/SOCK_Acceptor.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/SOCK_Connector.h
+++ b/src/include/ACE-lite/ace/SOCK_Connector.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/SOCK_Connector.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/SOCK_Stream.h
+++ b/src/include/ACE-lite/ace/SOCK_Stream.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/SOCK_Stream.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Singleton.h
+++ b/src/include/ACE-lite/ace/Singleton.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Singleton.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Svc_Handler.h
+++ b/src/include/ACE-lite/ace/Svc_Handler.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Svc_Handler.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Synch.h
+++ b/src/include/ACE-lite/ace/Synch.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Synch.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Test_and_Set.h
+++ b/src/include/ACE-lite/ace/Test_and_Set.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Test_and_Set.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/Time_Value.h
+++ b/src/include/ACE-lite/ace/Time_Value.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/Time_Value.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/ace/config.h
+++ b/src/include/ACE-lite/ace/config.h
@@ -1,4 +1,4 @@
-/* ACE-lite (#147) compatibility shim: lets unedited consumer code that says
+/* ACE-lite compatibility shim: lets unedited consumer code that says
    #include <ace/config.h> resolve to the bundled subset when src/include/ACE-lite
    is on the include path (in-tree build only).  The external --with-ace build
    adds -isystem $(ACEDIR) and never puts this dir on the path, so real libACE

--- a/src/include/ACE-lite/config.h
+++ b/src/include/ACE-lite/config.h
@@ -1,5 +1,5 @@
 /*
- * ACE-lite (issue #147).  src/include/ACE-lite/config.h
+ * ACE-lite.  src/include/ACE-lite/config.h
  * Umbrella config header, the bundled stand-in for <ace/config.h>.  ACE's
  * config.h carries platform feature macros; the ACE-lite subset needs none of
  * them, so this only pulls in the shared base types.

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "4e7d21ba"
 
 #endif /* _patch_h */


### PR DESCRIPTION
First of the six comment passes agreed after #473 (ComTerp) and #474 (ComUtil). Comments only, no code touched. `run_all.comt` green.

**41 files, 44 in, 46 out** — almost all of it one repeated line.

### What went

The library was built to a plan recorded in an issue, and the issue number went into all 38 of its files:

```
 * ACE-lite (issue #147).  src/include/ACE-lite/Event_Handler.h     x 18 headers
/* ACE-lite (#147) compatibility shim: ...                          x 14 ace/ shims
XCOMM ... (in-tree ACE subset, issue #147).                         x 2 Imakefiles
 * ACE-lite (issue #147).  src/ACE-lite/tests/log_fmt.cc            x 4 tests
```

It reads as if the number were part of what the file is, when what a reader needs is the sentence after it — which ACE class this is, and which slice of it ivtools uses.

The one *code* comment carrying a number went too: the `FD_SETSIZE` guard in `handle_events()` noted moving to `poll()` as future work "in issue #147". That is the tracker's business; what the guard does and why stays.

### What stayed, deliberately

**The file headers.** They document what each class is and how ivtools spells it — `typedef ACE_Acceptor<ComterpHandler, ACE_SOCK_ACCEPTOR> ComterpAcceptor;` — which is worth their length for a library that exists to be name-compatible with someone else's.

**All four in-body comments.** Each is a local hazard a reader has to know:

- cancel a handler's timers *before* `handle_close`, because `handle_close` can delete the handler and `expire_timers()` runs after the retire loop
- retire or reschedule a timer *before* firing it, because `handle_timeout` can re-enter `handle_events()` and the nested pass would fire it again
- clamp a non-positive select() wait to zero, because a negative `tv_usec` makes select() fail with EINVAL and drop the overdue timer
- set both `MSG_NOSIGNAL` and `SO_NOSIGPIPE`, because neither is portable alone

There was no bug narration to remove — this library was written once rather than debugged into shape, and it shows.

### One reference kept

`src/ACE-lite/NOTICE` keeps its issue reference. There the number is provenance, saying where this subset came from and why it exists, which is the one place that is the point.