### PR TITLE
Fix #348: dot(name) 1-arg form no longer segfaults

### DIFF
--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -477,11 +477,11 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
       /* al.method(args) -- fire, self-bound, not a plain attribute fetch.
 	 copy_stack_arg_post_eval needs the argoff bookmark still on the
 	 stack, so it must run before reset_stack(), same as every other
-	 stack_arg* read here.  nargs()>1 is required alongside after_nids!=-1:
-	 a missing 2nd arg (the 1-arg dot(a) form) reads back from
-	 peek_and_fire()'s stack_arg(1,true) as a default-constructed
-	 ComValue whose nids() is 0, indistinguishable from a real
-	 name-with-parens rhs by after_nids alone. */
+	 stack_arg* read here.  nargs()>1 excludes a bare dot(name) call:
+	 with no 2nd arg, peek_and_fire()'s stack_arg(1,true) returns a
+	 default-constructed ComValue whose nids() is 0 -- the same value
+	 after_nids carries for a genuine name-with-parens rhs, so
+	 after_nids alone can't tell the two apart. */
       int nargtoks;
       postfix_token* argtoks = copy_stack_arg_post_eval(1, nargtoks);
       reset_stack();

--- a/src/ComTerp/dotfunc.c
+++ b/src/ComTerp/dotfunc.c
@@ -473,11 +473,15 @@ void DotFunc::execute_core(ComValue before_part, ComValue after_raw, int after_n
     } else
       al = (AttributeList*) before_part.obj_val();
 
-    if (after_nids!=-1) {
+    if (after_nids!=-1 && nargs()>1) {
       /* al.method(args) -- fire, self-bound, not a plain attribute fetch.
 	 copy_stack_arg_post_eval needs the argoff bookmark still on the
 	 stack, so it must run before reset_stack(), same as every other
-	 stack_arg* read here. */
+	 stack_arg* read here.  nargs()>1 is required alongside after_nids!=-1:
+	 a missing 2nd arg (the 1-arg dot(a) form) reads back from
+	 peek_and_fire()'s stack_arg(1,true) as a default-constructed
+	 ComValue whose nids() is 0, indistinguishable from a real
+	 name-with-parens rhs by after_nids alone. */
       int nargtoks;
       postfix_token* argtoks = copy_stack_arg_post_eval(1, nargtoks);
       reset_stack();

--- a/src/ComTerp/dotfunc.h
+++ b/src/ComTerp/dotfunc.h
@@ -32,7 +32,7 @@
 #include <ComTerp/numfunc.h>
 #include <string>
 
-//: . (dot) operator, for compound variables | dotlst=dot(name) -- construct empty dottted pair list.
+//: . (dot) operator, for compound variables | dotlst=dot(name) -- get name's attribute list, creating an empty one if name isn't bound to one yet.
 // obj.method(args) also fires a FuncObj-valued attribute self-bound to
 // obj, evaluating args in the caller's own scope first -- see execute().
 class DotFunc : public ComFunc {
@@ -42,7 +42,7 @@ public:
     virtual void execute();
     virtual boolean post_eval() { return true; }
     virtual const char* docstring() {
-      return "%s (.) makes compound variables | dotlst=dot(name) -- construct empty dotted pair list"; }
+      return "%s (.) makes compound variables | dotlst=dot(name) -- get name's attribute list, creating an empty one if needed"; }
 
 
 protected:

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 56/68 (82%)
+// coverage: 59/71 (83%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
 //          -(empty-rhs)
@@ -23,7 +23,10 @@
 // mechanism: a method reaches a sibling by using the enclosing attrlist's
 // own ordinary name and an explicit dot-call, which also means nothing
 // enforces that name still points at the same object across a call
-// (tests 47-48).
+// (tests 47-48).  dot(name) -- the 1-arg explicit-call form, as opposed to
+// the ordinary infix a.b tested throughout -- returns the named variable's
+// attrlist, creating and binding an empty one if it wasn't already one,
+// aliased rather than copied either way (#348, tests 58-60).
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")
@@ -543,6 +546,35 @@ prev_ok=check_fail(:ok ok)
 r57=(:name foo55)
 ok=ok&&(r57.name==99)
 print("57 an unprotected symbol is looked up on read-back instead (expect 99): %v\n\n" r57.name)
+prev_ok=check_fail(:ok ok)
+
+// --- test 58: dot(name) -- the 1-arg explicit-call form -- on a variable
+// already bound to an attrlist returns that same attrlist, aliased rather
+// than a fresh copy (#348 regression: this used to segfault, since the
+// missing 2nd arg read back from the same default-constructed ComValue a
+// real name-with-parens rhs uses, misrouting into method dispatch) ---
+al58=attrlist(:p 1)
+r58=dot(al58)
+ok=ok&&(r58==al58)
+print("58 dot(al58) on a bound attrlist returns it, aliased (expect r58==al58): %v\n\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 59: dot(name) on a not-yet-bound variable lazily creates and
+// binds an empty attrlist under that name, the same get-or-create
+// semantics the infix operator already uses (dot's own before-variable
+// lookup in execute_core, shared by both call forms) ---
+r59=dot(dotarity59)
+ok=ok&&(type(r59)==`ObjectType)&&(type(dotarity59)==`ObjectType)&&(dotarity59==r59)
+print("59 dot(dotarity59) on an unbound name creates+binds an empty attrlist (expect true): %v\n\n" ok)
+prev_ok=check_fail(:ok ok)
+
+// --- test 60: the aliasing from test 58 is live, not a snapshot -- a
+// field written through the ordinary infix operator afterward is visible
+// through the earlier dot(name) result too, since both name the same
+// underlying AttributeList ---
+al58.q=2
+ok=ok&&(r58.q==2)
+print("60 al58.q=2 after dot(al58); r58.q sees it too, same object (expect 2): %v\n\n" r58.q)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "94961aa9"
+#define PATCH_KEY "ef9edecc"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

- `DotFunc::execute_core()` told "`al.method(args)`" (name-with-parens rhs) apart from a plain field access solely by `after_nids!=-1`. When `dot(name)` is called with only one argument, `peek_and_fire()`'s `stack_arg(1, true)` has nothing to peek and returns a default-constructed `ComValue` whose `nids()` happens to be `0` — indistinguishable from a real name-with-parens rhs by that check alone — so the missing-arg case was misrouted into method dispatch and crashed downstream (confirmed via a captured SIGSEGV inside `DotFunc::execute_core`).
- Gate that branch on `nargs()>1` as well, so a bare 1-arg `dot(name)` falls through to the existing get-or-lazily-create path instead, returning the named variable's attribute list (creating and binding an empty one if it wasn't already one) — the same get-or-create semantics the infix `.` operator's own auto-vivify behavior already uses elsewhere in the same function.
- Corrected `DotFunc`'s docstrings, which described `dot(name)` as constructing a fresh empty list — it's a get-or-create against the named variable, not a fresh detached construction like `list(:attr)`.

Investigated (empirically, via a built `comterp`) every syntactic spelling the infix `.` operator can take before deciding on this fix: true EOF after `.` is a hard parse error; `.` followed by real content greedily consumes it; and `.` immediately followed by a closing delimiter (`(a.)`, `if(...:then a.)`) is intercepted by the parser's always-on `_empty_statement` leniency (`src/ComUtil/_parser.c:58`), which synthesizes a no-op `empty()` call as the rhs rather than ever leaving a true Blank. So the crash is provably reachable only through the explicit `dot(name)` 1-arg call form, which this PR fixes.

## Test plan

- [x] Added tests 58-60 to `src/comterp_/tests/attrlist.comt`: `dot(name)` on an already-bound attrlist returns it aliased (not copied); `dot(name)` on an unbound variable lazily creates+binds an empty attrlist; the aliasing is live (a write through the infix operator is visible through the earlier `dot()` result).
- [x] Negative control: reverted the fix, rebuilt, and reproduced the original SIGSEGV in `DotFunc::execute_core`; restored the fix and confirmed it's gone.
- [x] Full regression suite (`run_all.comt`) run under `comterp`; compared against a baseline run on unmodified `master` — the same 4 pre-existing failures (`string`, `multibody`, `updown`, `runfile`) occur on both, none newly introduced by this change.
- [x] `attrlist.comt` (60 tests, including the 3 new ones) run clean under `comdraw` and `drawserv` as well as `comterp`.
- [x] Bumped `PATCH_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei)_