### PR TITLE
Fix #56: split() ignored a string :tokval delimiter

### DIFF
--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -342,7 +342,32 @@ void SplitStrFunc::execute() {
   boolean tokstr_charflag = tokstrv.is_type(ComValue::CharType);
   if(tokstrv.is_type(ComValue::IntType)) tokstrv = commav;
   if(tokvalv.is_type(ComValue::IntType)) tokvalv = commav;
-  
+
+  if (tokvalflag && tokvalv.is_string()) {
+    /* a bare string delimiter falls through char_val()'s default case
+       (attrvalue.c) as '\0', so ":tokval \";\"" used to silently never
+       match anything instead of splitting -- accept exactly one
+       character as the obvious equivalent of the CharType form. */
+    std::string tokvalscratch;
+    const char* tokvalstr = tokvalv.cstr(tokvalscratch);
+    if (strlen(tokvalstr) == 1) {
+      tokvalv = ComValue(tokvalstr[0]);
+    } else {
+      /* A real multi-character (substring) delimiter isn't supported --
+	 the scan below compares one character at a time throughout
+	 (the delimiter test, :keep's reinserted delimiter value, and
+	 the isspace-as-alternate-delimiter rule all assume a single
+	 char), so matching a whole substring would mean rewriting that
+	 scan, not just this coercion.  Warn and let tokvalv fall through
+	 char_val()'s own default of '\0' unchanged: no character of the
+	 input can ever equal '\0', so the string comes back as a single
+	 token, same as if a real one-character delimiter simply never
+	 appeared -- a known no-op, not a silent one. */
+      fprintf(stderr, "Warning: split() :tokval \"%s\" is not a single character -- "
+	      "no delimiter recognized, input returned unsplit (line %d)\n",
+              tokvalstr, funcstate()->linenum());
+    }
+  }
 
   if (symvalv.is_string()) {
     AttributeValueList* avl = new AttributeValueList();

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -321,6 +321,31 @@ void StrCapFunc::execute() {
 SplitStrFunc::SplitStrFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
+/* A bare string delimiter falls through char_val()'s default case
+   (attrvalue.c) as '\0', so a StringType :tokstr/:tokval used to
+   silently match nothing and split() never split at all.  A
+   one-character string is accepted as the obvious equivalent of the
+   CharType form.  A real multi-character (substring) delimiter isn't
+   supported -- the scan in SplitStrFunc::execute() compares one
+   character at a time throughout (the delimiter test, :keep's
+   reinserted delimiter value, and the isspace-as-alternate-delimiter
+   rule all assume a single char), so matching a whole substring would
+   mean rewriting that scan, not just this coercion -- reported and
+   refused outright (nil) rather than silently treated as a harmless
+   one-token split. */
+static boolean coerce_split_string_delim(ComValue& delimv, const char* keyword,
+                                          ComFunc* func) {
+  std::string scratch;
+  const char* str = delimv.cstr(scratch);
+  if (strlen(str) == 1) {
+    delimv = ComValue(str[0]);
+    return true;
+  }
+  fprintf(stderr, "Error: split() :%s \"%s\" is not a single character (line %d)\n",
+          keyword, str, func->funcstate()->linenum());
+  return false;
+}
+
 void SplitStrFunc::execute() {
   ComValue zerov(0, ComValue::IntType);
   ComValue commav(',');
@@ -343,30 +368,15 @@ void SplitStrFunc::execute() {
   if(tokstrv.is_type(ComValue::IntType)) tokstrv = commav;
   if(tokvalv.is_type(ComValue::IntType)) tokvalv = commav;
 
-  if (tokvalflag && tokvalv.is_string()) {
-    /* a bare string delimiter falls through char_val()'s default case
-       (attrvalue.c) as '\0', so ":tokval \";\"" used to silently never
-       match anything instead of splitting -- accept exactly one
-       character as the obvious equivalent of the CharType form. */
-    std::string tokvalscratch;
-    const char* tokvalstr = tokvalv.cstr(tokvalscratch);
-    if (strlen(tokvalstr) == 1) {
-      tokvalv = ComValue(tokvalstr[0]);
-    } else {
-      /* A real multi-character (substring) delimiter isn't supported --
-	 the scan below compares one character at a time throughout
-	 (the delimiter test, :keep's reinserted delimiter value, and
-	 the isspace-as-alternate-delimiter rule all assume a single
-	 char), so matching a whole substring would mean rewriting that
-	 scan, not just this coercion.  Reported and refused outright
-	 (nil) rather than silently returning the input as if it were a
-	 harmless one-token split -- the caller asked for a specific
-	 delimiter and none of it was honored. */
-      fprintf(stderr, "Error: split() :tokval \"%s\" is not a single character (line %d)\n",
-              tokvalstr, funcstate()->linenum());
-      push_stack(ComValue::nullval());
-      return;
-    }
+  if (tokstrflag && tokstrv.is_string() &&
+      !coerce_split_string_delim(tokstrv, "tokstr", this)) {
+    push_stack(ComValue::nullval());
+    return;
+  }
+  if (tokvalflag && tokvalv.is_string() &&
+      !coerce_split_string_delim(tokvalv, "tokval", this)) {
+    push_stack(ComValue::nullval());
+    return;
   }
 
   if (symvalv.is_string()) {

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -358,14 +358,14 @@ void SplitStrFunc::execute() {
 	 (the delimiter test, :keep's reinserted delimiter value, and
 	 the isspace-as-alternate-delimiter rule all assume a single
 	 char), so matching a whole substring would mean rewriting that
-	 scan, not just this coercion.  Warn and let tokvalv fall through
-	 char_val()'s own default of '\0' unchanged: no character of the
-	 input can ever equal '\0', so the string comes back as a single
-	 token, same as if a real one-character delimiter simply never
-	 appeared -- a known no-op, not a silent one. */
-      fprintf(stderr, "Warning: split() :tokval \"%s\" is not a single character -- "
-	      "no delimiter recognized, input returned unsplit (line %d)\n",
+	 scan, not just this coercion.  Reported and refused outright
+	 (nil) rather than silently returning the input as if it were a
+	 harmless one-token split -- the caller asked for a specific
+	 delimiter and none of it was honored. */
+      fprintf(stderr, "Error: split() :tokval \"%s\" is not a single character (line %d)\n",
               tokvalstr, funcstate()->linenum());
+      push_stack(ComValue::nullval());
+      return;
     }
   }
 

--- a/src/ComTerp/symbolfunc.c
+++ b/src/ComTerp/symbolfunc.c
@@ -368,10 +368,21 @@ void SplitStrFunc::execute() {
   if(tokstrv.is_type(ComValue::IntType)) tokstrv = commav;
   if(tokvalv.is_type(ComValue::IntType)) tokvalv = commav;
 
-  if (tokstrflag && tokstrv.is_string() &&
-      !coerce_split_string_delim(tokstrv, "tokstr", this)) {
-    push_stack(ComValue::nullval());
-    return;
+  if (tokstrflag && tokstrv.is_string()) {
+    if (!coerce_split_string_delim(tokstrv, "tokstr", this)) {
+      push_stack(ComValue::nullval());
+      return;
+    }
+    /* a one-character string delimiter is supposed to behave exactly
+       like the CharType form it was just coerced into -- tokstr_charflag
+       was captured above, before this coercion, so it's still false
+       here and the scan would (wrongly) also stop tokens at whitespace,
+       something an explicit ':tokstr \';\'' doesn't do (Greptile,
+       PR #493). It stays false for the *default* comma (no :tokstr
+       value at all, coerced from the IntType zerov above, not from a
+       real string argument), which is deliberately not treated as an
+       explicit char delimiter either. */
+    tokstr_charflag = true;
   }
   if (tokvalflag && tokvalv.is_string() &&
       !coerce_split_string_delim(tokvalv, "tokval", this)) {

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -257,5 +257,33 @@ ok=ok&&(at(lst 1)=="baz qux")
 print("28 split(\"foo bar,baz qux\" :tokstr ',') multi-word (expect {foo bar,baz qux}): %v\n\n" lst)
 prev_ok=check_fail(:ok ok)
 
+// --- test 29: :tokval accepts a one-character string the same as a
+// CharType delimiter -- char_val() on a bare StringType used to fall
+// through to '\0' (attrvalue.c's default case), so a string delimiter
+// silently matched nothing and split() never split at all. ---
+lst=split("1;2;3" :tokval ";")
+ok=ok&&(size(lst)==3)
+ok=ok&&(at(lst 0)==1)
+ok=ok&&(at(lst 2)==3)
+print("29 split(\"1;2;3\" :tokval \";\") one-char string delim (expect {1,2,3}): %v\n\n" lst)
+prev_ok=check_fail(:ok ok)
+
+// --- test 30: a real multi-character (substring) :tokval delimiter
+// isn't supported -- the scan is a one-character-at-a-time comparison
+// throughout, so matching a whole substring would mean rewriting it,
+// not just coercing the argument the way test 29 does.  Rather than
+// guess at a substring split or hard-error, it's treated as a known
+// no-op: warn on stderr (spawn a subprocess, see 1g above, since
+// comterp can't inspect its own stderr) and return the input as a
+// single unsplit token, same as a real delimiter that just never
+// appears in the string.  Same outcome for an empty string. ---
+out=*$$open("comterp \"split(\\\"axxbxxc\\\" :tokval \\\"xx\\\")\" 2>&1 | tr \"\\n\" \" \"" :pipe)
+warned=index(out "not a single character" :substr)
+lst2=split("axxbxxc" :tokval "xx")
+lst3=split("abc" :tokval "")
+ok=ok&&(warned!=nil && size(lst2)==1 && size(lst3)==1)
+print("30 split(:tokval \"xx\"|\"\") multi-char/empty string delim: warn, return unsplit (expect true): %v\n\n" (warned!=nil&&size(lst2)==1&&size(lst3)==1))
+prev_ok=check_fail(:ok ok)
+
 print("\nstring: %v\n" ok)
 ok

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -283,5 +283,24 @@ ok=ok&&(warned!=nil && lst2==nil && lst3==nil)
 print("30 split(:tokval \"xx\"|\"\") multi-char/empty string delim: error, return nil (expect true): %v\n\n" (warned!=nil&&lst2==nil&&lst3==nil))
 prev_ok=check_fail(:ok ok)
 
+// --- test 31: :tokstr accepts a one-character string the same as a
+// CharType delimiter -- the exact same char_val()-default-'\0' bug as
+// test 29's, just via :tokstr's own separate delimiter argument. ---
+lst=split("a;b;c" :tokstr ";")
+ok=ok&&(size(lst)==3)
+ok=ok&&(at(lst 0)=="a")
+ok=ok&&(at(lst 2)=="c")
+print("31 split(\"a;b;c\" :tokstr \";\") one-char string delim (expect {a,b,c}): %v\n\n" lst)
+prev_ok=check_fail(:ok ok)
+
+// --- test 32: same rejection as test 30, via :tokstr's delimiter. ---
+out=*$$open("comterp \"split(\\\"axxbxxc\\\" :tokstr \\\"xx\\\")\" 2>&1 | tr \"\\n\" \" \"" :pipe)
+warned=index(out "is not a single character" :substr)
+lst2=split("axxbxxc" :tokstr "xx")
+lst3=split("abc" :tokstr "")
+ok=ok&&(warned!=nil && lst2==nil && lst3==nil)
+print("32 split(:tokstr \"xx\"|\"\") multi-char/empty string delim: error, return nil (expect true): %v\n\n" (warned!=nil&&lst2==nil&&lst3==nil))
+prev_ok=check_fail(:ok ok)
+
 print("\nstring: %v\n" ok)
 ok

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -293,6 +293,19 @@ ok=ok&&(at(lst 2)=="c")
 print("31 split(\"a;b;c\" :tokstr \";\") one-char string delim (expect {a,b,c}): %v\n\n" lst)
 prev_ok=check_fail(:ok ok)
 
+// --- test 31b: the coerced string form has to behave exactly like the
+// CharType form it's equivalent to, not just split in the same places
+// -- tokstr_charflag (whether embedded whitespace is preserved inside
+// a token, or also treated as a delimiter) must agree between them too
+// (Greptile, PR #493: it didn't, until tokstr_charflag was recomputed
+// after the coercion instead of read from the pre-coercion type). ---
+lst_char=split("a b;c" :tokstr ';')
+lst_str=split("a b;c" :tokstr ";")
+ok=ok&&(lst_char==lst_str)
+ok=ok&&(size(lst_str)==2 && at(lst_str 0)=="a b")
+print("31b :tokstr char vs one-char string delim tokenize identically (expect true): %v\n\n" (lst_char==lst_str&&size(lst_str)==2&&at(lst_str 0)=="a b"))
+prev_ok=check_fail(:ok ok)
+
 // --- test 32: same rejection as test 30, via :tokstr's delimiter. ---
 out=*$$open("comterp \"split(\\\"axxbxxc\\\" :tokstr \\\"xx\\\")\" 2>&1 | tr \"\\n\" \" \"" :pipe)
 warned=index(out "is not a single character" :substr)

--- a/src/comterp_/tests/string.comt
+++ b/src/comterp_/tests/string.comt
@@ -271,18 +271,16 @@ prev_ok=check_fail(:ok ok)
 // --- test 30: a real multi-character (substring) :tokval delimiter
 // isn't supported -- the scan is a one-character-at-a-time comparison
 // throughout, so matching a whole substring would mean rewriting it,
-// not just coercing the argument the way test 29 does.  Rather than
-// guess at a substring split or hard-error, it's treated as a known
-// no-op: warn on stderr (spawn a subprocess, see 1g above, since
-// comterp can't inspect its own stderr) and return the input as a
-// single unsplit token, same as a real delimiter that just never
-// appears in the string.  Same outcome for an empty string. ---
+// not just coercing the argument the way test 29 does.  Reported and
+// refused outright (nil), not silently treated as a harmless one-token
+// split -- spawn a subprocess (see 1g above) since comterp can't
+// inspect its own stderr.  Same outcome for an empty string. ---
 out=*$$open("comterp \"split(\\\"axxbxxc\\\" :tokval \\\"xx\\\")\" 2>&1 | tr \"\\n\" \" \"" :pipe)
-warned=index(out "not a single character" :substr)
+warned=index(out "is not a single character" :substr)
 lst2=split("axxbxxc" :tokval "xx")
 lst3=split("abc" :tokval "")
-ok=ok&&(warned!=nil && size(lst2)==1 && size(lst3)==1)
-print("30 split(:tokval \"xx\"|\"\") multi-char/empty string delim: warn, return unsplit (expect true): %v\n\n" (warned!=nil&&size(lst2)==1&&size(lst3)==1))
+ok=ok&&(warned!=nil && lst2==nil && lst3==nil)
+print("30 split(:tokval \"xx\"|\"\") multi-char/empty string delim: error, return nil (expect true): %v\n\n" (warned!=nil&&lst2==nil&&lst3==nil))
 prev_ok=check_fail(:ok ok)
 
 print("\nstring: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "76a21537"
+#define PATCH_KEY "6a215377"
 
 #endif /* _patch_h */

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "c5a82ccb"
+#define PATCH_KEY "76a21537"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary
- `char_val()` (attrvalue.c) has no `StringType` case, so it fell through to the default `'\0'` — a string passed as `:tokval` matched nothing and `split()` silently returned the whole input as one token (`size(split("a;b;c" :tokval ";"))` was `1`).
- A one-character string is now accepted as the obvious equivalent of the `CharType` form (mirroring the existing `IntType`→`','` default coercion right above it in `SplitStrFunc::execute()`).
- A non-single-character string (too long, or empty) can't be honored — the scan in `SplitStrFunc::execute()` compares one character at a time throughout (the delimiter test, `:keep`'s reinserted delimiter value, and the isspace-as-alternate-delimiter rule all assume a single char), so matching a whole substring would mean rewriting that scan, not just this coercion. It's reported (`Error: split() :tokval "xx" is not a single character (line N)`) and refused outright (`nil`) rather than silently treated as a harmless one-token split.

## Test plan
- Added `string.comt` tests 29 (one-char string delimiter now splits correctly) and 30 (multi-char/empty string delimiter errors to `nil`, verified via a subprocess since comterp can't inspect its own stderr). Neither shadows an old test that needed inverting — this code path had no coverage before.
- Full `run_all.comt` regression suite verified green.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ)_