### PR TITLE
for(): accept multiple space-separated bodies, autostreaming all but the last

### DIFF
--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -168,22 +168,28 @@ void ForFunc::execute() {
   static int body_symid = symbol_add("body");
   ComValue initexpr(stack_arg_post_eval(0));
   ComValue* bodyexpr = nil;
-  if (nargsfixed()>4) {
-    fprintf(stderr, "Error: for loop with more than one body -- missing semicolon between statements (line %d)\n", funcstate()->linenum());
-    reset_stack();
-    push_stack(ComValue::nullval());
-    return;
-  }
   while (!SeqFunc::breakflag() && !comterp()->returnflag() && !comterp()->quitflag()) {
     SeqFunc::continueflag(0);
-    
+
     ComValue whileexpr(stack_arg_post_eval(1));
     if (whileexpr.is_false()) break;
     delete bodyexpr;
     ComValue keybody(stack_key_post_eval(body_symid, false, ComValue::unkval()));
     if (keybody.is_unknown() && nargsfixed()>= 4) {
-      bodyexpr = new ComValue(stack_arg_post_eval(3));
-    } 
+      /* positions 3..N-1 are one or more space-separated bodies.  All but
+	 the last run for side effects only; an orphaned stream among them
+	 gets drained instead of silently dropped.  The last body's value
+	 is kept. */
+      for (int i=3; i<nargsfixed(); i++) {
+	ComValue v(stack_arg_post_eval(i));
+	if (i<nargsfixed()-1) {
+	  if (v.is_stream() && v.stream_list() && v.stream_list()->refcount_==1)
+	    comterp()->orphan_stream_count(v);
+	} else {
+	  bodyexpr = new ComValue(v);
+	}
+      }
+    }
     else {
       bodyexpr = new ComValue(keybody);
     }

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -179,14 +179,18 @@ void ForFunc::execute() {
       /* positions 3..N-1 are one or more space-separated bodies.  All but
 	 the last run for side effects only; an orphaned stream among them
 	 gets drained instead of silently dropped.  The last body's value
-	 is kept. */
+	 is kept.  A control transfer (break/continue/return/quit) raised by
+	 an earlier body stops the remaining ones from running, same as
+	 SeqFunc::execute does for ';'. */
       for (int i=3; i<nargsfixed(); i++) {
 	ComValue v(stack_arg_post_eval(i));
-	if (i<nargsfixed()-1) {
-	  if (v.is_stream() && v.stream_list() && v.stream_list()->refcount_==1)
-	    comterp()->orphan_stream_count(v);
-	} else {
+	boolean control = SeqFunc::continueflag() || SeqFunc::breakflag() ||
+	  comterp()->returnflag() || comterp()->quitflag();
+	if (i==nargsfixed()-1 || control) {
 	  bodyexpr = new ComValue(v);
+	  if (control) break;
+	} else if (v.is_stream() && v.stream_list() && v.stream_list()->refcount_==1) {
+	  comterp()->orphan_stream_count(v);
 	}
       }
     }

--- a/src/ComTerp/postfunc.h
+++ b/src/ComTerp/postfunc.h
@@ -85,8 +85,8 @@ public:
     virtual void execute();
 
     virtual boolean post_eval() { return true; }
-    virtual const char* docstring() { 
-      return "val=%s(initexpr whileexpr [nextexpr [bodyexpr]] :body expr) -- for loop"; }
+    virtual const char* docstring() {
+      return "val=%s(initexpr whileexpr [nextexpr [bodyexpr [bodyexpr ...]]] :body expr) -- for loop; multiple bodies run in sequence, all but the last for side effects (with any orphan stream drained)"; }
     virtual const char** dockeys() {
       static const char* keys[] = {
 	":body expr explicit keyword for body of for loop",

--- a/src/comterp_/tests/multibody.comt
+++ b/src/comterp_/tests/multibody.comt
@@ -1,25 +1,7 @@
-// src/comterp_/tests/multibody.comt -- pins today's for()/while()/func()
-// single-body limitation: a non-final body's stream side effects aren't
-// merely "lost" today -- they never run at all, because the multi-body
-// form itself is rejected (for/while) or never becomes part of the body
-// (func) before any execution happens.
-//
-// This is the counter-evidence for a review concern raised on #483
-// (postfunc.c, removing SeqFunc's lhs-orphan-stream force-drain): that
-// concern assumes for()/while()/func() already run multiple
-// space-separated bodies today, sequenced through SeqFunc, and that #483
-// regresses a non-final body's deferred stream work (e.g. an overdriven
-// print()). They don't -- #481 (multiple space-separated bodies for
-// for()/while()/func()) is not implemented yet, so there is no existing
-// multi-body execution path for #483 to affect. Every test below proves
-// the would-be-non-final body never runs even once, via a hit counter,
-// not just that the overall call errors or returns the wrong value.
-//
-// Once #481 lands, INVERT every assertion below (grep "INVERT ON #481"):
-// a hard error becomes a successful multi-body run, "hits==0" becomes
-// "hits==1", and the orphan stream a would-be-non-final body produces
-// should drain via #481's own dedicated step (per #482), not silently
-// vanish and not get force-drained by SeqFunc either.
+// src/comterp_/tests/multibody.comt -- for(): multiple space-separated
+// bodies, all but the last run for side effects with orphan streams
+// drained (#481, for() only). while()/func() still single-body only,
+// pinned below for #481's follow-on PRs.
 //
 // funcs: for while func run
 //
@@ -29,31 +11,37 @@
 run("./testlib.comt")
 ok=true
 
-// --- test 1: for() with 2 space-separated bodies -- today a hard error
-// fires BEFORE the loop ever starts (ForFunc::execute checks
-// nargsfixed()>4 immediately after evaluating initexpr), so the first
-// body -- which would itself produce an orphaned stream if it ran --
-// never executes even once. hits==0 proves that directly, not just
-// r==nil. ---
+// --- test 1: for() with 2 space-separated bodies -- both run every
+// iteration, the first purely for side effects (hits counts each run),
+// the last kept as the loop's result. ---
 hits=0
-r=for(i=0 i<3 i=i+1  hits=hits+1;print(0..2) i*i)
-ok=ok&&(r==nil && hits==0)
-print("1 for() with 2 bodies: hard error, first body never runs (expect true): %v\n\n" (r==nil&&hits==0))
+r=for(i=0 i<3 i=i+1  hits=hits+1 i*i)
+ok=ok&&(r==4 && hits==3)
+print("1 for() with 2 bodies: both run every iteration, last kept (expect true): %v\n\n" (r==4&&hits==3))
 prev_ok=check_fail(:ok ok)
-// INVERT ON #481: r should be the last iteration's i*i (4), hits==3 (once
-// per iteration), and print(0..2)'s orphan stream should drain via #481's
-// own dedicated step instead of vanishing.
 
-// --- test 2: while() with 2 space-separated bodies -- same hard error,
-// same "never even started" guarantee. ---
+// --- test 1b: a non-final body producing an orphan stream gets drained
+// instead of silently dropped. drained,$$xs appends xs's elements into
+// drained as a side effect of being pulled (same idiom as
+// spirograph.comt's pts,$$xs,$$ys) -- if the for() loop didn't drain
+// this non-final body itself, drained would stay empty. ---
+xs=list(7,8,9)
+drained=list()
+r=for(i=0 i<2 i=i+1  drained,$$xs i)
+ok=ok&&(size(drained)==6 && r==1)
+print("1b for() non-final orphan stream body autostreams (expect true): %v\n\n" (size(drained)==6&&r==1))
+prev_ok=check_fail(:ok ok)
+
+// --- test 2: while() with 2 space-separated bodies -- still a hard
+// error; while() isn't done until a follow-on PR. ---
 hits=0
 i=0
 r=while(i<3  hits=hits+1;print(0..2) i=i+1)
 ok=ok&&(r==nil && hits==0)
 print("2 while() with 2 bodies: hard error, first body never runs (expect true): %v\n\n" (r==nil&&hits==0))
 prev_ok=check_fail(:ok ok)
-// INVERT ON #481: r should be the final i (3), hits==3, and print(0..2)'s
-// orphan stream should drain via #481's own dedicated step.
+// INVERT once while() gets the same treatment as for(): r should be the
+// final i (3), hits==3, and print(0..2)'s orphan stream should drain.
 
 // --- test 3: func() with 2 positionals -- today only positional 0 ever
 // becomes part of the function body; positional 1 is not "lost" at call
@@ -68,9 +56,9 @@ r=f()
 ok=ok&&(r==1 && hits==0)
 print("3 func() with 2 bodies: only position 0 runs, position 1 never does (expect true): %v\n\n" (r==1&&hits==0))
 prev_ok=check_fail(:ok ok)
-// INVERT ON #481: r should be whatever the LAST body evaluates to,
-// hits==1 (position 1 now runs), and print(0..2)'s orphan stream should
-// drain via #481's own dedicated step, not silently vanish.
+// INVERT once func() gets the same treatment as for(): r should be
+// whatever the LAST body evaluates to, hits==1 (position 1 now runs),
+// and print(0..2)'s orphan stream should drain.
 
 print("multibody: %v\n" ok)
 ok

--- a/src/comterp_/tests/multibody.comt
+++ b/src/comterp_/tests/multibody.comt
@@ -1,7 +1,8 @@
 // src/comterp_/tests/multibody.comt -- for(): multiple space-separated
 // bodies, all but the last run for side effects with orphan streams
-// drained (#481, for() only). while()/func() still single-body only,
-// pinned below for #481's follow-on PRs.
+// drained (#481, for() only). break()/continue()/return() in a non-final
+// body work exactly as they would in a single-body for(). while()/func()
+// still single-body only, pinned below for #481's follow-on PRs.
 //
 // funcs: for while func run
 //
@@ -30,6 +31,31 @@ drained=list()
 r=for(i=0 i<2 i=i+1  drained,$$xs i)
 ok=ok&&(size(drained)==6 && r==1)
 print("1b for() non-final orphan stream body autostreams (expect true): %v\n\n" (size(drained)==6&&r==1))
+prev_ok=check_fail(:ok ok)
+
+// --- test 1c: break() in a non-final body stops the remaining bodies for
+// that iteration and exits the loop, same as a single-body for() would. ---
+hits=0
+r=for(i=0 i<5 i=i+1  if(i==2 :then break()) hits=hits+1 i)
+ok=ok&&(hits==2 && r==true)
+print("1c for() break() in a non-final body skips later bodies, exits loop (expect true): %v\n\n" (hits==2&&r==true))
+prev_ok=check_fail(:ok ok)
+
+// --- test 1d: continue() in a non-final body stops the remaining bodies
+// for that iteration but the loop keeps going -- unlike break(), it falls
+// through to the next() clause instead of exiting. ---
+hits=0
+r=for(i=0 i<4 i=i+1  if(i==1 :then continue()) hits=hits+1 i)
+ok=ok&&(hits==3 && r==3)
+print("1d for() continue() in a non-final body skips later bodies, loop continues (expect true): %v\n\n" (hits==3&&r==3))
+prev_ok=check_fail(:ok ok)
+
+// --- test 1e: return() in a non-final body unwinds through the for() and
+// the enclosing func() body, same as it would from a single-body for(). ---
+f=func(hits=0; for(i=0 i<5 i=i+1  if(i==2 :then return(99)) hits=hits+1 i); hits)
+r=f()
+ok=ok&&(r==99)
+print("1e for() return() in a non-final body unwinds out of the enclosing func() (expect true): %v\n\n" (r==99))
 prev_ok=check_fail(:ok ok)
 
 // --- test 2: while() with 2 space-separated bodies -- still a hard

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "a791d2c9"
+#define PATCH_KEY "d0ce2dce"
 
 #endif /* _patch_h */

--- a/src/man/man1/comterp.1
+++ b/src/man/man1/comterp.1
@@ -265,7 +265,7 @@ Print a usage summary of all the invocation modes above and exit.
 
  val=if(testexpr :then expr :else expr) -- evaluate testexpr and execute the :then expression if true, the :else expression if false.
 
- val=for(initexpr whileexpr [nextexpr [bodyexpr]] :body expr) -- for loop
+ val=for(initexpr whileexpr [nextexpr [bodyexpr [bodyexpr ...]]] :body expr) -- for loop; multiple bodies run in sequence, all but the last for side effects (with any orphan stream drained)
 
  val=while(testexpr [bodyexpr] :nilchk :until :body expr ) -- while loop
 


### PR DESCRIPTION
## Summary

- `for()` now accepts more than one space-separated body instead of erroring out ("for loop with more than one body -- missing semicolon between statements"). All but the last body run for side effects only; the last is kept as the loop's result, exactly as the single-body case already worked.
- A non-final body that evaluates to an orphaned stream (`refcount_==1`, nothing else holding a reference) gets drained via `ComTerp::orphan_stream_count()` instead of silently vanishing -- the same treatment the top-level REPL already gives a stand-alone orphaned stream.
- No new postfix token or `ComFunc` class: `ForFunc::execute` already reads its body positional(s) via `stack_arg_post_eval(i)`, so this is a direct loop over the body's positional range (3..nargsfixed()-1), nothing more.

Part of #481 (multiple space-separated bodies for `for()`/`while()`/`func()`) -- **`for()` only**. `while()`/`func()` are left exactly as they are today (still hard-error / silently truncate) and will be addressed in follow-on PRs once this one is proven out, per #481's design writeup.

```
for(i=0 i<3 i=i+1  print(i) i*i)   // now: prints 0,1,2 as it goes, returns 4
```

## Testing

- `src/comterp_/tests/multibody.comt`: the `for()` test is inverted (both bodies now run every iteration, last one kept) and extended with a new case (`1b`) that specifically proves the non-final-orphan-stream-drain behavior, using the same `pts,$$xs,$$ys`-style comma-append idiom that #483's `spirograph.comt` regression turned up -- if the drain didn't happen, the accumulator list would stay empty. `while()`/`func()` tests are left pinning today's behavior for their own follow-on PRs.
- Manually verified: multi-body with 2 and 3 positionals, a non-final orphan-stream body, single-body (unchanged), and no-body (unchanged) all behave correctly.
- Full `src/comterp_/tests/run_all.comt` suite: clean.
- Full `src/comdraw/tests/run_all.comt` suite under `drawserv`/`xvfb`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ)_