### PR TITLE
Fix #87: a trailing newline in a quoted string display is no longer silently dropped

### DIFF
--- a/src/Attribute/paramlist.c
+++ b/src/Attribute/paramlist.c
@@ -902,7 +902,7 @@ int ParamList::output_text(ostream& out, const char* text, int indent) {
     if (len == 0) 
 	out << "\"\"";
     else {
-	for (beg = 0; beg < len; ) {
+	for (beg = 0; ; ) {
 	    Get_Line(text, len, beg, end, lineSize, nextBeg);
 	    int line_len = end - beg + 1;
 	    if (line_len >= INT_MAX>>2) {
@@ -912,12 +912,16 @@ int ParamList::output_text(ostream& out, const char* text, int indent) {
 	        const char* string = filter(&text[beg], line_len);
 		out << "\"" << string << "\"";
 	    }
+	    /* nextBeg>len (not just ==len) is what "no more segments" means: a
+	       line ending on the text's own last '\n' has nextBeg==len exactly,
+	       and that trailing newline still needs its own (empty) segment, or
+	       the display loses it entirely with no way to tell it was ever
+	       there. */
+	    if (nextBeg > len) break;
+	    out << "," << "\n";
+	    for (int i = 0; i < indent; i++)
+		out << "    ";
 	    beg = nextBeg;
-	    if (beg < len) {
-		out << "," << "\n";
-		for (int i = 0; i < indent; i++)
-		    out << "    ";
-	    }
 	}
     }
     return line_too_long ? -1 : (out.good() ? 0 : -1);

--- a/src/comterp_/tests/print.comt
+++ b/src/comterp_/tests/print.comt
@@ -218,5 +218,16 @@ ok=ok&&(p30=="P{1,2,3}\n")
 print("30 print(\"%d\" lst :str :prefix \"P\") wraps the value (expect P{1,2,3} and a newline): %v\n\n" p30)
 prev_ok=check_fail(:ok ok)
 
+// --- test 31: a trailing '\n' shows up in %v's quoted display, the same
+// way an embedded (non-trailing) '\n' already splits the display into two
+// quoted segments joined by a comma -- previously the trailing case showed
+// nothing at all, no different from a string with no newline ---
+v31=print("hello" :prefix "PREFIX" :str)
+disp31=print("%v" v31 :str)
+match31=(disp31=="\"PREFIXhello\",\n\"\"")
+ok=ok&&match31
+print("31 quoted display of print(\"hello\" :prefix \"PREFIX\" :str)'s trailing newline as a second, empty segment (expect true): %v\n\n" match31)
+prev_ok=check_fail(:ok ok)
+
 print("print: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "524c4961"
+#define PATCH_KEY "4223a1af"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`ParamList::output_text()` is what backs `%v`'s quoted string display (`ComValue::operator<<` calls it for `StringType`, `src/ComTerp/comvalue.c:245`). It splits the text at each `'\n'` into separate quoted segments joined by `",\n"` -- readable multi-line display for a string containing embedded newlines, e.g. `"a\nb"` displays as:
```
"a",
"b"
```
That part already works. The bug is specifically the **trailing** case: the loop only continued while `beg<len`, so a segment that starts exactly where the string ends (i.e. the string's last byte is `'\n'`) was never emitted. The display for `"PREFIXhello\n"` looked byte-for-byte identical to `"PREFIXhello"` with no trailing newline at all -- the information was silently discarded, not just hard to read.

This is exactly issue #87's repro:
```
v=print("hello" :prefix "PREFIX" :str)   // v is "PREFIXhello\n" -- confirmed via size(v)/at(v...)
print("result: %v\n" v)                  // shows "PREFIXhello", not "PREFIXhello\n"
```

## Fix

Continue past a line whose terminator lands exactly on the string's end (`nextBeg>len`, not just `>=len`), so the trailing newline gets its own empty final segment -- the same treatment an embedded newline already gets. `"PREFIXhello\n"` now displays as:
```
"PREFIXhello",
""
```

## Not in scope

The issue's closing note explicitly defends `%v`'s quoting itself ("By design %v adds extra to what is printed over %s ... If quotes aren't wanted just use %s") -- this PR doesn't touch that, only the specific information loss on a trailing newline. It also doesn't attempt to make `output_text`'s multi-segment format `eval()`-round-trippable through comterp's own expression grammar -- it never was (an embedded newline doesn't round-trip that way today either); it has its own dedicated reader (see below), which is what it's actually paired with.

## This isn't just a REPL-display fix

`ParamList::parse_text`/`parse_textbuf` -- the reader for this exact format, used by `nodecomp.c`, `textfile.c`, and `ovtext.c` to read multi-line text fields back out of `.sim` script files -- reconstructs each `,` between quoted segments as a literal `\n`. Traced by hand: `"PREFIXhello",` followed by an empty `""` reads back as exactly `"PREFIXhello\n"`. Before this fix, saving and reloading a text graphic (or a `TextFileComp`'s begin/end string) whose content ended in a newline would have silently lost it on the round trip.

## Test plan

Verified against:
- the issue's own repro
- an embedded (non-trailing) newline -- unaffected, unchanged
- a trailing non-newline control byte (`char(7)`) -- unaffected, doesn't enter this code path at all (no `'\n'` involved)
- a plain string with no newline -- unaffected
- multiple trailing newlines (`"a\n\n"`) -- each gets its own empty segment, matching the general "N newlines -> N+1 segments" invariant this fix restores
- hand-traced the `ParamList::parse_text` read side to confirm the new output round-trips correctly through the `.sim` format
- full `run_all.comt` regression suite, green throughout

`print.comt` gains test 31. Confirmed it actually fails without the fix by temporarily reverting it and rerunning (`false` instead of `true`).

I also tried to verify live against `comdraw`'s own test suite (`xvfb-run -a comdraw -stdin_off -runfile src/comdraw/tests/run_all.comt`, per AGENTS.md) since a couple of the other `output_text` call sites are in `OverlayUnidraw`/`GraphUnidraw` graphics export code, but the run hung with no output in this sandbox rather than completing or failing outright -- didn't chase further since the by-hand trace of the read/write pairing above is unambiguous and the change itself is narrowly scoped to the loop-termination condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7TKYU4p4nwT33GTLNwuMQ)_