### PR TITLE
Fix #342: integer literals above 32-bit int range no longer truncate silently

### DIFF
--- a/src/ComUtil/comutil.ci
+++ b/src/ComUtil/comutil.ci
@@ -106,7 +106,17 @@ typedef unsigned long  ABSPNTR;
 #define SHHEXU_MAX_DIGITS	4
 #define SHHEXU_MAX_STRING	"FFFF"
 
-#if __WORDSIZE == 64 
+/* LNINT_MAX_* (and its octal/hex counterparts) are the bounds of a
+   LongType value -- storage-format-agnostic to comterp script authors,
+   who see LongType simply as "twice IntType's width" and nothing about
+   the host C ABI underneath. That guarantee is free here only because
+   this target's C `long` genuinely is 64 bits (__WORDSIZE==64 below); a
+   target where C's `long` stays narrower than that (Windows' LLP64 model,
+   notably) would need to back LongType with an explicit 64-bit type there
+   instead of deriving these bounds from `long`'s own width -- the same
+   principle DFINT_MAX_* below already follows by pinning itself to
+   `int`'s own width rather than borrowing `long`'s. */
+#if __WORDSIZE == 64
 #define LNINT_MAX_DIGITS	19
 #define LNINT_MAX_STRING	"9223372036854775807"
 #define LNOCTS_MAX_DIGITS	21

--- a/src/ComUtil/comutil.ci
+++ b/src/ComUtil/comutil.ci
@@ -143,17 +143,25 @@ typedef unsigned long  ABSPNTR;
 #define DFHEXU_MAX_STRING	SHHEXU_MAX_STRING
 #endif
 
+/* "Default int" means C's `int` specifically -- 32 bits on every non-MSDOS
+   target this builds for, independent of `long`'s own width (LNINT_MAX_*
+   above, 32 or 64 bits per __WORDSIZE). These bounds must reflect `int`
+   itself, never `long`: the lexer below stores an in-range "default int"
+   token into a real 32-bit `int` (`*(int*)token = value`), so on an LP64
+   target -- `long` wider than `int` -- deriving them from LNINT_MAX_* lets
+   a magnitude past INT_MAX/UINT_MAX through as "default int", and that
+   store silently truncates it. */
 #if !defined(MSDOS)
-#define DFINT_MAX_DIGITS	LNINT_MAX_DIGITS
-#define DFINT_MAX_STRING	LNINT_MAX_STRING
-#define DFOCTS_MAX_DIGITS	LNOCTS_MAX_DIGITS
-#define DFOCTS_MAX_STRING	LNOCTS_MAX_STRING
-#define DFOCTU_MAX_DIGITS	LNOCTU_MAX_DIGITS
-#define DFOCTU_MAX_STRING	LNOCTU_MAX_STRING
-#define DFHEXS_MAX_DIGITS	LNHEXS_MAX_DIGITS
-#define DFHEXS_MAX_STRING	LNHEXS_MAX_STRING
-#define DFHEXU_MAX_DIGITS	LNHEXU_MAX_DIGITS
-#define DFHEXU_MAX_STRING	LNHEXU_MAX_STRING
+#define DFINT_MAX_DIGITS	10
+#define DFINT_MAX_STRING	"2147483647"
+#define DFOCTS_MAX_DIGITS	11
+#define DFOCTS_MAX_STRING	"17777777777"
+#define DFOCTU_MAX_DIGITS	11
+#define DFOCTU_MAX_STRING	"37777777777"
+#define DFHEXS_MAX_DIGITS	8
+#define DFHEXS_MAX_STRING	"7FFFFFFF"
+#define DFHEXU_MAX_DIGITS	8
+#define DFHEXU_MAX_STRING	"FFFFFFFF"
 #endif
 
 #define SHORT_INT_MACHINE (DFINT_MAX_DIGITS != LNINT_MAX_DIGITS)

--- a/src/comterp_/tests/TESTING.md
+++ b/src/comterp_/tests/TESTING.md
@@ -317,7 +317,7 @@ Every script `run_all.comt` runs, in the order it runs them. Three states:
 - **untracked** (`—`) -- no coverage header anywhere. The script runs and asserts,
   it has simply never been scored against the slot taxonomy.
 
-17 of 55 scripts declare coverage (four more are scored table-only, marked
+17 of 56 scripts declare coverage (four more are scored table-only, marked
 with a dagger). The rest are real tests with no coverage number,
 not gaps in testing -- do not read `—` as untested.
 
@@ -357,6 +357,7 @@ not gaps in testing -- do not read `—` as untested.
 | stringstream.comt         | stream $$ feed chunk next list size at print          |       — |     — |    — |
 | time.comt                 | time int srand help index                             |       — |     — |    — |
 | numstring.comt            | int long float double print                           |       — |     — |    — |
+| intliteral.comt           | print type                                            |       — |     — |    — |
 | keyword_lineend.comt      | func arg run help print list                          |       — |     — |    — |
 | keyword_trailing_semi.comt| if postfix index max errmsg print                     |       — |     — |    — |
 | funchelp.comt †             | help func arg narg local global (`help(f)` on a bare… |      19 |    24 |  79% |

--- a/src/comterp_/tests/intliteral.comt
+++ b/src/comterp_/tests/intliteral.comt
@@ -1,59 +1,96 @@
 // src/comterp_/tests/intliteral.comt -- integer literal parsing picks the
 // right storage type by magnitude, decimal/octal/hex alike
 //
-// funcs: print type
+// funcs: print type errmsg
 //
 // A bare integer literal's type (IntType vs LongType) is decided by its
 // magnitude alone: it fits in a 32-bit `int` or it doesn't, regardless of
 // how many digits that takes to write in decimal, octal (0...), or hex
 // (0x...).  DFINT_MAX_DIGITS/DFINT_MAX_STRING and their octal/hex
 // counterparts (comutil.ci) are where that boundary lives, and they must
-// reflect `int`'s own 32-bit width, not `long`'s: `long` is 64 bits on
-// this platform, so deriving them from the long bounds understates how
-// many literals need to promote to LongType, and a literal that should
-// have promoted gets written into a real 32-bit `int` instead, silently
+// reflect `int`'s own 32-bit width, not `long`'s -- `long`'s own width
+// varies by platform (32 or 64 bits), so deriving them from the long
+// bounds understates how many literals need to promote to LongType on a
+// platform where long is wider than int, and a literal that should have
+// promoted gets written into a real 32-bit `int` instead, silently
 // truncating its value.
 //
-// Each check below compares print()'s %v display against a literal
-// string written independently of the value under test, not against a
-// second copy of the same literal -- a truncated value compared to
-// itself would still read as "equal" and miss the bug entirely.
+// Test 1 (the INT_MAX boundary itself) holds on every platform: `int` is
+// 32 bits everywhere this builds. Tests 2-6 use magnitudes that need a
+// 64-bit long to represent at all, so each is gated on errmsg(:last)
+// after evaluating its literal: on a platform where long is narrower,
+// the lexer's own ERR_TOOBIGINT (not a bug -- there is genuinely no
+// integer type here big enough to hold the value) is caught and the
+// check is skipped rather than failed, the same way parser.comt gates
+// its deliberately-malformed-input tests.
+//
+// Each assertion compares print()'s %v display against a literal string
+// written independently of the value under test, not against a second
+// copy of the same literal -- a truncated value compared to itself would
+// still read as "equal" and miss the bug entirely.
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/intliteral.comt")
 
 ok=true
 
-// --- test 1: the last literal that still fits in a plain int (2^31-1) ---
+// --- test 1: the last literal that still fits in a plain int (2^31-1) --
+// int is 32 bits on every platform this builds, so this one always holds
 s1=print("%v" 2147483647 :str)
 ok=ok&&(s1=="2147483647")&&(type(2147483647)==`IntType)
 print("1 2147483647 (expect 2147483647 IntType): %v %s\n" s1 type(2147483647))
 
 // --- test 2: one past INT_MAX must promote to LongType with its value
 // intact, not wrap to a negative 32-bit truncation ---
-s2=print("%v" 2147483648 :str)
-ok=ok&&(s2=="2147483648L")&&(type(2147483648)==`LongType)
-print("2 2147483648 (expect 2147483648L LongType): %v %s\n" s2 type(2147483648))
+errmsg(:clear)
+v2=2147483648
+e2=errmsg(:last)
+if (e2==nil
+  :then (s2=print("%v" v2 :str);
+         ok=ok&&(s2=="2147483648L")&&(type(v2)==`LongType);
+         print("2 2147483648 (expect 2147483648L LongType): %v %s\n" s2 type(v2)))
+  :else print("2 2147483648 -- skipped, exceeds this platform's long range (%v)\n" e2))
 
 // --- test 3: well past INT_MAX, still nowhere near LONG_MAX ---
-s3=print("%v" 3000000000 :str)
-ok=ok&&(s3=="3000000000L")&&(type(3000000000)==`LongType)
-print("3 3000000000 (expect 3000000000L LongType): %v %s\n" s3 type(3000000000))
+errmsg(:clear)
+v3=3000000000
+e3=errmsg(:last)
+if (e3==nil
+  :then (s3=print("%v" v3 :str);
+         ok=ok&&(s3=="3000000000L")&&(type(v3)==`LongType);
+         print("3 3000000000 (expect 3000000000L LongType): %v %s\n" s3 type(v3)))
+  :else print("3 3000000000 -- skipped, exceeds this platform's long range (%v)\n" e3))
 
-// --- test 4: LONG_MAX itself, the far boundary ---
-s4=print("%v" 9223372036854775807 :str)
-ok=ok&&(s4=="9223372036854775807L")&&(type(9223372036854775807)==`LongType)
-print("4 9223372036854775807 (expect itself, L-suffixed, LongType): %v %s\n" s4 type(9223372036854775807))
+// --- test 4: LONG_MAX itself, the far boundary -- only representable
+// where long is 64 bits ---
+errmsg(:clear)
+v4=9223372036854775807
+e4=errmsg(:last)
+if (e4==nil
+  :then (s4=print("%v" v4 :str);
+         ok=ok&&(s4=="9223372036854775807L")&&(type(v4)==`LongType);
+         print("4 9223372036854775807 (expect itself, L-suffixed, LongType): %v %s\n" s4 type(v4)))
+  :else print("4 9223372036854775807 -- skipped, exceeds this platform's long range (%v)\n" e4))
 
 // --- test 5-6: the same magnitude boundary in octal and hex, not just
 // decimal -- all three share the same DFOCTS/DFOCTU/DFHEXS/DFHEXU bounds ---
-s5=print("%v" 0x100000000 :str)
-ok=ok&&(s5=="4294967296L")&&(type(0x100000000)==`LongType)
-print("5 0x100000000 (expect 4294967296L LongType): %v %s\n" s5 type(0x100000000))
+errmsg(:clear)
+v5=0x100000000
+e5=errmsg(:last)
+if (e5==nil
+  :then (s5=print("%v" v5 :str);
+         ok=ok&&(s5=="4294967296L")&&(type(v5)==`LongType);
+         print("5 0x100000000 (expect 4294967296L LongType): %v %s\n" s5 type(v5)))
+  :else print("5 0x100000000 -- skipped, exceeds this platform's long range (%v)\n" e5))
 
-s6=print("%v" 040000000000 :str)
-ok=ok&&(s6=="4294967296L")&&(type(040000000000)==`LongType)
-print("6 040000000000 (expect 4294967296L LongType): %v %s\n" s6 type(040000000000))
+errmsg(:clear)
+v6=040000000000
+e6=errmsg(:last)
+if (e6==nil
+  :then (s6=print("%v" v6 :str);
+         ok=ok&&(s6=="4294967296L")&&(type(v6)==`LongType);
+         print("6 040000000000 (expect 4294967296L LongType): %v %s\n" s6 type(v6)))
+  :else print("6 040000000000 -- skipped, exceeds this platform's long range (%v)\n" e6))
 
 print("intliteral: %v\n" ok)
 ok

--- a/src/comterp_/tests/intliteral.comt
+++ b/src/comterp_/tests/intliteral.comt
@@ -1,0 +1,59 @@
+// src/comterp_/tests/intliteral.comt -- integer literal parsing picks the
+// right storage type by magnitude, decimal/octal/hex alike
+//
+// funcs: print type
+//
+// A bare integer literal's type (IntType vs LongType) is decided by its
+// magnitude alone: it fits in a 32-bit `int` or it doesn't, regardless of
+// how many digits that takes to write in decimal, octal (0...), or hex
+// (0x...).  DFINT_MAX_DIGITS/DFINT_MAX_STRING and their octal/hex
+// counterparts (comutil.ci) are where that boundary lives, and they must
+// reflect `int`'s own 32-bit width, not `long`'s: `long` is 64 bits on
+// this platform, so deriving them from the long bounds understates how
+// many literals need to promote to LongType, and a literal that should
+// have promoted gets written into a real 32-bit `int` instead, silently
+// truncating its value.
+//
+// Each check below compares print()'s %v display against a literal
+// string written independently of the value under test, not against a
+// second copy of the same literal -- a truncated value compared to
+// itself would still read as "equal" and miss the bug entirely.
+//
+// Run from inside comterp, comdraw, or drawserv:
+//   run("src/comterp_/tests/intliteral.comt")
+
+ok=true
+
+// --- test 1: the last literal that still fits in a plain int (2^31-1) ---
+s1=print("%v" 2147483647 :str)
+ok=ok&&(s1=="2147483647")&&(type(2147483647)==`IntType)
+print("1 2147483647 (expect 2147483647 IntType): %v %s\n" s1 type(2147483647))
+
+// --- test 2: one past INT_MAX must promote to LongType with its value
+// intact, not wrap to a negative 32-bit truncation ---
+s2=print("%v" 2147483648 :str)
+ok=ok&&(s2=="2147483648L")&&(type(2147483648)==`LongType)
+print("2 2147483648 (expect 2147483648L LongType): %v %s\n" s2 type(2147483648))
+
+// --- test 3: well past INT_MAX, still nowhere near LONG_MAX ---
+s3=print("%v" 3000000000 :str)
+ok=ok&&(s3=="3000000000L")&&(type(3000000000)==`LongType)
+print("3 3000000000 (expect 3000000000L LongType): %v %s\n" s3 type(3000000000))
+
+// --- test 4: LONG_MAX itself, the far boundary ---
+s4=print("%v" 9223372036854775807 :str)
+ok=ok&&(s4=="9223372036854775807L")&&(type(9223372036854775807)==`LongType)
+print("4 9223372036854775807 (expect itself, L-suffixed, LongType): %v %s\n" s4 type(9223372036854775807))
+
+// --- test 5-6: the same magnitude boundary in octal and hex, not just
+// decimal -- all three share the same DFOCTS/DFOCTU/DFHEXS/DFHEXU bounds ---
+s5=print("%v" 0x100000000 :str)
+ok=ok&&(s5=="4294967296L")&&(type(0x100000000)==`LongType)
+print("5 0x100000000 (expect 4294967296L LongType): %v %s\n" s5 type(0x100000000))
+
+s6=print("%v" 040000000000 :str)
+ok=ok&&(s6=="4294967296L")&&(type(040000000000)==`LongType)
+print("6 040000000000 (expect 4294967296L LongType): %v %s\n" s6 type(040000000000))
+
+print("intliteral: %v\n" ok)
+ok

--- a/src/comterp_/tests/intliteral.comt
+++ b/src/comterp_/tests/intliteral.comt
@@ -17,12 +17,15 @@
 //
 // Test 1 (the INT_MAX boundary itself) holds on every platform: `int` is
 // 32 bits everywhere this builds. Tests 2-6 use magnitudes that need a
-// 64-bit long to represent at all, so each is gated on errmsg(:last)
-// after evaluating its literal: on a platform where long is narrower,
-// the lexer's own ERR_TOOBIGINT (not a bug -- there is genuinely no
-// integer type here big enough to hold the value) is caught and the
-// check is skipped rather than failed, the same way parser.comt gates
-// its deliberately-malformed-input tests.
+// 64-bit long to represent at all, so this platform's long width is
+// established once, up front, from whether the smallest of them
+// (INT_MAX+1) parses -- not re-checked per test. That distinction
+// matters: on a narrower-long platform the whole block is skipped, one
+// message, since nothing past INT_MAX has a representation to test
+// against there; but once this platform is established to support them,
+// a literal that unexpectedly fails to parse is a real regression and
+// must fail its assertion, not be swallowed as an assumed platform
+// limit the way a per-test error check would.
 //
 // Each assertion compares print()'s %v display against a literal string
 // written independently of the value under test, not against a second
@@ -40,57 +43,48 @@ s1=print("%v" 2147483647 :str)
 ok=ok&&(s1=="2147483647")&&(type(2147483647)==`IntType)
 print("1 2147483647 (expect 2147483647 IntType): %v %s\n" s1 type(2147483647))
 
-// --- test 2: one past INT_MAX must promote to LongType with its value
-// intact, not wrap to a negative 32-bit truncation ---
+// --- platform capability, established once: can this build's `long`
+// hold INT_MAX+1 at all?  If the smallest over-int magnitude here has no
+// representation, none of the larger ones tests 3-6 use do either. ---
 errmsg(:clear)
 v2=2147483648
 e2=errmsg(:last)
-if (e2==nil
-  :then (s2=print("%v" v2 :str);
-         ok=ok&&(s2=="2147483648L")&&(type(v2)==`LongType);
-         print("2 2147483648 (expect 2147483648L LongType): %v %s\n" s2 type(v2)))
-  :else print("2 2147483648 -- skipped, exceeds this platform's long range (%v)\n" e2))
+has_long64=(e2==nil)
 
-// --- test 3: well past INT_MAX, still nowhere near LONG_MAX ---
-errmsg(:clear)
-v3=3000000000
-e3=errmsg(:last)
-if (e3==nil
-  :then (s3=print("%v" v3 :str);
-         ok=ok&&(s3=="3000000000L")&&(type(v3)==`LongType);
-         print("3 3000000000 (expect 3000000000L LongType): %v %s\n" s3 type(v3)))
-  :else print("3 3000000000 -- skipped, exceeds this platform's long range (%v)\n" e3))
+if (has_long64
+  :then (
+    // --- test 2: one past INT_MAX must promote to LongType with its
+    // value intact, not wrap to a negative 32-bit truncation ---
+    s2=print("%v" v2 :str);
+    ok=ok&&(s2=="2147483648L")&&(type(v2)==`LongType);
+    print("2 2147483648 (expect 2147483648L LongType): %v %s\n" s2 type(v2));
 
-// --- test 4: LONG_MAX itself, the far boundary -- only representable
-// where long is 64 bits ---
-errmsg(:clear)
-v4=9223372036854775807
-e4=errmsg(:last)
-if (e4==nil
-  :then (s4=print("%v" v4 :str);
-         ok=ok&&(s4=="9223372036854775807L")&&(type(v4)==`LongType);
-         print("4 9223372036854775807 (expect itself, L-suffixed, LongType): %v %s\n" s4 type(v4)))
-  :else print("4 9223372036854775807 -- skipped, exceeds this platform's long range (%v)\n" e4))
+    // --- test 3: well past INT_MAX, still nowhere near LONG_MAX ---
+    v3=3000000000;
+    s3=print("%v" v3 :str);
+    ok=ok&&(s3=="3000000000L")&&(type(v3)==`LongType);
+    print("3 3000000000 (expect 3000000000L LongType): %v %s\n" s3 type(v3));
 
-// --- test 5-6: the same magnitude boundary in octal and hex, not just
-// decimal -- all three share the same DFOCTS/DFOCTU/DFHEXS/DFHEXU bounds ---
-errmsg(:clear)
-v5=0x100000000
-e5=errmsg(:last)
-if (e5==nil
-  :then (s5=print("%v" v5 :str);
-         ok=ok&&(s5=="4294967296L")&&(type(v5)==`LongType);
-         print("5 0x100000000 (expect 4294967296L LongType): %v %s\n" s5 type(v5)))
-  :else print("5 0x100000000 -- skipped, exceeds this platform's long range (%v)\n" e5))
+    // --- test 4: LONG_MAX itself, the far boundary ---
+    v4=9223372036854775807;
+    s4=print("%v" v4 :str);
+    ok=ok&&(s4=="9223372036854775807L")&&(type(v4)==`LongType);
+    print("4 9223372036854775807 (expect itself, L-suffixed, LongType): %v %s\n" s4 type(v4));
 
-errmsg(:clear)
-v6=040000000000
-e6=errmsg(:last)
-if (e6==nil
-  :then (s6=print("%v" v6 :str);
-         ok=ok&&(s6=="4294967296L")&&(type(v6)==`LongType);
-         print("6 040000000000 (expect 4294967296L LongType): %v %s\n" s6 type(v6)))
-  :else print("6 040000000000 -- skipped, exceeds this platform's long range (%v)\n" e6))
+    // --- test 5-6: the same magnitude boundary in octal and hex, not
+    // just decimal -- all three share the same DFOCTS/DFOCTU/DFHEXS/
+    // DFHEXU bounds ---
+    v5=0x100000000;
+    s5=print("%v" v5 :str);
+    ok=ok&&(s5=="4294967296L")&&(type(v5)==`LongType);
+    print("5 0x100000000 (expect 4294967296L LongType): %v %s\n" s5 type(v5));
+
+    v6=040000000000;
+    s6=print("%v" v6 :str);
+    ok=ok&&(s6=="4294967296L")&&(type(v6)==`LongType);
+    print("6 040000000000 (expect 4294967296L LongType): %v %s\n" s6 type(v6))
+    )
+  :else print("2-6 skipped: this platform's long can't represent INT_MAX+1 (%v)\n" e2))
 
 print("intliteral: %v\n" ok)
 ok

--- a/src/comterp_/tests/run_all.comt
+++ b/src/comterp_/tests/run_all.comt
@@ -141,6 +141,10 @@ if(run("./numstring.comt")
   :then print("pass: numstring\n")
   :else print("FAIL: numstring\n");topok=false)
 
+if(run("./intliteral.comt")
+  :then print("pass: intliteral\n")
+  :else print("FAIL: intliteral\n");topok=false)
+
 if(run("./keyword_lineend.comt")
   :then print("pass: keyword_lineend\n")
   :else print("FAIL: keyword_lineend\n");topok=false)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "84b30c72"
+#define PATCH_KEY "02f3f22d"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

Closes #342.

```
print(3000000000)                  -- printed -1294967296
print(2147483648)                  -- printed -2147483648  (INT_MAX + 1)
print(9223372036854775807)         -- printed -1           (true LONG_MAX)
```

No parse error, no warning — just a silently wrong value for any integer
literal above ~2.1 billion.

## Root cause

`src/ComUtil/comutil.ci` defines `DFINT_MAX_DIGITS`/`DFINT_MAX_STRING`
("default int", i.e. C's `int`) by aliasing `LNINT_MAX_DIGITS`/`LNINT_MAX_STRING`
("long int") on every non-MSDOS target:

```c
#if !defined(MSDOS)
#define DFINT_MAX_DIGITS	LNINT_MAX_DIGITS
#define DFINT_MAX_STRING	LNINT_MAX_STRING
...
```

That alias is correct on an old ILP32 Unix target, where `int` and `long`
are both 32 bits — which is almost certainly why it was written this way
originally. On this LP64 target (`__WORDSIZE == 64`, Linux/macOS), `long`
is 64 bits while `int` stayed 32, so the alias silently widened "fits in a
default int" to mean "fits in a `long`" — letting any magnitude up to
`LONG_MAX` (~9.2×10¹⁸) through the branch in `_lexscan.c`'s `TOK_DFINT`
case that stores the parsed value into a real 32-bit `int`:

```c
if( !long_num && ( *toklen-1 < DFINT_MAX_DIGITS || ... )) {
   int value;
   value = atoi( token );
   *(int *)token = value;
   ...
```

Anything past the true 32-bit boundary that this branch accepted got
truncated on that store. The same pattern (and the same bug) exists for
octal (`DFOCTS_MAX_*`/`DFOCTU_MAX_*`) and hex (`DFHEXS_MAX_*`/`DFHEXU_MAX_*`)
literals — confirmed: `print(0x100000000)` and `print(040000000000)` (2³²)
both printed `0` before this fix.

## Fix

Hardcoded `DFINT_MAX_DIGITS`/`DFINT_MAX_STRING` and the octal/hex
equivalents to `int`'s actual 32-bit bounds (`2147483647`, `17777777777`
octal, `37777777777` unsigned octal, `7FFFFFFF` hex, `FFFFFFFF` unsigned
hex) instead of deriving them from `LNINT_MAX_*`, so they no longer track
`long`'s width. Confirmed via `grep` that `_lexscan.c` is the only
consumer of these five constant pairs — no other blast radius.

## Test plan

- Added `src/comterp_/tests/intliteral.comt` (6 checks: the `INT_MAX`
  boundary itself stays `IntType`, one past it promotes to `LongType`
  with its value intact, well past it, `LONG_MAX` itself, and the same
  boundary in octal and hex), wired into `run_all.comt`.
- Each check compares `print()`'s `%v` display against an independently
  written expected string, not the same literal against itself — a
  truncated value compared to itself would still read as "equal" and
  miss the bug.
- Verified the new test **fails** against the pre-fix build (5 of 6
  assertions fail, reproducing the exact corrupted values from the
  issue) and **passes** against the fix.
- Full `run_all.comt` regression suite passes, zero failures.
- Verified manually beyond what the test asserts: `INT_MAX` (`2147483647`)
  stays plain `IntType` with no `L` suffix; ordinary small and negative
  ints (`42`, `-5`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei)_