### PR TITLE
Fix #341: refuse a list/attrlist write that would insert itself

### DIFF
--- a/src/Attribute/attribute.c
+++ b/src/Attribute/attribute.c
@@ -34,11 +34,13 @@ Attribute::Attribute(const char* name, AttributeValue* value) {
     else
 	symbolid = -1;
     valueptr = value;
+    _owner = nil;
 }
 
 Attribute::Attribute(int symid, AttributeValue* value) {
   symbolid = symid;
   valueptr = value;
+  _owner = nil;
 }
 
 Attribute::Attribute(const Attribute& attr) {
@@ -46,6 +48,7 @@ Attribute::Attribute(const Attribute& attr) {
     if (symbolid != -1) // for reference count
 	symbol_add(symbol_pntr(symbolid));
     valueptr = new AttributeValue(*attr.valueptr);
+    _owner = nil;
 }
 
 Attribute::~Attribute() {

--- a/src/Attribute/attribute.h
+++ b/src/Attribute/attribute.h
@@ -59,9 +59,16 @@ public:
     int SymbolId();
     // return the id of the symbol in the symbol table.
 
+    AttributeList* Owner() const { return _owner; }
+    // the AttributeList this Attribute is stored in, or nil for one not
+    // (or not yet) added to any list -- set by AttributeList::add_attr,
+    // the sole gateway by which an Attribute becomes part of a list's
+    // storage.
+
 protected:
     int symbolid;
     AttributeValue* valueptr;
+    AttributeList* _owner;
 
 friend class AttributeList;
 

--- a/src/Attribute/attrlist.c
+++ b/src/Attribute/attrlist.c
@@ -124,6 +124,7 @@ int AttributeList::add_attr(Attribute* attr) {
     }
     InsertBefore(i, attr);
     Resource::ref(attr);
+    attr->_owner = this;
     return 0;
 }
 

--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -136,6 +136,15 @@ void AssignFunc::execute() {
 	}
     } else if (operand1.is_object(Attribute::class_symid())) {
       Attribute* attr = (Attribute*)operand1.obj_val();
+      AttributeList* owner = attr->Owner();
+      if (owner && value_contains_container(*operand2, (void*)owner, true)) {
+	fprintf(stderr, "WARNING: refusing to insert an attrlist into itself -- line %d\n",
+		funcstate()->linenum());
+	delete operand2;
+	reset_stack();
+	push_stack(ComValue::nullval());
+	return;
+      }
       attr->Value(operand2);
     } else if (operand1.is_array() && operand1.lhs_assign()) {
       /* the @ operator: lst@N=val.  ListAtFunc (listfunc.c), seeing its

--- a/src/ComTerp/assignfunc.c
+++ b/src/ComTerp/assignfunc.c
@@ -120,6 +120,14 @@ void AssignFunc::execute() {
 	    }
 	    comterp()->localtable()->insert(operand1.symbol_val(), operand2);
 	} else if (attrlist) {
+	    if (value_contains_container(*operand2, (void*)attrlist, true)) {
+	      fprintf(stderr, "WARNING: refusing to insert an attrlist into itself -- line %d\n",
+		      funcstate()->linenum());
+	      delete operand2;
+	      reset_stack();
+	      push_stack(ComValue::nullval());
+	      return;
+	    }
 	    Resource::ref(attrlist);
 	    Attribute* attr = new Attribute(operand1.symbol_val(),
 					    operand2);

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -35,21 +35,32 @@
 #include <Attribute/attribute.h>
 #include <iostream.h>
 #include <string.h>
+#include <algorithm>
+#include <vector>
 
 #define TITLE "ListFunc"
 
 /*****************************************************************************/
 
-boolean value_contains_container(AttributeValue& val, void* target,
-				  boolean target_is_attrlist) {
+/* visited tracks every AttributeValueList/AttributeList already walked in
+   this search, by pointer, so a container reachable through more than one
+   path in 'val' -- or one that is itself part of a cycle unrelated to
+   target -- is walked at most once, rather than driving the recursion as
+   deep as the structure lets it go. */
+static boolean value_contains_container_rec(AttributeValue& val, void* target,
+					     boolean target_is_attrlist,
+					     std::vector<void*>& visited) {
   if (val.is_type(ComValue::ArrayType)) {
     AttributeValueList* avl = val.array_val();
     if (!target_is_attrlist && (void*)avl == target) return true;
     if (avl) {
+      if (std::find(visited.begin(), visited.end(), (void*)avl) != visited.end())
+	return false;
+      visited.push_back((void*)avl);
       ALIterator it;
       for (avl->First(it); !avl->Done(it); avl->Next(it)) {
 	AttributeValue* elt = avl->GetAttrVal(it);
-	if (elt && value_contains_container(*elt, target, target_is_attrlist))
+	if (elt && value_contains_container_rec(*elt, target, target_is_attrlist, visited))
 	  return true;
       }
     }
@@ -57,16 +68,25 @@ boolean value_contains_container(AttributeValue& val, void* target,
     AttributeList* al = (AttributeList*)val.obj_val();
     if (target_is_attrlist && (void*)al == target) return true;
     if (al) {
+      if (std::find(visited.begin(), visited.end(), (void*)al) != visited.end())
+	return false;
+      visited.push_back((void*)al);
       Iterator it;
       for (al->First(it); !al->Done(it); al->Next(it)) {
 	Attribute* attr = al->GetAttr(it);
 	if (attr && attr->Value() &&
-	    value_contains_container(*attr->Value(), target, target_is_attrlist))
+	    value_contains_container_rec(*attr->Value(), target, target_is_attrlist, visited))
 	  return true;
       }
     }
   }
   return false;
+}
+
+boolean value_contains_container(AttributeValue& val, void* target,
+				  boolean target_is_attrlist) {
+  std::vector<void*> visited;
+  return value_contains_container_rec(val, target, target_is_attrlist, visited);
 }
 
 ListFunc::ListFunc(ComTerp* comterp) : ComFunc(comterp) {

--- a/src/ComTerp/listfunc.c
+++ b/src/ComTerp/listfunc.c
@@ -40,6 +40,35 @@
 
 /*****************************************************************************/
 
+boolean value_contains_container(AttributeValue& val, void* target,
+				  boolean target_is_attrlist) {
+  if (val.is_type(ComValue::ArrayType)) {
+    AttributeValueList* avl = val.array_val();
+    if (!target_is_attrlist && (void*)avl == target) return true;
+    if (avl) {
+      ALIterator it;
+      for (avl->First(it); !avl->Done(it); avl->Next(it)) {
+	AttributeValue* elt = avl->GetAttrVal(it);
+	if (elt && value_contains_container(*elt, target, target_is_attrlist))
+	  return true;
+      }
+    }
+  } else if (val.is_object(AttributeList::class_symid())) {
+    AttributeList* al = (AttributeList*)val.obj_val();
+    if (target_is_attrlist && (void*)al == target) return true;
+    if (al) {
+      Iterator it;
+      for (al->First(it); !al->Done(it); al->Next(it)) {
+	Attribute* attr = al->GetAttr(it);
+	if (attr && attr->Value() &&
+	    value_contains_container(*attr->Value(), target, target_is_attrlist))
+	  return true;
+      }
+    }
+  }
+  return false;
+}
+
 ListFunc::ListFunc(ComTerp* comterp) : ComFunc(comterp) {
 }
 
@@ -257,6 +286,12 @@ void ListAtFunc::execute() {
     int nvv = nv.is_nil() ? avl->Number()-1 : nv.int_val();
     if (avl) {
       if (insflag) {
+	if (value_contains_container(insv, (void*)avl, false)) {
+	  fprintf(stderr, "WARNING: refusing to insert a list into itself -- line %d\n",
+		  funcstate()->linenum());
+	  push_stack(ComValue::nullval());
+	  return;
+	}
 	avl->Insert(nvv, new AttributeValue(insv));
 	push_stack(insv);
 	return;
@@ -264,6 +299,12 @@ void ListAtFunc::execute() {
 	/* nvv, not nv.int_val(): a nil index means the last item, and every
 	   other branch here already reads it that way -- this one wrote the
 	   first item instead. */
+	if (value_contains_container(setv, (void*)avl, false)) {
+	  fprintf(stderr, "WARNING: refusing to insert a list into itself -- line %d\n",
+		  funcstate()->linenum());
+	  push_stack(ComValue::nullval());
+	  return;
+	}
 	AttributeValue* oldv = avl->Set(nvv, new AttributeValue(setv));
 	delete oldv;
 	push_stack(setv);
@@ -301,8 +342,15 @@ void ListAtFunc::execute() {
 	  Attribute* attr = al->GetAttr(it);
 	  if (insflag) {
 	    fprintf(stderr, "Insert not yet supported for AttributeList\n");
-	  } else if (setflag)
+	  } else if (setflag) {
+	    if (value_contains_container(setv, (void*)al, true)) {
+	      fprintf(stderr, "WARNING: refusing to insert an attrlist into itself -- line %d\n",
+		      funcstate()->linenum());
+	      push_stack(ComValue::nullval());
+	      return;
+	    }
 	    *attr->Value() = setv;
+	  }
 	  /* return a detached single-entry attrlist, e.g. (:y 20), not a live
 	     handle into al: al@n=val must never write through, and handing back
 	     a live Attribute* would make that unenforceable, since AssignFunc

--- a/src/ComTerp/listfunc.h
+++ b/src/ComTerp/listfunc.h
@@ -35,6 +35,18 @@
 
 class ComTerp;
 class ComValue;
+class AttributeValue;
+
+// true if 'val' -- searched recursively through any nested ArrayType
+// element or AttributeList attribute value, including 'val' itself --
+// reaches the list or attrlist identity named by 'target'.
+// target_is_attrlist selects which kind of container 'target' names (an
+// AttributeValueList* for a plain list, an AttributeList* for an
+// attrlist), since the two are unrelated pointer types.  Shared by
+// ListAtFunc (listfunc.c) and AssignFunc (assignfunc.c), the two places a
+// list or attrlist gains a new element or attribute value.
+boolean value_contains_container(AttributeValue& val, void* target,
+				  boolean target_is_attrlist);
 
 //: create list command for ComTerp.
 // lst=list([lst|strm|val] :strmlst :attr :size n) -- create list, copy list, or convert stream

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 62/74 (84%)
+// coverage: 63/75 (84%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
 //          -(empty-rhs)
@@ -27,11 +27,12 @@
 // the ordinary infix a.b tested throughout -- returns the named variable's
 // attrlist, creating and binding an empty one if it wasn't already one,
 // aliased rather than copied either way (#348, tests 58-60).  Writing a
-// value into an attrlist -- dot-assign (al.field=val) or the explicit
-// at(al n :set val) form -- is refused, nil, with a warning to stderr,
-// if the value being written already reaches the attrlist itself,
-// directly or nested arbitrarily deep through other lists/attrlists
-// (#341, tests 61-64).
+// value into an attrlist -- dot-assign (al.field=val), the explicit
+// at(al n :set val) form, or a bare-symbol write inside a method body
+// self-bound on al -- is refused, nil, with a warning to stderr, if the
+// value being written already reaches the attrlist itself, directly or
+// nested arbitrarily deep through other lists/attrlists (#341, tests
+// 61-65).
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")
@@ -618,6 +619,19 @@ al64=attrlist(:w 1)
 r64=(al64.w=attrlist(:v 2))
 ok=ok&&(r64.v==2)&&(al64.w.v==2)
 print("64 al64.w=attrlist(:v 2) unrelated attrlist still writes (expect 2 2): %v %v\n\n" r64.v al64.w.v)
+prev_ok=check_fail(:ok ok)
+
+// --- test 65: the same refusal applies to a bare-symbol write inside a
+// self-bound method body (al.method=func(newfield=al)) -- a third,
+// distinct write path into an attrlist besides dot-assign and explicit
+// at(:set), since a bare symbol assigned while self-bound on al writes
+// straight into al's own attribute list (AssignFunc's func-scope
+// _alist branch), not through a live Attribute* handle ---
+al65=attrlist(:x 1)
+al65.setself=func(newfield=al65)
+al65.setself()
+ok=ok&&(al65.newfield==nil)
+print("65 self-bound bare-symbol write of al65 into itself refused (expect al65.newfield nil): %v\n\n" al65.newfield)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/comterp_/tests/attrlist.comt
+++ b/src/comterp_/tests/attrlist.comt
@@ -1,6 +1,6 @@
 // src/comterp_/tests/attrlist.comt -- test dot, list(:attr), and attrlist()
 //
-// coverage: 59/71 (83%)
+// coverage: 62/74 (84%)
 // funcs: dot list(:attr) attrlist at size attrname attrval + -
 // missing: at(:ins) at(stress-boundary) size(empty) attrname(stream) attrval(stream)
 //          -(empty-rhs)
@@ -26,7 +26,12 @@
 // (tests 47-48).  dot(name) -- the 1-arg explicit-call form, as opposed to
 // the ordinary infix a.b tested throughout -- returns the named variable's
 // attrlist, creating and binding an empty one if it wasn't already one,
-// aliased rather than copied either way (#348, tests 58-60).
+// aliased rather than copied either way (#348, tests 58-60).  Writing a
+// value into an attrlist -- dot-assign (al.field=val) or the explicit
+// at(al n :set val) form -- is refused, nil, with a warning to stderr,
+// if the value being written already reaches the attrlist itself,
+// directly or nested arbitrarily deep through other lists/attrlists
+// (#341, tests 61-64).
 //
 // Run from inside comterp, comdraw, or drawserv:
 //   run("src/comterp_/tests/attrlist.comt")
@@ -575,6 +580,44 @@ prev_ok=check_fail(:ok ok)
 al58.q=2
 ok=ok&&(r58.q==2)
 print("60 al58.q=2 after dot(al58); r58.q sees it too, same object (expect 2): %v\n\n" r58.q)
+prev_ok=check_fail(:ok ok)
+
+// --- test 61: dot-assign refuses to write an attrlist into one of its
+// own fields -- al61.x=al61 is refused, nil, rather than building a
+// self-referential structure that would recurse without end the moment
+// anything walks it (print, in particular) ---
+al61=attrlist(:x 1)
+r61=(al61.x=al61)
+ok=ok&&(r61==nil)&&(al61.x==1)
+print("61 al61.x=al61 refused (expect nil, al61.x unchanged 1): %v %v\n\n" r61 al61.x)
+prev_ok=check_fail(:ok ok)
+
+// --- test 62: the same refusal through the explicit at(al n :set val)
+// form, the other writable path into an attrlist besides dot-assign ---
+al62=attrlist(:y 1)
+r62=at(al62 0 :set al62)
+ok=ok&&(r62==nil)&&(al62.y==1)
+print("62 at(al62 0 :set al62) refused (expect nil, al62.y unchanged 1): %v %v\n\n" r62 al62.y)
+prev_ok=check_fail(:ok ok)
+
+// --- test 63: an indirect cycle -- a list holding a reference to al63 is
+// itself dot-assigned into al63, reaching back to al63 one level down
+// rather than directly.  The guard searches the value being written
+// recursively, through nested lists and attrlists alike, not just its
+// own top-level identity ---
+al63=attrlist(:z 1)
+inner63=list(al63)
+r63=(al63.z=inner63)
+ok=ok&&(r63==nil)&&(al63.z==1)
+print("63 al63.z=inner63 refused, inner63 nests al63 (expect nil, unchanged 1): %v %v\n\n" r63 al63.z)
+prev_ok=check_fail(:ok ok)
+
+// --- test 64: an ordinary, non-self-referential value is unaffected --
+// the guard only refuses a genuine cycle ---
+al64=attrlist(:w 1)
+r64=(al64.w=attrlist(:v 2))
+ok=ok&&(r64.v==2)&&(al64.w.v==2)
+print("64 al64.w=attrlist(:v 2) unrelated attrlist still writes (expect 2 2): %v %v\n\n" r64.v al64.w.v)
 prev_ok=check_fail(:ok ok)
 
 print("attrlist: %v\n" ok)

--- a/src/comterp_/tests/listat.comt
+++ b/src/comterp_/tests/listat.comt
@@ -130,5 +130,45 @@ idx17=0,2
 ok=ok&&(lst17@idx17==nil)&&(lst17@(0,2)==nil)&&(list(lst17@$$idx17)=={10,30})
 print("17 list index nil, stream index fans out (expect nil {10,30}): %v %v\n" lst17@idx17 list(lst17@$$idx17))
 
+// --- 18: at(lst n :set lst) -- inserting a list into itself is refused,
+// not a crash.  Before this guard, splicing a list into its own slot
+// built a self-referential structure that recursed without end the
+// moment anything walked it (print, in particular) ---
+lst18=list(10,20,30)
+r18=at(lst18 0 :set lst18)
+ok=ok&&(r18==nil)&&(lst18=={10,20,30})
+print("18 at(lst18 0 :set lst18) refused (expect nil, lst18 unchanged): %v %v\n" r18 lst18)
+
+// --- 19: the same refusal through the @ operator -- lst@0=lst is the
+// original repro (#341): print(lst) afterward must not crash either,
+// since the write never went through ---
+lst19=list(10,20,30)
+r19=(lst19@0=lst19)
+ok=ok&&(r19==nil)&&(lst19=={10,20,30})
+print("19 lst19@0=lst19 refused (expect nil, lst19 unchanged): %v %v\n" r19 lst19)
+
+// --- 20: an indirect cycle -- a list holding a reference to lst20 is
+// itself inserted into lst20, which would reach back to lst20 one level
+// down rather than directly.  The guard searches the value being
+// inserted recursively, not just its own top-level identity.  inner20 is
+// built via at(:set), not list(lst20) -- list() given a single list
+// argument copies its contents (a documented conversion, not a wrap), so
+// that spelling would never actually nest lst20 inside inner20 ---
+lst20=list(10,20,30)
+inner20=list(:size 1)
+at(inner20 0 :set lst20)
+r20=at(lst20 0 :set inner20)
+ok=ok&&(r20==nil)&&(lst20=={10,20,30})
+print("20 at(lst20 0 :set inner20) refused, inner20 nests lst20 (expect nil, unchanged): %v %v\n" r20 lst20)
+
+// --- 21: an ordinary, non-self-referential list value at the same slot
+// is unaffected -- the guard only refuses a genuine cycle.  list(99), a
+// genuine 1-element list, prints with a trailing comma ({99,}) to stay
+// unambiguous with the bare scalar {99} would otherwise parse as ---
+lst21=list(10,20,30)
+r21=at(lst21 0 :set list(99))
+ok=ok&&(r21=={99,})&&(lst21=={{99,},20,30})
+print("21 at(lst21 0 :set list(99)) unrelated list still writes (expect {99,} {{99,},20,30}): %v %v\n" r21 lst21)
+
 print("listat: %v\n" ok)
 ok

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "866020c2"
+#define PATCH_KEY "1f77cdfd"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

- Splicing a container into its own slot — `lst@0=lst`, `al.field=al`, or the explicit `at(lst|al n :set val)` forms — built a self-referential structure with no cycle guard anywhere in the render path (`ComValue::operator<<`, `AttributeList::serialize`): the next attempt to print it recursed without bound and crashed. Confirmed via direct reproduction of the issue's exact repro (`lst=list(10,20,30); lst@0=lst; print(lst)`).
- Per the issue owner's own design comment: guard at the point of construction/assignment rather than at render time. Every `at(:set)` of a list, `at(:set)` of an attrlist, or attrlist dot-assign now searches the value being written for the receiving list/attrlist's own identity — reachable directly or nested arbitrarily deep through other lists/attrlists — and refuses the write (nil, warning to stderr) if found, leaving the container unchanged.
- Guarded at the three actual write sites: `ListAtFunc`'s `:ins`/`:set` paths for a plain list and the explicit attrlist `:set` path (`listfunc.c`), and `AssignFunc`'s attrlist dot-assign path (`assignfunc.c`). `lst@N=val` reaches the same `ListAtFunc` `:set` path already covered, since `AssignFunc` re-drives it rather than writing through separately — no extra guard needed there.
- The search is a shared recursive helper, `value_contains_container` (`listfunc.c`/`.h`), walking both `ArrayType` and `AttributeList` structure uniformly so a cycle built through any mix of list/attrlist nesting is caught, not just a direct self-reference.
- The attrlist dot-assign site needs to know which `AttributeList` a live `Attribute*` handle belongs to, which nothing previously tracked. `Attribute` gains an `Owner()` accessor, set once by `AttributeList::add_attr` — the sole gateway an `Attribute` enters a list's storage through — nil for one never added to any list. This is purely additive (a new field with a safe default, set in exactly one place, read only by the new guard) and doesn't change any existing behavior.

## Test plan

- [x] Added tests 18-21 to `src/comterp_/tests/listat.comt`: `at(lst n :set lst)` and `lst@0=lst` (the original repro) both refused; an indirect cycle (a list nesting a reference to the receiver, then written back into it) also refused; an ordinary, unrelated list value at the same slot is unaffected.
- [x] Added tests 61-64 to `src/comterp_/tests/attrlist.comt`: attrlist dot-assign self-reference (`al.x=al`) and the explicit `at(al n :set al)` form both refused; an indirect cycle through a nested list refused; an ordinary, unrelated attrlist value unaffected.
- [x] Negative control: on a clean branch off latest `master` with the fix reverted, rebuilt, and reproduced the exact original crash (`lst=list(10,20,30); lst@0=lst; print(lst)` → SIGSEGV); restored the fix and confirmed it's gone.
- [x] Full regression suite (`run_all.comt`) run under `comterp`; same 4 pre-existing unrelated failures (`string`, `multibody`, `updown`, `runfile`) as an unmodified-master baseline, nothing new introduced.
- [x] `listat.comt` and `attrlist.comt` run clean under `comdraw` and `drawserv` as well as `comterp`.
- [x] Bumped `PATCH_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei)_