### PR TITLE
Doc/comments cleanup for the for()/while()/func() multi-body extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,6 +333,13 @@ worth looking.
 - **Everything is an expression**; there are no declarations. `func` is a
   *command* that returns a `FuncObj` — write `name=func(...)`, never
   `func name (...)`. A func that "returns nil" is usually this mistake.
+- **`for()`/`while()`/`func()` take one or more space-separated bodies.**
+  All but the last run for side effects (a non-final orphan stream gets
+  drained instead of dropped); the last is kept as the result. A space
+  used to either error (`for`/`while`) or silently drop everything past
+  the first body (`func`) — old habits that inserted a stray space where
+  a `;` was meant now change behavior instead of erroring or no-opping.
+  `postfix(expr)` shows whether something parsed as one body or several.
 - **Append with `,` (the tuple operator), not `list()`.** `lst,x` appends in
   place; `list(lst x)` builds a nested list-of-lists.
 - **A one-element list needs the trailing comma** -- `('x',)` is a one-element

--- a/doc/FUNC-AND-ARGS-DESIGN.md
+++ b/doc/FUNC-AND-ARGS-DESIGN.md
@@ -11,6 +11,15 @@ current spec. Every "future"/"awaits `:posteval`" marker left below is
 intentionally left in place as-written, with a note pointing at what it
 became, not rewritten to sound already-decided.
 
+The "one body, or many space-separated expressions run in sequence,
+last value out" shape below was written as this document's premise from
+the start, but wasn't actually true until much later: for years `func()`
+only ever incorporated its first positional into the `FuncObj`, silently
+dropping the rest. It now works exactly as described here — see
+`LANGUAGE.md`'s "for/while/func: autostreaming non-final bodies" section
+for the real, current spec (all but the last body run for side effects,
+with orphan-stream draining `for()`/`while()` also gained).
+
 ## The one-line shape
 
 > **A func is a verb with a stream of expressions that works on objects.**
@@ -129,9 +138,11 @@ body the stream.
 ## `func()` the command
 
 - Takes its **body span** (one body, or many space-separated expressions run in
-  sequence, last value out) plus exactly **one predefined keyword, `:echo`**
-  (`help(func)`: "echo the postfix version of parsed body"). `:echo` rides last
-  and is *thinned* by `func()` — consumed so it never leaks into the body.
+  sequence, last value out — see the note at the top of this document for
+  when that became true) plus two predefined keywords, `:echo`
+  (`help(func)`: "echo the postfix version of parsed body") and
+  `:posteval` (the future direction above, since landed). Both ride last
+  and are *thinned* by `func()` — consumed so neither leaks into the body.
 - **No formal positions.** The bodies are NOT positional args. (Don't conflate
   `func()`'s bodies with the funcobj's *call-time* positionals — different list,
   different end, different name.)
@@ -179,8 +190,11 @@ side-effecting `c(beep ding)` beeps/dings **once**, not "beep ding beep ding" �
 that awaited `:posteval`, which now gives you exactly this: `func(body
 :posteval)` re-fires `beep`/`ding` on each `arg(n)` read, see
 `posteval.comt`); multi-body
-`f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with `l==(1,2,3)`.
-(Note `==` (45) binds tighter than `,` (35), so the literal needs the parens.)
+`f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with `l==(1,2,3)`
+(Note `==` (45) binds tighter than `,` (35), so the literal needs the
+parens) -- not actually true when this was written (`func()` only ever
+ran its first body), so not in `funcarg.comt` either; it is true now, and
+the regression coverage for it lives in `multibody.comt` instead.
 
 ## Corrected: `assign` blocks clobbering a registered command — *not* rebinding a funcobj
 

--- a/doc/FUNC-AND-ARGS-DESIGN.md
+++ b/doc/FUNC-AND-ARGS-DESIGN.md
@@ -193,8 +193,11 @@ that awaited `:posteval`, which now gives you exactly this: `func(body
 `f=func(a0=arg(0) a1=arg(1) a2=arg(2) a0,a1,a2) l=f(1 2 3)` with `l==(1,2,3)`
 (Note `==` (45) binds tighter than `,` (35), so the literal needs the
 parens) -- not actually true when this was written (`func()` only ever
-ran its first body), so not in `funcarg.comt` either; it is true now, and
-the regression coverage for it lives in `multibody.comt` instead.
+ran its first body), so not in `funcarg.comt` either; verified true now
+(`l` does come back `{1,2,3}`), though this exact arg(0)/arg(1)/arg(2)
+shape isn't itself one of `multibody.comt`'s tests -- that file covers
+`func()`'s general multi-body sequencing (autostreaming, control
+transfer, nesting, dot-calls, error handling) with different examples.
 
 ## Corrected: `assign` blocks clobbering a registered command — *not* rebinding a funcobj
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -1879,11 +1879,14 @@ $(1,2,3)                 // same
 ```
 
 Now, whenever a stream is about to be discarded and nothing else
-references it, it's drained instead and its element count shown:
+references it, it's drained instead and its element count shown,
+bracketed to mark it as a count rather than a value (the same
+`[n]`/`{n}`/`(n)` wrapper convention `each()` and `size()` use elsewhere
+to tell a count from an ordinary integer on sight):
 
 ```
-0..100                  // 101
-$(1,2,3)                 // 3
+0..100                  // [101]
+$$(1,2,3)                // [3]
 ```
 
 This applies everywhere a value can be discarded, not just the last line
@@ -1905,7 +1908,7 @@ rather than the way `;` treats its own left side.
 
 A stream still bound to a variable is never
 touched -- draining checks whether anything else still references the
-same underlying stream buffer before doing anything, so `x=$(1,2,3)` at a
+same underlying stream buffer before doing anything, so `x=$$(1,2,3)` at a
 prompt (or as a non-final script statement) leaves `x` fully intact for
 later use, whether or not the surrounding expression that produced it is
 itself discarded.
@@ -1926,7 +1929,7 @@ method.)
 ```
 s=run("some-script-with-a-freestanding-stream.comt")   // []
 s                                                        // []  -- not drained; s is still bound
-each(s)                                                  // 101 -- explicit consumption still works
+each(s)                                                  // [101] -- explicit consumption still works
 ```
 
 `s` alone still prints `[]` rather than a count -- the value on top of
@@ -1938,8 +1941,33 @@ independent copy to drain, leaving `s` itself untouched:
 
 ```
 s=$$(1,2,3)
-$$s                     // 3  -- a fresh, orphaned copy: auto-drains
+$$s                     // [3]  -- a fresh, orphaned copy: auto-drains
 next(s)                 // 1  -- s was never touched
+```
+
+The guard is on the *object*, not on `s`'s name specifically -- any
+second live reference blocks the drain, not just the variable that
+first created it:
+
+```
+s=$$(1,2,3)
+L=(s)                   // grouping, not a list literal -- L names the same stream as s
+L                        // []  -- refcount 2 (s and L both point at it): not an orphan, not drained
+s=nil;                  // s's own binding is gone, but L still references the stream
+next(L)                 // 1   -- untouched the whole time
+```
+
+**A drained count can itself come from overdrive.** `type()` is an
+ordinary, non-post-eval command (`postfix(type)` shows no trailing `*`),
+so a stream argument overdrives it internally (*Overdrive rules* below):
+it doesn't run once on the stream, it runs once per element and the
+results are assembled into a brand-new stream. That result stream is
+freshly built and nothing holds a reference to it, so the moment it lands
+on top of the stack it's an orphan and gets auto-drained immediately, same
+as any other orphaned stream:
+
+```
+type($$(1,2,3))         // [3] -- three elementwise type() calls, overdriven and then auto-drained
 ```
 
 **Why this took decades to build.** ivtools' streams have held one strict

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -197,14 +197,18 @@ A script file (`.comt`) is a sequence of top-level expressions consumed
 one at a time. The return value of the script is the value of the last
 expression evaluated. By convention test scripts return `ok` (a boolean).
 
-The body argument to a control command (`for`, `while`, `if`, `switch`, `func`)
-is a **single expression**. The canonical way to express a
-multi-statement body is semicolons with no enclosing delimiters —
-the least punctuation needed:
+The body argument to `for`, `while`, and `func` can be **one or more**
+space-separated expressions — all but the last run for side effects
+(with any orphan stream result drained, same discipline as *Auto-draining
+an orphaned result* below), and the last is kept as the result. `if` and
+`switch` still take a single expression per branch. Semicolons still
+work too, and remain the way to fuse statements *inside* one of those
+positions — the two forms below are equivalent:
 
 ```
-for(i=0 i<10 i++ lst,i; total=total+i)   // canonical two-statement body
-for(i=0 i<10 i++ lst,i)                  // one statement, no ; needed
+for(i=0 i<10 i++ lst,i total=total+i)    // two bodies: lst,i for effect, total=total+i kept
+for(i=0 i<10 i++ lst,i; total=total+i)   // same result, one ';'-fused body instead
+for(i=0 i<10 i++ lst,i)                  // one body, no ; needed
 ```
 
 **Parens have no special body-grouping role.** Their purposes in
@@ -215,25 +219,52 @@ ComTerp are:
 3. **Stream literals** — `(val val ...)` when first token is a value
 4. **Precedence override** — `(a+b)*c` to override operator priority
 
-That's it. A body does not need parens. `(lst,i; total=total+i)` is
-a single `;`-sequence expression that happens to be wrapped in parens,
-but the parens add nothing — the semicolons do all the work:
+That's it. Wrapping a single body in parens does nothing —
+`(lst,i; total=total+i)` is just a `;`-sequence expression that happens
+to sit in parens:
 
 ```
 for(i=0 i<10 i++ (lst,i; total=total+i))  // works but parens unnecessary
 ```
 
-**Warning:** a space between two expressions inside parens — without a
-semicolon — is not a two-statement body. It is a stream literal:
+**Warning:** a space between two expressions *inside one set of parens*
+is not a second body — it's a stream literal (rule 3 above), one level
+down from the command call, regardless of how many space-separated
+bodies the surrounding `for()`/`while()`/`func()` call itself has. The
+difference between the two lines below is entirely the parens, not the
+space:
 
 ```
-for(i=0 i<10 i++ (lst,i total=total+i))   // body is a 2-element stream literal, not two statements -- loop no-ops
-for(i=0 i<10 i++ lst,i total=total+i)     // error: for loop with more than one body -- missing semicolon between statements
+for(i=0 i<10 i++ (lst,i total=total+i))   // ONE body: a 2-element stream literal, not two statements -- loop no-ops
+for(i=0 i<10 i++ lst,i total=total+i)     // TWO bodies (no parens): both run, same as the ';' form above
 ```
 
-`(ding beep)` parses as a stream literal of two values, not a grouped
-two-statement body. Code relying on space-separated statements inside
-parens without a semicolon needs a semicolon added between them.
+`(ding beep)` on its own is a stream literal of two values, never a
+grouped two-statement body — with or without an enclosing
+`for()`/`while()`/`func()`.
+
+**The same trap exists in any single-value slot, not just a
+`for()`/`while()`/`func()` body** — `if()`'s `:then`/`:else`, or any
+keyword value generally. `for()`/`while()`/`func()`'s real multi-body
+sequencing (bodies kept space-separated *at the command-call level*,
+last one kept, non-final ones autostreamed) is easy to mistake for "wrap
+several statements in parens and the last value comes back" — that
+mental model is wrong everywhere else, because parens-with-bare-spaces
+is *always* a stream literal, full stop, regardless of which slot it
+sits in. `if()` just receives that one `StreamType` value unexamined —
+there is no "last one kept," every element fires and none is special:
+
+```
+if(true :then (1 2 3))                        // 3 -- the ONE value is a stream; a bare top-level result auto-drains, showing its count
+if(true :then (print(1) print(2) print(3)))   // 123 then 3 -- all three print() calls fire, none is "the last body"
+x=if(true :then (1 2 3)); x                    // []  -- bound, so never drained; x still holds the raw, unconsumed stream
+```
+
+Two mechanisms that share surface appearance (parens, spaces, a value
+coming back) and do opposite things: `for()`/`while()`/`func()`'s
+multi-body keeps one value and runs the rest for effect; a stream
+literal handed to anything else is drained uniformly or not at all, with
+no body ever singled out as "the result."
 
 ## Types
 
@@ -719,22 +750,31 @@ if(testexpr :then trueexpr :else falseexpr)
 ### for
 
 ```
+for(initexpr whileexpr [nextexpr [bodyexpr [bodyexpr ...]]])
+
 for(i=0 i<10 i++
   print("%v\n" i))
+
+for(i=0 i<10 i++
+  lst,i total=total+i)   // two bodies: lst,i for effect, total kept
 ```
 
-Positional args: init, while-test, next, body. `:body expr` is an
-explicit keyword form for the body.
+Positional args: init, while-test, next, one or more space-separated
+bodies — see *for/while/func: autostreaming non-final bodies* below.
+`:body expr` is a deprecated legacy keyword — see the note there.
 
 ### while
 
 ```
+while(testexpr [bodyexpr [bodyexpr ...]] :nilchk :until)
+
 while(i<10
   print("%v\n" i); i++)
 ```
 
 Keywords: `:nilchk` (test for nil instead of false), `:until` (test
-after body), `:body expr` (explicit body keyword).
+after body). `:body expr` is a deprecated legacy keyword — see
+*for/while/func: autostreaming non-final bodies* below.
 
 ### return, break, continue
 
@@ -799,12 +839,16 @@ Square brackets indicate optional fixed args.
 Define a function with `func()`:
 
 ```
-f=func(body)
+f=func(body [body ...])
 ```
 
-The body is the first positional argument. There is no formal parameter
-list — any symbol used in the body is a local variable. Call with
-keyword args to initialize locals before the body runs:
+The body is one or more space-separated expressions — all but the last
+run for side effects (with any orphan stream result drained), and the
+last is kept as the call's result, same treatment `for()`/`while()`
+bodies get; see *for/while/func: autostreaming non-final bodies* below.
+There is no formal parameter list — any symbol used in the body is a
+local variable. Call with keyword args to initialize locals before the
+body runs:
 
 ```
 f=func(if(x>5 :then return(x*2)))
@@ -865,7 +909,9 @@ That's the standard test for closures in any language (define under a
 binding, escape, mutate, call), and `func()` passes it.
 
 **Which free variables get captured, and which don't.** A `FuncObj` is
-still just a saved token buffer (`_toks`/`_ntoks`) — nothing about *how*
+still just a saved token buffer — one span per body, concatenated, if
+there's more than one (`_toks`/`_ntoks` for the whole buffer,
+`_spanlens`/`_nspans` marking where each body ends) — nothing about *how*
 it runs changed, only *when* a free variable's value gets read:
 
 - **Read-only or read-before-write** — a name the body reads without
@@ -1829,8 +1875,22 @@ $(1,2,3)                 // 3
 
 This applies everywhere a value can be discarded, not just the last line
 of a script: every freestanding statement in a multi-line `.comt` script
-(each line is its own read-eval step), every `;`-joined statement, and
-the interactive prompt. A stream still bound to a variable is never
+(each line is its own read-eval step) and the interactive prompt.
+
+`;` is the one deliberate exception: its discarded left side is a plain
+discard, never drained, so a stream built purely for a side effect and
+thrown away via `;` still just vanishes, same as it always has:
+
+```
+0..3; 99                 // 99 -- the range is silently dropped, not drained
+```
+
+*for/while/func: autostreaming non-final bodies* below closes that gap
+for those three constructs specifically, by treating a non-final body's
+result the way a freestanding top-level statement is treated here,
+rather than the way `;` treats its own left side.
+
+A stream still bound to a variable is never
 touched -- draining checks whether anything else still references the
 same underlying stream buffer before doing anything, so `x=$(1,2,3)` at a
 prompt (or as a non-final script statement) leaves `x` fully intact for
@@ -1890,6 +1950,49 @@ detail: each freestanding statement's leftover result has to be drained
 before the *next* statement runs, not after, or a deferred side effect
 from one statement shows up interleaved into the following statement's
 own output.
+
+### for/while/func: autostreaming non-final bodies
+
+`for()`, `while()`, and `func()` all accept one or more space-separated
+bodies. All but the last run purely for side effects; the last is kept
+as the result:
+
+```
+hits=0
+r=for(i=0 i<3 i=i+1  hits=hits+1 i*i)   // r=4, hits=3
+```
+
+A non-final body that evaluates to an orphaned stream (nothing else
+holding a reference) is drained instead of silently discarded, the same
+principle as *Auto-draining an orphaned result* above, just applied to a
+construct's own interior rather than a top-level statement boundary:
+
+```
+xs=list(7,8,9)
+drained=list()
+for(i=0 i<2 i=i+1  drained,$$xs i)   // drained ends up {7,8,9,7,8,9}
+```
+
+A control transfer raised by a non-final body -- `break()`, `continue()`,
+`return()`, `quit()` -- stops the remaining bodies from running, exactly
+as `;` already does when its own left side raises one:
+
+```
+r=for(i=0 i<5 i=i+1  if(i==2 :then break()) i)   // stops at i==2, r is break()'s value
+```
+
+`func()`'s bodies are captured once at declaration time (see *Closures*
+above) and re-run at every call; a `for()`/`while()` inside one of them
+that autostreams or drains does so exactly as it would outside a `func()`
+-- nesting doesn't change any of this.
+
+**A retired keyword: `:body`.** `for()` and `while()` briefly had a
+`:body expr` keyword predating positional multi-body support, since
+retired and dropped from `help()` -- it never composed with positional
+bodies (given both, the positionals run and `:body`'s value is ignored,
+with a stderr warning) and used alone is the same warning plus the
+legacy single-body behavior, kept working for scripts still using it
+rather than broken outright.
 
 ### Files and pipes as streams
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -235,9 +235,22 @@ difference between the two lines below is entirely the parens, not the
 space:
 
 ```
-for(i=0 i<10 i++ (lst,i total=total+i))   // ONE body: a 2-element stream literal, not two statements -- loop no-ops
+for(i=0 i<10 i++ (lst,i total=total+i))   // ONE body: a fresh 2-element stream literal every iteration
 for(i=0 i<10 i++ lst,i total=total+i)     // TWO bodies (no parens): both run, same as the ';' form above
 ```
+
+The first line never gives per-iteration sequencing the way the second
+does. Nine of its ten stream literals are simply discarded, unexecuted,
+the moment the next iteration builds a new one — a stream literal isn't
+autostreamed the way a non-final *body* is, because it's one positional,
+not several. Only the last iteration's literal survives as `for()`'s own
+result, and it stays exactly as lazy as any other stream from there:
+left as a bare top-level statement, the auto-drain below runs it once;
+assigned to a variable, it sits inert (same as any bound stream) until
+something later drains *that* — `each()`, a further reference, and so
+on; discarded via `;` instead, nothing ever holds a reference to it
+again, so it never runs at all. None of these give `lst`/`total` the ten
+updates the second line actually produces.
 
 `(ding beep)` on its own is a stream literal of two values, never a
 grouped two-statement body — with or without an enclosing

--- a/src/ComTerp/postfunc.c
+++ b/src/ComTerp/postfunc.c
@@ -323,7 +323,9 @@ void SeqFunc::execute() {
     else {
       /* arg1 (the statement before this ";") is simply discarded, same as
 	 any other discarded value -- no forced draining of an orphaned
-	 stream here (see #482: that was never the intended semantics). */
+	 stream here.  for()/while()/func() bodies drain explicitly instead
+	 (each one's own body-sequencing loop calls orphan_stream_count()
+	 on a non-final result); ';' stays a plain discard on purpose. */
       ComValue arg2(stack_arg_post_eval(1, true));
       reset_stack();
       push_stack(arg2.is_blank() ? arg1 : arg2);

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -317,7 +317,7 @@ Every script `run_all.comt` runs, in the order it runs them. Three states:
 - **untracked** (`—`) -- no coverage header anywhere. The script runs and asserts,
   it has simply never been scored against the slot taxonomy.
 
-16 of 55 scripts are scored. The rest are real tests with no coverage number,
+17 of 55 scripts are scored. The rest are real tests with no coverage number,
 not gaps in testing -- do not read `—` as untested.
 
 | script | funcs | covered | total |  %  |
@@ -350,7 +350,7 @@ not gaps in testing -- do not read `—` as untested.
 | funcclosure.comt †          | func local global (declaration-time capture)          |      13 |    21 |  62% |
 | posteval.comt †             | func arg if (`:posteval` keyword)                     |      21 |    28 |  75% |
 | funcstream.comt           | func arg narg if while list local print               |       — |     — |    — |
-| multibody.comt            | for while func run                                    |       — |     — |    — |
+| multibody.comt            | for while func                                        |      30 |    33 |  91% |
 | nilcompare.comt           | func arg while list print                             |       — |     — |    — |
 | random.comt               | split index substr join eq size print + global while… |       — |     — |    — |
 | stringstream.comt         | stream $$ feed chunk next list size at print          |       — |     — |    — |

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -177,6 +177,71 @@ setup in the comment above:
 print("10 sum via while/next($$(1..5)) (expect 15): %v\n" total)
 ```
 
+### Side effects across calls: use a list, not a captured scalar
+
+A `func()` body's free variables are captured *by value* at declaration
+time (see `LANGUAGE.md`'s *Closures* section) — a read-before-write name
+like the `hits` in `func(hits=hits+1  hits+10)` resolves to a private,
+per-call local, not the outer `hits`. Asserting on the outer variable
+after calling the func silently checks the wrong thing — it never
+changes, call the func as many times as you like:
+
+```
+// wrong -- hits is captured by value, this outer copy never moves
+hits=0
+f=func(hits=hits+1  99)
+r=f()
+ok=ok&&(hits==1)             // always fails: outer hits is still 0
+```
+
+A list sidesteps this: its *binding* is captured the same way, but a
+list is a reference type, so appending to it inside the body mutates the
+same underlying object the outer variable points at:
+
+```
+// right -- hits is a list; the append is visible outside the call
+hits=list()
+f=func(hits,1  99)
+r=f()
+ok=ok&&(size(hits)==1)       // passes
+```
+
+This is the same idiom `multibody.comt`'s orphan-stream tests use
+(`drained,$$xs` as one of a `for()`/`while()`/`func()` body's own
+*non-final* positions, where it autostreams) for an unrelated reason —
+it turns out to double as the fix for capture-by-value hiding a func()
+test's own side effects. It has to be a non-final body or the very last
+statement of the script, though — `;` never autostreams its own
+discarded left side (see `LANGUAGE.md`'s *Auto-draining an orphaned
+result*), so `drained,$$xs; size(drained)` still reads back `0`: nothing
+ever pulled `$$xs`.
+
+### Asserting on stderr output: capture a subprocess
+
+A `.comt` script can't inspect its own process's stderr — a warning
+written via `fprintf(stderr, ...)` inside a C++ command has nowhere to
+land that `errmsg()` (which reads the *interpreter's* error state, not
+raw stderr text) can see. To assert on it, spawn a real subprocess and
+read its combined output back as a stream:
+
+```
+out=*$$open("comterp \"<script that prints on stderr>\" 2>&1 | tr \"\\n\" \" \"" :pipe)
+warned=index(out "expected substring" :substr)
+```
+
+`2>&1` merges stderr into stdout inside the subprocess so both are
+visible on the pipe; `tr "\n" " "` squashes the output to one line so
+`*$$open(:pipe)`'s single read captures everything at once. (The more
+obvious-looking `next()`-in-a-`while()`-loop idiom for reading a
+multi-line pipe misbehaves on stream-tagged strings once concatenated
+across iterations, unrelated to this fix; `*$$open(:pipe)`'s single
+already-flattened read is the idiom that reliably works.) The inner
+`comterp` script's own double quotes need escaping as `\"` since the
+whole thing is itself a ComTerp string literal.
+
+See `multibody.comt`'s tests for `for()`/`while()`'s retired `:body`
+keyword for a complete example asserting a deprecation warning this way.
+
 ### Rules for LLM-assisted authoring
 
 When an LLM generates or edits a `.comt` test script, it must follow
@@ -252,7 +317,7 @@ Every script `run_all.comt` runs, in the order it runs them. Three states:
 - **untracked** (`—`) -- no coverage header anywhere. The script runs and asserts,
   it has simply never been scored against the slot taxonomy.
 
-13 of 45 scripts are scored. The rest are real tests with no coverage number,
+16 of 55 scripts are scored. The rest are real tests with no coverage number,
 not gaps in testing -- do not read `—` as untested.
 
 | script | funcs | covered | total |  %  |
@@ -285,11 +350,14 @@ not gaps in testing -- do not read `—` as untested.
 | funcclosure.comt †          | func local global (declaration-time capture)          |      13 |    21 |  62% |
 | posteval.comt †             | func arg if (`:posteval` keyword)                     |      21 |    28 |  75% |
 | funcstream.comt           | func arg narg if while list local print               |       — |     — |    — |
+| multibody.comt            | for while func run                                    |       — |     — |    — |
 | nilcompare.comt           | func arg while list print                             |       — |     — |    — |
 | random.comt               | split index substr join eq size print + global while… |       — |     — |    — |
+| stringstream.comt         | stream $$ feed chunk next list size at print          |       — |     — |    — |
 | time.comt                 | time int srand help index                             |       — |     — |    — |
 | numstring.comt            | int long float double print                           |       — |     — |    — |
 | keyword_lineend.comt      | func arg run help print list                          |       — |     — |    — |
+| keyword_trailing_semi.comt| if postfix index max errmsg print                     |       — |     — |    — |
 | funchelp.comt †             | help func arg narg local global (`help(f)` on a bare… |      19 |    24 |  79% |
 | updown.comt               | shell()  socket()  remote()  remote(:nowait)  close(… |       — |     — |    — |
 | spread.comt               | spread stream print echo attrlist func narg list      |       — |     — |    — |
@@ -302,9 +370,13 @@ not gaps in testing -- do not read `—` as untested.
 | optable.comt              | —                                                     |       — |     — |    — |
 | starnext.comt             | * (unary next) * (binary mpy) optable(:table) optabl… |       — |     — |    — |
 | symboldrain.comt          | —                                                     |       — |     — |    — |
+| seqorder.comt             | func run                                              |       — |     — |    — |
 | bracket-brace-parity.comt | —                                                     |       — |     — |    — |
 | atop.comt                 | @ (at) at() attrname attrval postfix                  |       — |     — |    — |
 | wrapper.comt              | —                                                     |       — |     — |    — |
+| classreg.comt             | class size at lt func for                             |      11 |    14 |  79% |
+| classblank.comt           | class blank empty type                                |      10 |    12 |  83% |
+| typeall.comt              | type size at blank                                    |      12 |    15 |  80% |
 
 † recorded here but not declared by the script itself.
 

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -317,7 +317,8 @@ Every script `run_all.comt` runs, in the order it runs them. Three states:
 - **untracked** (`—`) -- no coverage header anywhere. The script runs and asserts,
   it has simply never been scored against the slot taxonomy.
 
-17 of 55 scripts are scored. The rest are real tests with no coverage number,
+17 of 55 scripts declare coverage (four more are scored table-only, marked
+with a dagger). The rest are real tests with no coverage number,
 not gaps in testing -- do not read `—` as untested.
 
 | script | funcs | covered | total |  %  |

--- a/src/comterp_/tests/multibody.comt
+++ b/src/comterp_/tests/multibody.comt
@@ -4,7 +4,9 @@
 // non-final body work exactly as they would in a single-body
 // loop/function call.
 //
-// funcs: for while func run
+// coverage: 30/33 (91%)
+// funcs: for while func
+// missing: func(nested-in-while) for(zero-iterations) while(zero-iterations)
 //
 // Run from inside comterp (cd to this dir first):
 //   run("./multibody.comt")
@@ -86,6 +88,40 @@ warned=index(out "is deprecated" :substr)
 ran=index(out " 3 " :substr)
 ok=ok&&(warned!=nil && ran!=nil)
 print("1g for() :body alone still fires every iteration (deprecated, not broken) (expect true): %v\n\n" (warned!=nil&&ran!=nil))
+prev_ok=check_fail(:ok ok)
+
+// --- test 1h: a non-final body that flags a runtime error (COMERR_SET,
+// e.g. divide-by-zero) doesn't stop the remaining bodies or corrupt
+// anything -- same soft-error philosophy as func()'s 3g/3h, checked here
+// for for() itself since for()/while() use a different evaluation path
+// (stack_arg_post_eval(), not ComTerpServ::run_one_span()) that never had
+// 3h's stack-balance bug in the first place; this pins that it stays that
+// way. ---
+r=for(i=0 i<2 i=i+1 3/0 99)
+sane=(1+1==2)
+ok=ok&&(r==99 && sane)
+print("1h for() non-final body erroring (COMERR_SET) doesn't stop or corrupt (expect true): %v\n\n" (r==99&&sane))
+prev_ok=check_fail(:ok ok)
+
+// --- test 1i: three space-separated bodies, not just two -- the first
+// two run for side effects every iteration, the third is kept. ---
+a=list()
+r=for(i=0 i<2 i=i+1  a,1 a,2 i*10)
+ok=ok&&(r==10 && size(a)==4)
+print("1i for() with 3 bodies: first two run for effect, third kept (expect true): %v\n\n" (r==10&&size(a)==4))
+prev_ok=check_fail(:ok ok)
+
+// --- test 1j: bare :body (no value at all) used alone still warns --
+// stack_key_present() detects presence regardless of whether there's a
+// value to fire, so a bare flag isn't a silent way to dodge the warning.
+// The loop still runs to completion off its own whileexpr/nextexpr (i
+// reaches 3), since bare :body never had anything to act as a body
+// anyway. ---
+out=*$$open("comterp \"i=0;for(i=0 i<3 i=i+1 :body);i\" 2>&1 | tr \"\\n\" \" \"" :pipe)
+warned=index(out "is deprecated" :substr)
+ran=index(out " 3 " :substr)
+ok=ok&&(warned!=nil && ran!=nil)
+print("1j for() bare :body (no value) still warns, loop still completes (expect true): %v\n\n" (warned!=nil&&ran!=nil))
 prev_ok=check_fail(:ok ok)
 
 // --- test 2: while() with 2 space-separated bodies -- both run every
@@ -170,6 +206,41 @@ warned=index(out "is deprecated" :substr)
 ran=index(out " 3 " :substr)
 ok=ok&&(warned!=nil && ran!=nil)
 print("2g while() :body alone still fires every iteration (deprecated, not broken) (expect true): %v\n\n" (warned!=nil&&ran!=nil))
+prev_ok=check_fail(:ok ok)
+
+// --- test 2h: a non-final body that flags a runtime error (COMERR_SET,
+// e.g. divide-by-zero) doesn't stop the remaining bodies or corrupt
+// anything -- same soft-error philosophy as func()'s 3g/3h, checked here
+// for while() itself since for()/while() use a different evaluation path
+// (stack_arg_post_eval(), not ComTerpServ::run_one_span()) that never had
+// 3h's stack-balance bug in the first place; this pins that it stays that
+// way. ---
+i=0
+r=while(i<2 3/0 i=i+1)
+sane=(1+1==2)
+ok=ok&&(r==2 && sane)
+print("2h while() non-final body erroring (COMERR_SET) doesn't stop or corrupt (expect true): %v\n\n" (r==2&&sane))
+prev_ok=check_fail(:ok ok)
+
+// --- test 2i: three space-separated bodies, not just two -- the first
+// two run for side effects every iteration, the third is kept. ---
+a=list()
+i=0
+r=while(i<2  a,1 a,2 i=i+1)
+ok=ok&&(r==2 && size(a)==4)
+print("2i while() with 3 bodies: first two run for effect, third kept (expect true): %v\n\n" (r==2&&size(a)==4))
+prev_ok=check_fail(:ok ok)
+
+// --- test 2j: bare :body (no value at all) used alone still warns --
+// same as 1j, for while() -- stack_key_present() detects presence
+// regardless of whether there's a value to fire.  The loop still runs to
+// completion off its own testexpr (i reaches 3), since bare :body never
+// had anything to act as a body anyway. ---
+out=*$$open("comterp \"i=0;while((i=i+1)<3 :body);i\" 2>&1 | tr \"\\n\" \" \"" :pipe)
+warned=index(out "is deprecated" :substr)
+ran=index(out " 3 " :substr)
+ok=ok&&(warned!=nil && ran!=nil)
+print("2j while() bare :body (no value) still warns, loop still completes (expect true): %v\n\n" (warned!=nil&&ran!=nil))
 prev_ok=check_fail(:ok ok)
 
 // --- test 3: func() with 2 space-separated bodies -- both run every

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "6faeac2a"
+#define PATCH_KEY "c5a82ccb"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Closes #488: doc/comments cleanup following #486/#489/#490's multi-body extension to `for()`/`while()`/`func()`, closing out the last loose ends from that series.

- Drops `postfunc.c`'s last GitHub issue-number reference in a code comment (`AGENTS.md`: code comments never cite one). `;` staying a plain, non-draining discard was already explained in place; just removed the ticket pointer.
- Fixes two flatly wrong `doc/LANGUAGE.md` examples left over from before multi-body support: one asserting `for(i=0 i<10 i++ lst,i total=total+i)` errors (it's valid, two-body syntax now), and the "the body argument ... is a single expression" claim for `for`/`while`/`func` (all three now take one or more).
- Adds a `for/while/func: autostreaming non-final bodies` section to `LANGUAGE.md` documenting the new per-body draining/control-transfer semantics and the retired `:body` keyword.
- Generalizes the parens-vs-stream-literal warning beyond `for()`'s body slot (issue #488's core ask) — the same trap already existed in any single-value slot (`if()`'s `:then`/`:else`, any keyword value), and multi-body's "last one kept" is easy to mistake for that pattern working there too, when it never has.
- Annotates `doc/FUNC-AND-ARGS-DESIGN.md`'s "one body, or many space-separated expressions run in sequence" premise — written as already-true from the start, but wasn't until now — in the same style the doc already uses for its `:posteval` "since landed" markers.
- Adds an `AGENTS.md` scripting gotcha for the behavior change (a stray space where a `;` was meant used to error or no-op; now it runs the code).

## Coverage stats for multibody.comt

`multibody.comt` never carried a coverage header — brought it up to TESTING.md's own standard rather than leave it as one more gap. Scoring it against the taxonomy surfaced two real, cheap-to-close gaps of its own:

- `for()`/`while()` never got a permanent regression test for the non-final-body-errors-via-`COMERR_SET` behavior that was only verified ad hoc while chasing `func()`'s stack-corruption bug in #490 — added (tests 1h/2h).
- Neither construct had a 3-body test or a bare-`:body`-used-alone test, even though `func()` already had both — added (1i/1j, 2i/2j).

`multibody.comt` now carries `// coverage: 30/33 (91%)`; `TESTING.md`'s coverage table gets its row (was "for while func run" with no numbers — `run()` there is just the `testlib.comt` bootstrap every script has, not something this script tests, so it's dropped from the funcs list) and its declared-script count (16 → 17 of 55).

`TESTING.md`'s coverage table was also missing seven other scripts already wired into `run_all.comt`, and undercounting the total (13/45 → 16/55 before the multibody.comt fix above); brought it back in sync, and added two new sections documenting testing techniques this whole series depended on: a list-based side channel for observing a `func()`'s side effects across its capture-by-value boundary, and subprocess capture for asserting on stderr output.

## Testing

- Full `src/comterp_/tests/run_all.comt` suite: clean (all 55 test files pass, `multibody.comt` now at 30 tests).
- Full `src/comdraw/tests/run_all.comt` suite under `drawserv`/`xvfb`: clean.
- `PATCH_KEY` bumped per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ)_