### PR TITLE
Stop five main()s citing the same issue for the same two comments

### DIFF
--- a/src/comdraw/main.c
+++ b/src/comdraw/main.c
@@ -301,7 +301,7 @@ static const char* extract_comtfile(int& argc, char** argv) {
 
 int main (int argc, char** argv) {
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
-       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+       restore tty echo first if tty_echo_off() ever ran. */
     tty_echo_install_signal_handlers();
     const char* comtfile = extract_comtfile(argc, argv);
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
@@ -392,13 +392,11 @@ int main (int argc, char** argv) {
 	       GUI commands (select(), etc.) that would otherwise dereference a null
 	       canvas and crash.  (Over the command socket the reactor is already
 	       pumping, so this only matters for the pre-Run() script path.)
-	       Not something the user typed -- one-shot suppress its self-echo
-	       (issue #76, ttyecho.c) rather than disable_prompt()/enable_prompt():
-	       update() itself pumps the reactor, and a held-open flag spanning
-	       that pump would wrongly suppress a genuinely reentrant paste's
-	       echo too; the one-shot flag is consumed by _lexscan.c during the
-	       synchronous parse of this one line, before update() ever starts
-	       pumping, so it can't overlap that window. */
+	       Not something the user typed, so suppress its self-echo with the
+	       one-shot flag rather than a held-open disable_prompt(): update()
+	       pumps the reactor, and a flag spanning that pump would suppress a
+	       genuinely reentrant paste's echo too.  The one-shot is consumed
+	       during the parse of this one line, before the pumping starts. */
 	    tty_echo_suppress_next();
 	    terp->run("update(1000000)\n");
 

--- a/src/comterp_/main.c
+++ b/src/comterp_/main.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[]) {
        e.g. drawmo's gsbrushB, where a far node's connection can drop mid-run. */
     signal(SIGPIPE, SIG_IGN);
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
-       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+       restore tty echo first if tty_echo_off() ever ran. */
     tty_echo_install_signal_handlers();
 
     boolean server_flag = argc>1 && strcmp(argv[1], "server") == 0;

--- a/src/drawserv_/main.c
+++ b/src/drawserv_/main.c
@@ -313,7 +313,7 @@ static const char* extract_comtfile(int& argc, char** argv) {
 int main (int argc, char** argv) {
     const char* comtfile = extract_comtfile(argc, argv);
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
-       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+       restore tty echo first if tty_echo_off() ever ran. */
     tty_echo_install_signal_handlers();
 
 #if 0
@@ -430,11 +430,9 @@ int main (int argc, char** argv) {
 	       Configure/Expose has bound the canvas -- OverlaySelection::Update()
 	       then repairs damage through a null canvas and segfaults.  Mapping the
 	       window here, before Run() owns the loop, closes that window.
-	       Not something the user typed -- one-shot suppress its self-echo
-	       (issue #76, ttyecho.c; see comdraw/main.c's fuller comment for
-	       why a one-shot flag, not a held-open disable_prompt(), is the
-	       reentrancy-safe way to suppress a single internal eval like
-	       this one). */
+	       Not something the user typed, so suppress its self-echo with the
+	       one-shot flag rather than a held-open disable_prompt() -- the
+	       reentrancy-safe way to quiet a single internal eval. */
 	    tty_echo_suppress_next();
 	    terp->run("update(1000000)\n");
 

--- a/src/flipbook/main.c
+++ b/src/flipbook/main.c
@@ -240,7 +240,7 @@ any idraw parameter is also accepted (see idraw man page)";
 
 int main (int argc, char** argv) {
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
-       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+       restore tty echo first if tty_echo_off() ever ran. */
     tty_echo_install_signal_handlers();
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
     int exit_status = 0;
@@ -320,11 +320,9 @@ int main (int argc, char** argv) {
 	   Run(), before the window's Configure/Expose has bound the canvas,
 	   which would otherwise dereference a null canvas and crash.  Mapping
 	   the window here, before Run() owns the loop, closes that window.
-	   Not something the user typed -- one-shot suppress its self-echo
-	   (issue #76, ttyecho.c; see comdraw/main.c's fuller comment for why
-	   a one-shot flag, not a held-open disable_prompt(), is the
-	   reentrancy-safe way to suppress a single internal eval like
-	   this one). */
+	   Not something the user typed, so suppress its self-echo with the
+	   one-shot flag rather than a held-open disable_prompt() -- the
+	   reentrancy-safe way to quiet a single internal eval. */
 	ComTerpServ* terp = ed->GetComTerp();
 	if (terp) {
 	  tty_echo_suppress_next();

--- a/src/graphdraw/main.c
+++ b/src/graphdraw/main.c
@@ -220,7 +220,7 @@ any idraw parameter is also accepted (see idraw man page)";
 
 int main (int argc, char** argv) {
     /* Ctrl-C (SIGINT) is the common way an interactive session ends --
-       restore tty echo first if tty_echo_off() ever ran, issue #76. */
+       restore tty echo first if tty_echo_off() ever ran. */
     tty_echo_install_signal_handlers();
     Dispatcher::instance(new AceDispatcher(ComterpHandler::reactor_singleton()));
     int exit_status = 0;
@@ -297,11 +297,9 @@ int main (int argc, char** argv) {
        Run(), before the window's Configure/Expose has bound the canvas,
        which would otherwise dereference a null canvas and crash.  Mapping
        the window here, before Run() owns the loop, closes that window.
-       Not something the user typed -- one-shot suppress its self-echo
-       (issue #76, ttyecho.c; see comdraw/main.c's fuller comment for why
-       a one-shot flag, not a held-open disable_prompt(), is the
-       reentrancy-safe way to suppress a single internal eval like
-       this one). */
+       Not something the user typed, so suppress its self-echo with the
+       one-shot flag rather than a held-open disable_prompt() -- the
+       reentrancy-safe way to quiet a single internal eval. */
     ComTerpServ* terp = ed->GetComTerp();
     if (terp) {
       tty_echo_suppress_next();

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "f2a6d80b"
+#define PATCH_KEY "2a6d80bf"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "b8c40f27"
+#define PATCH_KEY "f2a6d80b"
 
 #endif /* _patch_h */


### PR DESCRIPTION
Fifth of the six. Comments only, no code touched. **28 out, 20 in, 5 files.**

Every application's `main()` carries the tty-echo handling, and every one carried the issue number with it — five identical copies of the SIGINT comment, and four of the suppress-next comment, three of which additionally sent the reader to comdraw's copy for the real explanation.

```
comterp_/main.c    SIGINT
comdraw/main.c     SIGINT + suppress-next (the "fuller comment")
drawserv_/main.c   SIGINT + suppress-next -> "see comdraw/main.c's fuller comment"
flipbook/main.c    SIGINT + suppress-next -> "see comdraw/main.c's fuller comment"
graphdraw/main.c   SIGINT + suppress-next -> "see comdraw/main.c's fuller comment"
```

**The SIGINT one loses only the number.** Ctrl-C is how an interactive session usually ends, so restore echo first if it was ever turned off. That is the whole of it, and it fits in two lines.

**The suppress-next one keeps its reason** — `update()` pumps the reactor, and a held-open `disable_prompt()` spanning that pump would suppress a genuinely reentrant paste's echo as well, where the one-shot flag is consumed during the parse of the single line before any pumping starts. But it now says that in each place instead of pointing at another application's `main.c`.

A comment worth having in four files is worth writing in four files. Three of them were a pointer and nothing else, which costs a reader a file open to learn something that fits in three lines — and `ttyecho.c` still holds the long version for anyone who wants it.