### PR TITLE
Say what string_ptr() is, not what was tried instead

### DIFF
--- a/src/Attribute/attrlist.c
+++ b/src/Attribute/attrlist.c
@@ -222,20 +222,13 @@ void AttributeList::print_attrlist(std::ostream& out, AttributeList* al) {
 
 ostream& AttributeList::serialize(ostream& out, boolean parens) const {
 
-    /* bare mode (parens=false, the operator<< default) emits an empty list as
-       NOTHING -- not "()".  Every bare call site was audited and none depends on
-       "()" as a sentinel:
-         - ExportFunc::compout (unifunc.c) and OverlayScript::Attributes
-           (scriptview.c): per-component attrs trailing a command, read back as
-           bare ":key val" keywords, never as a "()" literal -- the stray "()" was
-           in fact the bug this split removed;
-         - ovcmds.c: the "# ..." imagemap comment lines (not parsed) and the
-           polygon(...) command (empty -> clean "polygon(...)", not "...()").
-       The value-display paths explicitly wrap and so still show "()" for an empty
-       list (round-trippable as an attribute-list literal): ComValue::operator<<
-       via serialize(out, true), and its brief "{...}" element form
-       ("(" << *al << ")", comvalue.c) -- which the bare inner now renders as a
-       single "()" instead of the old double "(())". */
+    /* bare mode -- parens=false, the operator<< default -- emits an empty list
+       as nothing rather than "()".  Bare output is per-component attributes
+       trailing a command, read back as ":key val" keywords, where a stray "()"
+       is not a sentinel but noise.
+
+       The value-display paths wrap explicitly and so still show "()" for an
+       empty list, which round-trips as an attribute-list literal. */
     AttributeList* attrlist = (AttributeList*)this;
     if (parens) out << "(";
     ALIterator i;

--- a/src/Attribute/attrvalue.h
+++ b/src/Attribute/attrvalue.h
@@ -254,19 +254,12 @@ public:
 
     const char* string_ptr();
     // lookup and return pointer to string associated with string.  Not
-    // slice-aware -- a sliced StringType (#395, ComValue::cstr(),
-    // comvalue.h) returns its whole shared backing string here, not just
-    // its own window.  Tried making this virtual so ComValue could
-    // override it and every existing caller would get slice-correct text
-    // automatically; reverted (#440 review) once it turned out the more
-    // common pattern in this codebase -- ComValue& x = stack_arg(n), a
-    // raw reference rather than a genuinely-constructed local copy --
-    // isn't safe to call a virtual method on at all (comterp.c's _stack
-    // grows via raw dmm_realloc, so a raw element's vtable pointer isn't
-    // reliably ComValue's own; confirmed live, wrong answer, no crash).
-    // One always-correct mechanism (cstr(), explicit at every call site)
-    // beats two mechanisms with a subtle, easy-to-miss safety line
-    // between them.
+    // slice-aware: a sliced StringType returns its whole shared backing
+    // string here rather than its own window, for which ComValue::cstr() is
+    // the slice-correct read.  Deliberately not virtual -- a ComValue& taken
+    // straight off the interpreter stack is a raw reference into an array
+    // grown by dmm_realloc, so its vtable pointer is not reliably ComValue's
+    // own and a virtual call there quietly returns the wrong text.
     const char* symbol_ptr();
     boolean global_flag();
     // return true if a symbol and the global flag is set.

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "6b8e40f1"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Third of the six. Comments only, no code touched. **28 out, 14 in, 2 files.** `run_all.comt` green.

### `string_ptr()` — the clearest case of the pattern

Most of the comment described an approach that was tried, why it was reverted, and what a review said about it. A caller needs one fact and one hazard:

- **the fact**: this is not slice-aware; `ComValue::cstr()` is the slice-correct read
- **the hazard**: it is deliberately *not* virtual, because a `ComValue&` taken straight off the interpreter stack is a raw reference into an array grown by `dmm_realloc`, so its vtable pointer is not reliably ComValue's own and a virtual call there quietly returns the wrong text

The hazard is the reason the method looks the way it does, so it stayed. The history of arriving at it did not.

### `attrlist.c` — an audit written into the source

The bare-mode comment listed every call site that had been checked, by file, to establish that none depended on `"()"` as a sentinel:

```
Every bare call site was audited and none depends on "()" as a sentinel:
  - ExportFunc::compout (unifunc.c) and OverlayScript::Attributes ...
  - ovcmds.c: the "# ..." imagemap comment lines ...
```

That audit was worth doing and is not worth keeping. What survives is the rule: bare output is per-component attributes read back as `:key val` keywords, where a stray `"()"` is noise, and the value-display paths wrap explicitly so an empty list still round-trips.

### What stayed

Three other long comments in this library are documentation rather than archaeology, and were left alone: the char-rendering rules in `attrvalue.c` (including why `isprint` past 0x7f cannot be trusted, since comdraw links X11 and fontconfig and either may call `setlocale`), `ParamList::filter`'s escaping contract, and `_comutil.h`'s note on why the class registrars hold names rather than symbol ids — interning in the header would put a `symbol_add()` call into libraries that never link ComUtil.