### PR TITLE
Revert #494: caret notation for char literals

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -2742,8 +2742,7 @@ coordinate as expected.
 
 String literals use double-quotes. Escape sequences: `\"` for a literal
 double-quote, `\n` for newline, `\t` for tab, `\\` for a literal
-backslash before `n`, `r`, or `t`, plus octal (`\007`) and hex (`\x1b`)
-escapes for an arbitrary byte, same as chars below.
+backslash before `n`, `r`, or `t`.
 
 Key string commands:
 
@@ -2768,66 +2767,6 @@ Note: `:substr` is only needed when the first arg to `index` is a list.
 When both args are strings, substring search is the default behavior.
 
 Single-quoted literals are chars, not strings: `'a'`, printed with `%c`.
-
-### Chars: display forms, and reading them back
-
-A char is one byte, and how it displays depends on what that byte is.
-Bare -- `print(x :str)`'s own return value, or any `%s`/`%c` slot --
-shows just the byte, no delimiters:
-
-```
-print('a' :str)         // "a"      -- printable: shown as itself
-print(char(7) :str)     // "^G"     -- control byte (0x00-0x1F, 0x7F): caret notation
-print(char(160) :str)   // "\240"   -- 0x80 and up: octal escape, same form strings use
-```
-
-Quoted -- which is what a bare char shows as at the REPL prompt, and
-the only form `AttributeList` serialization ever writes, since a bare
-`a` would parse back as a symbol -- all three take the same single
-quotes, and all three now read back as the byte that produced them:
-
-```
-char(7)          // '^G'    -- bare echo at the prompt is quoted
-eval("'^G'")      // 7 -- same byte back, caret notation included
-eval("'\007'")    // 7 -- the general escape reads it too, same byte
-```
-
-Caret notation is unambiguous only because a char is a single byte with
-its own pair of quotes -- concatenated bytes (a string, or a printed
-run of chars with no quotes at all) would make a literal `^` indistinguishable
-from the start of a control form. That is why caret notation is
-**char-only**: a string never uses it, even to display a control byte
-it holds, and a literal `^` typed inside a string is never read
-specially -- it is just the ordinary character 0x5E, same as inside
-any other pair of double quotes.
-
-```
-"a\007b"     // "a\007b"   -- a string's own control byte: backslash escape, always
-"^G"          // "^G"       -- two ordinary characters, not a control byte
-```
-
-Two bytes need an escape to sit between a char's own quotes at all,
-because they would otherwise be misread: a backslash would start an
-escape sequence, and an apostrophe would close the literal early. A
-literal caret needs one for the same reason caret notation exists in
-the first place -- unescaped, it reads as the start of a control byte,
-not itself:
-
-```
-char(92)    // '\\'   -- backslash
-char(39)    // '\''   -- apostrophe
-char(94)    // '\^'   -- caret
-```
-
-All three read back through the same general escape mechanism
-(`'\\'`, `'\''`, `'\^'` all reach the lexer's default case, which just
-takes whatever follows the backslash literally), so nothing about
-reading them back is caret-specific — only *writing* a caret needed a
-new case, since before it a literal `^` printed bare and read back as
-itself, an ordinary printable byte, correctly. What changed is that
-`'^X'` now also reads as `X^0x40` for `X` in `?`..`_`, matching the
-control-byte form the REPL already prints, so the value on screen and
-the value you can paste back are finally always the same thing.
 
 ### Slices
 

--- a/src/Attribute/attrvalue.c
+++ b/src/Attribute/attrvalue.c
@@ -858,14 +858,11 @@ void AttributeValue::out_char_brief(ostream& out, unsigned char cv, boolean quot
   const char* q = quoted ? "'" : "";
   if (cv < 0x80 && iscntrl(cv))
     out << q << '^' << (char)(cv ^ 0x40) << q;
-  /* the three bytes that cannot appear bare between the quotes: a backslash
-     would escape the closing quote, an apostrophe would be it, and a caret
-     would read back as the start of the control-byte notation just above
-     instead of itself.  All three escapes are lexer forms
-     ('\^' reads as 94 same as '\136' or a bare unquoted '^'), so these keep
-     round-tripping.  Unquoted there is nothing to escape from, and escaping
-     would corrupt the text. */
-  else if (quoted && (cv == '\\' || cv == '\'' || cv == '^'))
+  /* the two bytes that cannot appear bare between the quotes: a backslash
+     would escape the closing quote, and an apostrophe would be it.  Both
+     escapes are lexer forms, so these keep round-tripping.  Unquoted there is
+     nothing to escape from, and escaping would corrupt the text. */
+  else if (quoted && (cv == '\\' || cv == '\''))
     out << "'" << '\\' << (char)cv << "'";
   else if (cv < 0x80 && isprint(cv))
     out << q << (char)cv << q;

--- a/src/ComUtil/_lexscan.c
+++ b/src/ComUtil/_lexscan.c
@@ -543,23 +543,6 @@ int bs_ident = 0;
 	       return ERR_NLINCHAR;
 
 
-      /* Caret notation for a control byte, char literals only: '^X' is
-	 X^0x40 -- the read side of the caret notation
-	 AttributeValue::out_char_brief already writes, so what's echoed
-	 at the prompt can be pasted back in.  '?' through '_' (0x3F-0x5F)
-	 is the whole standard range: '^@'.'^_' land on 0x00-0x1F, '^?' on
-	 0x7F (DEL).  Gated on *toklen==0 so this only fires as the sole
-	 character of the literal -- a bare '^' with nothing matching
-	 after it (including a lone '^' right before the closing quote)
-	 falls through to the plain TOKEN_ADD below and reads as the
-	 caret byte itself, same as '\^' does. */
-	 else if( token_state == TOK_CHAR && CURR_CHAR == '^' && *toklen == 0 &&
-		  NEXT_CHAR >= 0x3F && NEXT_CHAR <= 0x5F ) {
-	    unsigned char ctrlval = NEXT_CHAR ^ 0x40;
-	    ADVANCE_CHAR;
-	    TOKEN_ADD( ctrlval );
-	    }
-
       /* Normal character added to string or character constant */
 	 else if( CURR_CHAR != '\\' )
 	    TOKEN_ADD( CURR_CHAR )

--- a/src/comterp_/tests/char.comt
+++ b/src/comterp_/tests/char.comt
@@ -97,48 +97,29 @@ al9=(:p char(97) :c char(7) :h char(160))
 ok=ok&&(print(al9 :str)=="(:p 'a' :c '^G' :h '\\240')")
 print("9 a char attribute value is quoted (expect (:p 'a' :c '^G' :h '\\240')): %s\n" print(al9 :str))
 
-// --- 10: a printable char attribute round-trips -- and so does a high byte,
-// which could not while it serialized between backquotes -- and so, now,
-// does the caret form: '^X' reads as X^0x40, the same control byte
-// out_char_brief wrote it from (issue #467).  '^?' is the one special case,
-// reading as 0x7f (DEL) rather than following the '?'^0x40 formula literally
-// -- 0x3f^0x40 happens to already equal 0x7f, so one range check covers both ---
+// --- 10: so a printable char attribute round-trips now, which it could not
+// when it serialized bare -- and so does a high byte, which could not while it
+// serialized between backquotes.  The caret form still does not: '^G' is a
+// display form the lexer does not read, and reads back as UnknownType.  That
+// is the one remaining place where what is written out cannot be read in ---
 al10=eval("(:p 'a')")
 ok=ok&&(type(attrval(al10))=="CharType")
 al10b=eval("(:h '\\240')")
 ok=ok&&(type(attrval(al10b))=="CharType")&&(attrval(al10b)==char(160))
 al10c=eval("(:c '^G')")
-ok=ok&&(type(attrval(al10c))=="CharType")&&(attrval(al10c)==char(7))
-al10d=eval("(:c '^?')")
-ok=ok&&(type(attrval(al10d))=="CharType")&&(attrval(al10d)==char(127))
-print("10 'a', '\\240', '^G', '^?' all read back as the char they display (expect CharType CharType CharType CharType): %s %s %s %s\n" type(attrval(al10)) type(attrval(al10b)) type(attrval(al10c)) type(attrval(al10d)))
+ok=ok&&(type(attrval(al10c))=="UnknownType")
+print("10 'a' and '\\240' read back as chars, '^G' does not (expect CharType CharType UnknownType): %s %s %s\n" type(attrval(al10)) type(attrval(al10b)) type(attrval(al10c)))
 
-// --- 11: the three bytes that cannot sit bare between the quotes -- a
-// backslash would escape the closing quote, an apostrophe would be it, and a
-// caret would read back as the start of caret notation instead of itself --
-// take the escape the lexer already reads, so they round-trip instead of
-// breaking the parse of everything after them (or, for the caret, silently
-// reading as some other control byte).  Before, a char attribute holding
-// 0x5c serialized as '\' and the whole enclosing attrlist came back nil ---
-al11=(:b char(92) :q char(39) :hat char(94) :next 42)
-ok=ok&&(print(al11 :str)=="(:b '\\\\' :q '\\'' :hat '\\^' :next 42)")
-r11=eval("(:b '\\\\' :q '\\'' :hat '\\^' :next 42)")
-ok=ok&&(int(attrval(r11@0))==92)&&(int(attrval(r11@1))==39)&&(int(attrval(r11@2))==94)&&(attrval(r11@3)==42)
-print("11 backslash, apostrophe and caret escape and round-trip (expect 92 39 94 42): %v %v %v %v\n" int(attrval(r11@0)) int(attrval(r11@1)) int(attrval(r11@2)) attrval(r11@3))
-
-// --- 12: the copy/paste principle at the top of #467, stated as an
-// assertion over the whole byte range -- for every byte 0-255, wrap
-// char(n) in a one-member attrlist (so its quotes actually get emitted;
-// print()'s own display is bare, per tests 1-8 above), print that quoted
-// form, and eval() it back.  Every byte should come back exactly what it
-// started as, whichever of the three display forms (bare, caret, octal)
-// wrote it. ---
-allok=true
-r12=for(n=0 n<256 n=n+1
-  qform=print((:v char(n)) :str)
-  allok=allok&&(attrval(eval(qform))==char(n)))
-print("12 every byte's quoted char(n) round-trips through eval() (expect true): %v\n" allok)
-ok=ok&&allok
+// --- 11: the two bytes that cannot sit bare between the quotes -- a backslash
+// would escape the closing quote, an apostrophe would be it -- take the escape
+// the lexer already reads, so they round-trip instead of breaking the parse of
+// everything after them.  Before, a char attribute holding 0x5c serialized as
+// '\' and the whole enclosing attrlist came back nil ---
+al11=(:b char(92) :q char(39) :next 42)
+ok=ok&&(print(al11 :str)=="(:b '\\\\' :q '\\'' :next 42)")
+r11=eval("(:b '\\\\' :q '\\'' :next 42)")
+ok=ok&&(int(attrval(r11@0))==92)&&(int(attrval(r11@1))==39)&&(attrval(r11@2)==42)
+print("11 backslash and apostrophe escape and round-trip (expect 92 39 42): %v %v %v\n" int(attrval(r11@0)) int(attrval(r11@1)) attrval(r11@2))
 
 print("char: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -19,6 +19,6 @@
    origin <key>`) -- GitHub (and git itself) resolve tags and commit SHAs
    through the same ref-lookup mechanism, so anyone can look up a
    PATCH_KEY value later and land on the exact commit it names. */
-#define PATCH_KEY "0207a995"
+#define PATCH_KEY "6a215377"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Reverts #494 (`0145aa5`).

#494 added lexer support for reading `'^X'` caret notation back as a char literal, and escaped a literal caret byte to `'\^'` on write. Extending the same idea to strings (tracked in #495) turned out to have a real backward-compatibility problem: making caret-notation *reading* apply inside string literals means any existing string containing an ordinary literal `^` next to a letter in `?`-`_` (extremely common in plain prose — `^C`, `^D`, `^J`, `^Z` are standard ways to describe control keys in documentation and help text) gets silently reinterpreted as a control byte on re-parse. This isn't hypothetical: it broke `char.comt`'s own test 5, whose format string contains `^A ^[ ^J ^?` as plain descriptive text, purely from being parsed.

Working through the alternatives (see #495) landed on a better long-term fix: use `\cX` (Perl/PCRE-style control-character escape — Larry Wall's convention, not an invented one) instead of bare caret notation, for both chars and strings, plus named-escape display (`\n`, `\t`, etc.) for the 7 control bytes that already have a C mnemonic. That's a clean redesign of the *display* convention control-byte chars have used since `3fa1b0b` (an ~20-day-old change, not long-standing), not an extension of #467's specific approach — reverting #467/#494 cleanly first makes that redesign straightforward rather than layering on top of read-side behavior that's being replaced anyway.

## What this reverts
- `src/ComUtil/_lexscan.c`: the `'^X'` char-literal reader.
- `src/Attribute/attrvalue.c`: the `'\^'` literal-caret write-escape.
- `src/comterp_/tests/char.comt`: tests 10-12 back to their pre-#467 form (test 10 pins `'^G'` as `UnknownType` again; tests 11/12 drop the caret cases).
- `doc/LANGUAGE.md`: the char-display section added for #467.
- `src/include/ivstd/patch.h`.

Caret notation for control-byte *display* (`char(10)` showing as `'^J'`) is untouched by this revert — that predates #467 entirely and is being replaced separately in the follow-up `\cX` PR, not by this one.

## Test plan
- Full `run_all.comt` regression suite verified green after rebuilding all affected libraries (ComUtil, Attribute, ComTerp).
- `char.comt` specifically re-verified: back to 11 tests, all passing, matching pre-#467 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ)_