### PR TITLE
Fix patternmask(N) scalar form losing its bits on export/import

### DIFF
--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -67,6 +67,8 @@
 
 #include <InterViews/transformer.h>
 #include <IV-2_6/InterViews/world.h>
+
+#include <OS/memory.h>
 #include <IV-X11/Xlib.h>
 #include <IV-X11/xdisplay.h>
 #include <IV-X11/xfont.h>
@@ -263,14 +265,16 @@ void CreateGraphicFunc::set_graphic_gs(AttributeList* al, Graphic* gr) {
 	remove_key(al, graypat_sym);
     } else if ((v = al->find(pattern_sym)) && v->is_array()) {
 	AttributeValueList* avl = v->array_val();
-	if (avl && avl->Number()==16) {
-	    int mask[16]; int i=0; Iterator it;
-	    for (avl->First(it); !avl->Done(it) && i<16; avl->Next(it))
+	int n = avl ? avl->Number() : 0;
+	if (n==1 || n==8 || n==16) {
+	    int mask[patternHeight];
+	    Memory::zero(mask, sizeof(mask));
+	    int i=0; Iterator it;
+	    for (avl->First(it); !avl->Done(it) && i<n; avl->Next(it))
 		mask[i++] = avl->GetAttrVal(it)->int_val();
-	    gr->SetPattern(new PSPattern(mask, 16));
-	} else if (avl && avl->Number()>=1) {
-	    Iterator it; avl->First(it);
-	    gr->SetPattern(new PSPattern(avl->GetAttrVal(it)->int_val(), -1));
+	    gr->SetPattern(catalog->FindPattern(mask, n));
+	} else {
+	    fprintf(stderr, "invalid :pattern list size %d\n", n);
 	}
 	remove_key(al, pattern_sym);
     }
@@ -1401,9 +1405,13 @@ void PatternMaskFunc::execute() {
 
     PSPattern* pattern = nil;
     std::string maskargs;
+    Catalog* catalog = unidraw->GetCatalog();
 
     if (bitsv.is_int()) {
-      pattern = new PSPattern(bitsv.int_val(), -1);
+      int seed[patternHeight];
+      Memory::zero(seed, sizeof(seed));
+      seed[0] = bitsv.int_val();
+      pattern = catalog->FindPattern(seed, 1);
       char buf[32];
       snprintf(buf, sizeof(buf), "%d", bitsv.int_val());
       maskargs = buf;

--- a/src/ComUnidraw/grfunc.c
+++ b/src/ComUnidraw/grfunc.c
@@ -1429,7 +1429,7 @@ void PatternMaskFunc::execute() {
 	if (i) mbuf << ",";
 	mbuf << mask[i];
       }
-      pattern = new PSPattern(mask, 16);
+      pattern = catalog->FindPattern(mask, 16);
       maskargs = mbuf.str();
     } else {
       fprintf(stderr, "patternbits argument not int or list\n");

--- a/src/comdraw/tests/gsexim.comt
+++ b/src/comdraw/tests/gsexim.comt
@@ -162,5 +162,25 @@ print("10a attributed graphic exports as %s\n" as1)
 print("10b and re-creates from it identically (expect true): %v\n" r10)
 print("10c with a separator before the first attribute (expect a position): %v\n\n" index(as1 " :myattr" :substr))
 
+// --- test 11: patternmask()'s scalar form (#382) -- a dither-seed int must
+//              export as an explicit, self-describing :pattern bitmask, not
+//              collapse to ":graypat -1".  -1 is a reserved sentinel meaning
+//              "bits follow" (see catalog.c's Catalog::FindPattern/
+//              ExpandToFullSize and psview.c's SetP proc), never a real gray
+//              fraction, so a genuine gray level can never legitimately be
+//              -1 -- colliding with it silently drops the actual bits.
+//              Round-trip it through re-import too: the reader has its own
+//              copy of the same bug for any non-16-element :pattern list. ---
+each(delete($$select(:all)))
+brush(65535,0); colors(`Red `White)
+rp=rect(0,0,40,40); patternmask(255)
+sp1=export(rp :string :percomp)
+ok=ok&&(index(sp1 ":graypat" :substr)==nil)
+ok=ok&&(index(sp1 ":pattern 0x00,0x00,0xff,0xff,0x00,0x00,0xff,0xff" :substr)!=nil)
+sp2=export(run(sp1 :str) :string :percomp)
+ok=ok&&(eq(sp1 sp2))
+print("11a patternmask(255) exports its bits, not :graypat -1: %s\n" sp1)
+print("11b re-imported and re-exported identically (expect true): %v\n\n" eq(sp1 sp2))
+
 print("gsexim: %v\n" ok)
 ok

--- a/src/drawserv_/tests/gstests.comt
+++ b/src/drawserv_/tests/gstests.comt
@@ -377,14 +377,12 @@ gsbrushB_test=func(
   if(!p3 :then print("gsbrushB: FAIL pattern did not reach ds3 intact\n" :err));
   if(ok :then print("gsbrushB: brush and pattern fanned out to both branches\n" :err));
 
-  /* --- patternmask, scalar form, again as a follow-on state change.  Note
-     what this can and cannot prove: PatternMaskFunc builds PSPattern(bits,-1),
-     which has GetSize()==0 and so exports through the graylevel branch as
-     ":graypat -1" whatever the scalar was.  So a match shows the patternmask
-     command crossed and took effect -- the far nodes default to :nonepat --
-     but not WHICH scalar arrived.  The 16-element form pins its bits exactly;
-     see gsbrushA. --- */
-  maskstr=":graypat -1";
+  /* --- patternmask, scalar form, again as a follow-on state change.
+     PatternMaskFunc resolves the dither-seed int through
+     catalog->FindPattern(seed, 1), a real sized-bits pattern, so like the
+     16-element form in gsbrushA this pins the exact bits that crossed --
+     not just that some patternmask command took effect. --- */
+  maskstr=":pattern 0x00,0x00,0xff,0xff,0x00,0x00,0xff,0xff";
   remote(sock1 "patternmask(255)");
   m2=on2 && gs_on_node(:bn_sock sock2 :bn_id id1 :bn_gs maskstr);
   m3=on3 && gs_on_node(:bn_sock sock3 :bn_id id1 :bn_gs maskstr);

--- a/src/include/ivstd/patch.h
+++ b/src/include/ivstd/patch.h
@@ -18,6 +18,6 @@
    the change lands, which is what makes a PATCH_KEY later resolve back
    to the commit it named. A PR that only bumps this value needs no
    separate tagging step and no tag-push commit. */
-#define PATCH_KEY "094ffcd3"
+#define PATCH_KEY "9cff2618"
 
 #endif /* _patch_h */


### PR DESCRIPTION
## Summary

`patternmask(N)`'s scalar form always exported as `:graypat -1` regardless of `N`, losing the actual pattern bits. `PatternMaskFunc::execute()` built `new PSPattern(bits, -1)`, misusing `PSPattern`'s gray-level constructor and passing `-1` as the "graylevel".

`-1` turns out to be a reserved sentinel throughout the codebase (`catalog.c`'s `Catalog::FindPattern`/`ExpandToFullSize`, `psview.c`'s `SetP` PostScript proc, `idcatalog.c`'s `.ps`-format reader) meaning "explicit bits follow, not a gray fraction" — a real gray level is always `0..1`. Because the buggy pattern's `GetSize()` stayed `0`, every consumer (`.sim` export, `export()`, and PostScript printing via `psview.c`) took the gray-level branch and emitted the bogus sentinel instead of the pattern's actual bits.

I confirmed `PSPattern`'s gray-level mode is a deliberate, legitimate feature (a continuous-tone PostScript fill optimization used by real percentage-gray catalog patterns via `Catalog::FindGrayLevel`) — this fix doesn't touch or repurpose that path. It routes `patternmask(N)`'s scalar through `catalog->FindPattern(seed, 1)`, the same sized-bits catalog machinery already used by `patternmask`'s 16-element list form, producing a genuine self-describing bitmap pattern (`GetSize()==1`).

While tracing the round trip I found a mirror bug in `CreateGraphicFunc::set_graphic_gs`'s `:pattern` reader: it only handled the exact 16-element list form and otherwise fell back to the same `PSPattern(int, -1)` misuse for any other size — including the 8-byte compact form the exporter now emits for `patternmask`'s scalar. Fixed that too, generalizing the reader to accept the three sizes `ExpandToFullSize` actually supports (1, 8, 16).

Also made `patternmask`'s 16-element list form route through `catalog->FindPattern(mask, 16)` instead of building its `PSPattern` directly — the scalar form already benefits from `FindPattern`'s catalog dedup (repeated identical patterns share one object/pixmap instead of each allocating its own), and there's no reason the list form shouldn't get the same consistency; `FindPattern` treats size 16 as a no-op pass-through, so this costs nothing.

## Changes

- `src/ComUnidraw/grfunc.c`: `PatternMaskFunc::execute()`'s scalar branch now resolves through `catalog->FindPattern(seed, 1)` instead of `new PSPattern(bits, -1)`; its 16-element list branch now resolves through `catalog->FindPattern(mask, 16)` instead of `new PSPattern(mask, 16)`, for dedup consistency between both forms. `CreateGraphicFunc::set_graphic_gs`'s `:pattern` reader now handles sizes 1/8/16 generically via `catalog->FindPattern`, instead of only 16 with a buggy fallback.
- `src/comdraw/tests/gsexim.comt`: new test 11 covering the export/reimport/re-export round trip for `patternmask(255)`.
- `src/drawserv_/tests/gstests.comt`: updated `gsbrushB`'s expected pattern string from the old (buggy) `:graypat -1` to the correct, now-exact `:pattern` bits, matching how `gsbrushA` already pins the 16-element form.
- `src/include/ivstd/patch.h`: bumped `PATCH_KEY`.

## Test plan

- [x] `src/comdraw/tests/run_all.comt` under `xvfb-run comdraw` — full suite green, including new gsexim test 11 (re-run after both commits)
- [x] `src/drawserv_/tests/drawmo --tests gsbrushA` — distributed round trip for the 16-element list form still passes exact-bits assertion after routing it through `FindPattern`
- [x] `src/drawserv_/tests/drawmo --tests gsbrushB` — distributed round trip for the scalar form passes with the corrected exact-bits assertion
- [x] Negative control: reverted the scalar fix, rebuilt, confirmed `patternmask(255)` and `patternmask(5)` both export as `:graypat -1` (the original bug); restored the fix and reconfirmed green
- [x] Verified `PSPattern`'s gray-level mode (used by real menu pattern grays) is untouched by reading `psview.c`'s PostScript writer and `idcatalog.c`'s `.ps` reader

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gpnqd8RDaZQ1LzRVWFYei)_