### PR TITLE
Take the issue numbers out of the DrawServ relay comments

### DIFF
--- a/src/DrawServ/drawlink.c
+++ b/src/DrawServ/drawlink.c
@@ -135,16 +135,12 @@ int DrawLink::open(uuid_t linkid) {
     ostream out(&obuf);
     std::ostringstream sbuf;
     sbuf << "drawlink(\"";
-    /* local_hostname() (ComUtil/util.c), not raw gethostname(): on macOS the
-       bare OS-level hostname is often whatever the router assigned over
-       DHCP (e.g. "Scotts-MBP.lan"), which isn't registered anywhere
-       resolvable via getaddrinfo() -- the peer's two-way connect-back to
-       this name then fails outright (ACE_INET_Addr construction error),
-       breaking the handshake.  local_hostname() uses the actual
-       Bonjour/mDNS-registered name (`scutil --get LocalHostName` +
-       ".local"), which every process on the LAN can resolve; it falls
-       back to plain gethostname() on non-Apple platforms, where this
-       distinction doesn't apply. */
+    /* local_hostname(), not raw gethostname(): on macOS the bare OS-level
+       hostname is often whatever the router assigned over DHCP, which nothing
+       can resolve through getaddrinfo(), so the peer's two-way connect-back to
+       that name fails and the handshake never completes.  local_hostname()
+       uses the mDNS-registered name instead, and falls back to gethostname()
+       where that distinction does not apply. */
     const char* buffer = local_hostname();
 
     uuid_t& sid = ((DrawServ*)unidraw)->sessionid();

--- a/src/DrawServ/linkcmd.c
+++ b/src/DrawServ/linkcmd.c
@@ -75,12 +75,11 @@ const char* LinkBrushCmd::dist_script() {
        temporarily unlocked through us (grid->unlocked()) via the incoming
        select(:unlock) -- forward those onward so a chain ds1->ds2->ds3 carries
        the change past the first hop.  Stamp the OWNER's key, not ours, so the
-       forwarded :unlock/:lock bracket stays valid at the next hop; today that
-       key is derivable (selectorkey), but once it becomes a per-owner signature
-       (issue #163, the atomic select(:body :sign) follow-on) only the owner
-       could mint it, so the relay must forward, never re-derive.  Record the
-       owner sid so
-       ExecuteCmd can exclude the link back toward the origin. */
+       forwarded :unlock/:lock bracket stays valid at the next hop.  Today that
+       key is derivable through selectorkey(), but once it becomes a per-owner
+       signature only the owner can mint it, so the relay must forward it rather
+       than re-derive.  Record the owner sid too, so ExecuteCmd can exclude the
+       link back toward the origin. */
     for (sel->First(it); !sel->Done(it); sel->Next(it)) {
         OverlayView* view = (OverlayView*)sel->GetView(it);
         OverlayComp* comp = view ? (OverlayComp*)view->GetSubject() : nil;
@@ -92,13 +91,12 @@ const char* LinkBrushCmd::dist_script() {
             if (!any) {
                 sbuf << "s=select();select(grid(";
                 any = true;
-                /* INTERIM LIMITATION: the owner key+sid are captured from the
-                   FIRST matching comp only, so the whole dance relays under one
+                /* interim limitation: the owner key and sid come from the
+                   first matching comp only, so the whole dance relays under one
                    owner's :unlock/:lock key and ExecuteCmd excludes one back-
-                   link.  Correct today, when a selection's comps share an owner;
-                   a mixed-ownership selection would mis-stamp the rest.  Revisit
-                   when per-owner signatures land (issue #163) -- the dance would
-                   then have to group comps by owner and emit one bracket each. */
+                   link.  Correct while a selection's comps share an owner; a
+                   mixed-ownership selection would mis-stamp the rest, and would
+                   need grouping by owner with one bracket each. */
                 if (grid->selected() == LinkSelection::LocallySelected) {
                     owner_key = drawserv->sessionidkey();
                     uuid_copy(_dist_owner_sid, drawserv->sessionid());
@@ -479,13 +477,12 @@ const char* LinkColorCmd::dist_script() {
             if (!any) {
                 sbuf << "s=select();select(grid(";
                 any = true;
-                /* INTERIM LIMITATION: the owner key+sid are captured from the
-                   FIRST matching comp only, so the whole dance relays under one
+                /* interim limitation: the owner key and sid come from the
+                   first matching comp only, so the whole dance relays under one
                    owner's :unlock/:lock key and ExecuteCmd excludes one back-
-                   link.  Correct today, when a selection's comps share an owner;
-                   a mixed-ownership selection would mis-stamp the rest.  Revisit
-                   when per-owner signatures land (issue #163) -- the dance would
-                   then have to group comps by owner and emit one bracket each. */
+                   link.  Correct while a selection's comps share an owner; a
+                   mixed-ownership selection would mis-stamp the rest, and would
+                   need grouping by owner with one bracket each. */
                 if (grid->selected() == LinkSelection::LocallySelected) {
                     owner_key = drawserv->sessionidkey();
                     uuid_copy(_dist_owner_sid, drawserv->sessionid());

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "d05b39c8"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Second of the six. Comments only, no code touched. **29 out, 22 in, 2 files.**

This library needed the least of any so far — it has no bug narration in it at all.

### The three references

All in `linkcmd.c`, all making the same point: the owner's key is **forwarded rather than re-derived**, because once it becomes a per-owner signature only the owner could mint it. That reasoning is exactly what someone editing the relay has to know, and it survives without the number. The interim-limitation note (which appears twice) still says what the limitation is and what a mixed-ownership selection would need instead — just not where that is tracked.

### One other trim

`drawlink.c` explained the macOS hostname problem through a specific machine's name and the exact `scutil` invocation:

```
bare OS-level hostname is often whatever the router assigned over
DHCP (e.g. "Scotts-MBP.lan"), which isn't registered anywhere
resolvable ... (`scutil --get LocalHostName` + ".local")
```

What matters locally is that the bare hostname often resolves nowhere, so the peer's two-way connect-back fails and the handshake never completes. The rest was detail from the day it was diagnosed — and `local_hostname()` is one function call away for anyone who wants it.

### What stayed

The long comments here are load-bearing, and all of them stayed:

- why the requests are taken back when nobody answers — the count would be inherited through `CopyFlags` and waited on again, and a graphic left `WaitingToBeSelected` is one a late grant would still be accepted into, so `select()` would report nothing acquired and then quietly acquire it
- what `unlocked` means for `Reserve()`, and why a bracket that never closed leaves a graphic selectable by anyone
- what the `grid(:table)` columns are

Nothing in this library was written to explain how a bug was found, which is why there was so little to do.