### PR TITLE
Take the issue numbers out of the docs, and one changelog entry with them

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1300,8 +1300,8 @@ size(side)     // 2
 `arg(n)` has no lvalue form — there's no `arg(0)=...` — so there's
 nothing to protect by caching it. A keyword *can* be written (`y=5`),
 and any write (plain or compound) freezes it into an ordinary owned
-local from that point on — the same write-freezes convention #310's
-capture classifier already uses for a free variable — but a keyword
+local from that point on — the same write-freezes convention the capture
+classifier already uses for a free variable — but a keyword
 that's only ever read stays a live tap for as long as it's read.
 
 Assigning to a keyword before ever reading it, or never reading it at
@@ -1355,9 +1355,9 @@ beyond the keyword declaration itself.
 
 **The gate is dynamic within the limits of one static classification
 pass.** A whole `;`-joined statement chain is tokenized and classified
-once, before any of it runs — the same fact issue #328 is built around.
-Two cases correctly stay dynamic across that: an *undefined* name (the
-original #328 forward-reference shape) and a name that's *already*
+once, before any of it runs.  Two cases correctly stay dynamic across
+that: an *undefined* name, the forward-reference shape, and a name
+that's *already*
 `:posteval` at that single classification pass — both get pedepth-marked
 so the real dispatch-time gate re-checks the *current* value right when
 the call fires, honoring a reassignment that happened earlier in the same

--- a/doc/SLICES.md
+++ b/doc/SLICES.md
@@ -111,7 +111,7 @@ via `symbol_len()`.
 (`numfunc.c:249-`) is where `+` decides in-place vs. copy. Operand `a`
 must be `is_only_string()` (`StringType`, never `SymbolType` — a
 symbol's characters are its identity, shared by every value holding
-that symid, #393; writing through one would corrupt everyone else's
+that symid; writing through one would corrupt everyone else's
 view). Given that, the in-place condition is:
 
 ```
@@ -304,19 +304,20 @@ being "the same" object, so any command that used to lean on "a
 string's symid is already a proper registered symbol" needs to
 re-derive from the text instead of trusting the symid.
 
-## 8. Known gaps
+## 8. Surviving a boxed copy
 
-- **`#437`/`#438` — RESOLVED, PRs #450/#451.** A slice/colon-list used
-  to lose its `sliced()`/`coloned()` tag (and even `narg`/`nkey`/`nids`)
-  whenever a `ComValue` was boxed into a plain `AttributeValue`-based
-  container — a function keyword argument, a captured free variable,
-  or any `AttributeList`/`AttributeValueList` entry. Fixed by widening
-  `AttributeValue` itself to carry that block (128 bits: the existing
-  `_command_symid`/`_state` union slot plus three new ints), so a
-  plain `new AttributeValue(value)` now copies it too, and by giving
-  `AttributeValue` a generic render-hook slot so `AttributeList`'s own
-  top-level print can go through `ComValue::operator<<` for the two
-  types (`ArrayType`/`StringType`) that need it.
+A slice keeps its `sliced()` tag — and a colon-list its `coloned()` tag,
+along with `narg`/`nkey`/`nids` — when the `ComValue` is boxed into a
+plain `AttributeValue`-based container: a function keyword argument, a
+captured free variable, or any `AttributeList`/`AttributeValueList`
+entry.  `AttributeValue` carries that block itself, so a plain
+`new AttributeValue(value)` copies it, and a generic render-hook slot
+lets `AttributeList`'s own top-level print go through
+`ComValue::operator<<` for the two types (`ArrayType`/`StringType`)
+that need it.
+
+## 9. Known gaps
+
 - `:set`/`:ins`/`:del` through a slice — not yet supported; falls
   through to `nil`.
 - Slicing a plain list/array — only `is_only_string()` triggers slice

--- a/src/ComTerp/HACKING.md
+++ b/src/ComTerp/HACKING.md
@@ -292,11 +292,10 @@ command calls with explicit parens:
   `FuncObj`-valued attribute of `a` — including when it happens to also
   be a registered global command, like `type` or `print` — this warns
   and returns nil rather than falling through to that global command.
-  That's a deliberate change from the pre-#295 behavior (parens used to
-  mean "evaluate this as an ordinary sub-expression first," which for a
-  registered name fired the *global* command, ignoring `a` entirely);
-  dot access is now consistently "look in the object" whether or not
-  parens follow.
+  That's a deliberate change: parens used to mean "evaluate this as an
+  ordinary sub-expression first," which for a registered name fired the
+  *global* command, ignoring `a` entirely.  Dot access is now
+  consistently "look in the object" whether or not parens follow.
 
 This is implemented in `_parser.c` at the bare identifier emission
 point (line ~1028): when the top of the operator stack is the `dot`

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -319,7 +319,7 @@ coverage number yet, so both read `—` here.
 | script        | funcs                                                                         | notes                                                      |
 |---------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
 | parser.comt   | attrlist(:literal) parse error lock-in via errmsg()                           | add errmsg() assertions for bare-value-after-keyword cases |
-| return.comt   | func() empty parens, func() positional varargs, arg(`sym) keyword lookup      | unscored — needs assertions, not just output               |
+| return.comt   | func() empty parens, func() positional varargs, arg(`sym) keyword lookup      |
 
 ### Planned coverage (ivtools-3.0)
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -282,7 +282,7 @@ not gaps in testing -- do not read `—` as untested.
 | deeptest.comt             | list attrlist at size attrname attrval + - . for whi… |       — |     — |    — |
 | bigbuf.comt               | + sum                                                 |       — |     — |    — |
 | funcarg.comt †              | func arg narg (positional args, keyword-as-variable,… |      18 |    26 |  69% |
-| funcclosure.comt †          | func local global (declaration-time capture, #310)    |      13 |    21 |  62% |
+| funcclosure.comt †          | func local global (declaration-time capture)          |      13 |    21 |  62% |
 | posteval.comt †             | func arg if (`:posteval` keyword)                     |      21 |    28 |  75% |
 | funcstream.comt           | func arg narg if while list local print               |       — |     — |    — |
 | nilcompare.comt           | func arg while list print                             |       — |     — |    — |
@@ -319,13 +319,13 @@ coverage number yet, so both read `—` here.
 | script        | funcs                                                                         | notes                                                      |
 |---------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
 | parser.comt   | attrlist(:literal) parse error lock-in via errmsg()                           | add errmsg() assertions for bare-value-after-keyword cases |
-| return.comt   | func() empty parens, func() positional varargs, arg(`sym) keyword lookup      | see issue #94                                              |
+| return.comt   | func() empty parens, func() positional varargs, arg(`sym) keyword lookup      | unscored — needs assertions, not just output               |
 
 ### Planned coverage (ivtools-3.0)
 
 | script      | funcs                                                                                                          | notes         |
 |-------------|----------------------------------------------------------------------------------------------------------------|---------------|
-| stream.comt | stream literal `(0 1 2 3)`, mixed `(0 :flag 1 :color red)`, keyword element detection via class()/attrname()/attrval() | see issue #94 |
+| stream.comt | stream literal `(0 1 2 3)`, mixed `(0 :flag 1 :color red)`, keyword element detection via class()/attrname()/attrval() | unscored      |
 
 ## The Self-Hosted Test Suite
 

--- a/src/drawserv_/tests/TESTING.md
+++ b/src/drawserv_/tests/TESTING.md
@@ -52,7 +52,7 @@ loopback exactly as on a real display.
 
 The deeper fix -- have the listener accept IPv6 too (dual-stack), so `"localhost"`
 works regardless of resolver order -- is ACE-build-dependent (`ACE_HAS_IPV6`) and
-is left to the in-tree ACE-lite work (issue #147). Until then, distributed
+is left to the in-tree ACE-lite work. Until then, distributed
 ivtools across IPv6-preferring hosts should use IPv4 literals.
 
 ## Port Convention


### PR DESCRIPTION
Last of the six. Docs only — no source, no code. **28 out, 28 in, 5 files.**

Documentation reads as settled truth. An issue number in it points at something still in motion, so a reader who follows one lands in a discussion rather than an answer.

### Nine references, reworded to say the thing directly

```
LANGUAGE.md   "the same write-freezes convention #310's capture classifier uses"
              "the same fact issue #328 is built around" / "the original #328 shape"
SLICES.md     "shared by every value holding that symid, #393"
HACKING.md    "a deliberate change from the pre-#295 behavior"
TESTING.md    "(declaration-time capture, #310)"
              "see issue #94"  x2
drawserv/TESTING.md  "left to the in-tree ACE-lite work (issue #147)"
```

The two `see issue #94` cells were the interesting ones: the note there is really **"unscored"** — a script that prints output nobody asserts against — which is what a reader of a coverage table wants to know. They say that now.

### SLICES.md needed more than a reword

Its `## 8. Known gaps` list opened with an entry marked **RESOLVED**, naming the two issues it closed and the two PRs that closed them, then explaining at length how slices survive being boxed into a plain `AttributeValue`. That is not a gap, and hasn't been one for a while.

It is now `## 8. Surviving a boxed copy` — a short section stating how the mechanism works, in the present tense — ahead of `## 9. Known gaps`, which now contains only gaps.

### One reference kept

`AGENTS.md:276` keeps its `#223`:

> **Code comments never reference GitHub issue/PR numbers** (`#223`, etc.)

That is the sentence stating this very rule, and the number in it is the example. Removing it would take the illustration out of the instruction.

---

This completes the set: #473 ComTerp, #474 ComUtil, #475 ACE-lite, #476 DrawServ, #477 Attribute, #478 ComUnidraw, #479 main.c, and this one. Every GitHub reference outside `.comt` test scripts is now gone from the tree.