### PR TITLE
Take the issue numbers out of ComUnidraw, and one duplicated paragraph with them

### DIFF
--- a/src/ComUnidraw/comeditor.c
+++ b/src/ComUnidraw/comeditor.c
@@ -406,9 +406,8 @@ void ComEditor::keystroke(const Event& e) {
     // like SHIFT_FLAG -- orthogonal to :shiftcapture below, which
     // only decides whether Shift's normal pan/tool-shortcut is ALSO
     // suppressed.  meta_is_down() tests Mod1Mask, which on essentially
-    // every current keyboard IS Alt (Alt and Meta share the same bit; a
-    // keyboard with a dedicated Meta key hasn't shipped since the
-    // Lisp-machine era).  Event has no super_is_down() of its own, so
+    // every current keyboard IS Alt, the two sharing a bit.  Event has no
+    // super_is_down() of its own, so
     // Mod4 (the Windows-logo key on a PC, or Cmd under XQuartz on a Mac)
     // is tested directly via keymask().
     unsigned long flags = (shifted ? SHIFT_FLAG : 0)
@@ -498,17 +497,11 @@ void ComEditor::shiftcapture_poll() {
    too, without changing their BARE (unchorded, unshifted) behavior at
    all.
 
-   Escape is always readable ("Esc"/"ESC"), never the raw \x1b byte:
-   unlike Tab/Backspace/Enter/Space, which return their genuine C
-   escape-sequence literal (\t, \b, \r) or a directly-typeable
-   printable char (' ') when bare -- a real, first-class representation
-   in the language -- Escape has no such literal in standard C/C++ (no
-   \e), so \x1b was never "Esc as itself" the way \t is "Tab as
-   itself"; it was just the generic numeric-byte escape doing double
-   duty, spelling out a byte value with no more claim to being "Esc"
-   than \x41 has to being 'A'. Scripts comparing against \x1b (matching
-   what a terminal would send) is what caused the original keydrive()
-   Esc-detection bug this PR's sibling caught -- see git log. */
+   Escape is always readable ("Esc"/"ESC"), never the raw \x1b byte.
+   Tab/Backspace/Enter/Space each have a genuine C escape literal (\t, \b,
+   \r) or are directly typeable (' '), so bare they return themselves;
+   standard C++ has no \e, so \x1b was never "Esc as itself" the way \t is
+   Tab -- only the generic numeric-byte escape spelling out a value. */
 static const char* core_keyname(unsigned long ks, boolean shifted, boolean chorded,
 				 char* buf, size_t bufsz) {
     boolean textual = shifted || chorded;
@@ -563,16 +556,13 @@ static const char* core_keyname(unsigned long ks, boolean shifted, boolean chord
       case XK_Insert:    base = "ins";   break;  // curses KEY_IC; "ins" reads better
       default:
 	/* X11's Latin-1 keysyms are numerically identical to their ASCII
-	   codepoint across the whole printable range (space 0x20 through
-	   tilde 0x7e) -- verified directly, not just for letters/digits:
-	   [ ] { } ( ) < > ` ' " : ; , . and every shifted-numeric symbol
-	   (! @ # $ % ^ & *) all match too.  So any printable-ASCII keysym
-	   just IS its own character.  keystroke() folds shift into ks
-	   itself for letters (Shift+d arrives as XK_D) and X11 already
-	   resolves shifted symbols to their own distinct keysym (Shift+[
-	   is XK_braceleft, not XK_bracketleft), so this already carries
-	   the right character either way -- the uppercasing loop below is
-	   a harmless no-op for anything that isn't a lowercase letter. */
+	   codepoint across the whole printable range, space 0x20 through
+	   tilde 0x7e, punctuation and shifted symbols included -- so any
+	   printable-ASCII keysym is its own character.  keystroke() folds
+	   shift into ks for letters, and X11 resolves shifted symbols to
+	   their own keysym (Shift+[ is XK_braceleft), so the right character
+	   arrives either way and the uppercasing loop below is a no-op for
+	   anything that is not a lowercase letter. */
 	if (ks>=0x20 && ks<=0x7e) {
 	    one[0] = (char)ks; one[1] = '\0'; base = one;
 	} else {

--- a/src/ComUnidraw/grdotfunc.h
+++ b/src/ComUnidraw/grdotfunc.h
@@ -36,13 +36,10 @@ public:
     GrDotFunc(ComTerp*);
 
     virtual void execute();
-    /* Explicit, not just inherited: GrDotFunc predates DotFunc becoming
-       post_eval (issue #295/#301) and originally relied on its args
-       already being fired eagerly by the framework -- silently inheriting
-       post_eval()==true from DotFunc broke that (arg 0 arrived as a raw,
-       unfired CommandType token instead of a real value) without anyone
-       updating execute() to match, until this override made the mismatch
-       obvious and execute() was rewritten below to be post_eval-aware. */
+    /* declared explicitly rather than left to inheritance: this class
+       predates DotFunc becoming post_eval, and inheriting that silently makes
+       arg 0 arrive as an unfired CommandType token rather than a value.
+       Naming it here keeps execute() and post_eval() visibly in step. */
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
       return "%s(.) makes compound variables, and gives access to ComponentView AttributeList's."; }

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1669,12 +1669,12 @@ void SelectFunc::execute() {
 
       /* Clear() above hid the outgoing selection's tic marks and highlighting
 	 and nothing put them back.  unidraw->Update() cannot: it defers, and
-	 the repaint it schedules repairs the damage that hiding them made --
-	 over anything drawn here beforehand.  Selection::Update repairs and
-	 then draws, which is the order that survives, and it is what #210 took
-	 out of here for the cost of its Repair; keep that saving where it was
-	 aimed, at animation loops, which run with handles disabled.  Read the
-	 editor's selection since a wait may have replaced ours. */
+	 the repaint it schedules repairs the damage that hiding them made, over
+	 anything drawn here beforehand.  Selection::Update repairs and then
+	 draws, which is the order that survives.  Guarded on HandlesEnabled(),
+	 so animation loops -- which run with handles off -- still skip the cost
+	 of its Repair.  Read the editor's selection, since a wait may have
+	 replaced ours. */
       OverlaySelection* shown = (OverlaySelection*)_ed->GetSelection();
       if (shown && shown->HandlesEnabled())
 	shown->Update(viewer);

--- a/src/ComUnidraw/groupfunc.c
+++ b/src/ComUnidraw/groupfunc.c
@@ -172,9 +172,8 @@ void GroupFunc::execute() {
     OverlayViewer* viewer = (OverlayViewer*)GetEditor()->GetViewer();
 
     /* gather the current selection to group -- the "regroup" half of
-       growgroup, but sourced from the selection instead of an existing
-       group's members (see #157: growgroup/trimgroup could grow/trim a group
-       but there was no way to bootstrap one). */
+       growgroup, sourced from the selection rather than an existing group's
+       members, so a group can be bootstrapped and not only grown or trimmed. */
     Clipboard* cb = new Clipboard();
     cb->Init(viewer->GetSelection());
 

--- a/src/ComUnidraw/grstrmfunc.c
+++ b/src/ComUnidraw/grstrmfunc.c
@@ -37,15 +37,12 @@ GrStreamFunc::GrStreamFunc(ComTerp* comterp) : StreamFunc(comterp) {
 }
 
 void GrStreamFunc::execute() {
-  /* Stream literals ((1 2 3), nargstotal()>1) and the empty-stream literal
-     ([], nargs()==0) are unconditionally delegated to the base class --
-     this override only has anything of its own to add for the single-
-     already-evaluated-value case below (peeking for a ComponentView to
-     unwrap). Without this check, stack_arg_post_eval(0) ran unconditionally
-     against zero or several args, silently producing nothing: confirmed
-     live under drawserv/comdraw, (1 2 3) and [] each printed empty instead
-     of the literal stream -- the same class of bug as #301/#303 (a Gr*
-     override outrunning what the base class actually handles). */
+  /* stream literals -- (1 2 3), nargstotal()>1 -- and the empty literal [],
+     nargs()==0, go straight to the base class.  This override only adds
+     something for the single already-evaluated value below, where it peeks for
+     a ComponentView to unwrap.  Without the check, stack_arg_post_eval(0) runs
+     against zero or several args and silently produces nothing, so a literal
+     prints empty. */
   if (nargstotal() > 1 || nargs() == 0) {
     StreamFunc::execute();
     return;
@@ -82,13 +79,11 @@ void GrStreamFunc::execute() {
     
   } else {
 
-    /* Not a compview -- e.g. a plain list, as from zoo.haslegs() above.
-       convertv above already fired the (post_eval) argument once to make
-       this check; re-firing it via a fresh StreamFunc::exec() would run
-       the source expression's side effects a second time (confirmed live:
-       a self-bound method returning a list of matches ran its whole body,
-       print()s and all, twice under $$). Hand the already-evaluated value
-       straight to the shared conversion logic instead. */
+    /* not a compview -- a plain list, say.  convertv above already fired the
+       post_eval argument once to make this check, and re-firing it through a
+       fresh StreamFunc::exec() would run the source expression's side effects
+       a second time.  Hand the already-evaluated value to the shared
+       conversion logic instead. */
     reset_stack();
     push_stream_from_value(convertv);
     return;

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "a37c9e05"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Fourth of the six. Comments only, no code touched. **57 out, 38 in, 5 files.**

### The four references and two "confirmed live" accounts

In each case the fact underneath was worth keeping and the provenance was not:

- a group can be **bootstrapped** from a selection, not only grown or trimmed
- `GrDotFunc` names `post_eval()` explicitly because inheriting it silently makes arg 0 arrive as an unfired `CommandType` token
- a stream literal must go straight to the base class, or `stack_arg_post_eval(0)` runs against zero or several args and the literal prints empty
- re-firing an already-fired `post_eval` argument runs the source expression's side effects a second time

### The duplicated paragraph

`grfunc.c` had the same explanation written twice, ten lines apart, once for each of the two Update paths — the second copy carrying the number of the PR that had removed the call being restored. It is now one comment about ordering: `Selection::Update` repairs and *then* draws, which is the order that survives, and the `HandlesEnabled()` guard is what keeps animation loops from paying for the Repair.

### Also trimmed, found while there

`comeditor.c`'s keyboard handling is well documented and mostly stayed, but three passages were argument rather than reference:

- a paragraph on why Escape has no C literal, ending "the original `keydrive()` Esc-detection bug this PR's sibling caught — see git log"
- "verified directly, not just for letters/digits" ahead of a list of punctuation that was checked
- "a keyboard with a dedicated Meta key hasn't shipped since the Lisp-machine era"

The facts survive: Escape is always readable rather than a raw `\x1b`, printable-ASCII keysyms are their own character, and `meta_is_down()` tests Mod1Mask which is Alt.