### PR TITLE
CI lint + Greptile doc for AGENTS.md's comment rules

### DIFF
--- a/.github/greptile-comment-rules.md
+++ b/.github/greptile-comment-rules.md
@@ -1,0 +1,67 @@
+# Comment review rules for Greptile
+
+This is a static copy of the two comment rules from `AGENTS.md` (repo root,
+"Code comments" section), formatted for Greptile's custom-context knowledge
+base. `AGENTS.md` is the source of truth -- if the two ever disagree, fix
+this file to match it. There is no automatic sync, so re-copy this file's
+body whenever those rules change in `AGENTS.md`.
+
+Paste the section below into this repo's Greptile knowledge base (Custom
+Context) so review passes flag violations automatically, the same way the
+in-repo CI lint (`.github/scripts/check_comment_rules.py`) catches them
+mechanically -- the CI check only looks at literal `#<digits>` tokens and a
+handful of narration phrases; Greptile's judgment is the backstop for the
+subtler phrasing the mechanical check misses.
+
+---
+
+## Instructions for the reviewer
+
+When reviewing a diff that adds or edits a comment in a `.c` or `.h` file
+(`.comt` test files are exempt), check it against both rules below and
+raise a review finding for either violation.
+
+### Rule 1 -- no GitHub issue/PR numbers in source comments
+
+A comment must never contain a GitHub issue or PR reference: `#223`,
+`(#485)`, `Fixes #94`, `Closes #501`, `PR #493`, "see issue 147", etc. That
+context belongs only in the commit message and PR description -- external,
+mutable state has no business embedded in the source tree.
+
+### Rule 2 -- comments describe the code as it is, not its history
+
+A comment must read exactly as it would if the code had been written
+correctly the first time: state the invariant, the mechanism, or the
+trade-off a future reader needs. Flag a comment that instead narrates:
+
+- how the code used to be broken or what the old behavior was,
+- how a bug was diagnosed, found, or reasoned about,
+- how or why a fix was made, or a contrast against a prior design
+  ("rather than the old approach", "instead of the previous helper",
+  "switched back to", etc.).
+
+This applies even to a comment written specifically to explain a bug fix --
+the fix's story belongs in the commit message and PR description, not the
+comment. The one exception (per `AGENTS.md`): a comment may stay long-form
+when a spot genuinely needs it to head off a likely misreading that would
+cause real chaos -- that's a judgment call, not a loophole for narration.
+
+### Examples
+
+Bad:
+```c
+// Fixed #485: this used to return a bare int, we now wrap it in brackets.
+```
+
+Bad (references a removed helper -- still narrating history):
+```c
+// Stamp the wrapper here instead of through the old helper, which
+// silently dropped it on an unelided return.
+```
+
+Good:
+```c
+// Stamped in place: a copy of this value discards the wrapper
+// (AttributeValue::assignval() never copies it), so read it by
+// reference rather than assign it elsewhere.
+```

--- a/.github/scripts/check_comment_rules.py
+++ b/.github/scripts/check_comment_rules.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Lint added .c/.h comments against the two rules in AGENTS.md:
+
+  1. No GitHub issue/PR numbers in source comments (#223, Fixes #94, ...).
+  2. A comment describes the code as it is, not the story of how it got
+     that way (no fix narration: "used to", "the bug", "diagnosed", ...).
+
+Only lines *added* by the diff between BASE and HEAD are checked, and only
+the comment-bearing portion of each line -- a `#` inside a string literal
+(a hex color, an error message) is not a violation. .comt files are exempt,
+matching AGENTS.md.
+
+Rule 1 is a hard failure (exit 1): the pattern is unambiguous. Rule 2 is
+inherently fuzzy, so it is reported as a non-blocking warning for a human
+(or the next review pass) to judge -- AGENTS.md itself carves out an
+exception for comments that genuinely need the long version.
+
+Usage: check_comment_rules.py [BASE] [HEAD]
+  BASE defaults to origin/master, HEAD defaults to HEAD.
+"""
+import re
+import subprocess
+import sys
+
+ISSUE_RE = re.compile(r'#\d+')
+
+NARRATION_PATTERNS = [re.compile(p, re.IGNORECASE) for p in [
+    r'\bused to\b',
+    r'\bpreviously\b',
+    r'\bthis (?:bug|fix)\b',
+    r'\bthe bug\b',
+    r'\bwas broken\b',
+    r'\bsilently broke\b',
+    r'\bdiagnosed\b',
+    r'\bdiscovered\b',
+    r'\bfixed by\b',
+    r'\bprior to this\b',
+    r'\bbefore this (?:fix|change|commit|patch)\b',
+    r'\bregression\b',
+    r'\bwe (?:caught|found)\b',
+    r'\brather than the (?:old|previous|prior)\b',
+    r'\brather than (?:through|via) (?:a|the)\b',
+]]
+
+
+def sh(*args):
+    return subprocess.run(args, capture_output=True, text=True, check=True).stdout
+
+
+def extract_comment_lines(text):
+    """Map 1-based line number -> comment-only text on that line.
+
+    A small state-machine C/C++ lexer: tracks // and /* */ comments,
+    "string" and 'char' literals (with backslash escapes) so a `#123`
+    inside a string, or a `//` inside a URL string, is never mistaken for
+    comment content.
+    """
+    n = len(text)
+    i = 0
+    line_no = 1
+    buf = {}
+
+    def emit(ln, ch):
+        buf.setdefault(ln, []).append(ch)
+
+    state = 'CODE'
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ''
+        if state == 'CODE':
+            if c == '/' and nxt == '/':
+                state = 'LINE_COMMENT'
+                i += 2
+            elif c == '/' and nxt == '*':
+                state = 'BLOCK_COMMENT'
+                i += 2
+            elif c == '"':
+                state = 'STRING'
+                i += 1
+            elif c == "'":
+                state = 'CHAR'
+                i += 1
+            elif c == '\n':
+                line_no += 1
+                i += 1
+            else:
+                i += 1
+        elif state == 'LINE_COMMENT':
+            if c == '\n':
+                state = 'CODE'
+                line_no += 1
+                i += 1
+            else:
+                emit(line_no, c)
+                i += 1
+        elif state == 'BLOCK_COMMENT':
+            if c == '*' and nxt == '/':
+                state = 'CODE'
+                i += 2
+            elif c == '\n':
+                line_no += 1
+                i += 1
+            else:
+                emit(line_no, c)
+                i += 1
+        elif state == 'STRING':
+            if c == '\\' and i + 1 < n:
+                i += 2
+            elif c == '"':
+                state = 'CODE'
+                i += 1
+            elif c == '\n':
+                state = 'CODE'  # malformed, but don't hang the lexer
+                line_no += 1
+                i += 1
+            else:
+                i += 1
+        elif state == 'CHAR':
+            if c == '\\' and i + 1 < n:
+                i += 2
+            elif c == "'":
+                state = 'CODE'
+                i += 1
+            elif c == '\n':
+                state = 'CODE'
+                line_no += 1
+                i += 1
+            else:
+                i += 1
+    return {ln: ''.join(chars) for ln, chars in buf.items()}
+
+
+def added_lines_by_file(base, head):
+    """Map changed .c/.h path -> set of new-file line numbers it added."""
+    diff = sh('git', 'diff', '--unified=0', '--no-color', base, head,
+              '--', '*.c', '*.h')
+    files = {}
+    cur_file = None
+    cur_new_line = None
+    hunk_re = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@')
+    for line in diff.splitlines():
+        if line.startswith('+++ '):
+            path = line[4:]
+            if path == '/dev/null':
+                cur_file = None
+            else:
+                cur_file = path[2:] if path.startswith('b/') else path
+                files.setdefault(cur_file, set())
+        elif line.startswith('@@'):
+            m = hunk_re.match(line)
+            if m:
+                cur_new_line = int(m.group(1))
+        elif line.startswith('+') and not line.startswith('+++'):
+            if cur_file is not None and cur_new_line is not None:
+                files[cur_file].add(cur_new_line)
+                cur_new_line += 1
+        # '-' lines don't consume a new-file line number; -U0 has no context lines.
+    return files
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else 'origin/master'
+    head = sys.argv[2] if len(sys.argv) > 2 else 'HEAD'
+
+    try:
+        files = added_lines_by_file(base, head)
+    except subprocess.CalledProcessError as e:
+        print(f"check_comment_rules: couldn't diff {base}..{head}, skipping "
+              f"(not blocking on tooling failure): {e.stderr.strip()}")
+        return 0
+
+    failures = []
+    warnings = []
+    for path, lines in files.items():
+        if not lines:
+            continue
+        try:
+            content = sh('git', 'show', f'{head}:{path}')
+        except subprocess.CalledProcessError:
+            continue  # file deleted or renamed away in this diff
+        comments = extract_comment_lines(content)
+        for ln in sorted(lines):
+            text = comments.get(ln, '')
+            if not text.strip():
+                continue
+            for m in ISSUE_RE.finditer(text):
+                failures.append(
+                    f"{path}:{ln}: comment references an issue/PR number "
+                    f"({m.group(0)!r}) -- belongs in the commit message/PR "
+                    f"description, not the source tree (AGENTS.md rule 1)")
+            for pat in NARRATION_PATTERNS:
+                m = pat.search(text)
+                if m:
+                    warnings.append(
+                        f"{path}:{ln}: comment may narrate a fix "
+                        f"({m.group(0)!r}) instead of describing current "
+                        f"behavior -- review against AGENTS.md rule 2")
+                    break  # one flag per line is enough
+
+    if warnings:
+        print("### Possible fix-narration in comments (AGENTS.md rule 2, "
+              "non-blocking -- judgment call)")
+        for w in warnings:
+            print(f"  {w}")
+        print()
+
+    if failures:
+        print("### Issue/PR numbers in comments (AGENTS.md rule 1, blocking)")
+        for f in failures:
+            print(f"  {f}")
+        print()
+        print(f"{len(failures)} comment(s) violate AGENTS.md's no-issue-number "
+              "rule. Move that context to the commit message or PR "
+              "description and describe the code itself in the comment.")
+        return 1
+
+    print("check_comment_rules: no issue-number violations in added "
+          f"comments ({len(warnings)} narration warning(s)).")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/check_comment_rules.py
+++ b/.github/scripts/check_comment_rules.py
@@ -51,96 +51,113 @@ def sh(*args):
     return subprocess.run(args, capture_output=True, text=True, check=True).stdout
 
 
-def extract_comment_lines(text):
-    """Map 1-based line number -> comment-only text on that line.
+def splice_lines(text):
+    """Resolve backslash-newline line splicing (translation phase 2).
 
-    A small state-machine C/C++ lexer: tracks // and /* */ comments,
-    "string" and 'char' literals (with backslash escapes) so a `#123`
-    inside a string, or a `//` inside a URL string, is never mistaken for
-    comment content.
+    Real compilers do this as a raw character-stream pass *before* any
+    tokenizing -- including before recognizing a `//`/`/*` delimiter, so a
+    `/` and `/` separated only by a spliced line ending do combine into a
+    line comment (confirmed against g++: it even warns -Wcomment on this
+    exact shape). Splicing has to happen first and separately for the same
+    reason: peeking one character ahead to recognize a two-character
+    delimiter only sees the right character if the splice already ran.
+
+    Returns (logical_text, line_of) where line_of[k] is the 1-based
+    original physical line number of logical_text[k], so a match found
+    after splicing can still be attributed to the physical line a diff
+    would report as added.
     """
     n = len(text)
-    i = 0
+    logical_chars = []
+    line_of = []
     line_no = 1
+    i = 0
+    while i < n:
+        if text[i] == '\\' and i + 1 < n and text[i + 1] == '\n':
+            i += 2
+            line_no += 1
+            continue
+        logical_chars.append(text[i])
+        line_of.append(line_no)
+        if text[i] == '\n':
+            line_no += 1
+        i += 1
+    return logical_chars, line_of
+
+
+def extract_comment_lines(text):
+    """Map 1-based (original, pre-splice) line number -> comment-only text
+    contributed by that line.
+
+    A small state-machine C/C++ lexer over the spliced character stream:
+    tracks // and /* */ comments, "string" and 'char' literals (with
+    backslash escapes) so a `#123` inside a string, or a `//` inside a URL
+    string, is never mistaken for comment content.
+    """
+    chars, line_of = splice_lines(text)
+    m = len(chars)
     buf = {}
 
     def emit(ln, ch):
         buf.setdefault(ln, []).append(ch)
 
     state = 'CODE'
-    while i < n:
-        # Backslash-newline line splicing (translation phase 2) applies
-        # uniformly, inside comments, strings, and code alike, and doesn't
-        # end whatever's currently open -- a line-comment spliced onto the
-        # next physical line is still one comment. Handled once here,
-        # ahead of the per-state dispatch below, rather than duplicated in
-        # each state's own escape handling.
-        if text[i] == '\\' and i + 1 < n and text[i + 1] == '\n':
-            i += 2
-            line_no += 1
-            continue
-        c = text[i]
-        nxt = text[i + 1] if i + 1 < n else ''
+    k = 0
+    while k < m:
+        c = chars[k]
+        nxt = chars[k + 1] if k + 1 < m else ''
+        ln = line_of[k]
         if state == 'CODE':
             if c == '/' and nxt == '/':
                 state = 'LINE_COMMENT'
-                i += 2
+                k += 2
             elif c == '/' and nxt == '*':
                 state = 'BLOCK_COMMENT'
-                i += 2
+                k += 2
             elif c == '"':
                 state = 'STRING'
-                i += 1
+                k += 1
             elif c == "'":
                 state = 'CHAR'
-                i += 1
-            elif c == '\n':
-                line_no += 1
-                i += 1
+                k += 1
             else:
-                i += 1
+                k += 1
         elif state == 'LINE_COMMENT':
             if c == '\n':
                 state = 'CODE'
-                line_no += 1
-                i += 1
+                k += 1
             else:
-                emit(line_no, c)
-                i += 1
+                emit(ln, c)
+                k += 1
         elif state == 'BLOCK_COMMENT':
             if c == '*' and nxt == '/':
                 state = 'CODE'
-                i += 2
-            elif c == '\n':
-                line_no += 1
-                i += 1
+                k += 2
             else:
-                emit(line_no, c)
-                i += 1
+                emit(ln, c)
+                k += 1
         elif state == 'STRING':
-            if c == '\\' and i + 1 < n:
-                i += 2
+            if c == '\\' and k + 1 < m:
+                k += 2
             elif c == '"':
                 state = 'CODE'
-                i += 1
+                k += 1
             elif c == '\n':
                 state = 'CODE'  # malformed, but don't hang the lexer
-                line_no += 1
-                i += 1
+                k += 1
             else:
-                i += 1
+                k += 1
         elif state == 'CHAR':
-            if c == '\\' and i + 1 < n:
-                i += 2
+            if c == '\\' and k + 1 < m:
+                k += 2
             elif c == "'":
                 state = 'CODE'
-                i += 1
+                k += 1
             elif c == '\n':
                 state = 'CODE'
-                line_no += 1
-                i += 1
+                k += 1
             else:
-                i += 1
+                k += 1
     return {ln: ''.join(chars) for ln, chars in buf.items()}
 
 

--- a/.github/scripts/check_comment_rules.py
+++ b/.github/scripts/check_comment_rules.py
@@ -15,6 +15,10 @@ inherently fuzzy, so it is reported as a non-blocking warning for a human
 (or the next review pass) to judge -- AGENTS.md itself carves out an
 exception for comments that genuinely need the long version.
 
+Fails closed: a base ref that can't be resolved, or a changed file that
+can't be read for any reason other than having been deleted/renamed away,
+also exits 1 -- an unverified diff is not a passing one.
+
 Usage: check_comment_rules.py [BASE] [HEAD]
   BASE defaults to origin/master, HEAD defaults to HEAD.
 """
@@ -65,6 +69,16 @@ def extract_comment_lines(text):
 
     state = 'CODE'
     while i < n:
+        # Backslash-newline line splicing (translation phase 2) applies
+        # uniformly, inside comments, strings, and code alike, and doesn't
+        # end whatever's currently open -- a line-comment spliced onto the
+        # next physical line is still one comment. Handled once here,
+        # ahead of the per-state dispatch below, rather than duplicated in
+        # each state's own escape handling.
+        if text[i] == '\\' and i + 1 < n and text[i + 1] == '\n':
+            i += 2
+            line_no += 1
+            continue
         c = text[i]
         nxt = text[i + 1] if i + 1 < n else ''
         if state == 'CODE':
@@ -165,19 +179,31 @@ def main():
     try:
         files = added_lines_by_file(base, head)
     except subprocess.CalledProcessError as e:
-        print(f"check_comment_rules: couldn't diff {base}..{head}, skipping "
-              f"(not blocking on tooling failure): {e.stderr.strip()}")
-        return 0
+        # Fail the gate rather than fail open: a base ref that can't be
+        # resolved (a too-shallow checkout, a rewritten branch) means no
+        # comment was actually checked, and a silently green lint step is a
+        # worse outcome than a CI failure someone has to look at. The
+        # caller (ci.yml) is responsible for handing this script refs that
+        # do resolve -- e.g. falling back to origin/master instead of a
+        # zero-SHA "before" on a branch's first push.
+        print(f"check_comment_rules: couldn't diff {base}..{head}: "
+              f"{e.stderr.strip()}")
+        return 1
 
     failures = []
     warnings = []
+    errors = []
     for path, lines in files.items():
         if not lines:
             continue
         try:
             content = sh('git', 'show', f'{head}:{path}')
-        except subprocess.CalledProcessError:
-            continue  # file deleted or renamed away in this diff
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.strip()
+            if 'does not exist' in stderr:
+                continue  # file deleted or renamed away in this diff
+            errors.append(f"{path}: couldn't read {head}:{path}: {stderr}")
+            continue
         comments = extract_comment_lines(content)
         for ln in sorted(lines):
             text = comments.get(ln, '')
@@ -204,6 +230,13 @@ def main():
             print(f"  {w}")
         print()
 
+    if errors:
+        print("### Files this check couldn't read (blocking -- an unverified "
+              "file is not a passing one)")
+        for e in errors:
+            print(f"  {e}")
+        print()
+
     if failures:
         print("### Issue/PR numbers in comments (AGENTS.md rule 1, blocking)")
         for f in failures:
@@ -212,6 +245,8 @@ def main():
         print(f"{len(failures)} comment(s) violate AGENTS.md's no-issue-number "
               "rule. Move that context to the commit message or PR "
               "description and describe the code itself in the comment.")
+
+    if failures or errors:
         return 1
 
     print("check_comment_rules: no issue-number violations in added "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history, not the default shallow clone: the comment-rules
+          # lint step below diffs against the PR base / previous push to
+          # find added lines, which a depth-1 checkout can't resolve.
+          fetch-depth: 0
+
+      # Pure git + python3, no build deps -- the cheapest possible gate, so
+      # it runs before anything else. Checks added .c/.h comments against
+      # AGENTS.md's two comment rules (no issue/PR numbers; describe the
+      # code as it is, not its fix history). See the script's own docstring
+      # for what's a hard failure vs. a non-blocking warning.
+      - name: Lint - code comment rules (AGENTS.md)
+        run: |
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ] && \
+               [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          else
+            BASE_SHA="origin/master"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+          echo "Diffing $BASE_SHA..$HEAD_SHA"
+          python3 .github/scripts/check_comment_rules.py "$BASE_SHA" "$HEAD_SHA"
 
       - name: Install build & test dependencies
         run: |

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "9bef1ad4"
+#define PATCH_KEY "b8a2c505"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Follow-up to #501: while addressing Greptile's review there, two of my own
added comments violated AGENTS.md's own comment rules (no GitHub issue/PR
numbers; describe the code as it is, not its fix history) — caught only
because I was asked to check by hand. This PR adds two backstops so that
doesn't need to keep happening manually:

- `.github/scripts/check_comment_rules.py` — diffs added `.c`/`.h` lines
  and checks the comment text against AGENTS.md's two rules:
  - No GitHub issue/PR number references (`#223`, `Fixes #94`, ...) —
    **hard CI failure**, since the pattern is unambiguous.
  - No fix-narration language ("used to", "the bug", "diagnosed", ...) —
    **non-blocking warning**, since that rule is inherently a judgment
    call (AGENTS.md itself carves out exceptions).
  - Tracks real C/C++ comment spans (not string/char literals), so a hex
    color literal or an error string containing `#1` doesn't
    false-positive.
- `.github/workflows/ci.yml` — wires the check in as the first, cheapest
  step (pure git + python3, no build deps), before the dependency install
  and the full imake build.
- `.github/greptile-comment-rules.md` — the same two rules written up for
  Greptile's custom-context knowledge base, as a judgment-based backstop
  for the narration phrasing the mechanical keyword check misses. (Not
  wired up automatically — paste its content into this repo's Greptile
  Custom Context; I understand a knowledge base rule has already been
  added on the Greptile side to cover this.)

## Test plan

- Ran the lint script against a sandbox repo: correctly hard-fails on a
  synthetic `Fixes #485` comment, and does **not** false-positive on a
  `"#7d9ec0"` hex-color string literal or a `"block #1"` error message —
  confirming it only inspects real comment text, not string literals.
- Verified line attribution inside a multi-line `/* */` block comment.
- Ran it against this session's own added comments (including the
  original, since-rewritten #501 comments) — correctly flagged the
  narration language once a matching pattern was added; correctly found
  nothing once those comments were rewritten to state the invariant
  instead.
- Validated `ci.yml` with a YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei)_