### PR TITLE
Fix #390: PanCmd::Unexecute applies each pan delta to the wrong axis

### DIFF
--- a/src/OverlayUnidraw/ovcamcmds.c
+++ b/src/OverlayUnidraw/ovcamcmds.c
@@ -251,8 +251,8 @@ void PanCmd::Execute() {
 void PanCmd::Unexecute() {
     OverlayViewer* v = (OverlayViewer*) GetEditor()->GetViewer();
     Perspective basep = *v->GetPerspective();
-    basep.cury -= _px;
-    basep.curx -= _py;
+    basep.curx -= _px;
+    basep.cury -= _py;
     v->Adjust(basep);
 }
 

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "1f77cdfd"
+#define PATCH_KEY "094ffcd3"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

- `PanCmd::Execute()` (`src/OverlayUnidraw/ovcamcmds.c`) adds `_px` to `curx` and `_py` to `cury`. `PanCmd::Unexecute()` subtracted `_px` from `cury` and `_py` from `curx` instead — the two axes swapped — so undo only lands back at the starting point when `_px==_py`; for any other pan it lands at `(x-_py, y-_px)` instead of `(x, y)`.
- Swapped the two assignments so `Unexecute()` mirrors `Execute()` exactly (`curx -= _px; cury -= _py;`), matching the pattern `ZoomCmd::Execute()`/`Unexecute()` already use correctly a few classes up in the same file (dividing where `Execute` multiplies, same axis assignments).
- Per discussion on the issue: `PanCmd::Reversible()` returns `false`, consistently across every camera command in this file (`ZoomCmd`, `PreciseZoomCmd`, `FixedPanCmd` are all `false` too) — not inherited from a shared default, each overrides it individually. That reads as a deliberate, consistent choice (view navigation isn't a document edit) rather than an oversight, so this PR only fixes the wrong arithmetic and leaves `Reversible()` as is — no behavior change to the live, reachable undo history.

## Test plan

This one's honest about its limits: `Unexecute()` is not reachable through any live path today (`Reversible()` false → never logged for undo; nothing else calls it — checked). So there's no `.comt` script or running-app scenario that exercises the buggy line at all, unlike the ComTerp-interpreter fixes in this repo's recent history.

- [x] Verified by direct comparison: the fix makes `Unexecute()` algebraically the exact inverse of `Execute()` (same two fields, same two deltas, subtraction undoing addition) — not something that needs runtime execution to establish, the same way `ZoomCmd`'s already-correct `Unexecute()` wasn't written that way by coincidence.
- [x] `ovcamcmds.c` and the full `OverlayUnidraw` library rebuild clean.
- [x] `comdraw` relinked and run under `xvfb-run`; `pan(10 20)` (the live, reachable `Execute()` path, unaffected by this change) still runs without error — confirms nothing in the surrounding file broke.
- [x] Bumped `PATCH_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei)_